### PR TITLE
release-19.2: opt: don't generate invalid lookup semi/anti joins

### DIFF
--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -1232,8 +1232,20 @@ func (c *CustomFuncs) GenerateLookupJoins(
 			continue
 		}
 
-		// Case 2 (see function comment).
+		// All code that follows is for case 2 (see function comment).
+
 		if scanPrivate.Flags.NoIndexJoin {
+			continue
+		}
+		if joinType == opt.SemiJoinOp || joinType == opt.AntiJoinOp {
+			// We cannot use a non-covering index for semi and anti join. Note that
+			// since the semi/anti join doesn't pass through any columns, "non
+			// covering" here means that not all columns in the ON condition are
+			// available.
+			//
+			// TODO(radu): We could create a semi/anti join on top of an inner join if
+			// the lookup columns form a key (to guarantee that input rows are not
+			// duplicated by the inner join).
 			continue
 		}
 

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1195,6 +1195,58 @@ memo (optimized, ~7KB, required=[presentation: a:4,b:5,n:2,m:1])
  ├── G6: (variable a)
  └── G7: (variable m)
 
+# Lookup semi-join with index that contains all columns in the join condition.
+opt
+SELECT m, n FROM small WHERE EXISTS(SELECT 1 FROM abcd WHERE m = a)
+----
+semi-join (lookup abcd@secondary)
+ ├── columns: m:1(int) n:2(int)
+ ├── key columns: [1] = [4]
+ ├── scan small
+ │    └── columns: m:1(int) n:2(int)
+ └── filters (true)
+
+# We should not generate a lookup semi-join when the index doesn't contain all
+# columns in the join condition.
+opt
+SELECT m, n FROM small WHERE EXISTS(SELECT 1 FROM abcd WHERE m = a AND n = c)
+----
+semi-join (hash)
+ ├── columns: m:1(int) n:2(int)
+ ├── scan small
+ │    └── columns: m:1(int) n:2(int)
+ ├── scan abcd
+ │    └── columns: a:4(int) c:6(int)
+ └── filters
+      ├── m = a [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+      └── n = c [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+
+# Lookup anti-join with index that contains all columns in the join condition.
+opt
+SELECT m, n FROM small WHERE NOT EXISTS(SELECT 1 FROM abcd WHERE m = a)
+----
+anti-join (lookup abcd@secondary)
+ ├── columns: m:1(int) n:2(int)
+ ├── key columns: [1] = [4]
+ ├── scan small
+ │    └── columns: m:1(int) n:2(int)
+ └── filters (true)
+
+# We should not generate a lookup anti-join when the index doesn't contain all
+# columns in the join condition.
+opt
+SELECT m, n FROM small WHERE NOT EXISTS(SELECT 1 FROM abcd WHERE m = a AND n = c)
+----
+anti-join (hash)
+ ├── columns: m:1(int) n:2(int)
+ ├── scan small
+ │    └── columns: m:1(int) n:2(int)
+ ├── scan abcd
+ │    └── columns: a:4(int) c:6(int)
+ └── filters
+      ├── m = a [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+      └── n = c [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+
 # --------------------------------------------------
 # GenerateLookupJoinsWithFilter
 # --------------------------------------------------


### PR DESCRIPTION
Backport 1/1 commits from #50845.

/cc @cockroachdb/release

---

The GenerateLookupJoins code supports use of non-covering indexes; in
this case it creates two nested lookup joins, where the top one acts
as an index join.

The rule incorrectly does the same for semi and anti join, but this
doesn't work. It's not even a correct plan, as the semi/anti join
doesn't output the column that is used by the index join. There is a
transformation possible here for if the lookup columns in
the index form a key (then we could use an inner join); this is left
as a TODO.

I noticed that GenerateLookupJoinsWithFilter rule could also work on
Semi/Anti joins; I will enable that in a separate change.

Fixes #50779.

Release note (bug fix): Fixed "column not in input" internal error in
some corner cases.
