### PR TITLE
partitionccl,kvserver: skip some flaky tests

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1284,6 +1284,9 @@ func TestSelectPartitionExprs(t *testing.T) {
 func TestRepartitioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	// Skipping as part of test-infra-team flaky test cleanup.
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/49112")
+
 	// This test configures many sub-tests and is too slow to run under nightly
 	// race stress.
 	if testutils.NightlyStress() && util.RaceEnabled {

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -1518,6 +1518,9 @@ func TestStoreRangeMergeRHSLeaseExpiration(t *testing.T) {
 func TestStoreRangeMergeConcurrentRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	// Skipping as part of test-infra-team flaky test cleanup.
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/50795")
+
 	ctx := context.Background()
 	storeCfg := kvserver.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -211,6 +211,9 @@ func TestCheckConsistencyReplay(t *testing.T) {
 func TestCheckConsistencyInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	// Skipping as part of test-infra-team flaky test cleanup.
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/50830")
+
 	const numStores = 3
 	testKnobs := kvserver.StoreTestingKnobs{}
 

--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -140,6 +140,10 @@ func TestGossipFirstRange(t *testing.T) {
 // restarted after losing its data) without the cluster breaking.
 func TestGossipHandlesReplacedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	// Skipping as part of test-infra-team flaky test cleanup.
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/50024")
+
 	if testing.Short() {
 		// As of Nov 2018 it takes 3.6s.
 		t.Skip("short")


### PR DESCRIPTION
This commit skips 4 tests as part of the test-infra-team flaky
test cleanup:

TestGossipHandlesReplacedNode
TestStoreRangeMergeConcurrentRequests
TestCheckConsistencyInconsistent
TestRepartitioning

Informs #50024
Informs #50795
Informs #50830
Informs #49112

Release note: None