### PR TITLE
build,cmd/roachtest: progress towards nightly Pebble benchmarking

### DIFF
--- a/build/teamcity-nightly-pebble.sh
+++ b/build/teamcity-nightly-pebble.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# This script is run by the Pebble Nightly - AWS TeamCity build
+# configuration.
+
+set -eo pipefail
+
+if [[ "$GOOGLE_EPHEMERAL_CREDENTIALS" ]]; then
+  echo "$GOOGLE_EPHEMERAL_CREDENTIALS" > creds.json
+  gcloud auth activate-service-account --key-file=creds.json
+  export ROACHPROD_USER=teamcity
+else
+  echo 'warning: GOOGLE_EPHEMERAL_CREDENTIALS not set' >&2
+  echo "Assuming that you've run \`gcloud auth login\` from inside the builder." >&2
+fi
+
+set -ux
+
+if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
+  ssh-keygen -q -N "" -f ~/.ssh/id_rsa
+fi
+
+# The artifacts dir should match up with that supplied by TC.
+artifacts=$PWD/artifacts
+mkdir -p "${artifacts}"
+chmod o+rwx "${artifacts}"
+
+# Disable global -json flag.
+export PATH=$PATH:$(GOFLAGS=; go env GOPATH)/bin
+
+build_tag=$(git describe --abbrev=0 --tags --match=v[0-9]*)
+
+make bin/roachprod bin/roachtest
+
+rm -fr vendor/github.com/cockroachdb/pebble
+git clone https://github.com/cockroachdb/pebble vendor/github.com/cockroachdb/pebble
+GOOS=linux go build -o pebble.linux github.com/cockroachdb/pebble/cmd/pebble
+export PEBBLE_BIN=pebble.linux
+
+# NB: We specify "true" for the --cockroach and --workload binaries to
+# prevent roachtest from complaining (and failing) when it can't find
+# them. The pebble roachtests don't actually use either cockroach or
+# workload.
+exit_status=0
+if ! timeout -s INT $((1000*60)) bin/roachtest run \
+  --build-tag "${build_tag}" \
+  --slack-token "${SLACK_TOKEN-}" \
+  --cluster-id "${TC_BUILD_ID-$(date +"%Y%m%d%H%M%S")}" \
+  --cloud "aws" \
+  --cockroach "true" \
+  --roachprod "$PWD/bin/roachprod" \
+  --workload "true" \
+  --artifacts "$artifacts" \
+  --parallelism 3 \
+  --teamcity \
+  --cpu-quota=384 \
+  tag:pebble pebble; then
+  exit_status=$?
+fi
+
+# TODO(peter):
+# - Collect the artifacts. Add them to a branch of the Pebble repo.
+# - Process the artifacts into a static site served by Github pages.
+
+exit "$exit_status"

--- a/pkg/cmd/roachtest/pebble.go
+++ b/pkg/cmd/roachtest/pebble.go
@@ -1,0 +1,89 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+)
+
+func registerPebble(r *testRegistry) {
+	pebble := os.Getenv("PEBBLE_BIN")
+	if pebble == "" {
+		pebble = "./pebble.linux"
+	}
+
+	run := func(ctx context.Context, t *test, c *cluster, size int) {
+		c.Put(ctx, pebble, "./pebble")
+
+		const initialKeys = 10_000_000
+		const cache = 4 << 30 // 4 GB
+		const duration = 10 * time.Minute
+		const dataDir = "$(dirname {store-dir})"
+		const dataTar = dataDir + "/data.tar"
+		const benchDir = dataDir + "/bench"
+
+		// Generate the initial DB state. This is somewhat time consuming for
+		// larger value sizes, so we do this once and reuse the same DB state on
+		// all of the workloads.
+		initCmd := fmt.Sprintf(
+			"./pebble bench ycsb %s"+
+				" --wipe "+
+				" --workload=read=100"+
+				" --concurrency=1"+
+				" --values=%d"+
+				" --initial-keys=%d"+
+				" --cache=%d"+
+				" --num-ops=1",
+			benchDir, size, initialKeys, cache)
+		c.Run(ctx, c.All(), initCmd)
+		c.Run(ctx, c.All(), "rm -f "+dataTar+"; tar cvPf "+dataTar+" "+benchDir)
+
+		for _, workload := range []string{"A", "B", "C", "D", "E"} {
+			keys := "zipf"
+			switch workload {
+			case "D":
+				keys = "uniform"
+			}
+
+			cmd := fmt.Sprintf(
+				"rm -fr %s && tar xPf %s &&"+
+					" ./pebble bench ycsb %s"+
+					" --workload=%s"+
+					" --concurrency=256"+
+					" --values=%d"+
+					" --keys=%s"+
+					" --initial-keys=0"+
+					" --prepopulated-keys=%d"+
+					" --cache=%d"+
+					" --duration=%s",
+				benchDir, dataTar, benchDir, workload, size, keys, initialKeys, cache, duration)
+			c.Run(ctx, c.All(), cmd)
+		}
+	}
+
+	for _, size := range []int{64, 1024, 4096} {
+		size := size
+		r.Add(testSpec{
+			Name:       fmt.Sprintf("pebble/ycsb/size=%d", size),
+			Owner:      OwnerStorage,
+			Timeout:    2 * time.Hour,
+			MinVersion: "v20.1.0",
+			Cluster:    makeClusterSpec(1, cpu(16)),
+			Tags:       []string{"pebble"},
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				run(ctx, t, c, size)
+			},
+		})
+	}
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -60,6 +60,7 @@ func registerTests(r *testRegistry) {
 	registerLibPQ(r)
 	registerNamespaceUpgrade(r)
 	registerNetwork(r)
+	registerPebble(r)
 	registerPgjdbc(r)
 	registerPgx(r)
 	registerPsycopg(r)


### PR DESCRIPTION
#### build: add teamcity-nightly-pebble.sh

Release note: None

#### cmd/roachtest: add pebble/ycsb/* roachtests

Add `pebble/ycsb/size={64,1024,4096}` roachtests which run Pebble-only 
version of the ycsb A, B, C, D, and E workloads with different value sizes.

The pebble roachtests are benchmarks, not correctness tests. They are 
hidden behind the `pebble` tag and only run if `tag:pebble` is specified.

Release note: None

#### cmd/roachtest: allow disabling of the post-test checks

Allow disabling the post-test replica divergence and dead-node checks.
These checks only make sense for tests which run a cockroach cluster.

Release note: None