### PR TITLE
kv: drop default for kv.bulk_sst.sync_size and kv.snapshot_sst.sync_size

### DIFF
--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -858,7 +858,7 @@ var recoverySnapshotRate = settings.RegisterPublicValidatedByteSizeSetting(
 var snapshotSSTWriteSyncRate = settings.RegisterByteSizeSetting(
 	"kv.snapshot_sst.sync_size",
 	"threshold after which snapshot SST writes must fsync",
-	2<<20, /* 2 MiB */
+	bulkIOWriteBurst,
 )
 
 func snapshotRateLimit(

--- a/pkg/kv/kvserver/syncing_write.go
+++ b/pkg/kv/kvserver/syncing_write.go
@@ -25,8 +25,10 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// bulkIOWriteBurst is the burst for the BulkIOWriteLimiter.
-const bulkIOWriteBurst = 2 * 1024 * 1024 // 2MB
+// bulkIOWriteBurst is the burst for the BulkIOWriteLimiter. It is also used as
+// the default value for the kv.bulk_sst.sync_size and kv.snapshot_sst.sync_size
+// cluster settings.
+const bulkIOWriteBurst = 512 << 10 // 512 KB
 
 const bulkIOWriteLimiterLongWait = 500 * time.Millisecond
 


### PR DESCRIPTION
These were both defaulting to 2MB per fsync. In Peter's testing, 512 MB per sync is a better value.

@petermattis do you have experiments I can link to for this, or will I need to spin up a few IMPORT roachtests to test out the new defaults? I guess I'll want to do that regardless.