### PR TITLE
logictest: audit vectorize logic test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -4,11 +4,20 @@
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
+# NOTE: all queries in this file should run with vectorize=experimental_always
+# unless they are known to be unsupported (like CREATE, INSERT, etc). If you do
+# need to execute an unsupported query, follow the pattern of
+#   RESET vectorize
+#   <unsupported query>
+#   SET vectorize = experimental_always
 statement ok
-CREATE TABLE a (a INT, b INT, c INT4, PRIMARY KEY (a, b))
+SET vectorize = experimental_always
 
 statement ok
-INSERT INTO a SELECT g//2, g, g FROM generate_series(0,2000) g(g)
+RESET vectorize;
+CREATE TABLE a (a INT, b INT, c INT4, PRIMARY KEY (a, b));
+INSERT INTO a SELECT g//2, g, g FROM generate_series(0,2000) g(g);
+SET vectorize = experimental_always
 
 query II
 SELECT a, CASE WHEN a = 0 THEN 0 WHEN a = 1 THEN 3 ELSE 5 END FROM a ORDER BY 1, 2 LIMIT 6
@@ -22,7 +31,9 @@ SELECT a, CASE WHEN a = 0 THEN 0 WHEN a = 1 THEN 3 ELSE 5 END FROM a ORDER BY 1,
 
 # Regression test for 40574.
 statement ok
-CREATE TABLE t40574(pk INTEGER PRIMARY KEY, col0 INTEGER, col1 FLOAT, col2 TEXT, col3 INTEGER, col4 FLOAT, col5 TEXT)
+RESET vectorize;
+CREATE TABLE t40574(pk INTEGER PRIMARY KEY, col0 INTEGER, col1 FLOAT, col2 TEXT, col3 INTEGER, col4 FLOAT, col5 TEXT);
+SET vectorize = experimental_always
 
 query I
 SELECT pk FROM t40574 WHERE (col0 > 9 AND (col1 <= 6.38 OR col0 =5) AND (col0 = 7 OR col4 = 7))
@@ -52,13 +63,11 @@ SELECT b FROM a WHERE b = 0 OR 1/b = 1
 1
 
 statement ok
+RESET vectorize;
 CREATE TABLE bools (b BOOL, i INT, PRIMARY KEY (b, i)); INSERT INTO bools VALUES (true, 0), (false, 1), (true, 2), (false, 3);
-
-statement ok
-CREATE TABLE nulls (a INT, b INT)
-
-statement ok
-INSERT INTO nulls VALUES (NULL, NULL), (NULL, 1), (1, NULL), (1, 1)
+CREATE TABLE nulls (a INT, b INT);
+INSERT INTO nulls VALUES (NULL, NULL), (NULL, 1), (1, NULL), (1, 1);
+SET vectorize = experimental_always
 
 query I
 SELECT count(*) FROM a
@@ -207,18 +216,15 @@ true 2
 # Mismatched column types in projection. Not handled yet but should fall back
 # gracefully.
 statement ok
-CREATE TABLE intdecfloat (a INT, b DECIMAL, c INT4, d INT2, e FLOAT8)
-
-statement ok
-INSERT INTO intdecfloat VALUES (1, 2.0, 3, 4, 3.5)
+RESET vectorize;
+CREATE TABLE intdecfloat (a INT, b DECIMAL, c INT4, d INT2, e FLOAT8);
+INSERT INTO intdecfloat VALUES (1, 2.0, 3, 4, 3.5);
+SET vectorize = experimental_always
 
 query I
 SELECT (a + b)::INT FROM intdecfloat
 ----
 3
-
-statement ok
-SET vectorize = experimental_always
 
 query BB
 SELECT b > a, e < b FROM intdecfloat
@@ -250,17 +256,11 @@ SELECT a/b, a/c, b/c, b/d, c/d FROM intdecfloat
 ----
 0.5  0.33333333333333333333  0.66666666666666666667  0.5  0.75
 
-statement ok
-RESET vectorize
-
 # vectorized decimal arithmetic
 statement ok
-CREATE table decimals (a DECIMAL, b DECIMAL)
-
-statement ok
-INSERT INTO decimals VALUES(123.0E200, 12.3)
-
-statement ok
+RESET vectorize;
+CREATE table decimals (a DECIMAL, b DECIMAL);
+INSERT INTO decimals VALUES(123.0E200, 12.3);
 SET vectorize = experimental_always
 
 query R
@@ -283,9 +283,6 @@ SELECT a-b FROM decimals
 ----
 12299999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999987.7
 
-statement ok
-RESET vectorize
-
 # AND expressions.
 query IIBB rowsort
 SELECT a, b, a < 2 AND b > 0 AND a * b != 3, a < 2 AND b < 2 FROM a WHERE a < 2 AND b > 0 AND a * b != 3
