### PR TITLE
vendor: bump Pebble to d845c8c2d870

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200626145914-3b86a4009c3b
+	github.com/cockroachdb/pebble v0.0.0-20200701140535-d845c8c2d870
 	github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200626145914-3b86a4009c3b h1:b5RgMeYJLTpUIDQiqD2sVnH50coTiT2fWFAWzl8nH9c=
-github.com/cockroachdb/pebble v0.0.0-20200626145914-3b86a4009c3b/go.mod h1:crLnbSFbwAcQNs9FPfI1avHb5BqVgqZcr4r+IzpJ5FM=
+github.com/cockroachdb/pebble v0.0.0-20200701140535-d845c8c2d870 h1:i3u72LNTDBSV49gRfJkfv/wjQHOnb9zknH+DXs3+zEI=
+github.com/cockroachdb/pebble v0.0.0-20200701140535-d845c8c2d870/go.mod h1:crLnbSFbwAcQNs9FPfI1avHb5BqVgqZcr4r+IzpJ5FM=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd h1:KFOt5I9nEKZgCnOSmy8r4Oykh8BYQO8bFOTgHDS8YZA=


### PR DESCRIPTION
```
7cbb7d6 internal/rate: deflake TestLongRunningQPS
06feeaa db: bump nextFileNum past obsolete file numbers on Open
fc51635 build: rework build rules to remove redundancy
839ee18 build: replace GO111MODULE=off with -mod=vendor
133d4e3 cmd/pebble: output a Go-bench format summary line for `bench ycsb`
daeb562 db: add Metrics.Total and Iterator.Metrics
c459622 db: fix DeleteRangeFlushDelay for batches edited with SetRepr, Apply
931bab4 travis: build all variations of go1.14
```