### PR TITLE
geo: fix up remaining encoding problems with POINT EMPTY

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
-	github.com/twpayne/go-geom v1.3.0
+	github.com/twpayne/go-geom v1.3.2
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 	go.etcd.io/etcd v0.0.0-00010101000000-000000000000
 	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,6 @@ github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=
-github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/dave/dst v0.24.0 h1:5wtsjxee7nUDlKEz4i6ewJVn1193vfv2UpEXKqzmaUI=
 github.com/dave/dst v0.24.0/go.mod h1:UMDJuIRPfyUCC78eFuB+SV/WI8oDeyFDvM/JR6NI3IU=
 github.com/dave/gopackages v0.0.0-20170318123100-46e7023ec56e/go.mod h1:i00+b/gKdIDIxuLDFob7ustLAVqhsZRk2qVZrArELGQ=
@@ -597,8 +595,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/twpayne/go-geom v1.3.0 h1:jwhmbnQv5VTfAgohevKBuzisQSdXGjfquZ7FC8aVUzU=
-github.com/twpayne/go-geom v1.3.0/go.mod h1:90yvs0wf/gyT5eQ9W4v5WOZ9w/Xnrj5RMlA9XNKqxyA=
+github.com/twpayne/go-geom v1.3.2 h1:4E9aSr+B5y+wjTFf2fNmxsnYSZD2k1nSdDyos3ZQ/EY=
+github.com/twpayne/go-geom v1.3.2/go.mod h1:vFTJTOBkeN903mbhV6FYSTOUjglpV6WA8J11fNiUXaQ=
 github.com/twpayne/go-kml v1.5.0 h1:CNWBxCmyWg1158dWbfdZsuUkUtHITrkntJS3iJhazJQ=
 github.com/twpayne/go-kml v1.5.0/go.mod h1:g/OG8Q8JUxqFw8LGXE44W7osn1uXDAYaVFr1Yld43yc=
 github.com/twpayne/go-polyline v1.0.0/go.mod h1:ICh24bcLYBX8CknfvNPKqoTbe+eg+MX1NPyJmSBo7pU=

--- a/pkg/geo/encode.go
+++ b/pkg/geo/encode.go
@@ -29,9 +29,9 @@ import (
 	"github.com/twpayne/go-geom/encoding/wkt"
 )
 