@@ -294,14 +291,14 @@ SELECT a, b, a < 2 AND b > 0 AND a * b != 3, a < 2 AND b < 2 FROM a WHERE a < 2 
 1  2  true  false
 
 statement ok
-CREATE TABLE b (a INT, b STRING, PRIMARY KEY (b,a))
-
-statement ok
+RESET vectorize;
+CREATE TABLE b (a INT, b STRING, PRIMARY KEY (b,a));
 INSERT INTO b VALUES
   (0, 'a'),
   (1, 'a'),
   (0, 'b'),
-  (1, 'b')
+  (1, 'b');
+SET vectorize = experimental_always
 
 query IT rowsort
 SELECT sum_int(a), b from b group by b
@@ -312,18 +309,11 @@ SELECT sum_int(a), b from b group by b
 # Test that lookup joins run fine through columnar execution.
 
 statement ok
-CREATE TABLE c (a INT, b INT, c INT, d INT, PRIMARY KEY (a, c), INDEX sec (b))
-
-statement ok
-CREATE TABLE d (a INT, b INT, PRIMARY KEY (b, a))
-
-statement ok
-INSERT INTO c VALUES (1, 1, 1, 0), (2, 1, 2, 0)
-
-statement ok
-INSERT INTO d VALUES (1, 1), (1, 2)
-
-statement ok
+RESET vectorize;
+CREATE TABLE c (a INT, b INT, c INT, d INT, PRIMARY KEY (a, c), INDEX sec (b));
+CREATE TABLE d (a INT, b INT, PRIMARY KEY (b, a));
+INSERT INTO c VALUES (1, 1, 1, 0), (2, 1, 2, 0);
+INSERT INTO d VALUES (1, 1), (1, 2);
 ALTER TABLE c INJECT STATISTICS '[
   {
     "columns": ["a"],
@@ -333,14 +323,13 @@ ALTER TABLE c INJECT STATISTICS '[
   }
 ]'
 
-statement ok
-SET optimizer = on
-
-# Ensure that a lookup join is used.
-query I
-SELECT count(*) FROM [EXPLAIN SELECT c.a FROM c JOIN d ON d.b = c.b] WHERE tree LIKE '%lookup-join%'
+# Ensure that a lookup join is used. Note that this query cannot be run with
+# vectorize=experimental_always, but we check that the vectorized plan contains
+# a wrapped joinReader processor.
+query B
+SELECT count(*) > 0 FROM [EXPLAIN (VEC) SELECT c.a FROM c JOIN d ON d.b = c.b] WHERE text LIKE '%rowexec.joinReader%'
 ----
-1
+true
 
 statement ok
 SET vectorize = experimental_always
@@ -390,16 +379,11 @@ SELECT c.a FROM c INNER LOOKUP JOIN c@sec AS s ON c.b=s.b
 2
 
 # Test that LIKE expressions are properly handled by vectorized execution.
-statement ok
-RESET vectorize
 
 statement ok
-CREATE TABLE e (x TEXT)
-
-statement ok
-INSERT INTO e VALUES ('abc'), ('xyz'), (NULL)
-
-statement ok
+RESET vectorize;
+CREATE TABLE e (x TEXT);
+INSERT INTO e VALUES ('abc'), ('xyz'), (NULL);
 SET vectorize = experimental_always
 
 query T
@@ -459,16 +443,13 @@ NULL  NULL  NULL   NULL   NULL   NULL   NULL   NULL   NULL
 abc   true  false  true   false  true   false  true   false
 xyz   true  false  false  true   false  true   false  true
 
-statement ok
-RESET optimizer; RESET vectorize; RESET distsql; RESET vectorize_row_count_threshold
-
 # Regression test for composite null handling
 # https://github.com/cockroachdb/cockroach/issues/37358
 statement ok
-CREATE TABLE composite (d DECIMAL, INDEX d_idx (d))
-
-statement ok
-INSERT INTO composite VALUES (NULL), (1), (1.0), (1.00)
+RESET vectorize;
+CREATE TABLE composite (d DECIMAL, INDEX d_idx (d));
+INSERT INTO composite VALUES (NULL), (1), (1.0), (1.00);
+SET vectorize = experimental_always
 
 query T rowsort
 SELECT d FROM composite@primary
@@ -486,18 +467,24 @@ NULL
 1.0
 1.00
 
+statement ok
+RESET vectorize
+
 # Test unhandled type conversion. (Should fall back to distsql.)
 query T
 SELECT ARRAY(SELECT 1) FROM a LIMIT 1
 ----
 {1}
 
+statement ok
+SET vectorize = experimental_always
+
 # Regression test for decoding OID type.
 statement ok
