### PR TITLE
sql: add cache for jobs to avoid querying system.jobs to find existing jobs

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -21,6 +21,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -637,6 +638,7 @@ func (s *Server) newConnExecutor(
 	ex.extraTxnState.descCollection = descs.MakeCollection(s.cfg.LeaseManager,
 		s.cfg.Settings, s.dbCache.getDatabaseCache(), s.dbCache)
 	ex.extraTxnState.txnRewindPos = -1
+	ex.extraTxnState.schemaChangeJobsCache = make(map[sqlbase.ID]*jobs.Job)
 	ex.mu.ActiveQueries = make(map[ClusterWideID]*queryMeta)
 	ex.machine = fsm.MakeMachine(TxnStateTransitions, stateNoTxn{}, &ex.state)
 
@@ -937,6 +939,11 @@ type connExecutor struct {
 		// that staged them commits.
 		jobs jobsCollection
 
+		// schemaChangeJobsCache is a map of descriptor IDs to Jobs.
+		// Used in createOrUpdateSchemaChangeJob so we can check if a job has been
+		// queued up for the given ID.
+		schemaChangeJobsCache map[sqlbase.ID]*jobs.Job
+
 		// autoRetryCounter keeps track of the which iteration of a transaction
 		// auto-retry we're currently in. It's 0 whenever the transaction state is not
 		// stateOpen.
@@ -1149,6 +1156,10 @@ func (ex *connExecutor) resetExtraTxnState(
 	ctx context.Context, dbCacheHolder *databaseCacheHolder, ev txnEvent,
 ) error {
 	ex.extraTxnState.jobs = nil
+
+	for k := range ex.extraTxnState.schemaChangeJobsCache {
+		delete(ex.extraTxnState.schemaChangeJobsCache, k)
+	}
 
 	ex.extraTxnState.descCollection.ReleaseAll(ctx)
 
@@ -1980,18 +1991,19 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			DB:                 ex.server.cfg.DB,
 			TypeResolver:       p,
 		},
-		SessionMutator:    ex.dataMutator,
-		VirtualSchemas:    ex.server.cfg.VirtualSchemas,
-		Tracing:           &ex.sessionTracing,
-		StatusServer:      ex.server.cfg.StatusServer,
-		MemMetrics:        &ex.memMetrics,
-		Descs:             &ex.extraTxnState.descCollection,
-		ExecCfg:           ex.server.cfg,
-		DistSQLPlanner:    ex.server.cfg.DistSQLPlanner,
-		TxnModesSetter:    ex,
-		Jobs:              &ex.extraTxnState.jobs,
-		schemaAccessors:   scInterface,
-		sqlStatsCollector: ex.statsCollector,
+		SessionMutator:       ex.dataMutator,
+		VirtualSchemas:       ex.server.cfg.VirtualSchemas,
+		Tracing:              &ex.sessionTracing,
+		StatusServer:         ex.server.cfg.StatusServer,
+		MemMetrics:           &ex.memMetrics,
+		Descs:                &ex.extraTxnState.descCollection,
+		ExecCfg:              ex.server.cfg,
+		DistSQLPlanner:       ex.server.cfg.DistSQLPlanner,
+		TxnModesSetter:       ex,
+		Jobs:                 &ex.extraTxnState.jobs,
+		SchemaChangeJobCache: ex.extraTxnState.schemaChangeJobsCache,
+		schemaAccessors:      scInterface,
+		sqlStatsCollector:    ex.statsCollector,
 	}
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -782,6 +782,10 @@ type ExecutorTestingKnobs struct {
 	// WithStatementTrace is called after the statement is executed in
 	// execStmtInOpenState.
 	WithStatementTrace func(span opentracing.Span, stmt string)
+
+	// RunAfterSCJobsCacheLookup is called after the SchemaChangeJobCache is checked for
+	// a given table id.
+	RunAfterSCJobsCacheLookup func(*jobs.Job)
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -70,7 +70,13 @@ type extendedEvalContext struct {
 
 	TxnModesSetter txnModesSetter
 
+	// Jobs refers to jobs in extraTxnState. Jobs is a pointer to a jobsCollection
+	// which is a slice because we need calls to resetExtraTxnState to reset the
+	// jobsCollection.
 	Jobs *jobsCollection
+
+	// SchemaChangeJobCache refers to schemaChangeJobsCache in extraTxnState.
+	SchemaChangeJobCache map[sqlbase.ID]*jobs.Job
 
 	schemaAccessors *schemaInterface
 

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -81,24 +81,12 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 		}
 	}
 	var job *jobs.Job
-	// Iterate through the queued jobs to find an existing schema change job for
-	// this table, if it exists.
-	// TODO (lucy): Looking up each job to determine this is not ideal. Maybe
-	// we need some additional state in extraTxnState to help with lookups.
-	for _, jobID := range *p.extendedEvalCtx.Jobs {
-		var err error
-		j, err := p.ExecCfg().JobRegistry.LoadJobWithTxn(ctx, jobID, p.txn)
-		if err != nil {
-			return err
-		}
-		schemaDetails, ok := j.Details().(jobspb.SchemaChangeDetails)
-		if !ok {
-			continue
-		}
-		if schemaDetails.TableID == tableDesc.ID {
-			job = j
-			break
-		}
+	if cachedJob, ok := p.extendedEvalCtx.SchemaChangeJobCache[tableDesc.ID]; ok {
+		job = cachedJob
+	}
+
+	if p.extendedEvalCtx.ExecCfg.TestingKnobs.RunAfterSCJobsCacheLookup != nil {
+		p.extendedEvalCtx.ExecCfg.TestingKnobs.RunAfterSCJobsCacheLookup(job)
 	}
 
 	var spanList []jobspb.ResumeSpanList
@@ -133,6 +121,7 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 		if err != nil {
 			return err
 		}
+		p.extendedEvalCtx.SchemaChangeJobCache[tableDesc.ID] = newJob
 		// Only add a MutationJob if there's an associated mutation.
 		// TODO (lucy): get rid of this when we get rid of MutationJobs.
 		if mutationID != sqlbase.InvalidMutationID {

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -439,5 +440,72 @@ func TestSerializedUDTsInTableDescriptor(t *testing.T) {
 		if _, err := sqlDB.Exec("DROP TABLE t"); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+// TestJobsCache verifies that a job for a given table gets cached and reused
+// for following schema changes in the same transaction.
+func TestJobsCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	foundInCache := false
+	runAfterSCJobsCacheLookup := func(job *jobs.Job) {
+		if job != nil {
+			foundInCache = true
+		}
+	}
+
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs.SQLExecutor = &ExecutorTestingKnobs{
+		RunAfterSCJobsCacheLookup: runAfterSCJobsCacheLookup,
+	}
+
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	// ALTER TABLE t1 ADD COLUMN x INT should have created a job for the table
+	// we're altering.
+	// Further schema changes to the table should have an existing cache
+	// entry for the job.
+	if _, err := sqlDB.Exec(`
+CREATE TABLE t1();
+BEGIN;
+ALTER TABLE t1 ADD COLUMN x INT;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqlDB.Exec(`
+ALTER TABLE t1 ADD COLUMN y INT;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	if !foundInCache {
+		t.Fatal("expected a job to be found in cache for table t1, " +
+			"but a job was not found")
+	}
+
+	// Verify that the cache is cleared once the transaction ends.
+	// Commit the old transaction.
+	if _, err := sqlDB.Exec(`
+COMMIT;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	foundInCache = false
+
+	if _, err := sqlDB.Exec(`
+BEGIN;
+ALTER TABLE t1 ADD COLUMN z INT;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	if foundInCache {
+		t.Fatal("expected a job to not be found in cache for table t1, " +
+			"but a job was found")
 	}
 }

--- a/pkg/sql/testdata/ddl_analysis/ddl_analysis
+++ b/pkg/sql/testdata/ddl_analysis/ddl_analysis
@@ -36,7 +36,7 @@ CREATE TABLE t10();
 count
 GRANT ALL ON * TO TEST
 ----
-160
+50
 
 count
 CREATE ROLE rolea


### PR DESCRIPTION
Currently, we perform a loop through all existing jobs which involves
querying a system table to check if there is an existing job for the current
table undergoing a schema change. To avoid this query, we can use a cache
to map TableIDs to jobs.

Fixes #50165, #50783

Release note: None