### PR TITLE
opt: fix ResolvedType() for aggregateInfo in the optbuilder

### DIFF
--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -270,6 +270,11 @@ func (a *aggregateInfo) Eval(_ *tree.EvalContext) (tree.Datum, error) {
 	panic(errors.AssertionFailedf("aggregateInfo must be replaced before evaluation"))
 }
 
+// ResolvedType is part of the tree.TypedExpr interface.
+func (a *aggregateInfo) ResolvedType() *types.T {
+	return a.col.typ
+}
+
 var _ tree.Expr = &aggregateInfo{}
 var _ tree.TypedExpr = &aggregateInfo{}
 

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3939,3 +3939,38 @@ scalar-group-by
  └── aggregations
       └── const-agg [as=percentile_cont:6]
            └── percentile_cont:6
+
+# Regression test for #46914.
+exec-ddl
+CREATE TABLE t0(c0 INT)
+----
+
+build format=(show-types,show-scalars)
+SELECT * FROM t0 GROUP BY t0.c0 HAVING min((CASE WHEN false THEN NULL END):::FLOAT) IS NOT NAN
+----
+project
+ ├── columns: c0:1(int)
+ └── select
+      ├── columns: c0:1(int) min:4(float!null)
+      ├── group-by
+      │    ├── columns: c0:1(int) min:4(float)
+      │    ├── grouping columns: c0:1(int)
+      │    ├── project
+      │    │    ├── columns: column3:3(float) c0:1(int)
+      │    │    ├── scan t0
+      │    │    │    └── columns: c0:1(int) rowid:2(int!null)
+      │    │    └── projections
+      │    │         └── case [as=column3:3, type=float]
+      │    │              ├── true [type=bool]
+      │    │              ├── when [type=float]
+      │    │              │    ├── false [type=bool]
+      │    │              │    └── cast: FLOAT8 [type=float]
+      │    │              │         └── null [type=unknown]
+      │    │              └── null [type=float]
+      │    └── aggregations
+      │         └── min [as=min:4, type=float]
+      │              └── variable: column3:3 [type=float]
+      └── filters
+           └── ne [type=bool]
+                ├── variable: min:4 [type=float]
+                └── const: NaN [type=float]


### PR DESCRIPTION
Prior to this commit, it was possible that calling `ResolvedType()`
on an `aggregateInfo` object returned the wrong type. This was because
`aggregateInfo` did not implement `ResolvedType()`, and was therefore
passing the call to the embedded `tree.FuncExpr`, which may have been
stripped of its original type information. This commit fixes the
problem by adding an implementation of `ResolvedType()` to `aggregateInfo`,
which simply returns the type of the aggregation column represented by
the struct.

Fixes #46914

Release note (bug fix): Fixed an internal error that could happen
during planning for some queries with aggregate functions embedded in
complex scalar expressions.