-CREATE TABLE t38754 (a OID PRIMARY KEY)
-
-statement ok
-INSERT INTO t38754 VALUES (1)
+RESET vectorize;
+CREATE TABLE t38754 (a OID PRIMARY KEY);
+INSERT INTO t38754 VALUES (1);
+SET vectorize = experimental_always
 
 query O
 SELECT * FROM t38754
@@ -518,13 +505,11 @@ SELECT b FROM a WHERE b < 0.5
 
 # Test unsupported scrub (should fall back to distsql).
 statement ok
-CREATE TABLE t38626 (id int PRIMARY KEY, name STRING, CONSTRAINT abc CHECK (name > 'he'))
-
-statement ok
-INSERT INTO t38626 VALUES (1, 'hello')
-
-statement ok
-EXPERIMENTAL SCRUB TABLE t38626
+RESET vectorize;
+CREATE TABLE t38626 (id int PRIMARY KEY, name STRING, CONSTRAINT abc CHECK (name > 'he'));
+INSERT INTO t38626 VALUES (1, 'hello');
+EXPERIMENTAL SCRUB TABLE t38626;
+SET vectorize = experimental_always
 
 # Regression test for issue with reading from system tables that have no
 # sentinel keys.
@@ -541,7 +526,9 @@ SELECT * FROM system.namespace LIMIT 1
 # Regression test for issue with fetching from unique indexes with embedded
 # nulls.
 statement ok
-CREATE TABLE t38753 (x INT PRIMARY KEY, y INT, UNIQUE INDEX (y)); INSERT INTO t38753 VALUES (0, NULL)
+RESET vectorize;
+CREATE TABLE t38753 (x INT PRIMARY KEY, y INT, UNIQUE INDEX (y)); INSERT INTO t38753 VALUES (0, NULL);
+SET vectorize = experimental_always
 
 query II
 SELECT * FROM t38753 ORDER BY y;
@@ -561,18 +548,19 @@ SELECT * FROM (SELECT count(*) AS x FROM b) WHERE x > 0;
 
 # Regression test for #38908
 statement ok
-CREATE TABLE t38908 (x INT)
-
-statement ok
-INSERT INTO t38908 VALUES (1)
-
-statement ok
-SET vectorize=experimental_always
+RESET vectorize;
+CREATE TABLE t38908 (x INT);
+INSERT INTO t38908 VALUES (1);
+SET vectorize = experimental_always
 
 query I
 SELECT * FROM t38908 WHERE x IN (1, 2)
 ----
 1
+
+# For now, we use the default vectorize setting for this query.
+# TODO(yuzefovich): with distributed configs this fails with 'zero length
+# schema unsupported' coming from NewRecordBatchSerializer(). Investigate this.
 
 statement ok
 RESET vectorize
@@ -583,12 +571,15 @@ SELECT 0, 1 + 2, 3 * 4 FROM a HAVING true
 ----
 0 3 12
 
+statement ok
+SET vectorize = experimental_always
+
 # Testing some builtin functions.
 statement ok
-CREATE TABLE builtin_test (x STRING, y INT)
-
-statement ok
-INSERT INTO builtin_test VALUES ('Hello', 3), ('There', 2)
+RESET vectorize;
+CREATE TABLE builtin_test (x STRING, y INT);
+INSERT INTO builtin_test VALUES ('Hello', 3), ('There', 2);
+SET vectorize = experimental_always
 
 query T rowsort
 SELECT substring(x, 1, y) FROM builtin_test
@@ -620,10 +611,10 @@ SELECT abs(y) FROM builtin_test
 2
 
 statement ok
-CREATE TABLE extract_test (x DATE)
-
-statement ok
-INSERT INTO extract_test VALUES ('2017-01-01')
+RESET vectorize;
+CREATE TABLE extract_test (x DATE);
+INSERT INTO extract_test VALUES ('2017-01-01');
+SET vectorize = experimental_always
 
 query R
 SELECT EXTRACT(YEAR FROM x) FROM extract_test
@@ -632,7 +623,9 @@ SELECT EXTRACT(YEAR FROM x) FROM extract_test
 
 # Regression test for #38937
 statement ok
-CREATE TABLE t38937 (_int2) AS SELECT 1::INT2
+RESET vectorize;
+CREATE TABLE t38937 (_int2) AS SELECT 1::INT2;
+SET vectorize = experimental_always
 
 query I
 SELECT sum_int(_int2) FROM t38937
@@ -642,13 +635,11 @@ SELECT sum_int(_int2) FROM t38937
 # Regression tests for #38959
 
 statement ok
