### PR TITLE
release-20.1: backupccl: fix bug when restoring cluster with empty db as highest id

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -310,6 +310,25 @@ func TestEmptyFullClusterRestore(t *testing.T) {
 	sqlDBRestore.CheckQueryResults(t, checkQuery, sqlDB.QueryStr(t, checkQuery))
 }
 
+// Regression test for #50561.
+func TestClusterRestoreEmptyDB(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const numAccounts = 10
+	_, _, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone)
+	defer cleanupFn()
+	defer cleanupEmptyCluster()
+
+	sqlDB.Exec(t, `CREATE DATABASE some_db`)
+	sqlDB.Exec(t, `CREATE DATABASE some_db_2`)
+	sqlDB.Exec(t, `BACKUP TO $1`, localFoo)
+	sqlDBRestore.Exec(t, `RESTORE FROM $1`, localFoo)
+
+	checkQuery := "SHOW DATABASES"
+	sqlDBRestore.CheckQueryResults(t, checkQuery, sqlDB.QueryStr(t, checkQuery))
+}
+
 func TestDisallowFullClusterRestoreOnNonFreshCluster(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -189,6 +189,13 @@ func allocateTableRewrites(
 		}
 	}
 
+	// Include the database descriptors when calculating the max ID.
+	for _, database := range databasesByID {
+		if int64(database.ID) > maxDescIDInBackup {
+			maxDescIDInBackup = int64(database.ID)
+		}
+	}
+
 	needsNewParentIDs := make(map[string][]sqlbase.ID)
 
 	// Increment the DescIDGenerator so that it is higher than the max desc ID in


### PR DESCRIPTION
Backport 1/1 commits from #50759.

/cc @cockroachdb/release

---

Previously, there was a bug where cluster restore would fail when the
largest descriptor in the backup was a database. This commit fixes the
bug.

Fixes #50561.

Release note (bug fix): Previously, there was a bug where cluster
restore would fail when the largest descriptor in the backup was a
database. This is typically seen when the last action in backing up
cluster was a database creation.
