### PR TITLE
geogfn: apply bounding box calculations for DWithin

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -472,7 +472,7 @@ func (g *Geography) AsS2(emptyBehavior EmptyBehavior) ([]s2.Region, error) {
 	return S2RegionsFromGeom(geomRepr, emptyBehavior)
 }
 
-// BoundingRect returns the bounding rectangle of the given Geography.
+// BoundingRect returns the bounding s2.Rect of the given Geography.
 func (g *Geography) BoundingRect() s2.Rect {
 	bbox := g.spatialObject.BoundingBox
 	if bbox == nil {
@@ -482,6 +482,11 @@ func (g *Geography) BoundingRect() s2.Rect {
 		Lat: r1.Interval{Lo: bbox.LoY, Hi: bbox.HiY},
 		Lng: s1.Interval{Lo: bbox.LoX, Hi: bbox.HiX},
 	}
+}
+
+// BoundingCap returns the bounding s2.Cap of the given Geography.
+func (g *Geography) BoundingCap() s2.Cap {
+	return g.BoundingRect().CapBound()
 }
 
 // IsLinearRingCCW returns whether a given linear ring is counter clock wise.

--- a/pkg/geo/geogfn/distance.go
+++ b/pkg/geo/geogfn/distance.go
@@ -21,6 +21,12 @@ import (
 	"github.com/golang/geo/s2"
 )
 
+// SpheroidErrorFraction is an error fraction to compensate for using a sphere
+// to calculate the distance for what is actually a spheroid. The distance
+// calculation has an error that is bounded by (2 * spheroid.Flattening)%.
+// This 5% margin is pretty safe.
+const SpheroidErrorFraction = 0.05
+
 // Distance returns the distance between geographies a and b on a sphere or spheroid.
 // Returns a geo.EmptyGeometryError if any of the Geographies are EMPTY.
 func Distance(
@@ -216,12 +222,6 @@ func distanceGeographyRegions(
 	}
 	return minDistance, nil
 }
-
-// SpheroidErrorFraction is an error fraction to compensate for using a sphere
-// to calculate the distance for what is actually a spheroid. The distance
-// calculation has an error that is bounded by (2 * spheroid.Flattening)%.
-// This 5% margin is pretty safe.
-const SpheroidErrorFraction = 0.05
 
 // geographyMinDistanceUpdater finds the minimum distance using a sphere.
 // Methods will return early if it finds a minimum distance <= stopAfterLE.

--- a/pkg/geo/geogfn/dwithin.go
+++ b/pkg/geo/geogfn/dwithin.go
@@ -13,6 +13,7 @@ package geogfn
 import (
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/errors"
+	"github.com/golang/geo/s1"
 )
 
 // DWithin returns whether a is within distance d of b, i.e. Distance(a, b) <= d.
@@ -25,6 +26,18 @@ func DWithin(
 	}
 	if distance < 0 {
 		return false, errors.Newf("dwithin distance cannot be less than zero")
+	}
+	spheroid, err := a.Spheroid()
+	if err != nil {
+		return false, err
+	}
+
+	angleToExpand := s1.Angle(distance / spheroid.SphereRadius)
+	if useSphereOrSpheroid == UseSpheroid {
+		angleToExpand *= (1 + SpheroidErrorFraction)
+	}
+	if !a.BoundingCap().Expanded(angleToExpand).Intersects(b.BoundingCap()) {
+		return false, nil
 	}
 
 	aRegions, err := a.AsS2(geo.EmptyBehaviorError)
@@ -39,10 +52,6 @@ func DWithin(
 		if geo.IsEmptyGeometryError(err) {
 			return false, nil
 		}
-		return false, err
-	}
-	spheroid, err := a.Spheroid()
-	if err != nil {
 		return false, err
 	}
 	maybeClosestDistance, err := distanceGeographyRegions(spheroid, useSphereOrSpheroid, aRegions, bRegions, distance)


### PR DESCRIPTION
Expand a BoundingRect by a given radius (using s2.Cap) and apply
intersection to do fairly cheap bounding box calculations before doing
the expensive DWithin logic.

Release note: None