-CREATE TABLE t38959 (a INT PRIMARY KEY, b INT, c INT, d INT, INDEX b_idx (b) STORING (c, d), UNIQUE INDEX c_idx (c) STORING (b, d))
-
-statement ok
-INSERT INTO t38959 VALUES (1, 2, 3, 4)
-
-statement ok
-SET tracing=on,kv,results
+RESET vectorize;
+CREATE TABLE t38959 (a INT PRIMARY KEY, b INT, c INT, d INT, INDEX b_idx (b) STORING (c, d), UNIQUE INDEX c_idx (c) STORING (b, d));
+INSERT INTO t38959 VALUES (1, 2, 3, 4);
+SET tracing=on,kv,results;
+SET vectorize = experimental_always
 
 query IIII
 SELECT * FROM t38959@c_idx
@@ -656,16 +647,16 @@ SELECT * FROM t38959@c_idx
 1 2 3 4
 
 statement ok
-SET tracing=off
+RESET vectorize;
+SET tracing=off;
+SET vectorize = experimental_always
 
 statement ok
-CREATE TABLE t38959_2 (x INT PRIMARY KEY, y INT, z FLOAT, INDEX xy (x, y), INDEX zyx (z, y, x), FAMILY (x), FAMILY (y), FAMILY (z))
-
-statement ok
-INSERT INTO t38959_2 VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0)
-
-statement ok
-SET tracing=on,kv,results
+RESET vectorize;
+CREATE TABLE t38959_2 (x INT PRIMARY KEY, y INT, z FLOAT, INDEX xy (x, y), INDEX zyx (z, y, x), FAMILY (x), FAMILY (y), FAMILY (z));
+INSERT INTO t38959_2 VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0);
+SET tracing=on,kv,results;
+SET vectorize = experimental_always
 
 query I
 SELECT min(x) FROM t38959_2 WHERE (y, z) = (2, 3.0)
@@ -673,11 +664,15 @@ SELECT min(x) FROM t38959_2 WHERE (y, z) = (2, 3.0)
 1
 
 statement ok
-SET tracing=off
+RESET vectorize;
+SET tracing=off;
+SET vectorize = experimental_always
 
 # Test for #38858 -- handle aggregates correctly on an empty table.
 statement ok
-CREATE TABLE empty (a INT PRIMARY KEY, b FLOAT)
+RESET vectorize;
+CREATE TABLE empty (a INT PRIMARY KEY, b FLOAT);
+SET vectorize = experimental_always
 
 # GROUP BY is omitted, so aggregates are in scalar context.
 query IIIIIRR
@@ -692,10 +687,10 @@ SELECT count(*), count(a), sum_int(a), min(a), max(a), sum(b), avg(b) FROM empty
 
 
 statement ok
-CREATE TABLE t_38995 (a INT PRIMARY KEY)
-
-statement ok
-INSERT INTO t_38995 VALUES (1), (2), (3)
+RESET vectorize;
+CREATE TABLE t_38995 (a INT PRIMARY KEY);
+INSERT INTO t_38995 VALUES (1), (2), (3);
+SET vectorize = experimental_always
 
 query II
 SELECT a, ordinality*2 FROM t_38995 WITH ORDINALITY
@@ -706,10 +701,10 @@ SELECT a, ordinality*2 FROM t_38995 WITH ORDINALITY
 
 # Test for #39827, top k sort with bytes.
 statement ok
-CREATE TABLE t_39827 (a STRING)
-
-statement ok
-INSERT INTO t_39827 VALUES ('hello'), ('world'), ('a'), ('foo')
+RESET vectorize;
+CREATE TABLE t_39827 (a STRING);
+INSERT INTO t_39827 VALUES ('hello'), ('world'), ('a'), ('foo');
+SET vectorize = experimental_always
 
 query T
 SELECT a FROM t_39827 ORDER BY a LIMIT 2
@@ -719,17 +714,25 @@ foo
 
 # Regression test for #40227, an issue with flat bytes implementation.
 statement ok
+RESET vectorize;
 CREATE TABLE t_40227 AS SELECT g FROM generate_series(0, 5) AS g
+
+# For now, we use the default vectorize setting for this query.
+# TODO(yuzefovich): with distributed configs this fails with 'zero length
+# schema unsupported' coming from NewRecordBatchSerializer(). Investigate this.
 
 statement ok
 SELECT '' FROM t_40227 AS t1 JOIN t_40227 AS t2 ON true
 
+statement ok
+SET vectorize = experimental_always
+
 # Tests for #39417
 statement ok
-CREATE TABLE t39417 (x int8)
-
-statement ok
-INSERT INTO t39417 VALUES (10)
+RESET vectorize;
+CREATE TABLE t39417 (x int8);
+INSERT INTO t39417 VALUES (10);
+SET vectorize = experimental_always
 
 query R
 select (x/1) from t39417
@@ -737,12 +740,16 @@ select (x/1) from t39417
 10
 
 # Regression tests for #39540, an issue caused by shallow copying decimals.
