### PR TITLE
colexec: simplify DrainMeta and Close implementations

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -387,7 +387,7 @@ func (r opResult) createDiskBackedSort(
 				args.FDSemaphore,
 				diskAccount,
 			)
-			r.ToClose = append(r.ToClose, es.(colexec.IdempotentCloser))
+			r.ToClose = append(r.ToClose, es.(colexec.Closer))
 			return es
 		},
 		args.TestingKnobs.SpillingCallbackFn,
@@ -839,7 +839,7 @@ func NewColOperator(
 							args.TestingKnobs.DelegateFDAcquisitions,
 							diskAccount,
 						)
-						result.ToClose = append(result.ToClose, ehj.(colexec.IdempotentCloser))
+						result.ToClose = append(result.ToClose, ehj.(colexec.Closer))
 						return ehj
 					},
 					args.TestingKnobs.SpillingCallbackFn,
@@ -908,7 +908,7 @@ func NewColOperator(
 			}
 
 			result.Op = mj
-			result.ToClose = append(result.ToClose, mj.(colexec.IdempotentCloser))
+			result.ToClose = append(result.ToClose, mj.(colexec.Closer))
 			result.ColumnTypes = make([]*types.T, len(leftTypes)+len(rightTypes))
 			copy(result.ColumnTypes, leftTypes)
 			if !core.MergeJoiner.Type.ShouldIncludeRightColsInOutput() {
@@ -1025,8 +1025,8 @@ func NewColOperator(
 					)
 					// NewRelativeRankOperator sometimes returns a constOp when there
 					// are no ordering columns, so we check that the returned operator
-					// is an IdempotentCloser.
-					if c, ok := result.Op.(colexec.IdempotentCloser); ok {
+					// is an Closer.
+					if c, ok := result.Op.(colexec.Closer); ok {
 						result.ToClose = append(result.ToClose, c)
 					}
 				default:

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // Columnarizer turns an execinfra.RowSource input into an Operator output, by
@@ -31,12 +30,6 @@ import (
 type Columnarizer struct {
 	execinfra.ProcessorBase
 	NonExplainable
-
-	// mu is used to protect against concurrent DrainMeta and Next calls, which
-	// are currently allowed.
-	// TODO(asubiotto): Explore calling DrainMeta from the same goroutine as Next,
-	//  which will simplify this model.
-	mu syncutil.Mutex
 
 	allocator  *colmem.Allocator
 	input      execinfra.RowSource
@@ -101,8 +94,6 @@ func (c *Columnarizer) Init() {
 
 // Next is part of the Operator interface.
 func (c *Columnarizer) Next(context.Context) coldata.Batch {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.batch.ResetInternalBatch()
 	// Buffer up n rows.
 	nRows := 0
@@ -152,8 +143,6 @@ var _ execinfrapb.MetadataSource = &Columnarizer{}
 
 // DrainMeta is part of the MetadataSource interface.
 func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.MoveToDraining(nil /* err */)
 	for {
 		meta := c.DrainHelper()

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -89,20 +89,14 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 
 	c.Init()
 
+	// If the metadata is obtained through this Next call, the Columnarizer still
+	// returns it in DrainMeta.
+	_ = c.Next(ctx)
+
 	// Calling DrainMeta from the vectorized execution engine should propagate to
 	// non-vectorized components as calling ConsumerDone and then draining their
 	// metadata.
-	metaCh := make(chan []execinfrapb.ProducerMetadata)
-	go func() {
-		metaCh <- c.DrainMeta(ctx)
-	}()
-
-	// Make Next race with DrainMeta, this should be supported by the
-	// Columnarizer. If the metadata is obtained through this Next call, the
-	// Columnarizer still returns it in DrainMeta.
-	_ = c.Next(ctx)
-
-	meta := <-metaCh
+	meta := c.DrainMeta(ctx)
 	require.True(t, len(meta) == 1)
 	require.True(t, testutils.IsError(meta[0].Err, errMsg))
 	require.True(t, rb.Done)

--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -242,12 +242,12 @@ func (d *diskSpillerBase) reset(ctx context.Context) {
 //  from some runTests subtests when not draining the input fully. The test
 //  should pass in the testing.T object used so that the caller can decide to
 //  explicitly close the input after checking the test.
-func (d *diskSpillerBase) IdempotentClose(ctx context.Context) error {
+func (d *diskSpillerBase) Close(ctx context.Context) error {
 	if !d.close() {
 		return nil
 	}
-	if c, ok := d.diskBackedOp.(IdempotentCloser); ok {
-		return c.IdempotentClose(ctx)
+	if c, ok := d.diskBackedOp.(Closer); ok {
+		return c.Close(ctx)
 	}
 	return nil
 }

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
 )
@@ -159,12 +158,6 @@ type externalHashJoiner struct {
 	twoInputNode
 	NonExplainable
 	closerHelper
-
-	// mu is used to protect against concurrent IdempotentClose and Next calls,
-	// which are currently allowed.
-	// TODO(asubiotto): Explore calling IdempotentClose from the same goroutine as
-	//  Next, which will simplify this model.
-	mu syncutil.Mutex
 
 	state              externalHashJoinerState
 	unlimitedAllocator *colmem.Allocator
@@ -486,8 +479,6 @@ func (hj *externalHashJoiner) partitionBatch(
 }
 
 func (hj *externalHashJoiner) Next(ctx context.Context) coldata.Batch {
-	hj.mu.Lock()
-	defer hj.mu.Unlock()
 StateChanged:
 	for {
 		switch hj.state {
@@ -701,7 +692,7 @@ StateChanged:
 			return b
 
 		case externalHJFinished:
-			if err := hj.idempotentCloseLocked(ctx); err != nil {
+			if err := hj.Close(ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -711,13 +702,7 @@ StateChanged:
 	}
 }
 
-func (hj *externalHashJoiner) IdempotentClose(ctx context.Context) error {
-	hj.mu.Lock()
-	defer hj.mu.Unlock()
-	return hj.idempotentCloseLocked(ctx)
-}
-
-func (hj *externalHashJoiner) idempotentCloseLocked(ctx context.Context) error {
+func (hj *externalHashJoiner) Close(ctx context.Context) error {
 	if !hj.close() {
 		return nil
 	}
@@ -728,8 +713,8 @@ func (hj *externalHashJoiner) idempotentCloseLocked(ctx context.Context) error {
 	if err := hj.rightPartitioner.Close(ctx); err != nil && retErr == nil {
 		retErr = err
 	}
-	if c, ok := hj.diskBackedSortMerge.(IdempotentCloser); ok {
-		if err := c.IdempotentClose(ctx); err != nil && retErr == nil {
+	if c, ok := hj.diskBackedSortMerge.(Closer); ok {
+		if err := c.Close(ctx); err != nil && retErr == nil {
 			retErr = err
 		}
 	}

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -307,7 +307,7 @@ func createDiskBackedHashJoiner(
 	numForcedRepartitions int,
 	delegateFDAcquisitions bool,
 	testingSemaphore semaphore.Semaphore,
-) (colexecbase.Operator, []*mon.BoundAccount, []*mon.BytesMonitor, []IdempotentCloser, error) {
+) (colexecbase.Operator, []*mon.BoundAccount, []*mon.BytesMonitor, []Closer, error) {
 	args := &NewColOperatorArgs{
 		Spec:                spec,
 		Inputs:              inputs,

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -325,7 +325,7 @@ func createDiskBackedSorter(
 	delegateFDAcquisitions bool,
 	diskQueueCfg colcontainer.DiskQueueCfg,
 	testingSemaphore semaphore.Semaphore,
-) (colexecbase.Operator, []*mon.BoundAccount, []*mon.BytesMonitor, []IdempotentCloser, error) {
+) (colexecbase.Operator, []*mon.BoundAccount, []*mon.BytesMonitor, []Closer, error) {
 	sorterSpec := &execinfrapb.SorterSpec{
 		OutputOrdering:   execinfrapb.Ordering{Columns: ordCols},
 		OrderingMatchLen: uint32(matchLen),

--- a/pkg/sql/colexec/limit.go
+++ b/pkg/sql/colexec/limit.go
@@ -71,12 +71,12 @@ func (c *limitOp) Next(ctx context.Context) coldata.Batch {
 //  from some runTests subtests when not draining the input fully. The test
 //  should pass in the testing.T object used so that the caller can decide to
 //  explicitly close the input after checking the test.
-func (c *limitOp) IdempotentClose(ctx context.Context) error {
+func (c *limitOp) Close(ctx context.Context) error {
 	if !c.close() {
 		return nil
 	}
-	if closer, ok := c.input.(IdempotentCloser); ok {
-		return closer.IdempotentClose(ctx)
+	if closer, ok := c.input.(Closer); ok {
+		return closer.Close(ctx)
 	}
 	return nil
 }

--- a/pkg/sql/colexec/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_exceptall.eg.go
@@ -42219,8 +42219,6 @@ func (o *mergeJoinExceptAllOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinExceptAllOp) Next(ctx context.Context) coldata.Batch {
-	o.mu.Lock()
-	defer o.mu.Unlock()
 	o.output.ResetInternalBatch()
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_fullouter.eg.go
@@ -48354,8 +48354,6 @@ func (o *mergeJoinFullOuterOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinFullOuterOp) Next(ctx context.Context) coldata.Batch {
-	o.mu.Lock()
-	defer o.mu.Unlock()
 	o.output.ResetInternalBatch()
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/mergejoiner_inner.eg.go
@@ -32468,8 +32468,6 @@ func (o *mergeJoinInnerOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinInnerOp) Next(ctx context.Context) coldata.Batch {
-	o.mu.Lock()
-	defer o.mu.Unlock()
 	o.output.ResetInternalBatch()
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_intersectall.eg.go
@@ -33616,8 +33616,6 @@ func (o *mergeJoinIntersectAllOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinIntersectAllOp) Next(ctx context.Context) coldata.Batch {
-	o.mu.Lock()
-	defer o.mu.Unlock()
 	o.output.ResetInternalBatch()
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftanti.eg.go
@@ -40413,8 +40413,6 @@ func (o *mergeJoinLeftAntiOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinLeftAntiOp) Next(ctx context.Context) coldata.Batch {
-	o.mu.Lock()
-	defer o.mu.Unlock()
 	o.output.ResetInternalBatch()
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftouter.eg.go
@@ -40552,8 +40552,6 @@ func (o *mergeJoinLeftOuterOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinLeftOuterOp) Next(ctx context.Context) coldata.Batch {
-	o.mu.Lock()
-	defer o.mu.Unlock()
 	o.output.ResetInternalBatch()
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
@@ -32303,8 +32303,6 @@ func (o *mergeJoinLeftSemiOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinLeftSemiOp) Next(ctx context.Context) coldata.Batch {
-	o.mu.Lock()
-	defer o.mu.Unlock()
 	o.output.ResetInternalBatch()
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_rightouter.eg.go
@@ -40270,8 +40270,6 @@ func (o *mergeJoinRightOuterOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinRightOuterOp) Next(ctx context.Context) coldata.Batch {
-	o.mu.Lock()
-	defer o.mu.Unlock()
 	o.output.ResetInternalBatch()
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -1657,8 +1657,6 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 // */}}
 
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
-	o.mu.Lock()
-	defer o.mu.Unlock()
 	o.output.ResetInternalBatch()
 	for {
 		switch o.state {

--- a/pkg/sql/colexec/op_creation.go
+++ b/pkg/sql/colexec/op_creation.go
@@ -78,9 +78,8 @@ type NewColOperatorResult struct {
 	ColumnTypes      []*types.T
 	InternalMemUsage int
 	MetadataSources  []execinfrapb.MetadataSource
-	// ToClose is a slice of components that need to be Closed. Close should be
-	// idempotent.
-	ToClose     []IdempotentCloser
+	// ToClose is a slice of components that need to be Closed.
+	ToClose     []Closer
 	IsStreaming bool
 	OpMonitors  []*mon.BytesMonitor
 	OpAccounts  []*mon.BoundAccount

--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -129,6 +129,14 @@ type IdempotentCloser interface {
 	IdempotentClose(ctx context.Context) error
 }
 
+type CallbackCloser struct {
+	CloseCb func(context.Context) error
+}
+
+func (c *CallbackCloser) IdempotentClose(ctx context.Context) error {
+	return c.CloseCb(ctx)
+}
+
 // closerHelper is a simple helper that helps Operators implement
 // IdempotentCloser. If close returns true, resources may be released, if it
 // returns false, close has already been called.

--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -123,22 +123,24 @@ type ResettableOperator interface {
 	resetter
 }
 
-// IdempotentCloser is an object that releases resource on the first call to
-// IdempotentClose but does nothing for any subsequent call.
-type IdempotentCloser interface {
-	IdempotentClose(ctx context.Context) error
+// Closer is an object that releases resources when Close is called.
+type Closer interface {
+	Close(ctx context.Context) error
 }
 
+// CallbackCloser is a utility struct that implements the Closer interface by
+// calling a provided callback.
 type CallbackCloser struct {
 	CloseCb func(context.Context) error
 }
 
-func (c *CallbackCloser) IdempotentClose(ctx context.Context) error {
+// Close implements the Closer interface.
+func (c *CallbackCloser) Close(ctx context.Context) error {
 	return c.CloseCb(ctx)
 }
 
 // closerHelper is a simple helper that helps Operators implement
-// IdempotentCloser. If close returns true, resources may be released, if it
+// Closer. If close returns true, resources may be released, if it
 // returns false, close has already been called.
 // use.
 type closerHelper struct {
@@ -157,7 +159,7 @@ func (c *closerHelper) close() bool {
 
 type closableOperator interface {
 	colexecbase.Operator
-	IdempotentCloser
+	Closer
 }
 
 type noopOperator struct {

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -77,7 +77,10 @@ type OrderedSynchronizer struct {
 	outColsMap []int
 }
 
-var _ colexecbase.Operator = &OrderedSynchronizer{}
+var (
+	_ colexecbase.Operator = &OrderedSynchronizer{}
+	_ Closer               = &OrderedSynchronizer{}
+)
 
 // ChildCount implements the execinfrapb.OpNode interface.
 func (o *OrderedSynchronizer) ChildCount(verbose bool) int {
@@ -344,12 +347,12 @@ func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.Produ
 	return bufferedMeta
 }
 
-func (o *OrderedSynchronizer) IdempotentClose(ctx context.Context) error {
+func (o *OrderedSynchronizer) Close(ctx context.Context) error {
 	for _, input := range o.inputs {
 		for _, closer := range input.ToClose {
-			if err := closer.IdempotentClose(ctx); err != nil {
+			if err := closer.Close(ctx); err != nil {
 				if log.V(1) {
-					log.Infof(ctx, "ordered synchronizer error closing IdempotentCloser: %v", err)
+					log.Infof(ctx, "ordered synchronizer error closing Closer: %v", err)
 				}
 			}
 		}

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // OrderedSynchronizer receives rows from multiple inputs and produces a single
@@ -349,13 +348,7 @@ func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.Produ
 
 func (o *OrderedSynchronizer) Close(ctx context.Context) error {
 	for _, input := range o.inputs {
-		for _, closer := range input.ToClose {
-			if err := closer.Close(ctx); err != nil {
-				if log.V(1) {
-					log.Infof(ctx, "ordered synchronizer error closing Closer: %v", err)
-				}
-			}
-		}
+		input.ToClose.CloseAndLogOnErr(ctx, "ordered synchronizer")
 	}
 	return nil
 }

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -97,7 +97,10 @@ type OrderedSynchronizer struct {
 	outColsMap []int
 }
 
-var _ colexecbase.Operator = &OrderedSynchronizer{}
+var (
+	_ colexecbase.Operator = &OrderedSynchronizer{}
+	_ Closer               = &OrderedSynchronizer{}
+)
 
 // ChildCount implements the execinfrapb.OpNode interface.
 func (o *OrderedSynchronizer) ChildCount(verbose bool) int {
@@ -242,12 +245,12 @@ func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.Produ
 	return bufferedMeta
 }
 
-func (o *OrderedSynchronizer) IdempotentClose(ctx context.Context) error {
+func (o *OrderedSynchronizer) Close(ctx context.Context) error {
 	for _, input := range o.inputs {
 		for _, closer := range input.ToClose {
-			if err := closer.IdempotentClose(ctx); err != nil {
+			if err := closer.Close(ctx); err != nil {
 				if log.V(1) {
-					log.Infof(ctx, "ordered synchronizer error closing IdempotentCloser: %v", err)
+					log.Infof(ctx, "ordered synchronizer error closing Closer: %v", err)
 				}
 			}
 		}

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // {{/*
@@ -247,13 +246,7 @@ func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.Produ
 
 func (o *OrderedSynchronizer) Close(ctx context.Context) error {
 	for _, input := range o.inputs {
-		for _, closer := range input.ToClose {
-			if err := closer.Close(ctx); err != nil {
-				if log.V(1) {
-					log.Infof(ctx, "ordered synchronizer error closing Closer: %v", err)
-				}
-			}
-		}
+		input.ToClose.CloseAndLogOnErr(ctx, "ordered synchronizer")
 	}
 	return nil
 }

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // {{/*
@@ -239,6 +240,19 @@ func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.Produ
 		bufferedMeta = append(bufferedMeta, input.MetadataSources.DrainMeta(ctx)...)
 	}
 	return bufferedMeta
+}
+
+func (o *OrderedSynchronizer) IdempotentClose(ctx context.Context) error {
+	for _, input := range o.inputs {
+		for _, closer := range input.ToClose {
+			if err := closer.IdempotentClose(ctx); err != nil {
+				if log.V(1) {
+					log.Infof(ctx, "ordered synchronizer error closing IdempotentCloser: %v", err)
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (o *OrderedSynchronizer) compareRow(batchIdx1 int, batchIdx2 int) int {

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -120,9 +120,9 @@ type SynchronizerInput struct {
 	// MetadataSources are metadata sources in the input tree that should be
 	// drained in the same goroutine as Op.
 	MetadataSources execinfrapb.MetadataSources
-	// ToClose are IdempotentClosers in the input tree that should be closed in
-	// the same goroutine as Op.
-	ToClose []IdempotentCloser
+	// ToClose are Closers in the input tree that should be closed in the same
+	// goroutine as Op.
+	ToClose []Closer
 }
 
 func operatorsToSynchronizerInputs(ops []colexecbase.Operator) []SynchronizerInput {
@@ -219,7 +219,7 @@ func (s *ParallelUnorderedSynchronizer) init(ctx context.Context) {
 				s.internalWaitGroup.Done()
 				s.externalWaitGroup.Done()
 				for _, closer := range input.ToClose {
-					if err := closer.IdempotentClose(ctx); err != nil {
+					if err := closer.Close(ctx); err != nil {
 						if log.V(1) {
 							log.Infof(ctx, "error closing Closer: %v", err)
 						}

--- a/pkg/sql/colexec/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/relative_rank_tmpl.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
 )
@@ -244,12 +243,6 @@ const relativeRankUtilityQueueMemLimitFraction = 0.1
 type _RELATIVE_RANK_STRINGOp struct {
 	relativeRankInitFields
 
-	// mu is used to protect against concurrent IdempotentClose and Next calls,
-	// which are currently allowed.
-	// TODO(asubiotto): Explore calling IdempotentClose from the same goroutine as
-	//  Next, which will simplify this model.
-	mu syncutil.Mutex
-
 	// {{if .IsPercentRank}}
 	// rank indicates which rank should be assigned to the next tuple.
 	rank int64
@@ -318,8 +311,6 @@ func (r *_RELATIVE_RANK_STRINGOp) Init() {
 }
 
 func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
-	r.mu.Lock()
-	defer r.mu.Unlock()
 	var err error
 	for {
 		switch r.state {
@@ -605,7 +596,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.idempotentCloseLocked(ctx); err != nil {
+			if err := r.Close(ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -618,13 +609,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (r *_RELATIVE_RANK_STRINGOp) IdempotentClose(ctx context.Context) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.idempotentCloseLocked(ctx)
-}
-
-func (r *_RELATIVE_RANK_STRINGOp) idempotentCloseLocked(ctx context.Context) error {
+func (r *_RELATIVE_RANK_STRINGOp) Close(ctx context.Context) error {
 	if !r.close() {
 		return nil
 	}

--- a/pkg/sql/colexec/routers.go
+++ b/pkg/sql/colexec/routers.go
@@ -493,9 +493,9 @@ type HashRouter struct {
 	// metadataSources is a slice of execinfrapb.MetadataSources that need to be
 	// drained when the HashRouter terminates.
 	metadataSources execinfrapb.MetadataSources
-	// closers is a slice of IdempotentClosers that need to be closed when the
-	// hash router terminates.
-	closers []IdempotentCloser
+	// closers is a slice of Closers that need to be closed when the hash router
+	// terminates.
+	closers []Closer
 
 	// unblockedEventsChan is a channel shared between the HashRouter and its
 	// outputs. outputs send events on this channel when they are unblocked by a
@@ -543,7 +543,7 @@ func NewHashRouter(
 	fdSemaphore semaphore.Semaphore,
 	diskAccounts []*mon.BoundAccount,
 	toDrain []execinfrapb.MetadataSource,
-	toClose []IdempotentCloser,
+	toClose []Closer,
 ) (*HashRouter, []colexecbase.DrainableOperator) {
 	if diskQueueCfg.CacheMode != colcontainer.DiskQueueCacheModeDefault {
 		colexecerror.InternalError(errors.Errorf("hash router instantiated with incompatible disk queue cache mode: %d", diskQueueCfg.CacheMode))
@@ -584,7 +584,7 @@ func newHashRouterWithOutputs(
 	unblockEventsChan <-chan struct{},
 	outputs []routerOutput,
 	toDrain []execinfrapb.MetadataSource,
-	toClose []IdempotentCloser,
+	toClose []Closer,
 ) *HashRouter {
 	r := &HashRouter{
 		OneInputNode:        NewOneInputNode(input),
@@ -711,9 +711,9 @@ func (r *HashRouter) Run(ctx context.Context) {
 	close(r.waitForMetadata)
 
 	for _, closer := range r.closers {
-		if err := closer.IdempotentClose(ctx); err != nil {
+		if err := closer.Close(ctx); err != nil {
 			if log.V(1) {
-				log.Infof(ctx, "error closing IdempotentCloser: %v", err)
+				log.Infof(ctx, "error closing Closer: %v", err)
 			}
 		}
 	}

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // SerialUnorderedSynchronizer is an Operator that combines multiple Operator
@@ -92,13 +91,7 @@ func (s *SerialUnorderedSynchronizer) DrainMeta(
 // Close is part of the Closer interface.
 func (s *SerialUnorderedSynchronizer) Close(ctx context.Context) error {
 	for _, input := range s.inputs {
-		for _, closer := range input.ToClose {
-			if err := closer.Close(ctx); err != nil {
-				if log.V(1) {
-					log.Infof(ctx, "serial unordered synchronizer error closing Closer: %v", err)
-				}
-			}
-		}
+		input.ToClose.CloseAndLogOnErr(ctx, "serial unordered synchronizer")
 	}
 	return nil
 }

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -32,8 +32,11 @@ type SerialUnorderedSynchronizer struct {
 	curSerialInputIdx int
 }
 
-var _ colexecbase.Operator = &SerialUnorderedSynchronizer{}
-var _ execinfra.OpNode = &SerialUnorderedSynchronizer{}
+var (
+	_ colexecbase.Operator = &SerialUnorderedSynchronizer{}
+	_ execinfra.OpNode     = &SerialUnorderedSynchronizer{}
+	_ Closer               = &SerialUnorderedSynchronizer{}
+)
 
 // ChildCount implements the execinfra.OpNode interface.
 func (s *SerialUnorderedSynchronizer) ChildCount(verbose bool) int {
@@ -86,13 +89,13 @@ func (s *SerialUnorderedSynchronizer) DrainMeta(
 	return bufferedMeta
 }
 
-// IdempotentClose is part of the IdempotentCloser interface.
-func (s *SerialUnorderedSynchronizer) IdempotentClose(ctx context.Context) error {
+// Close is part of the Closer interface.
+func (s *SerialUnorderedSynchronizer) Close(ctx context.Context) error {
 	for _, input := range s.inputs {
 		for _, closer := range input.ToClose {
-			if err := closer.IdempotentClose(ctx); err != nil {
+			if err := closer.Close(ctx); err != nil {
 				if log.V(1) {
-					log.Infof(ctx, "serial unordered synchronizer error closing IdempotentCloser: %v", err)
+					log.Infof(ctx, "serial unordered synchronizer error closing Closer: %v", err)
 				}
 			}
 		}

--- a/pkg/sql/colexec/simple_project.go
+++ b/pkg/sql/colexec/simple_project.go
@@ -142,12 +142,12 @@ func (d *simpleProjectOp) Next(ctx context.Context) coldata.Batch {
 //  from some runTests subtests when not draining the input fully. The test
 //  should pass in the testing.T object used so that the caller can decide to
 //  explicitly close the input after checking the test.
-func (d *simpleProjectOp) IdempotentClose(ctx context.Context) error {
+func (d *simpleProjectOp) Close(ctx context.Context) error {
 	if !d.close() {
 		return nil
 	}
-	if c, ok := d.input.(IdempotentCloser); ok {
-		return c.IdempotentClose(ctx)
+	if c, ok := d.input.(Closer); ok {
+		return c.Close(ctx)
 	}
 	return nil
 }

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -333,11 +333,11 @@ func runTestsWithTyps(
 				"non-nulls in the input tuples, we expect for all nulls injection to "+
 				"change the output")
 		}
-		if c, ok := originalOp.(IdempotentCloser); ok {
-			require.NoError(t, c.IdempotentClose(ctx))
+		if c, ok := originalOp.(Closer); ok {
+			require.NoError(t, c.Close(ctx))
 		}
-		if c, ok := opWithNulls.(IdempotentCloser); ok {
-			require.NoError(t, c.IdempotentClose(ctx))
+		if c, ok := opWithNulls.(Closer); ok {
+			require.NoError(t, c.Close(ctx))
 		}
 	})
 }
@@ -460,10 +460,10 @@ func runTestsWithoutAllNullsInjection(
 						assert.False(t, maybeHasNulls(b))
 					}
 				}
-				if c, ok := op.(IdempotentCloser); ok {
+				if c, ok := op.(Closer); ok {
 					// Some operators need an explicit Close if not drained completely of
 					// input.
-					assert.NoError(t, c.IdempotentClose(ctx))
+					assert.NoError(t, c.Close(ctx))
 				}
 			}
 		})

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync"
 
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -25,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/logtags"
 )
 
@@ -78,35 +76,19 @@ type Inbox struct {
 	// right after init. To be used for unit testing.
 	ctxInterceptorFn func(context.Context)
 
-	// We need two mutexes because a single mutex is insufficient to handle
-	// concurrent calls to Next() and DrainMeta(). See comment in DrainMeta.
-	stateMu struct {
-		syncutil.Mutex
-		// initialized prevents double initialization. Should not be used by the
-		// RunWithStream goroutine.
-		initialized bool
-		// done prevents double closing. It should not be used by the RunWithStream
-		// goroutine.
-		done bool
-		// nextRunning indicates whether Next goroutine is running at the moment.
-		nextRunning bool
-		// nextExited is a condition variable on which DrainMeta might block in
-		// order to wait for Next goroutine to exit.
-		nextExited *sync.Cond
-		// nextShouldExit indicates to Next goroutine that it should exit. It must
-		// only be updated by DrainMeta goroutine.
-		nextShouldExit bool
-		// bufferedMeta buffers any metadata found in Next when reading from the
-		// stream and is returned by DrainMeta.
-		bufferedMeta []execinfrapb.ProducerMetadata
-	}
+	// initialized prevents double initialization. Should not be used by the
+	// RunWithStream goroutine.
+	initialized bool
+	// done prevents double closing. It should not be used by the RunWithStream
+	// goroutine.
+	done bool
+	// bufferedMeta buffers any metadata found in Next when reading from the
+	// stream and is returned by DrainMeta.
+	bufferedMeta []execinfrapb.ProducerMetadata
 
-	streamMu struct {
-		syncutil.Mutex
-		// stream is the RPC stream. It is set when RunWithStream is called but
-		// only the Next and DrainMeta goroutines may access it.
-		stream flowStreamServer
-	}
+	// stream is the RPC stream. It is set when RunWithStream is called but
+	// only the Next/DrainMeta goroutine may access it.
+	stream flowStreamServer
 
 	scratch struct {
 		data []*array.Data
@@ -140,38 +122,32 @@ func NewInbox(
 	}
 	i.scratch.data = make([]*array.Data, len(typs))
 	i.scratch.b = allocator.NewMemBatch(typs)
-	i.stateMu.bufferedMeta = make([]execinfrapb.ProducerMetadata, 0)
-	i.stateMu.nextExited = sync.NewCond(&i.stateMu)
 	return i, nil
 }
 
-// maybeInitLocked calls Inbox.initLocked if the inbox is not initialized and
-// returns an error if the initialization was not successful. Usually this is
-// because the given context is canceled before the remote stream arrives.
-// NOTE: i.stateMu *must* be held when calling this function.
-func (i *Inbox) maybeInitLocked(ctx context.Context) error {
-	if !i.stateMu.initialized {
-		if err := i.initLocked(ctx); err != nil {
+// maybeInit calls Inbox.init if the inbox is not initialized and returns an
+// error if the initialization was not successful. Usually this is because the
+// given context is canceled before the remote stream arrives.
+func (i *Inbox) maybeInit(ctx context.Context) error {
+	if !i.initialized {
+		if err := i.init(ctx); err != nil {
 			return err
 		}
-		i.stateMu.initialized = true
+		i.initialized = true
 	}
 	return nil
 }
 
-// initLocked initializes the Inbox for operation by blocking until
+// init initializes the Inbox for operation by blocking until
 // RunWithStream sets the stream to read from. ctx ownership is retained until
 // the stream arrives (to allow for unblocking the wait for a stream), at which
 // point ownership is transferred to RunWithStream. This should only be called
 // from the reader goroutine when it needs a stream.
-// NOTE: i.stateMu *must* be held when calling this function because it is
-// sufficient to protect access to i.streamMu.stream since the stream will only
-// be accessed after the initialization.
-func (i *Inbox) initLocked(ctx context.Context) error {
+func (i *Inbox) init(ctx context.Context) error {
 	// Wait for the stream to be initialized. We're essentially waiting for the
 	// remote connection.
 	select {
-	case i.streamMu.stream = <-i.streamCh:
+	case i.stream = <-i.streamCh:
 	case err := <-i.timeoutCh:
 		i.errCh <- fmt.Errorf("%s: remote stream arrived too late", err)
 		return err
@@ -187,12 +163,11 @@ func (i *Inbox) initLocked(ctx context.Context) error {
 	return nil
 }
 
-// closeLocked closes the inbox, ensuring that any call to RunWithStream will
-// return immediately. closeLocked is idempotent.
-// NOTE: i.stateMu *must* be held when calling this function.
-func (i *Inbox) closeLocked() {
-	if !i.stateMu.done {
-		i.stateMu.done = true
+// close closes the inbox, ensuring that any call to RunWithStream will
+// return immediately. close is idempotent.
+func (i *Inbox) close() {
+	if !i.done {
+		i.done = true
 		close(i.errCh)
 	}
 }
@@ -246,15 +221,7 @@ func (i *Inbox) Init() {}
 // The Inbox will exit when either the context passed in on the first call to
 // Next is canceled or when DrainMeta goroutine tells it to do so.
 func (i *Inbox) Next(ctx context.Context) coldata.Batch {
-	i.stateMu.Lock()
-	stateMuLocked := true
-	i.stateMu.nextRunning = true
-	defer func() {
-		i.stateMu.nextRunning = false
-		i.stateMu.nextExited.Signal()
-		i.stateMu.Unlock()
-	}()
-	if i.stateMu.done {
+	if i.done {
 		return coldata.ZeroBatch
 	}
 
@@ -265,13 +232,7 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 		// goroutine listening for context cancellation. errCh must still be closed
 		// during normal termination.
 		if err := recover(); err != nil {
-			if !stateMuLocked {
-				// The panic occurred while we were Recv'ing when we were holding
-				// i.streamMu and were not holding i.stateMu.
-				i.stateMu.Lock()
-				i.streamMu.Unlock()
-			}
-			i.closeLocked()
+			i.close()
 			colexecerror.InternalError(err)
 		}
 	}()
@@ -280,30 +241,18 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 	// ungracefully or when DrainMeta has been called (which indicates a graceful
 	// termination). DrainMeta will use the stream to read any remaining metadata
 	// after Next returns a zero-length batch during normal execution.
-	if err := i.maybeInitLocked(ctx); err != nil {
+	if err := i.maybeInit(ctx); err != nil {
 		// An error occurred while initializing the Inbox and is likely caused by
 		// the connection issues. It is expected that such an error can occur.
 		colexecerror.ExpectedError(err)
 	}
 
 	for {
-		// DrainMeta goroutine indicated to us that we should exit. We do so
-		// without closing errCh since DrainMeta still needs the stream.
-		if i.stateMu.nextShouldExit {
-			return coldata.ZeroBatch
-		}
-
-		i.stateMu.Unlock()
-		stateMuLocked = false
-		i.streamMu.Lock()
-		m, err := i.streamMu.stream.Recv()
-		i.streamMu.Unlock()
-		i.stateMu.Lock()
-		stateMuLocked = true
+		m, err := i.stream.Recv()
 		if err != nil {
 			if err == io.EOF {
 				// Done.
-				i.closeLocked()
+				i.close()
 				return coldata.ZeroBatch
 			}
 			i.errCh <- err
@@ -321,7 +270,7 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 					// DrainMeta.
 					colexecerror.ExpectedError(meta.Err)
 				}
-				i.stateMu.bufferedMeta = append(i.stateMu.bufferedMeta, meta)
+				i.bufferedMeta = append(i.bufferedMeta, meta)
 			}
 			// Continue until we get the next batch or EOF.
 			continue
@@ -343,9 +292,7 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 
 func (i *Inbox) sendDrainSignal(ctx context.Context) error {
 	log.VEvent(ctx, 2, "Inbox sending drain signal to Outbox")
-	// It is safe to Send without holding the mutex because it is legal to call
-	// Send and Recv from different goroutines.
-	if err := i.streamMu.stream.Send(&execinfrapb.ConsumerSignal{DrainRequest: &execinfrapb.DrainRequest{}}); err != nil {
+	if err := i.stream.Send(&execinfrapb.ConsumerSignal{DrainRequest: &execinfrapb.DrainRequest{}}); err != nil {
 		if log.V(1) {
 			log.Warningf(ctx, "Inbox unable to send drain signal to Outbox: %+v", err)
 		}
@@ -354,67 +301,32 @@ func (i *Inbox) sendDrainSignal(ctx context.Context) error {
 	return nil
 }
 
-// DrainMeta is part of the MetadataGenerator interface. DrainMeta may be
+// DrainMeta is part of the MetadataGenerator interface. DrainMeta may not be
 // called concurrently with Next.
-// Note: DrainMeta will cause Next goroutine to finish.
 func (i *Inbox) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
-	i.stateMu.Lock()
-	defer i.stateMu.Unlock()
-	allMeta := i.stateMu.bufferedMeta
-	i.stateMu.bufferedMeta = i.stateMu.bufferedMeta[:0]
+	allMeta := i.bufferedMeta
+	i.bufferedMeta = i.bufferedMeta[:0]
 
-	if i.stateMu.done {
+	if i.done {
+		// Next exhausted the stream of metadata.
 		return allMeta
 	}
+	defer i.close()
 
 	ctx = logtags.AddTag(ctx, "streamID", i.streamID)
 
-	// We want draining the Inbox to work regardless of whether or not we have a
-	// goroutine in Next. We essentially need to do two things: 1) Is the stream
-	// safe to use? If yes, then 2) Make sure nobody else is receiving.
-	// Unfortunately, there is no way to cancel a Recv on a stream, so we need to
-	// do this by sending the message. However, we can't unconditionally send a
-	// message since we don't know the state of the stream (is it initialized?).
-	// This leaves us with having two separate mutexes, one for the state and
-	// another one for the stream (to make sure we wait until the Next goroutine
-	// has finished Recv'ing).
-	drainSignalSent := false
-	if i.stateMu.initialized {
-		if err := i.sendDrainSignal(ctx); err != nil {
-			return allMeta
-		}
-		drainSignalSent = true
-		i.stateMu.nextShouldExit = true
-		for i.stateMu.nextRunning {
-			i.stateMu.nextExited.Wait()
-		}
-		// It is possible that Next goroutine has buffered more metadata, so we
-		// need to grab it.
-		allMeta = append(allMeta, i.stateMu.bufferedMeta...)
-		i.stateMu.bufferedMeta = i.stateMu.bufferedMeta[:0]
-	}
-
-	// Note that unlocking defer from above will execute after this defer because
-	// the unlocking one will be pushed below on the stack, so we still will have
-	// the lock when this one is executed.
-	defer i.closeLocked()
-
-	if err := i.maybeInitLocked(ctx); err != nil {
+	if err := i.maybeInit(ctx); err != nil {
 		if log.V(1) {
 			log.Warningf(ctx, "Inbox unable to initialize stream while draining metadata: %+v", err)
 		}
 		return allMeta
 	}
-	if !drainSignalSent {
-		if err := i.sendDrainSignal(ctx); err != nil {
-			return allMeta
-		}
+	if err := i.sendDrainSignal(ctx); err != nil {
+		return allMeta
 	}
 
-	i.streamMu.Lock()
-	defer i.streamMu.Unlock()
 	for {
-		msg, err := i.streamMu.stream.Recv()
+		msg, err := i.stream.Recv()
 		if err != nil {
 			if err == io.EOF {
 				break

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -178,13 +178,14 @@ func TestInboxTimeout(t *testing.T) {
 }
 
 // TestInboxShutdown is a random test that spawns a goroutine for handling a
-// FlowStream RPC (setting up an inbound stream, or RunWithStream), a goroutine
-// to read from an Inbox (Next goroutine), and a goroutine to drain the Inbox
-// (DrainMeta goroutine). These goroutines race against each other and the
+// FlowStream RPC (setting up an inbound stream, or RunWithStream), and a
+// goroutine to read from an Inbox (Next and DrainMeta goroutine) that gets
+// randomly canceled.
+// These goroutines race against each other and the
 // desired state is that everything is cleaned up at the end. Examples of
 // scenarios that are tested by this test include but are not limited to:
 //  - DrainMeta called before Next and before a stream arrives.
-//  - DrainMeta called concurrently with Next with an active stream.
+//  - DrainMeta called with an active stream.
 //  - A forceful cancellation of Next but no call to DrainMeta.
 func TestInboxShutdown(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -197,17 +198,48 @@ func TestInboxShutdown(t *testing.T) {
 		// shutdown scenarios in the middle of data processing are always tested. If
 		// false, they sometimes will be.
 		infiniteBatches    = rng.Float64() < 0.5
-		drainMetaSleep     = time.Millisecond * time.Duration(rng.Intn(10))
+		cancelSleep        = time.Millisecond * time.Duration(rng.Intn(10))
 		nextSleep          = time.Millisecond * time.Duration(rng.Intn(10))
 		runWithStreamSleep = time.Millisecond * time.Duration(rng.Intn(10))
 		typs               = []*types.T{types.Int}
 		batch              = coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), 0 /* length */, rng.Float64())
 	)
 
-	for _, runDrainMetaGoroutine := range []bool{false, true} {
+	// drainMetaScenario specifies when DrainMeta should be called in the Next
+	// goroutine.
+	type drainMetaScenario int
+	const (
+		// drainMetaBeforeNext specifies that DrainMeta should be called before the
+		// Next goroutine.
+		drainMetaBeforeNext drainMetaScenario = iota
+		// drainMetaPrematurely specifies that DrainMeta should be called after the
+		// first call to Next.
+		drainMetaPrematurely
+		// drianMetaAfterNextIsExhausted specifies that DrainMeta should be called
+		// after Next returns a zero-length batch.
+		drainMetaAfterNextIsExhausted
+		// drainMetaNotCalled specifies that DrainMeta is not called during
+		// execution.
+		drainMetaNotCalled
+		maxDrainMetaScenario
+	)
+
+	for _, cancel := range []bool{false, true} {
 		for _, runNextGoroutine := range []bool{false, true} {
+			drainScenario := drainMetaScenario(rng.Intn(int(maxDrainMetaScenario)))
+			if infiniteBatches {
+				// This test won't finish unless we drain at some point.
+				drainScenario = drainMetaPrematurely
+			}
+			if cancel {
+				// If a cancel happens, we don't want to call DrainMeta because the mock
+				// RPC layer doesn't handle this case well. The drain signal could be
+				// sent over a closed channel. The real RPC layer would return EOF, but
+				// it's not easy to check for a closed channel without reading from it.
+				drainScenario = drainMetaNotCalled
+			}
 			for _, runRunWithStreamGoroutine := range []bool{false, true} {
-				if runDrainMetaGoroutine == false && runNextGoroutine == false && runRunWithStreamGoroutine == true {
+				if runNextGoroutine == false && runRunWithStreamGoroutine == true {
 					// This is sort of like a remote node connecting to the inbox, but the
 					// inbox will never be spawned. This is dealt with by another part of
 					// the code (the flow registry times out inbound RPCs if a consumer is
@@ -217,8 +249,8 @@ func TestInboxShutdown(t *testing.T) {
 				rpcLayer := makeMockFlowStreamRPCLayer()
 
 				t.Run(fmt.Sprintf(
-					"drain=%t/next=%t/stream=%t/inf=%t",
-					runDrainMetaGoroutine, runNextGoroutine, runRunWithStreamGoroutine, infiniteBatches,
+					"cancel=%t/next=%t/stream=%t/inf=%t",
+					cancel, runNextGoroutine, runRunWithStreamGoroutine, infiniteBatches,
 				), func(t *testing.T) {
 					inboxCtx, inboxCancel := context.WithCancel(context.Background())
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
@@ -270,28 +302,26 @@ func TestInboxShutdown(t *testing.T) {
 											return
 										}
 										var draining uint32
-										if runDrainMetaGoroutine {
-											// Listen for the drain signal.
-											wg.Add(1)
-											go func() {
-												defer wg.Done()
-												for {
-													cs, err := rpcLayer.client.Recv()
-													if cs != nil && cs.DrainRequest != nil {
-														atomic.StoreUint32(&draining, 1)
+										// Listen for the drain signal.
+										wg.Add(1)
+										go func() {
+											defer wg.Done()
+											for {
+												cs, err := rpcLayer.client.Recv()
+												if cs != nil && cs.DrainRequest != nil {
+													atomic.StoreUint32(&draining, 1)
+													return
+												}
+												// TODO(asubiotto): Generate some metadata and test
+												//  that it is received.
+												if err != nil {
+													if err == io.EOF {
 														return
 													}
-													// TODO(asubiotto): Generate some metadata and test
-													//  that it is received.
-													if err != nil {
-														if err == io.EOF {
-															return
-														}
-														errCh <- err
-													}
+													errCh <- err
 												}
-											}()
-										}
+											}
+										}()
 										msg := &execinfrapb.ProducerMessage{Data: execinfrapb.ProducerData{RawBytes: buffer.Bytes()}}
 										batchesToSend := rng.Intn(65536)
 										for i := 0; infiniteBatches || i < batchesToSend; i++ {
@@ -331,6 +361,10 @@ func TestInboxShutdown(t *testing.T) {
 									if !runNextGoroutine {
 										return
 									}
+									if drainScenario == drainMetaBeforeNext {
+										_ = inbox.DrainMeta(inboxCtx)
+										return
+									}
 									if nextSleep != 0 {
 										time.Sleep(nextSleep)
 									}
@@ -340,6 +374,13 @@ func TestInboxShutdown(t *testing.T) {
 									)
 									for !done && err == nil {
 										err = colexecerror.CatchVectorizedRuntimeError(func() { b := inbox.Next(inboxCtx); done = b.Length() == 0 })
+										if drainScenario == drainMetaPrematurely {
+											_ = inbox.DrainMeta(inboxCtx)
+											return
+										}
+									}
+									if drainScenario == drainMetaAfterNextIsExhausted {
+										_ = inbox.DrainMeta(inboxCtx)
 									}
 									errCh <- err
 								}()
@@ -347,24 +388,19 @@ func TestInboxShutdown(t *testing.T) {
 							},
 						},
 						{
-							name: "DrainMeta",
+							name: "Cancel",
 							asyncOperation: func() chan error {
 								errCh := make(chan error)
 								go func() {
 									defer func() {
-										inboxCancel()
+										if cancel {
+											inboxCancel()
+										}
 										close(errCh)
 									}()
-									// Sleep before checking for whether to run a drain meta
-									// goroutine or not, because we want to insert a potential delay
-									// before canceling the inbox context in any case.
-									if drainMetaSleep != 0 {
-										time.Sleep(drainMetaSleep)
+									if cancelSleep != 0 {
+										time.Sleep(cancelSleep)
 									}
-									if !runDrainMetaGoroutine {
-										return
-									}
-									_ = inbox.DrainMeta(inboxCtx)
 								}()
 								return errCh
 							},

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -63,7 +63,7 @@ type Outbox struct {
 	draining        uint32
 	metadataSources []execinfrapb.MetadataSource
 	// closers is a slice of Closers that need to be Closed on termination.
-	closers []colexec.IdempotentCloser
+	closers []colexec.Closer
 
 	scratch struct {
 		buf *bytes.Buffer
@@ -81,7 +81,7 @@ func NewOutbox(
 	input colexecbase.Operator,
 	typs []*types.T,
 	metadataSources []execinfrapb.MetadataSource,
-	toClose []colexec.IdempotentCloser,
+	toClose []colexec.Closer,
 ) (*Outbox, error) {
 	c, err := colserde.NewArrowBatchConverter(typs)
 	if err != nil {
@@ -108,7 +108,7 @@ func NewOutbox(
 
 func (o *Outbox) close(ctx context.Context) {
 	for _, closer := range o.closers {
-		if err := closer.IdempotentClose(ctx); err != nil {
+		if err := closer.Close(ctx); err != nil {
 			if log.V(1) {
 				log.Infof(ctx, "error closing Closer: %v", err)
 			}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -122,10 +122,10 @@ type vectorizedFlow struct {
 
 	testingInfo struct {
 		// numClosers is the number of components in the flow that implement
-		// IdempotentClose. This is used for testing assertions.
+		// Close. This is used for testing assertions.
 		numClosers int32
 		// numClosed is a pointer to an int32 that is updated atomically when a
-		// component's IdempotentClose method is called. This is used for testing
+		// component's Close method is called. This is used for testing
 		// assertions.
 		numClosed *int32
 	}
@@ -402,7 +402,7 @@ type flowCreatorHelper interface {
 type opDAGWithMetaSources struct {
 	rootOperator    colexecbase.Operator
 	metadataSources []execinfrapb.MetadataSource
-	toClose         []colexec.IdempotentCloser
+	toClose         []colexec.Closer
 }
 
 // remoteComponentCreator is an interface that abstracts the constructors for
@@ -413,7 +413,7 @@ type remoteComponentCreator interface {
 		input colexecbase.Operator,
 		typs []*types.T,
 		metadataSources []execinfrapb.MetadataSource,
-		toClose []colexec.IdempotentCloser,
+		toClose []colexec.Closer,
 	) (*colrpc.Outbox, error)
 	newInbox(allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error)
 }
@@ -425,7 +425,7 @@ func (vectorizedRemoteComponentCreator) newOutbox(
 	input colexecbase.Operator,
 	typs []*types.T,
 	metadataSources []execinfrapb.MetadataSource,
-	toClose []colexec.IdempotentCloser,
+	toClose []colexec.Closer,
 ) (*colrpc.Outbox, error) {
 	return colrpc.NewOutbox(allocator, input, typs, metadataSources, toClose)
 }
@@ -565,7 +565,7 @@ func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 	outputTyps []*types.T,
 	stream *execinfrapb.StreamEndpointSpec,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
-	toClose []colexec.IdempotentCloser,
+	toClose []colexec.Closer,
 	factory coldata.ColumnFactory,
 ) (execinfra.OpNode, error) {
 	// TODO(yuzefovich): we should collect some statistics on the outbox (e.g.
@@ -612,7 +612,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 	outputTyps []*types.T,
 	output *execinfrapb.OutputRouterSpec,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
-	toClose []colexec.IdempotentCloser,
+	toClose []colexec.Closer,
 	factory coldata.ColumnFactory,
 ) error {
 	if output.Type != execinfrapb.OutputRouterSpec_BY_HASH {
@@ -704,7 +704,7 @@ func (s *vectorizedFlowCreator) setupInput(
 	input execinfrapb.InputSyncSpec,
 	opt flowinfra.FuseOpt,
 	factory coldata.ColumnFactory,
-) (colexecbase.Operator, []execinfrapb.MetadataSource, []colexec.IdempotentCloser, error) {
+) (colexecbase.Operator, []execinfrapb.MetadataSource, []colexec.Closer, error) {
 	inputStreamOps := make([]colexec.SynchronizerInput, 0, len(input.Streams))
 	// Before we can safely use types we received over the wire in the
 	// operators, we need to make sure they are hydrated. In row execution
@@ -768,13 +768,13 @@ func (s *vectorizedFlowCreator) setupInput(
 			}
 			op = os
 			metaSources = []execinfrapb.MetadataSource{os}
-			toClose = []colexec.IdempotentCloser{os}
+			toClose = []colexec.Closer{os}
 		} else {
 			if opt == flowinfra.FuseAggressively {
 				sync := colexec.NewSerialUnorderedSynchronizer(inputStreamOps)
 				op = sync
 				metaSources = []execinfrapb.MetadataSource{sync}
-				toClose = []colexec.IdempotentCloser{sync}
+				toClose = []colexec.Closer{sync}
 			} else {
 				sync := colexec.NewParallelUnorderedSynchronizer(inputStreamOps, s.waitGroup)
 				op = sync
@@ -821,7 +821,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 	op colexecbase.Operator,
 	opOutputTypes []*types.T,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
-	toClose []colexec.IdempotentCloser,
+	toClose []colexec.Closer,
 	factory coldata.ColumnFactory,
 ) error {
 	output := &pspec.Output[0]
@@ -972,7 +972,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 		// toClose is similar to metadataSourcesQueue with the difference that these
 		// components do not produce metadata and should be Closed even during
 		// non-graceful termination.
-		toClose := make([]colexec.IdempotentCloser, 0, 1)
+		toClose := make([]colexec.Closer, 0, 1)
 		inputs = inputs[:0]
 		for i := range pspec.Input {
 			input, metadataSources, closers, err := s.setupInput(ctx, flowCtx, pspec.Input[i], opt, factory)
@@ -1018,14 +1018,14 @@ func (s *vectorizedFlowCreator) setupFlow(
 		metadataSourcesQueue = append(metadataSourcesQueue, result.MetadataSources...)
 		if flowCtx.Cfg != nil && flowCtx.Cfg.TestingKnobs.CheckVectorizedFlowIsClosedCorrectly {
 			for _, closer := range result.ToClose {
-				func(c colexec.IdempotentCloser) {
+				func(c colexec.Closer) {
 					closed := false
 					toClose = append(toClose, &colexec.CallbackCloser{CloseCb: func(ctx context.Context) error {
 						if !closed {
 							closed = true
 							atomic.AddInt32(&s.numClosed, 1)
 						}
-						return c.IdempotentClose(ctx)
+						return c.Close(ctx)
 					}})
 				}(closer)
 			}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -120,6 +120,16 @@ type vectorizedFlow struct {
 		}
 	}
 
+	testingInfo struct {
+		// numClosers is the number of components in the flow that implement
+		// IdempotentClose. This is used for testing assertions.
+		numClosers int32
+		// numClosed is a pointer to an int32 that is updated atomically when a
+		// component's IdempotentClose method is called. This is used for testing
+		// assertions.
+		numClosed *int32
+	}
+
 	testingKnobs struct {
 		// onSetupFlow is a testing knob that is called before calling
 		// creator.setupFlow with the given creator.
@@ -234,6 +244,8 @@ func (f *vectorizedFlow) Setup(
 	}
 	_, err = creator.setupFlow(ctx, f.GetFlowCtx(), spec.Processors, opt)
 	if err == nil {
+		f.testingInfo.numClosers = creator.numClosers
+		f.testingInfo.numClosed = &creator.numClosed
 		f.operatorConcurrency = creator.operatorConcurrency
 		f.streamingMemAccounts = append(f.streamingMemAccounts, creator.streamingMemAccounts...)
 		f.monitors = append(f.monitors, creator.monitors...)
@@ -284,6 +296,12 @@ func (f *vectorizedFlow) Cleanup(ctx context.Context) {
 	}
 	for _, mon := range f.monitors {
 		mon.Stop(ctx)
+	}
+
+	if f.Cfg.TestingKnobs.CheckVectorizedFlowIsClosedCorrectly {
+		if numClosed := atomic.LoadInt32(f.testingInfo.numClosed); numClosed != f.testingInfo.numClosers {
+			colexecerror.InternalError(fmt.Sprintf("expected %d components to be closed, but found that only %d were", f.testingInfo.numClosers, numClosed))
+		}
 	}
 
 	f.tempStorage.createdStateMu.Lock()
@@ -457,6 +475,11 @@ type vectorizedFlowCreator struct {
 
 	diskQueueCfg colcontainer.DiskQueueCfg
 	fdSemaphore  semaphore.Semaphore
+
+	// numClosers and numClosed are used to assert during testing that the
+	// expected number of components are closed.
+	numClosers int32
+	numClosed  int32
 }
 
 func newVectorizedFlowCreator(
@@ -654,7 +677,10 @@ func (s *vectorizedFlowCreator) setupRouter(
 				}
 			}
 			s.streamIDToInputOp[stream.StreamID] = opDAGWithMetaSources{
-				rootOperator: localOp, metadataSources: []execinfrapb.MetadataSource{op}, toClose: toClose,
+				rootOperator:    localOp,
+				metadataSources: []execinfrapb.MetadataSource{op},
+				// toClose will be closed by the HashRouter.
+				toClose: nil,
 			}
 		}
 	}
@@ -678,7 +704,7 @@ func (s *vectorizedFlowCreator) setupInput(
 	input execinfrapb.InputSyncSpec,
 	opt flowinfra.FuseOpt,
 	factory coldata.ColumnFactory,
-) (colexecbase.Operator, []execinfrapb.MetadataSource, error) {
+) (colexecbase.Operator, []execinfrapb.MetadataSource, []colexec.IdempotentCloser, error) {
 	inputStreamOps := make([]colexec.SynchronizerInput, 0, len(input.Streams))
 	// Before we can safely use types we received over the wire in the
 	// operators, we need to make sure they are hydrated. In row execution
@@ -687,7 +713,7 @@ func (s *vectorizedFlowCreator) setupInput(
 	// their types from InputSyncSpec, so this is a convenient place to do the
 	// hydration so that all operators get the valid types.
 	if err := execinfrapb.HydrateTypeSlice(flowCtx.EvalCtx, input.ColumnTypes); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	for _, inputStream := range input.Streams {
 		switch inputStream.Type {
@@ -696,19 +722,20 @@ func (s *vectorizedFlowCreator) setupInput(
 			inputStreamOps = append(inputStreamOps, colexec.SynchronizerInput{
 				Op:              in.rootOperator,
 				MetadataSources: in.metadataSources,
+				ToClose:         in.toClose,
 			})
 		case execinfrapb.StreamEndpointSpec_REMOTE:
 			// If the input is remote, the input operator does not exist in
 			// streamIDToInputOp. Create an inbox.
 			if err := s.checkInboundStreamID(inputStream.StreamID); err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			inbox, err := s.remoteComponentCreator.newInbox(
 				colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx), factory),
 				input.ColumnTypes, inputStream.StreamID,
 			)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			s.addStreamEndpoint(inputStream.StreamID, inbox, s.waitGroup)
 			op := colexecbase.Operator(inbox)
@@ -718,16 +745,17 @@ func (s *vectorizedFlowCreator) setupInput(
 					execinfrapb.StreamIDTagKey, nil, /* monitors */
 				)
 				if err != nil {
-					return nil, nil, err
+					return nil, nil, nil, err
 				}
 			}
 			inputStreamOps = append(inputStreamOps, colexec.SynchronizerInput{Op: op, MetadataSources: []execinfrapb.MetadataSource{inbox}})
 		default:
-			return nil, nil, errors.Errorf("unsupported input stream type %s", inputStream.Type)
+			return nil, nil, nil, errors.Errorf("unsupported input stream type %s", inputStream.Type)
 		}
 	}
 	op := inputStreamOps[0].Op
 	metaSources := inputStreamOps[0].MetadataSources
+	toClose := inputStreamOps[0].ToClose
 	if len(inputStreamOps) > 1 {
 		statsInputs := inputStreamOps
 		if input.Type == execinfrapb.InputSyncSpec_ORDERED {
@@ -736,19 +764,25 @@ func (s *vectorizedFlowCreator) setupInput(
 				inputStreamOps, input.ColumnTypes, execinfrapb.ConvertToColumnOrdering(input.Ordering),
 			)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			op = os
 			metaSources = []execinfrapb.MetadataSource{os}
+			toClose = []colexec.IdempotentCloser{os}
 		} else {
 			if opt == flowinfra.FuseAggressively {
 				sync := colexec.NewSerialUnorderedSynchronizer(inputStreamOps)
 				op = sync
 				metaSources = []execinfrapb.MetadataSource{sync}
+				toClose = []colexec.IdempotentCloser{sync}
 			} else {
 				sync := colexec.NewParallelUnorderedSynchronizer(inputStreamOps, s.waitGroup)
 				op = sync
 				metaSources = []execinfrapb.MetadataSource{sync}
+				// toClose is set to nil because the ParallelUnorderedSynchronizer takes
+				// care of closing these components itself since they need to be closed
+				// from the same goroutine as Next.
+				toClose = nil
 				s.operatorConcurrency = true
 			}
 			// Don't use the unordered synchronizer's inputs for stats collection
@@ -768,18 +802,17 @@ func (s *vectorizedFlowCreator) setupInput(
 				op, statsInputsAsOps, -1 /* id */, "" /* idTagKey */, nil, /* monitors */
 			)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 		}
 	}
-	return op, metaSources, nil
+	return op, metaSources, toClose, nil
 }
 
 // setupOutput sets up any necessary infrastructure according to the output
-// spec of pspec. The metadataSourcesQueue is fully consumed by either
-// connecting it to a component that can drain these MetadataSources (root
-// materializer or outbox) or storing it in streamIDToInputOp with the given op
-// to be processed later.
+// spec of pspec. The metadataSourcesQueue and toClose slices are fully consumed
+// by either passing them to an outbox or HashRouter to be drained/closed, or
+// storing them in streamIDToInputOp with the given op to be processed later.
 // NOTE: The caller must not reuse the metadataSourcesQueue.
 func (s *vectorizedFlowCreator) setupOutput(
 	ctx context.Context,
@@ -942,11 +975,12 @@ func (s *vectorizedFlowCreator) setupFlow(
 		toClose := make([]colexec.IdempotentCloser, 0, 1)
 		inputs = inputs[:0]
 		for i := range pspec.Input {
-			input, metadataSources, err := s.setupInput(ctx, flowCtx, pspec.Input[i], opt, factory)
+			input, metadataSources, closers, err := s.setupInput(ctx, flowCtx, pspec.Input[i], opt, factory)
 			if err != nil {
 				return nil, err
 			}
 			metadataSourcesQueue = append(metadataSourcesQueue, metadataSources...)
+			toClose = append(toClose, closers...)
 			inputs = append(inputs, input)
 		}
 
@@ -982,7 +1016,23 @@ func (s *vectorizedFlowCreator) setupFlow(
 			return nil, errors.Wrapf(err, "not enough memory to setup vectorized plan")
 		}
 		metadataSourcesQueue = append(metadataSourcesQueue, result.MetadataSources...)
-		toClose = append(toClose, result.ToClose...)
+		if flowCtx.Cfg != nil && flowCtx.Cfg.TestingKnobs.CheckVectorizedFlowIsClosedCorrectly {
+			for _, closer := range result.ToClose {
+				func(c colexec.IdempotentCloser) {
+					closed := false
+					toClose = append(toClose, &colexec.CallbackCloser{CloseCb: func(ctx context.Context) error {
+						if !closed {
+							closed = true
+							atomic.AddInt32(&s.numClosed, 1)
+						}
+						return c.IdempotentClose(ctx)
+					}})
+				}(closer)
+			}
+			s.numClosers += int32(len(result.ToClose))
+		} else {
+			toClose = append(toClose, result.ToClose...)
+		}
 
 		op := result.Op
 		if s.recordingStats {

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -57,7 +57,7 @@ type callbackCloser struct {
 	closeCb func() error
 }
 
-func (c callbackCloser) IdempotentClose(_ context.Context) error {
+func (c callbackCloser) Close(_ context.Context) error {
 	return c.closeCb()
 }
 
@@ -244,7 +244,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					idToClosed.Unlock()
 					outbox, err := colrpc.NewOutbox(
 						colmem.NewAllocator(ctx, outboxMemAcc, testColumnFactory), outboxInput, typs, outboxMetadataSources,
-						[]colexec.IdempotentCloser{callbackCloser{closeCb: func() error {
+						[]colexec.Closer{callbackCloser{closeCb: func() error {
 							idToClosed.Lock()
 							idToClosed.mapping[id] = true
 							idToClosed.Unlock()
@@ -326,7 +326,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					typs,
 					nil, /* output */
 					[]execinfrapb.MetadataSource{materializerMetadataSource},
-					[]colexec.IdempotentCloser{callbackCloser{closeCb: func() error {
+					[]colexec.Closer{callbackCloser{closeCb: func() error {
 						materializerCalledClose = true
 						return nil
 					}}}, /* toClose */

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -44,7 +44,7 @@ func (c callbackRemoteComponentCreator) newOutbox(
 	input colexecbase.Operator,
 	typs []*types.T,
 	metadataSources []execinfrapb.MetadataSource,
-	toClose []colexec.IdempotentCloser,
+	toClose []colexec.Closer,
 ) (*colrpc.Outbox, error) {
 	return c.newOutboxFn(allocator, input, typs, metadataSources)
 }

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -211,6 +211,10 @@ type TestingKnobs struct {
 	// stall time and bytes sent. It replaces them with a zero value.
 	DeterministicStats bool
 
+	// CheckVectorizedFlowIsClosedCorrectly checks that all components in a flow
+	// were closed explicitly in flow.Cleanup.
+	CheckVectorizedFlowIsClosedCorrectly bool
+
 	// Changefeed contains testing knobs specific to the changefeed system.
 	Changefeed base.ModuleTestingKnobs
 

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1244,7 +1244,7 @@ func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
 	}
 
 	distSQLKnobs := &execinfra.TestingKnobs{
-		MetadataTestLevel: execinfra.Off, DeterministicStats: true,
+		MetadataTestLevel: execinfra.Off, DeterministicStats: true, CheckVectorizedFlowIsClosedCorrectly: true,
 	}
 	if cfg.sqlExecUseDisk {
 		distSQLKnobs.ForceDiskSpill = true


### PR DESCRIPTION
Since DrainMeta and Close are now called from the same goroutine as Next, the implementations can be simplified. This PR does that in a couple of commits and fixes a bug in the first commit.

Release note: None