-// EWKBToWKT transforms a given EWKB to WKT.
-func EWKBToWKT(b geopb.EWKB, maxDecimalDigits int) (geopb.WKT, error) {
-	t, err := ewkb.Unmarshal([]byte(b))
+// SpatialObjectToWKT transforms a given SpatialObject to WKT.
+func SpatialObjectToWKT(so geopb.SpatialObject, maxDecimalDigits int) (geopb.WKT, error) {
+	t, err := ewkb.Unmarshal([]byte(so.EWKB))
 	if err != nil {
 		return "", err
 	}
@@ -39,9 +39,9 @@ func EWKBToWKT(b geopb.EWKB, maxDecimalDigits int) (geopb.WKT, error) {
 	return geopb.WKT(ret), err
 }
 
-// EWKBToEWKT transforms a given EWKB to EWKT.
-func EWKBToEWKT(b geopb.EWKB, maxDecimalDigits int) (geopb.EWKT, error) {
-	t, err := ewkb.Unmarshal([]byte(b))
+// SpatialObjectToEWKT transforms a given SpatialObject to EWKT.
+func SpatialObjectToEWKT(so geopb.SpatialObject, maxDecimalDigits int) (geopb.EWKT, error) {
+	t, err := ewkb.Unmarshal([]byte(so.EWKB))
 	if err != nil {
 		return "", err
 	}
@@ -55,9 +55,9 @@ func EWKBToEWKT(b geopb.EWKB, maxDecimalDigits int) (geopb.EWKT, error) {
 	return geopb.EWKT(ret), err
 }
 
-// EWKBToWKB transforms a given EWKB to WKB.
-func EWKBToWKB(b geopb.EWKB, byteOrder binary.ByteOrder) (geopb.WKB, error) {
-	t, err := ewkb.Unmarshal([]byte(b))
+// SpatialObjectToWKB transforms a given SpatialObject to WKB.
+func SpatialObjectToWKB(so geopb.SpatialObject, byteOrder binary.ByteOrder) (geopb.WKB, error) {
+	t, err := ewkb.Unmarshal([]byte(so.EWKB))
 	if err != nil {
 		return nil, err
 	}
@@ -65,8 +65,8 @@ func EWKBToWKB(b geopb.EWKB, byteOrder binary.ByteOrder) (geopb.WKB, error) {
 	return geopb.WKB(ret), err
 }
 
-// EWKBToGeoJSONFlag maps to the ST_AsGeoJSON flags for PostGIS.
-type EWKBToGeoJSONFlag int
+// SpatialObjectToGeoJSONFlag maps to the ST_AsGeoJSON flags for PostGIS.
+type SpatialObjectToGeoJSONFlag int
 
 // These should be kept with ST_AsGeoJSON in PostGIS.
 // 0: means no option
@@ -75,12 +75,12 @@ type EWKBToGeoJSONFlag int
 // 4: GeoJSON Long CRS (e.g urn:ogc:def:crs:EPSG::4326)
 // 8: GeoJSON Short CRS if not EPSG:4326 (default)
 const (
-	EWKBToGeoJSONFlagIncludeBBox EWKBToGeoJSONFlag = 1 << (iota)
-	EWKBToGeoJSONFlagShortCRS
-	EWKBToGeoJSONFlagLongCRS
-	EWKBToGeoJSONFlagShortCRSIfNot4326
+	SpatialObjectToGeoJSONFlagIncludeBBox SpatialObjectToGeoJSONFlag = 1 << (iota)
+	SpatialObjectToGeoJSONFlagShortCRS
+	SpatialObjectToGeoJSONFlagLongCRS
+	SpatialObjectToGeoJSONFlagShortCRSIfNot4326
 
-	EWKBToGeoJSONFlagZero = 0
+	SpatialObjectToGeoJSONFlagZero = 0
 )
 
 // geomToGeoJSONCRS converts a geom to its CRS GeoJSON form.
@@ -104,36 +104,41 @@ func geomToGeoJSONCRS(t geom.T, long bool) (*geojson.CRS, error) {
 	return crs, nil
 }
 
-// EWKBToGeoJSON transforms a given EWKB to GeoJSON.
-func EWKBToGeoJSON(b geopb.EWKB, maxDecimalDigits int, flag EWKBToGeoJSONFlag) ([]byte, error) {
-	t, err := ewkb.Unmarshal([]byte(b))
+// SpatialObjectToGeoJSON transforms a given SpatialObject to GeoJSON.
+func SpatialObjectToGeoJSON(
+	so geopb.SpatialObject, maxDecimalDigits int, flag SpatialObjectToGeoJSONFlag,
+) ([]byte, error) {
+	t, err := ewkb.Unmarshal([]byte(so.EWKB))
 	if err != nil {
 		return nil, err
 	}
 	options := []geojson.EncodeGeometryOption{
 		geojson.EncodeGeometryWithMaxDecimalDigits(maxDecimalDigits),
 	}
-	if flag&EWKBToGeoJSONFlagIncludeBBox != 0 {
-		options = append(
-			options,
-			geojson.EncodeGeometryWithBBox(),
-		)
+	if flag&SpatialObjectToGeoJSONFlagIncludeBBox != 0 {
+		// Do not encoding empty bounding boxes.
+		if so.BoundingBox != nil {
+			options = append(
+				options,
+				geojson.EncodeGeometryWithBBox(),
+			)
+		}
 	}
 	// Take CRS flag in order of precedence.
 	if t.SRID() != 0 {
-		if flag&EWKBToGeoJSONFlagLongCRS != 0 {
+		if flag&SpatialObjectToGeoJSONFlagLongCRS != 0 {
 			crs, err := geomToGeoJSONCRS(t, true /* long */)
 			if err != nil {
 				return nil, err
 			}
 			options = append(options, geojson.EncodeGeometryWithCRS(crs))
-		} else if flag&EWKBToGeoJSONFlagShortCRS != 0 {
+		} else if flag&SpatialObjectToGeoJSONFlagShortCRS != 0 {
 			crs, err := geomToGeoJSONCRS(t, false /* long */)
 			if err != nil {
 				return nil, err
 			}
 			options = append(options, geojson.EncodeGeometryWithCRS(crs))
-		} else if flag&EWKBToGeoJSONFlagShortCRSIfNot4326 != 0 {
+		} else if flag&SpatialObjectToGeoJSONFlagShortCRSIfNot4326 != 0 {
 			if t.SRID() != 4326 {
 				crs, err := geomToGeoJSONCRS(t, false /* long */)
 				if err != nil {
@@ -147,19 +152,19 @@ func EWKBToGeoJSON(b geopb.EWKB, maxDecimalDigits int, flag EWKBToGeoJSONFlag) (
 	return geojson.Marshal(t, options...)
 }
 
-// EWKBToWKBHex transforms a given EWKB to WKBHex.
-func EWKBToWKBHex(b geopb.EWKB) (string, error) {
-	t, err := ewkb.Unmarshal([]byte(b))
+// SpatialObjectToWKBHex transforms a given SpatialObject to WKBHex.
+func SpatialObjectToWKBHex(so geopb.SpatialObject) (string, error) {
+	t, err := ewkb.Unmarshal([]byte(so.EWKB))
 	if err != nil {
 		return "", err
 	}
-	ret, err := wkbhex.Encode(t, DefaultEWKBEncodingFormat)
+	ret, err := wkbhex.Encode(t, DefaultEWKBEncodingFormat, wkbcommon.WKBOptionEmptyPointHandling(wkbcommon.EmptyPointHandlingNaN))
 	return strings.ToUpper(ret), err
 }
 
-// EWKBToKML transforms a given EWKB to KML.
-func EWKBToKML(b geopb.EWKB) (string, error) {
-	t, err := ewkb.Unmarshal([]byte(b))
+// SpatialObjectToKML transforms a given SpatialObject to KML.
+func SpatialObjectToKML(so geopb.SpatialObject) (string, error) {
+	t, err := ewkb.Unmarshal([]byte(so.EWKB))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/geo/encode_test.go
+++ b/pkg/geo/encode_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEWKBToWKT(t *testing.T) {
+func TestSpatialObjectToWKT(t *testing.T) {
 	testCases := []struct {
 		ewkt             geopb.EWKT
 		maxDecimalDigits int
@@ -32,14 +32,14 @@ func TestEWKBToWKT(t *testing.T) {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
 			so, err := parseEWKT(geopb.SpatialObjectType_GeometryType, tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
-			encoded, err := EWKBToWKT(so.EWKB, tc.maxDecimalDigits)
+			encoded, err := SpatialObjectToWKT(so, tc.maxDecimalDigits)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, encoded)
 		})
 	}
 }
 
-func TestEWKBToEWKT(t *testing.T) {
+func TestSpatialObjectToEWKT(t *testing.T) {
 	testCases := []struct {
 		ewkt             geopb.EWKT
 		maxDecimalDigits int
@@ -54,14 +54,14 @@ func TestEWKBToEWKT(t *testing.T) {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
 			so, err := parseEWKT(geopb.SpatialObjectType_GeometryType, tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
-			encoded, err := EWKBToEWKT(so.EWKB, tc.maxDecimalDigits)
+			encoded, err := SpatialObjectToEWKT(so, tc.maxDecimalDigits)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, encoded)
 		})
 	}
 }
 
-func TestEWKBToWKB(t *testing.T) {
+func TestSpatialObjectToWKB(t *testing.T) {
 	testCases := []struct {
 		ewkt     geopb.EWKT
 		expected geopb.WKB
@@ -74,48 +74,48 @@ func TestEWKBToWKB(t *testing.T) {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
 			so, err := parseEWKT(geopb.SpatialObjectType_GeometryType, tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
-			encoded, err := EWKBToWKB(so.EWKB, DefaultEWKBEncodingFormat)
+			encoded, err := SpatialObjectToWKB(so, DefaultEWKBEncodingFormat)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, encoded)
 		})
 	}
 }
 
-func TestEWKBToGeoJSON(t *testing.T) {
+func TestSpatialObjectToGeoJSON(t *testing.T) {
 	testCases := []struct {
 		ewkt     geopb.EWKT
-		flag     EWKBToGeoJSONFlag
+		flag     SpatialObjectToGeoJSONFlag
 		expected string
 	}{
-		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagZero, `{"type":"Point","coordinates":[1,1]}`},
-		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}`},
-		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRS | EWKBToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}`},
-		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRS, `{"type":"Point","coordinates":[1,1]}`},
-		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagLongCRS, `{"type":"Point","coordinates":[1,1]}`},
-		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","coordinates":[1,1]}`},
-		{"POINT(1.1234567 1.9876543)", EWKBToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","coordinates":[1.123457,1.987654]}`},
-		{"SRID=4326;POINT(1.0 1.0)", EWKBToGeoJSONFlagZero, `{"type":"Point","coordinates":[1,1]}`},
-		{"SRID=4326;POINT(1.0 1.0)", EWKBToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}`},
-		{"SRID=4326;POINT(1.0 1.0)", EWKBToGeoJSONFlagLongCRS, `{"type":"Point","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,1]}`},
-		{"SRID=4326;POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRS, `{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:4326"}},"coordinates":[1,1]}`},
-		{"SRID=4004;POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRS, `{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:4004"}},"coordinates":[1,1]}`},
-		{"SRID=4004;POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRS | EWKBToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"crs":{"type":"name","properties":{"name":"EPSG:4004"}},"coordinates":[1,1]}`},
-		{"SRID=4326;POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","coordinates":[1,1]}`},
-		{"SRID=4004;POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:4004"}},"coordinates":[1,1]}`},
+		{"POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagZero, `{"type":"Point","coordinates":[1,1]}`},
+		{"POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}`},
+		{"POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagShortCRS | SpatialObjectToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}`},
+		{"POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagShortCRS, `{"type":"Point","coordinates":[1,1]}`},
+		{"POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagLongCRS, `{"type":"Point","coordinates":[1,1]}`},
+		{"POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","coordinates":[1,1]}`},
+		{"POINT(1.1234567 1.9876543)", SpatialObjectToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","coordinates":[1.123457,1.987654]}`},
+		{"SRID=4326;POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagZero, `{"type":"Point","coordinates":[1,1]}`},
+		{"SRID=4326;POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}`},
+		{"SRID=4326;POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagLongCRS, `{"type":"Point","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,1]}`},
+		{"SRID=4326;POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagShortCRS, `{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:4326"}},"coordinates":[1,1]}`},
+		{"SRID=4004;POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagShortCRS, `{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:4004"}},"coordinates":[1,1]}`},
+		{"SRID=4004;POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagShortCRS | SpatialObjectToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"crs":{"type":"name","properties":{"name":"EPSG:4004"}},"coordinates":[1,1]}`},
+		{"SRID=4326;POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","coordinates":[1,1]}`},
+		{"SRID=4004;POINT(1.0 1.0)", SpatialObjectToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:4004"}},"coordinates":[1,1]}`},
 	}
 
 	for _, tc := range testCases {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
 			so, err := parseEWKT(geopb.SpatialObjectType_GeometryType, tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
-			encoded, err := EWKBToGeoJSON(so.EWKB, 6, tc.flag)
+			encoded, err := SpatialObjectToGeoJSON(so, 6, tc.flag)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, string(encoded))
 		})
 	}
 }
 
-func TestEWKBToWKBHex(t *testing.T) {
+func TestSpatialObjectToWKBHex(t *testing.T) {
 	testCases := []struct {
 		ewkt     geopb.EWKT
 		expected string
@@ -128,14 +128,14 @@ func TestEWKBToWKBHex(t *testing.T) {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
 			so, err := parseEWKT(geopb.SpatialObjectType_GeometryType, tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
-			encoded, err := EWKBToWKBHex(so.EWKB)
+			encoded, err := SpatialObjectToWKBHex(so)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, encoded)
 		})
 	}
 }
 
-func TestEWKBToKML(t *testing.T) {
+func TestSpatialObjectToKML(t *testing.T) {
 	testCases := []struct {
 		ewkt     geopb.EWKT
 		expected string
@@ -150,7 +150,7 @@ func TestEWKBToKML(t *testing.T) {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
 			so, err := parseEWKT(geopb.SpatialObjectType_GeometryType, tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
-			encoded, err := EWKBToKML(so.EWKB)
+			encoded, err := SpatialObjectToKML(so)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, encoded)
 		})

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -295,7 +295,7 @@ INSERT INTO parse_test (geom, geog) VALUES
   (ST_GeomFromGeoJSON('{"type":"Point","coordinates":[1,2]}'::jsonb), ST_GeogFromGeoJSON('{"type":"Point","coordinates":[1,2]}'::jsonb)),
   (ST_GeomFromWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex')), ST_GeogFromWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex'))),
   (ST_GeomFromEWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex')), ST_GeogFromEWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex'))),
- -- (ST_GeomFromText('POINT EMPTY'), ST_GeogFromText('POINT EMPTY')), # broken as twpayne/go-geom GeoJSON EMPTY handling is broken.
+  (ST_GeomFromText('POINT EMPTY'), ST_GeogFromText('POINT EMPTY')),
   (ST_GeomFromGeoJSON('null':::jsonb), ST_GeogFromGeoJSON('null':::jsonb))
 
 query BB
@@ -330,6 +330,8 @@ POINT (1 1)                                         POINT (1 1)  [1 1 0 0 0 0 0 
 <Point><coordinates>1,1</coordinates></Point>
 POINT (1 1)                                         POINT (1 1)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,1</coordinates></Point>
+POINT EMPTY                                         POINT EMPTY  [1 1 0 0 0 0 0 0 0 0 0 248 127 0 0 0 0 0 0 248 127]  [1 1 0 0 0 0 0 0 0 0 0 248 127 0 0 0 0 0 0 248 127]  [0 0 0 0 1 127 248 0 0 0 0 0 0 127 248 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 248 127 0 0 0 0 0 0 248 127]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates></coordinates></Point>
 NULL                                                NULL  NULL  NULL  NULL  NULL  NULL
 
 
@@ -347,6 +349,7 @@ FROM parse_test ORDER BY id ASC
 {"type":"Point","coordinates":[1,2]}                                                          {"type":"Point","coordinates":[1,2]}                                                          {"type":"Point","bbox":[1,2,1,2],"coordinates":[1,2]}
 {"type":"Point","coordinates":[1,1]}                                                          {"type":"Point","coordinates":[1,1]}                                                          {"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}
 {"type":"Point","coordinates":[1,1]}                                                          {"type":"Point","coordinates":[1,1]}                                                          {"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}
+{"type":"Point","coordinates":[]}                                                             {"type":"Point","coordinates":[]}                                                             {"type":"Point","coordinates":[]}
 NULL                                                                                          NULL                                                                                          NULL
 
 # tests casts
@@ -364,6 +367,7 @@ FROM parse_test ORDER BY id ASC
 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]              {"coordinates": [1, 2], "type": "Point"}       0101000000000000000000F03F0000000000000040
 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]            {"coordinates": [1, 1], "type": "Point"}       0101000000000000000000F03F000000000000F03F
 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]            {"coordinates": [1, 1], "type": "Point"}       0101000000000000000000F03F000000000000F03F
+[1 1 0 0 0 0 0 0 0 0 0 248 127 0 0 0 0 0 0 248 127]          {"coordinates": [], "type": "Point"}           0101000000000000000000F87F000000000000F87F
 NULL                                                         NULL                                           NULL
 
 query TTT
@@ -380,6 +384,7 @@ FROM parse_test ORDER BY id ASC
 0101000000000000000000F03F0000000000000040          0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040
 0101000000000000000000F03F000000000000F03F          0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F
 0101000000000000000000F03F000000000000F03F          0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F
+0101000000000000000000F87F000000000000F87F          0101000000000000000000F87F000000000000F87F  0101000000000000000000F87F000000000000F87F
 NULL                                                NULL                                        NULL
 
 
@@ -399,24 +404,25 @@ POINT (1 2)                                                        POINT (1 2)  
 POINT (1 2)                                                        POINT (1 2)       {"type":"Point","coordinates":[1,2]}                                                          {"type":"Point","coordinates":[1,2]}
 POINT (1 1)                                                        POINT (1 1)       {"type":"Point","coordinates":[1,1]}                                                          {"type":"Point","coordinates":[1,1]}
 POINT (1 1)                                                        POINT (1 1)       {"type":"Point","coordinates":[1,1]}                                                          {"type":"Point","coordinates":[1,1]}
+POINT EMPTY                                                        POINT EMPTY       {"type":"Point","coordinates":[]}                                                             {"type":"Point","coordinates":[]}
 NULL                                                               NULL              NULL                                                                                          NULL
 
-query TTTT
+query TTT
 SELECT
-  ST_AsHexWKB(geom),
   ST_AsHexEWKB(geom),
   ST_AsHexEWKB(geom, 'ndr'),
   ST_AsHexEWKB(geom, 'xdr')
 FROM parse_test ORDER BY id ASC
 ----
-0101000000E17A14AE47E1F83F00000000000000C0  0101000000E17A14AE47E1F83F00000000000000C0          0101000000E17A14AE47E1F83F00000000000000C0          00000000013FF8E147AE147AE1C000000000000000
-0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  0020000001000010E63FF00000000000004000000000000000
-0101000000000000000000F03F0000000000000040  0101000020A40F0000000000000000F03F0000000000000040  0101000020A40F0000000000000000F03F0000000000000040  002000000100000FA43FF00000000000004000000000000000
-0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040          0101000000000000000000F03F0000000000000040          00000000013FF00000000000004000000000000000
-0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040          0101000000000000000000F03F0000000000000040          00000000013FF00000000000004000000000000000
-0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F          0101000000000000000000F03F000000000000F03F          00000000013FF00000000000003FF0000000000000
-0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F          0101000000000000000000F03F000000000000F03F          00000000013FF00000000000003FF0000000000000
-NULL                                        NULL                                                NULL                                                NULL
+0101000000E17A14AE47E1F83F00000000000000C0          0101000000E17A14AE47E1F83F00000000000000C0          00000000013FF8E147AE147AE1C000000000000000
+0101000020E6100000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  0020000001000010E63FF00000000000004000000000000000
+0101000020A40F0000000000000000F03F0000000000000040  0101000020A40F0000000000000000F03F0000000000000040  002000000100000FA43FF00000000000004000000000000000
+0101000000000000000000F03F0000000000000040          0101000000000000000000F03F0000000000000040          00000000013FF00000000000004000000000000000
+0101000000000000000000F03F0000000000000040          0101000000000000000000F03F0000000000000040          00000000013FF00000000000004000000000000000
+0101000000000000000000F03F000000000000F03F          0101000000000000000000F03F000000000000F03F          00000000013FF00000000000003FF0000000000000
+0101000000000000000000F03F000000000000F03F          0101000000000000000000F03F000000000000F03F          00000000013FF00000000000003FF0000000000000
+0101000000000000000000F87F000000000000F87F          0101000000000000000000F87F000000000000F87F          00000000017FF80000000000007FF8000000000000
+NULL                                                NULL                                                NULL
 
 query TTTTTTT
 SELECT
@@ -443,6 +449,8 @@ POINT (1 1)                                         SRID=4326;POINT (1 1)  [1 1 
 <Point><coordinates>1,1</coordinates></Point>
 POINT (1 1)                                         SRID=4326;POINT (1 1)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,1</coordinates></Point>
+POINT EMPTY                                         SRID=4326;POINT EMPTY  [1 1 0 0 0 0 0 0 0 0 0 248 127 0 0 0 0 0 0 248 127]  [1 1 0 0 0 0 0 0 0 0 0 248 127 0 0 0 0 0 0 248 127]  [0 0 0 0 1 127 248 0 0 0 0 0 0 127 248 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 248 127 0 0 0 0 0 0 248 127]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates></coordinates></Point>
 NULL                                                NULL  NULL  NULL  NULL  NULL  NULL
 
 query TTT
@@ -459,6 +467,7 @@ FROM parse_test ORDER BY id ASC
 {"type":"Point","coordinates":[1,2]}       {"type":"Point","coordinates":[1,2]}       {"type":"Point","bbox":[1,2,1,2],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,2]}
 {"type":"Point","coordinates":[1,1]}       {"type":"Point","coordinates":[1,1]}       {"type":"Point","bbox":[1,1,1,1],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,1]}
 {"type":"Point","coordinates":[1,1]}       {"type":"Point","coordinates":[1,1]}       {"type":"Point","bbox":[1,1,1,1],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,1]}
+{"type":"Point","coordinates":[]}          {"type":"Point","coordinates":[]}          {"type":"Point","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[]}
 NULL                                       NULL                                       NULL
 
 # tests casts
@@ -476,6 +485,7 @@ FROM parse_test ORDER BY id ASC
 [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]             {"coordinates": [1, 2], "type": "Point"}       0101000020E6100000000000000000F03F0000000000000040
 [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]           {"coordinates": [1, 1], "type": "Point"}       0101000020E6100000000000000000F03F000000000000F03F
 [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]           {"coordinates": [1, 1], "type": "Point"}       0101000020E6100000000000000000F03F000000000000F03F
+[1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 248 127 0 0 0 0 0 0 248 127]         {"coordinates": [], "type": "Point"}           0101000020E6100000000000000000F87F000000000000F87F
 NULL                                                                    NULL                                           NULL
 
 query TTT
@@ -492,6 +502,7 @@ FROM parse_test ORDER BY id ASC
 0101000020E6100000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040
 0101000020E6100000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F
 0101000020E6100000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F
+0101000020E6100000000000000000F87F000000000000F87F  0101000020E6100000000000000000F87F000000000000F87F  0101000020E6100000000000000000F87F000000000000F87F
 NULL                                                NULL                                                NULL
 
 query TTTT
@@ -509,6 +520,7 @@ FROM parse_test ORDER BY id ASC
 0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  0020000001000010E63FF00000000000004000000000000000
 0101000000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  0020000001000010E63FF00000000000003FF0000000000000
 0101000000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  0020000001000010E63FF00000000000003FF0000000000000
+0101000000000000000000F87F000000000000F87F  0101000020E6100000000000000000F87F000000000000F87F  0101000020E6100000000000000000F87F000000000000F87F  0020000001000010E67FF80000000000007FF8000000000000
 NULL                                        NULL                                                NULL                                                NULL
 
 query TTTTTTTT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -674,7 +674,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		defProps(),
 		geometryOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				wkt, err := geo.EWKBToWKT(g.Geometry.EWKB(), defaultWKTDecimalDigits)
+				wkt, err := geo.SpatialObjectToWKT(g.Geometry.SpatialObject(), defaultWKTDecimalDigits)
 				return tree.NewDString(string(wkt)), err
 			},
 			types.String,
@@ -692,7 +692,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				g := args[0].(*tree.DGeometry)
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
-				wkt, err := geo.EWKBToWKT(g.Geometry.EWKB(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
+				wkt, err := geo.SpatialObjectToWKT(g.Geometry.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
 				return tree.NewDString(string(wkt)), err
 			},
 			Info: infoBuilder{
@@ -702,7 +702,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		},
 		geographyOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
-				wkt, err := geo.EWKBToWKT(g.Geography.EWKB(), defaultWKTDecimalDigits)
+				wkt, err := geo.SpatialObjectToWKT(g.Geography.SpatialObject(), defaultWKTDecimalDigits)
 				return tree.NewDString(string(wkt)), err
 			},
 			types.String,
@@ -720,7 +720,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				g := args[0].(*tree.DGeography)
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
-				wkt, err := geo.EWKBToWKT(g.Geography.EWKB(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
+				wkt, err := geo.SpatialObjectToWKT(g.Geography.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
 				return tree.NewDString(string(wkt)), err
 			},
 			Info: infoBuilder{
@@ -733,7 +733,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		defProps(),
 		geometryOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				ewkt, err := geo.EWKBToEWKT(g.Geometry.EWKB(), defaultWKTDecimalDigits)
+				ewkt, err := geo.SpatialObjectToEWKT(g.Geometry.SpatialObject(), defaultWKTDecimalDigits)
 				return tree.NewDString(string(ewkt)), err
 			},
 			types.String,
@@ -751,7 +751,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				g := args[0].(*tree.DGeometry)
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
-				ewkt, err := geo.EWKBToEWKT(g.Geometry.EWKB(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
+				ewkt, err := geo.SpatialObjectToEWKT(g.Geometry.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
 				return tree.NewDString(string(ewkt)), err
 			},
 			Info: infoBuilder{
@@ -761,7 +761,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		},
 		geographyOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
-				ewkt, err := geo.EWKBToEWKT(g.Geography.EWKB(), defaultWKTDecimalDigits)
+				ewkt, err := geo.SpatialObjectToEWKT(g.Geography.SpatialObject(), defaultWKTDecimalDigits)
 				return tree.NewDString(string(ewkt)), err
 			},
 			types.String,
@@ -779,7 +779,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				g := args[0].(*tree.DGeography)
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
-				ewkt, err := geo.EWKBToEWKT(g.Geography.EWKB(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
+				ewkt, err := geo.SpatialObjectToEWKT(g.Geography.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
 				return tree.NewDString(string(ewkt)), err
 			},
 			Info: infoBuilder{
@@ -792,7 +792,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		defProps(),
 		geometryOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				wkb, err := geo.EWKBToWKB(g.Geometry.EWKB(), geo.DefaultEWKBEncodingFormat)
+				wkb, err := geo.SpatialObjectToWKB(g.Geometry.SpatialObject(), geo.DefaultEWKBEncodingFormat)
 				return tree.NewDBytes(tree.DBytes(wkb)), err
 			},
 			types.Bytes,
@@ -801,7 +801,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		),
 		geographyOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
-				wkb, err := geo.EWKBToWKB(g.Geography.EWKB(), geo.DefaultEWKBEncodingFormat)
+				wkb, err := geo.SpatialObjectToWKB(g.Geography.SpatialObject(), geo.DefaultEWKBEncodingFormat)
 				return tree.NewDBytes(tree.DBytes(wkb)), err
 			},
 			types.Bytes,
@@ -818,7 +818,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				g := args[0].(*tree.DGeometry)
 				text := string(tree.MustBeDString(args[1]))
 
-				wkb, err := geo.EWKBToWKB(g.Geometry.EWKB(), geo.StringToByteOrder(text))
+				wkb, err := geo.SpatialObjectToWKB(g.Geometry.SpatialObject(), geo.StringToByteOrder(text))
 				return tree.NewDBytes(tree.DBytes(wkb)), err
 			},
 			Info: infoBuilder{
@@ -837,7 +837,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				g := args[0].(*tree.DGeography)
 				text := string(tree.MustBeDString(args[1]))
 
-				wkb, err := geo.EWKBToWKB(g.Geography.EWKB(), geo.StringToByteOrder(text))
+				wkb, err := geo.SpatialObjectToWKB(g.Geography.SpatialObject(), geo.StringToByteOrder(text))
 				return tree.NewDBytes(tree.DBytes(wkb)), err
 			},
 			Info: infoBuilder{
@@ -870,7 +870,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		defProps(),
 		geometryOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				hexwkb, err := geo.EWKBToWKBHex(g.Geometry.EWKB())
+				hexwkb, err := geo.SpatialObjectToWKBHex(g.Geometry.SpatialObject())
 				return tree.NewDString(hexwkb), err
 			},
 			types.String,
@@ -879,7 +879,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		),
 		geographyOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
-				hexwkb, err := geo.EWKBToWKBHex(g.Geography.EWKB())
+				hexwkb, err := geo.SpatialObjectToWKBHex(g.Geography.SpatialObject())
 				return tree.NewDString(hexwkb), err
 			},
 			types.String,
@@ -976,7 +976,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		defProps(),
 		geometryOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				kml, err := geo.EWKBToKML(g.Geometry.EWKB())
+				kml, err := geo.SpatialObjectToKML(g.Geometry.SpatialObject())
 				return tree.NewDString(kml), err
 			},
 			types.String,
@@ -985,7 +985,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		),
 		geographyOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
-				kml, err := geo.EWKBToKML(g.Geography.EWKB())
+				kml, err := geo.SpatialObjectToKML(g.Geography.SpatialObject())
 				return tree.NewDString(kml), err
 			},
 			types.String,
@@ -997,7 +997,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		defProps(),
 		geometryOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				geojson, err := geo.EWKBToGeoJSON(g.Geometry.EWKB(), defaultGeoJSONDecimalDigits, geo.EWKBToGeoJSONFlagShortCRSIfNot4326)
+				geojson, err := geo.SpatialObjectToGeoJSON(g.Geometry.SpatialObject(), defaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagShortCRSIfNot4326)
 				return tree.NewDString(string(geojson)), err
 			},
 			types.String,
@@ -1018,7 +1018,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				g := args[0].(*tree.DGeometry)
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
-				geojson, err := geo.EWKBToGeoJSON(g.Geometry.EWKB(), fitMaxDecimalDigitsToBounds(maxDecimalDigits), geo.EWKBToGeoJSONFlagShortCRSIfNot4326)
+				geojson, err := geo.SpatialObjectToGeoJSON(g.Geometry.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits), geo.SpatialObjectToGeoJSONFlagShortCRSIfNot4326)
 				return tree.NewDString(string(geojson)), err
 			},
 			Info: infoBuilder{
@@ -1036,8 +1036,8 @@ var geoBuiltins = map[string]builtinDefinition{
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				g := args[0].(*tree.DGeometry)
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
-				options := geo.EWKBToGeoJSONFlag(tree.MustBeDInt(args[2]))
-				geojson, err := geo.EWKBToGeoJSON(g.Geometry.EWKB(), fitMaxDecimalDigitsToBounds(maxDecimalDigits), options)
+				options := geo.SpatialObjectToGeoJSONFlag(tree.MustBeDInt(args[2]))
+				geojson, err := geo.SpatialObjectToGeoJSON(g.Geometry.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits), options)
 				return tree.NewDString(string(geojson)), err
 			},
 			Info: infoBuilder{
@@ -1054,7 +1054,7 @@ Options is a flag that can be bitmasked. The options are:
 		},
 		geographyOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
-				geojson, err := geo.EWKBToGeoJSON(g.Geography.EWKB(), defaultGeoJSONDecimalDigits, geo.EWKBToGeoJSONFlagZero)
+				geojson, err := geo.SpatialObjectToGeoJSON(g.Geography.SpatialObject(), defaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
 				return tree.NewDString(string(geojson)), err
 			},
 			types.String,
@@ -1075,7 +1075,7 @@ Options is a flag that can be bitmasked. The options are:
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				g := args[0].(*tree.DGeography)
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
-				geojson, err := geo.EWKBToGeoJSON(g.Geography.EWKB(), fitMaxDecimalDigitsToBounds(maxDecimalDigits), geo.EWKBToGeoJSONFlagZero)
+				geojson, err := geo.SpatialObjectToGeoJSON(g.Geography.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits), geo.SpatialObjectToGeoJSONFlagZero)
 				return tree.NewDString(string(geojson)), err
 			},
 			Info: infoBuilder{
@@ -1093,8 +1093,8 @@ Options is a flag that can be bitmasked. The options are:
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				g := args[0].(*tree.DGeography)
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
-				options := geo.EWKBToGeoJSONFlag(tree.MustBeDInt(args[2]))
-				geojson, err := geo.EWKBToGeoJSON(g.Geography.EWKB(), fitMaxDecimalDigitsToBounds(maxDecimalDigits), options)
+				options := geo.SpatialObjectToGeoJSONFlag(tree.MustBeDInt(args[2]))
+				geojson, err := geo.SpatialObjectToGeoJSON(g.Geography.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits), options)
 				return tree.NewDString(string(geojson)), err
 			},
 			Info: infoBuilder{

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -951,13 +951,13 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 		case *DJSON:
 			return v, nil
 		case *DGeography:
-			j, err := geo.EWKBToGeoJSON(v.Geography.EWKB(), -1, geo.EWKBToGeoJSONFlagZero)
+			j, err := geo.SpatialObjectToGeoJSON(v.Geography.SpatialObject(), -1, geo.SpatialObjectToGeoJSONFlagZero)
 			if err != nil {
 				return nil, err
 			}
 			return ParseDJSON(string(j))
 		case *DGeometry:
-			j, err := geo.EWKBToGeoJSON(v.Geometry.EWKB(), -1, geo.EWKBToGeoJSONFlagZero)
+			j, err := geo.SpatialObjectToGeoJSON(v.Geometry.SpatialObject(), -1, geo.SpatialObjectToGeoJSONFlagZero)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
* Bump twpayne/go-geom to pick up some changes.
* Rename geo.EWKBTo* to geopb.SpatialObjectTo* to allow for more
  flexibility.
* Fix AsHexEWKB to allow empty point encoding.
* Fix GeoJSON bounding box nil issue.

Release note: None