+# For now, we use the default vectorize setting for this query.
+# TODO(yuzefovich): with distributed configs this fails with 'zero length
+# schema unsupported' coming from NewRecordBatchSerializer(). Investigate this.
 statement ok
+RESET vectorize;
 CREATE TABLE IF NOT EXISTS t_39540 AS
 	SELECT
 		g % 2 = 0 AS _bool, g::DECIMAL AS _decimal
 	FROM
-		generate_series(0, 5) AS g
+		generate_series(0, 5) AS g;
 
 query R rowsort
 SELECT
@@ -757,34 +764,33 @@ ORDER BY
 ----
 1296 values hashing to cad02075a867c3c0564bf80fe665eed6
 
+statement ok
+SET vectorize = experimental_always
+
 # Regression test for #40372.
 statement ok
+RESET vectorize;
 CREATE TABLE t40372_1 (
   a INT,
   b INT,
   c FLOAT,
   d FLOAT
-)
-
-statement ok
+);
 INSERT INTO t40372_1 VALUES
   (1, 1, 1, 1),
   (2, 2, 2, 2),
-  (3, 3, 3, 3)
-
-statement ok
+  (3, 3, 3, 3);
 CREATE TABLE t40372_2 (
   a INT,
   b FLOAT,
   c FLOAT,
   d INT
-)
-
-statement ok
+);
 INSERT INTO t40372_2 VALUES
   (1, 1, 1, 1),
   (2, 2, 2, 2),
-  (3, 3, 3, 3)
+  (3, 3, 3, 3);
+SET vectorize = experimental_always
 
 query IIRR rowsort
 SELECT * FROM t40372_1 NATURAL JOIN t40372_2
@@ -795,10 +801,10 @@ SELECT * FROM t40372_1 NATURAL JOIN t40372_2
 
 # Test that comparison against a null value selects the value out.
 statement ok
-CREATE TABLE tnull(a INT, b INT)
-
-statement ok
-INSERT INTO tnull VALUES(NULL, 238)
+RESET vectorize;
+CREATE TABLE tnull(a INT, b INT);
+INSERT INTO tnull VALUES(NULL, 238);
+SET vectorize = experimental_always
 
 query I rowsort
 SELECT a FROM tnull WHERE (a<=b OR a>=b)
@@ -807,10 +813,10 @@ SELECT a FROM tnull WHERE (a<=b OR a>=b)
 # Test that AND'ing a true value with another true value while one of them is
 # actually NULL returns NULL.
 statement ok
-CREATE TABLE t1(a INTEGER, b INTEGER, c INTEGER)
-
-statement ok
-INSERT INTO t1 VALUES(NULL,2,1)
+RESET vectorize;
+CREATE TABLE t1(a INTEGER, b INTEGER, c INTEGER);
+INSERT INTO t1 VALUES(NULL,2,1);
+SET vectorize = experimental_always
 
 # We need both parenthesis in WHERE clause so that the AND operation under test
 # is not optimized out.
@@ -822,10 +828,10 @@ SELECT CASE WHEN a <= b THEN 1 ELSE 2 END
 
 # Regression tests for NULL expression handling.
 statement ok
-CREATE TABLE t_case_null (x INT)
-
-statement ok
-INSERT INTO t_case_null VALUES (0)
+RESET vectorize;
+CREATE TABLE t_case_null (x INT);
+INSERT INTO t_case_null VALUES (0);
+SET vectorize = experimental_always
 
 query I
 SELECT CASE WHEN x = 0 THEN 0 ELSE NULL END FROM t_case_null
@@ -856,6 +862,7 @@ SELECT * FROM t_case_null WHERE x = 0 AND NULL
 
 # Regression test for #40732.
 statement ok
+RESET vectorize;
 CREATE TABLE t40732 AS SELECT g::INT8 AS _int8,
                               g::FLOAT8 AS _float8,
                               '2001-01-01'::DATE
@@ -864,10 +871,9 @@ CREATE TABLE t40732 AS SELECT g::INT8 AS _int8,
                               g::DECIMAL AS _decimal,
                               g::STRING AS _string,
                               g::STRING::BYTES AS _bytes
-                         FROM generate_series(1, 5) AS g
-
-statement ok
-INSERT INTO t40732 DEFAULT VALUES
+                         FROM generate_series(1, 5) AS g;
+INSERT INTO t40732 DEFAULT VALUES;
+SET vectorize = experimental_always
 
 query I
 SELECT *
@@ -892,10 +898,16 @@ ORDER BY col_2976
 4
 4
 
+statement ok
+RESET vectorize
+
 query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.exec.query.is-vectorized' AND usage_count > 0
 ----
 sql.exec.query.is-vectorized
