### PR TITLE
release-20.1: kv: unset CanForwardReadTimestamp flag on batches that spans ranges

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -701,7 +701,7 @@ func unsetCanForwardReadTimestampFlag(ctx context.Context, ba *roachpb.BatchRequ
 			// Assert this for our own sanity.
 			if _, ok := ba.GetArg(roachpb.EndTxn); ok {
 				log.Fatalf(ctx, "batch unexpected contained requests "+
-					"that need to refresh and an EndTxn request: %s", ba)
+					"that need to refresh and an EndTxn request: %s", ba.String())
 			}
 			return
 		}
@@ -902,6 +902,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	}
 	qiBatchIdx := batchIdx + 1
 	qiResponseCh := make(chan response, 1)
+	qiBaCopy := qiBa // avoids escape to heap
 
 	runTask := ds.rpcContext.Stopper.RunAsyncTask
 	if ds.disableParallelBatches {
@@ -977,7 +978,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 		}
 		// Populate the pre-commit QueryIntent batch response. If we made it
 		// here then we know we can ignore intent missing errors.
-		qiReply.reply = qiBa.CreateReply()
+		qiReply.reply = qiBaCopy.CreateReply()
 		for _, ru := range qiReply.reply.Responses {
 			ru.GetQueryIntent().FoundIntent = true
 		}

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -674,6 +674,40 @@ func splitBatchAndCheckForRefreshSpans(
 	return parts
 }
 
+// unsetCanForwardReadTimestampFlag ensures that if a batch is going to
+// be split across ranges and any of its requests would need to refresh
+// on read timestamp bumps, it does not have its CanForwardReadTimestamp
+// flag set. It would be incorrect to allow part of a batch to perform a
+// server-side refresh if another part of the batch that was sent to a
+// different range would also need to refresh. Such behavior could cause
+// a transaction to observe an inconsistent snapshot and violate
+// serializability.
+func unsetCanForwardReadTimestampFlag(ctx context.Context, ba *roachpb.BatchRequest) {
+	if !ba.CanForwardReadTimestamp {
+		// Already unset.
+		return
+	}
+	for _, req := range ba.Requests {
+		if roachpb.NeedsRefresh(req.GetInner()) {
+			// Unset the flag.
+			ba.CanForwardReadTimestamp = false
+
+			// We would need to also unset the CanCommitAtHigherTimestamp flag
+			// on any EndTxn request in the batch, but it turns out that because
+			// we call this function when a batch is split across ranges, we'd
+			// already have bailed if the EndTxn wasn't a parallel commit — and
+			// if it was a parallel commit then we must not have any requests
+			// that need to refresh (see txnCommitter.canCommitInParallel).
+			// Assert this for our own sanity.
+			if _, ok := ba.GetArg(roachpb.EndTxn); ok {
+				log.Fatalf(ctx, "batch unexpected contained requests "+
+					"that need to refresh and an EndTxn request: %s", ba)
+			}
+			return
+		}
+	}
+}
+
 // Send implements the batch.Sender interface. It subdivides the Batch
 // into batches admissible for sending (preventing certain illegal
 // mixtures of requests), executes each individual part (which may
@@ -1131,6 +1165,8 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 			return nil, errNo1PCTxn
 		}
 	}
+	// Make sure the CanForwardReadTimestamp flag is set to false, if necessary.
+	unsetCanForwardReadTimestampFlag(ctx, &ba)
 
 	// Make an empty slice of responses which will be populated with responses
 	// as they come in via Combine().

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -158,6 +158,7 @@ func (r *Replica) handleReadOnlyLocalEvalResult(
 
 	if lResult.AcquiredLocks != nil {
 		// These will all be unreplicated locks.
+		log.Eventf(ctx, "acquiring %d unreplicated locks", len(lResult.AcquiredLocks))
 		for i := range lResult.AcquiredLocks {
 			r.concMgr.OnLockAcquired(ctx, &lResult.AcquiredLocks[i])
 		}


### PR DESCRIPTION
Backport 2/4 commits from #50633.

/cc @cockroachdb/release

---

Fixes #50202.

In #50202, we saw that we would accidentally allow batches to be split on range boundaries and continue to carry the `CanForwardReadTimestamp` flag. This can lead to serializability violations under very specific conditions:
1. the first operation that the transaction performs is a batch of locking read requests (due to implicit or explicit SFU)
2. this batch of locking reads spans multiple ranges
3. this batch of locking reads is issued in parallel by the DistSender
4. this locking read hits contention and is bumped on at least one of the ranges due to a WriteTooOld error
5. an unreplicated lock from one of the non-refreshed sub-batches is lost during a lease transfer.

It turns out that the `kv/contention` roachtest meets these requirements perfectly when implicit SFU support is added to UPSERT statements: #50180. It creates a tremendous amount of contention and issues a batch of locking ScanRequests during a LookupJoin as its first operation. This materializes as ConditionFailedErrors (which should be impossible) in the CPuts that the UPSERT issues to maintain the table's secondary index.

This PR fixes this bug by ensuring that if a batch is going to be split across ranges and any of its requests would need to refresh on read timestamp bumps, it does not have its CanForwardReadTimestamp flag set. It would be incorrect to allow part of a batch to perform a server-side refresh if another part of the batch might have returned a different result at the higher timestamp, which is a fancy way of saying that it needs to refresh because it is using optimistic locking. Such behavior could cause a transaction to observe an inconsistent snapshot and violate serializability.

It then adds support for locking scans to kvnemesis, which would have caught to bug fairly easily.

Finally, it fixes a KV API UX issue around locking scans and retry errors. Before this change, it was possible for a non-transactional locking scan (which itself doesn't make much sense) to hit a WriteTooOld  retry error. This was caused by eager propagation of WriteTooOld errors from MVCC when FailOnMoreRecent was enabled for an MVCCScan. I'd appreciate if @itsbilal could give that last commit a review.

Release note (bug fix): fix a rare bug where a multi-Range SELECT FOR UPDATE statement containing an IN clause could fail to observe a consistent snapshot and violate serializability.
