### PR TITLE
sql: don't write to slow query log if disabled

### DIFF
--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -188,7 +188,7 @@ func (p *planner) maybeLogStatementInternal(
 		logger.Logf(ctx, "%s %q %s %q %s %.3f %d %s %d",
 			lbl, appName, logTrigger, stmtStr, plStr, age, rows, auditErrStr, numRetries)
 	}
-	if queryDuration > slowLogThreshold {
+	if slowQueryLogEnabled && queryDuration > slowLogThreshold {
 		logger := p.execCfg.SlowQueryLogger
 		logger.Logf(ctx, "%.3fms %s %q %s %q %s %d %q %d",
 			age, lbl, appName, logTrigger, stmtStr, plStr, rows, execErrStr, numRetries)


### PR DESCRIPTION
Previously, if we were writing to any execution log, we'd also write to
the slow query log even if it were disabled.

This commit fixes the oversight.

Release note (sql change): don't write to the slow query log in any
circumstances unless explicitly enabled.