+
+statement ok
+SET vectorize = experimental_always
 
 # Test IS NULL (and alike) projections.
 query IBBIBB rowsort
@@ -951,7 +963,9 @@ NULL  1     1
 # Regression test for #42816 - top K sort when K is greater than
 # coldata.BatchSize().
 statement ok
-CREATE TABLE t_42816 (a int); INSERT INTO t_42816 SELECT * FROM generate_series(0, 1025)
+RESET vectorize;
+CREATE TABLE t_42816 (a int); INSERT INTO t_42816 SELECT * FROM generate_series(0, 1025);
+SET vectorize = experimental_always
 
 query I
 SELECT * FROM t_42816 ORDER BY a OFFSET 1020 LIMIT 10
@@ -965,8 +979,10 @@ SELECT * FROM t_42816 ORDER BY a OFFSET 1020 LIMIT 10
 
 # Regression tests for #42994
 statement ok
+RESET vectorize;
 CREATE TABLE t42994 (a INT PRIMARY KEY, b BIT, INDEX i (a, b));
 INSERT INTO t42994 VALUES (1, 1::BIT);
+SET vectorize = experimental_always
 
 query I
 SELECT a FROM t42994@i
@@ -974,8 +990,10 @@ SELECT a FROM t42994@i
 1
 
 statement ok
+RESET vectorize;
 CREATE TABLE t42994_2 (a BIT PRIMARY KEY, b INT, UNIQUE INDEX i (b));
 INSERT INTO t42994_2 VALUES (1::BIT, NULL);
+SET vectorize = experimental_always
 
 query I
 SELECT b FROM t42994_2@i
@@ -984,20 +1002,21 @@ NULL
 
 # Regression test for zeroing out an aggregate value when NULLs are present.
 statement ok
-SELECT
-	max(s)
-FROM
-	(
-		SELECT
-			s, i
-		FROM
-			(VALUES ('1', 1), (NULL, 2)) AS t (s, i)
-	)
-GROUP BY
-	i
+RESET vectorize;
+CREATE TABLE t43429(s STRING, i INT);
+INSERT INTO t43429 VALUES ('1', 1), (NULL, 2);
+SET vectorize = experimental_always
+
+query T
+SELECT max(s) FROM t43429 GROUP BY i ORDER BY 1
+----
+NULL
+1
 
 statement ok
-CREATE TABLE t43550(a INT2 PRIMARY KEY); INSERT INTO t43550 VALUES (1)
+RESET vectorize;
+CREATE TABLE t43550(a INT2 PRIMARY KEY); INSERT INTO t43550 VALUES (1);
+SET vectorize = experimental_always
 
 query I
 SELECT CASE WHEN a = 0 THEN a ELSE 1:::INT8 END FROM t43550
@@ -1006,7 +1025,9 @@ SELECT CASE WHEN a = 0 THEN a ELSE 1:::INT8 END FROM t43550
 
 # Regression test for #43855.
 statement ok
-CREATE TABLE t43855(o OID, r REGPROCEDURE)
+RESET vectorize;
+CREATE TABLE t43855(o OID, r REGPROCEDURE);
+SET vectorize = experimental_always
 
 query i
 SELECT CASE WHEN o = 0 THEN 0:::OID ELSE r END FROM t43855
@@ -1021,14 +1042,18 @@ SELECT max(c) FROM a
 
 # Regression test for starting wrapped processors multiple times.
 statement ok
-CREATE TABLE t44133_0(c0 STRING); CREATE TABLE t44133_1(c0 STRING UNIQUE NOT NULL)
+RESET vectorize;
+CREATE TABLE t44133_0(c0 STRING); CREATE TABLE t44133_1(c0 STRING UNIQUE NOT NULL);
+SET vectorize = experimental_always
 
 statement ok
 SELECT * FROM t44133_0, t44133_1 WHERE t44133_0.c0 NOT BETWEEN t44133_1.c0 AND '' AND (t44133_1.c0 IS NULL)
 
 # Regression test for CASE operator with unhandled output type.
 statement ok
-CREATE TABLE t44304(c0 INT); INSERT INTO t44304 VALUES (0)
+RESET vectorize;
+CREATE TABLE t44304(c0 INT); INSERT INTO t44304 VALUES (0);
+SET vectorize = experimental_always
 
 query I
 SELECT * FROM t44304 WHERE CASE WHEN t44304.c0 > 0 THEN NULL END
@@ -1036,7 +1061,9 @@ SELECT * FROM t44304 WHERE CASE WHEN t44304.c0 > 0 THEN NULL END
 
 # Regression test for CASE operator and flat bytes.
 statement ok
