### PR TITLE
kv/kvclient: avoid letting BatchRequests escape to heap

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -664,7 +664,7 @@ func unsetCanForwardReadTimestampFlag(ctx context.Context, ba *roachpb.BatchRequ
 			// Assert this for our own sanity.
 			if _, ok := ba.GetArg(roachpb.EndTxn); ok {
 				log.Fatalf(ctx, "batch unexpected contained requests "+
-					"that need to refresh and an EndTxn request: %s", ba)
+					"that need to refresh and an EndTxn request: %s", ba.String())
 			}
 			return
 		}
@@ -874,6 +874,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	}
 	qiBatchIdx := batchIdx + 1
 	qiResponseCh := make(chan response, 1)
+	qiBaCopy := qiBa // avoids escape to heap
 
 	runTask := ds.rpcContext.Stopper.RunAsyncTask
 	if ds.disableParallelBatches {
@@ -949,7 +950,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 		}
 		// Populate the pre-commit QueryIntent batch response. If we made it
 		// here then we know we can ignore intent missing errors.
-		qiReply.reply = qiBa.CreateReply()
+		qiReply.reply = qiBaCopy.CreateReply()
 		for _, ru := range qiReply.reply.Responses {
 			ru.GetQueryIntent().FoundIntent = true
 		}


### PR DESCRIPTION
The first one in `divideAndSendBatchToRanges` was caused by #50633.

While here, avoid the allocation in `divideAndSendParallelCommit`.