-CREATE TABLE t44624(c0 STRING, c1 BOOL); INSERT INTO t44624(rowid, c0, c1) VALUES (0, '', true), (1, '', NULL)
+RESET vectorize;
+CREATE TABLE t44624(c0 STRING, c1 BOOL); INSERT INTO t44624(rowid, c0, c1) VALUES (0, '', true), (1, '', NULL);
+SET vectorize = experimental_always
 
 query TB rowsort
 SELECT * FROM t44624 ORDER BY CASE WHEN c1 IS NULL THEN c0 WHEN true THEN c0 END
@@ -1046,7 +1073,9 @@ SELECT * FROM t44624 ORDER BY CASE WHEN c1 IS NULL THEN c0 WHEN true THEN c0 END
 
 # Regression test for 44726 (unknown WHEN expression type).
 statement ok
-CREATE TABLE t44726(c0 INT); INSERT INTO t44726(c0) VALUES (0)
+RESET vectorize;
+CREATE TABLE t44726(c0 INT); INSERT INTO t44726(c0) VALUES (0);
+SET vectorize = experimental_always
 
 query I
 SELECT * FROM t44726 WHERE 0 > (CASE WHEN nullif(NULL, ilike_escape('', current_user(), '')) THEN 0 ELSE t44726.c0 END)
@@ -1055,7 +1084,9 @@ SELECT * FROM t44726 WHERE 0 > (CASE WHEN nullif(NULL, ilike_escape('', current_
 # Regression test for wrongly performing bounds check elimination on flat bytes
 # which might lead to a crash.
 statement ok
-CREATE TABLE t44822(c0 BYTES); CREATE VIEW v0(c0) AS SELECT min(t44822.c0) FROM t44822
+RESET vectorize;
+CREATE TABLE t44822(c0 BYTES); CREATE VIEW v0(c0) AS SELECT min(t44822.c0) FROM t44822;
+SET vectorize = experimental_always
 
 query T
 SELECT * FROM v0 WHERE v0.c0 NOT BETWEEN v0.c0 AND v0.c0
@@ -1064,24 +1095,25 @@ SELECT * FROM v0 WHERE v0.c0 NOT BETWEEN v0.c0 AND v0.c0
 # Regression test for #44935 (decimals with different number of trailing zeroes
 # hashing to different values).
 statement ok
-CREATE TABLE t44935 (x decimal); INSERT INTO t44935 VALUES (1.0), (1.00)
+RESET vectorize;
+CREATE TABLE t44935 (x decimal); INSERT INTO t44935 VALUES (1.0), (1.00);
+SET vectorize = experimental_always
 
 query I
 SELECT count(*) FROM (SELECT DISTINCT x FROM t44935)
 ----
 1
 
-# Regression test for #45481.
+# Regression test for #45481. Generate all combinations of values 1 to 7.
 statement ok
-CREATE TABLE t45481 (a INT, b INT, c FLOAT, d DECIMAL, e STRING, f BYTES, g UUID, PRIMARY KEY (a, b, c, d, e, f, g))
-
-# Generate all combinations of values 1 to 7.
-statement ok
+RESET vectorize;
+CREATE TABLE t45481 (a INT, b INT, c FLOAT, d DECIMAL, e STRING, f BYTES, g UUID, PRIMARY KEY (a, b, c, d, e, f, g));
 INSERT INTO t45481 SELECT a, b, c::FLOAT, d::DECIMAL, d::STRING, d::STRING::BYTES, rpad(d::STRING, 32, d::STRING)::UUID FROM
    generate_series(1, 7) AS a(a),
    generate_series(1, 7) AS b(b),
    generate_series(1, 7) AS c(c),
-   generate_series(1, 7) AS d(d)
+   generate_series(1, 7) AS d(d);
+SET vectorize = experimental_always
 
 query IRTTTR
 SELECT b, d, e, f, g, sum(a) FROM t45481 GROUP BY b, d, e, f, g ORDER BY b, d, e, f, g
@@ -1138,20 +1170,11 @@ SELECT b, d, e, f, g, sum(a) FROM t45481 GROUP BY b, d, e, f, g ORDER BY b, d, e
 
 # Test that unsupported post process specs get wrapped in the vectorized engine.
 statement ok
-CREATE TABLE mixed_type_a (a INT, b TIMESTAMPTZ)
-
-statement ok
-CREATE TABLE mixed_type_b (a INT, b INTERVAL, c TIMESTAMP)
-
-statement ok
-INSERT INTO mixed_type_a VALUES (0, 0::TIMESTAMPTZ)
-
-statement ok
-INSERT INTO mixed_type_b VALUES (0, INTERVAL '0 days', 0::TIMESTAMP)
-
-# Set vectorize to experimental_always to ensure that no error occurs when
-# planning these mixed-type operations.
-statement ok
+RESET vectorize;
+CREATE TABLE mixed_type_a (a INT, b TIMESTAMPTZ);
+CREATE TABLE mixed_type_b (a INT, b INTERVAL, c TIMESTAMP);
+INSERT INTO mixed_type_a VALUES (0, 0::TIMESTAMPTZ);
+INSERT INTO mixed_type_b VALUES (0, INTERVAL '0 days', 0::TIMESTAMP);
 SET vectorize=experimental_always
 
 query B
@@ -1171,26 +1194,28 @@ SELECT * FROM mixed_type_a AS a JOIN mixed_type_b AS b ON a.a = b.a AND a.b < (n
 ----
 0  1970-01-01 00:00:00 +0000 UTC  0  00:00:00  1970-01-01 00:00:00 +0000 +0000
 
-statement ok
-RESET vectorize
-
 # Regression for 46140.
 statement ok
+RESET vectorize;
 DROP TABLE IF EXISTS t0, t1;
 CREATE TABLE t0(c0 INT);
 CREATE TABLE t1(c0 BOOL) INTERLEAVE IN PARENT t0(rowid);
 INSERT INTO t0(c0) VALUES (0);
-INSERT INTO t1(rowid, c0) VALUES(0, TRUE)
+INSERT INTO t1(rowid, c0) VALUES(0, TRUE);
+SET vectorize=experimental_always
 
 query I
 SELECT max(t1.rowid) FROM t1 WHERE t1.c0
 ----
 0
 
+
 # Regression for #46183.
 statement ok
+RESET vectorize;
 CREATE TABLE t46183 (x INT PRIMARY KEY, y JSONB, INVERTED INDEX (y));
-INSERT INTO t46183 VALUES (1, '{"y": "hello"}')
+INSERT INTO t46183 VALUES (1, '{"y": "hello"}');
+SET vectorize = experimental_always
 
 query I
 SELECT count(*) FROM t46183 WHERE y->'y' = to_jsonb('hello')
@@ -1200,11 +1225,13 @@ SELECT count(*) FROM t46183 WHERE y->'y' = to_jsonb('hello')
 # Regression test for #47029 (not resetting nulls vector when cfetcher read a
 # NULL value in the interleaved table).
 statement ok
+RESET vectorize;
 CREATE TABLE t47029_0(c0 INT);
 CREATE TABLE t47029_1(c0 INT);
 INSERT INTO t47029_0(c0) VALUES(0);
 INSERT INTO t47029_1(c0) VALUES(NULL);
-CREATE INDEX ON t47029_1(c0) INTERLEAVE IN PARENT t47029_0(c0)
+CREATE INDEX ON t47029_1(c0) INTERLEAVE IN PARENT t47029_0(c0);
+SET vectorize = experimental_always
 
 query I
 SELECT * FROM t47029_0 WHERE (t47029_0.rowid > 0) IS NULL
@@ -1213,8 +1240,10 @@ SELECT * FROM t47029_0 WHERE (t47029_0.rowid > 0) IS NULL
 # Regression for #47115 (cfetcher sometimes not reading value component
 # of composite encoded data).
 statement ok
+RESET vectorize;
 CREATE TABLE t47715 (c0 DECIMAL PRIMARY KEY, c1 INT UNIQUE);
-INSERT INTO t47715(c0) VALUES (1819487610)
+INSERT INTO t47715(c0) VALUES (1819487610);
+SET vectorize = experimental_always
 
 query T
 SELECT c0 FROM t47715 ORDER by c1
@@ -1222,7 +1251,14 @@ SELECT c0 FROM t47715 ORDER by c1
 1819487610
 
 # Regression for flat bytes vector not being reset when it is reused by a
-# projecting operator.
+# projecting operator. Interestingly, this query contains a subquery which is
+# handled as core.LocalPlanNode which we cannot wrap, so it cannot be run with
+# experimental_always setting. I'm not sure whether it serves the purpose with
+# which it was added, but we might as well keep the query.
+
+statement ok
+RESET vectorize
+
 query TTT
 WITH
     with_194015 (col_1548014)
@@ -1287,3 +1323,6 @@ NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
 NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
 NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
 NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
+
+statement ok
+SET vectorize = experimental_always


### PR DESCRIPTION
The intention of `vectorize` logic test is making sure that certain
features are supported by the vectorized engine. This can be done with
using `vectorize=experimental_always`. The intention of the file was to
have this setting used by "default" apart from cases when certain
queries need the fall back to row engine (e.g. CREATE, INSERT, etc).
This commit audits the whole file and imposes
```
   RESET vectorize
   <unsupported query>
   SET vectorize = experimental_always
```
structure on all queries. The audit turned out that there are some
queries that are either fully unsupported (meaning the fallback to row
engine is required) or unsupported when distributed. This commit doesn't
address those concerns and leaves them as TODOs.

Release note: None