### PR TITLE
publish-*artifacts: merge implementations of putRelease / putNonRelease

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -13,33 +13,47 @@
 package release
 
 import (
+	"archive/tar"
+	"archive/zip"
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"log"
+	"mime"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/cockroachdb/errors"
 )
 
-// linuxStaticLibsRe returns the regexp of all static libraries.
-var linuxStaticLibsRe = func() *regexp.Regexp {
-	libs := strings.Join([]string{
-		regexp.QuoteMeta("linux-vdso.so."),
-		regexp.QuoteMeta("librt.so."),
-		regexp.QuoteMeta("libpthread.so."),
-		regexp.QuoteMeta("libdl.so."),
-		regexp.QuoteMeta("libm.so."),
-		regexp.QuoteMeta("libc.so."),
-		regexp.QuoteMeta("libresolv.so."),
-		strings.Replace(regexp.QuoteMeta("ld-linux-ARCH.so."), "ARCH", ".*", -1),
-	}, "|")
-	return regexp.MustCompile(libs)
-}()
+var (
+	// linuxStaticLibsRe returns the regexp of all static libraries.
+	linuxStaticLibsRe = func() *regexp.Regexp {
+		libs := strings.Join([]string{
+			regexp.QuoteMeta("linux-vdso.so."),
+			regexp.QuoteMeta("librt.so."),
+			regexp.QuoteMeta("libpthread.so."),
+			regexp.QuoteMeta("libdl.so."),
+			regexp.QuoteMeta("libm.so."),
+			regexp.QuoteMeta("libc.so."),
+			regexp.QuoteMeta("libresolv.so."),
+			strings.Replace(regexp.QuoteMeta("ld-linux-ARCH.so."), "ARCH", ".*", -1),
+		}, "|")
+		return regexp.MustCompile(libs)
+	}()
+	osVersionRe = regexp.MustCompile(`\d+(\.\d+)*-`)
+)
+
+var (
+	// NoCache is a string constant to send no-cache to AWS.
+	NoCache = "no-cache"
+)
 
 // SupportedTarget contains metadata about a supported target.
 type SupportedTarget struct {
@@ -103,7 +117,7 @@ func MakeWorkload(pkgDir string) error {
 	return cmd.Run()
 }
 
-// MakeRelease makes the release binary.
+// MakeRelease makes the release binary and associated files.
 func MakeRelease(b SupportedTarget, pkgDir string, opts ...MakeReleaseOption) error {
 	params := makeReleaseAndVerifyOptions{
 		execFn: DefaultExecFn,
@@ -155,4 +169,257 @@ func MakeRelease(b SupportedTarget, pkgDir string, opts ...MakeReleaseOption) er
 		}
 	}
 	return nil
+}
+
+// TrimDotExe trims '.exe. from `name` and returns the result (and whether any
+// trimming has occurred).
+func TrimDotExe(name string) (string, bool) {
+	const dotExe = ".exe"
+	return strings.TrimSuffix(name, dotExe), strings.HasSuffix(name, dotExe)
+}
+
+// S3Putter is an interface allowing uploads to S3.
+type S3Putter interface {
+	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
+}
+
+// S3KeyRelease extracts the target archive base and archive
+// name for the given parameters.
+func S3KeyRelease(suffix string, buildType string, versionStr string) (string, string) {
+	targetSuffix, hasExe := TrimDotExe(suffix)
+	// TODO(tamird): remove this weirdness. Requires updating
+	// "users" e.g. docs, cockroachdb/cockroach-go, maybe others.
+	if strings.Contains(buildType, "linux") {
+		targetSuffix = strings.Replace(targetSuffix, "gnu-", "", -1)
+		targetSuffix = osVersionRe.ReplaceAllLiteralString(targetSuffix, "")
+	}
+
+	archiveBase := fmt.Sprintf("cockroach-%s", versionStr)
+	targetArchiveBase := archiveBase + targetSuffix
+	if hasExe {
+		return targetArchiveBase, targetArchiveBase + ".zip"
+	}
+	return targetArchiveBase, targetArchiveBase + ".tgz"
+}
+
+// NonReleaseFile is a file to upload when publishing a non-release.
+type NonReleaseFile struct {
+	// S3FileName is the name of the file stored in S3.
+	S3FileName string
+	// S3FilePath is the path the file should be stored within the  Cockroach bucket.
+	S3FilePath string
+	// S3RedirectPathPrefix is the prefix of the path that redirects  to the S3FilePath.
+	// It is suffixed with .VersionStr or .LATEST, depending on whether  the branch is
+	// the master branch.
+	S3RedirectPathPrefix string
+
+	// LocalAbsolutePath is the location of the file to upload in the local OS.
+	LocalAbsolutePath string
+}
+
+// MakeCRDBBinaryNonReleaseFile creates a NonRelease object for the
+// CRDB binary.
+func MakeCRDBBinaryNonReleaseFile(
+	base string, localAbsolutePath string, versionStr string,
+) NonReleaseFile {
+	remoteName, hasExe := TrimDotExe(base)
+	// TODO(tamird): do we want to keep doing this? No longer
+	// doing so requires updating cockroachlabs/production, and
+	// possibly cockroachdb/cockroach-go.
+	remoteName = osVersionRe.ReplaceAllLiteralString(remoteName, "")
+
+	fileName := fmt.Sprintf("%s.%s", remoteName, versionStr)
+	if hasExe {
+		fileName += ".exe"
+	}
+
+	return NonReleaseFile{
+		S3FileName:           fileName,
+		S3FilePath:           fileName,
+		S3RedirectPathPrefix: remoteName,
+		LocalAbsolutePath:    localAbsolutePath,
+	}
+}
+
+// PutNonReleaseOptions are options to pass into PutNonRelease.
+type PutNonReleaseOptions struct {
+	// Branch is the branch from which the release is being uploaded from.
+	Branch string
+	// BucketName is the bucket to upload the files to.
+	BucketName string
+
+	// Files are all the files to be uploaded into S3.
+	Files []NonReleaseFile
+}
+
+// PutNonRelease uploads non-release related files to S3.
+func PutNonRelease(svc S3Putter, o PutNonReleaseOptions) {
+	const repoName = "cockroach"
+	for _, f := range o.Files {
+		disposition := mime.FormatMediaType("attachment", map[string]string{
+			"filename": f.S3FileName,
+		})
+
+		fileToUpload, err := os.Open(f.LocalAbsolutePath)
+		if err != nil {
+			log.Fatalf("failed to open %s: %s", f.LocalAbsolutePath, err)
+		}
+		defer func() {
+			_ = fileToUpload.Close()
+		}()
+
+		// NB: The leading slash is required to make redirects work
+		// correctly since we reuse this key as the redirect location.
+		versionKey := fmt.Sprintf("/%s/%s", repoName, f.S3FilePath)
+		log.Printf("Uploading to s3://%s%s", o.BucketName, versionKey)
+		if _, err := svc.PutObject(&s3.PutObjectInput{
+			Bucket:             &o.BucketName,
+			ContentDisposition: &disposition,
+			Key:                &versionKey,
+			Body:               fileToUpload,
+		}); err != nil {
+			log.Fatalf("s3 upload %s: %s", versionKey, err)
+		}
+
+		latestSuffix := o.Branch
+		if latestSuffix == "master" {
+			latestSuffix = "LATEST"
+		}
+		latestKey := fmt.Sprintf("%s/%s.%s", repoName, f.S3RedirectPathPrefix, latestSuffix)
+		if _, err := svc.PutObject(&s3.PutObjectInput{
+			Bucket:                  &o.BucketName,
+			CacheControl:            &NoCache,
+			Key:                     &latestKey,
+			WebsiteRedirectLocation: &versionKey,
+		}); err != nil {
+			log.Fatalf("s3 redirect to %s: %s", versionKey, err)
+		}
+	}
+}
+
+// ArchiveFile is a file to store in the a archive for a release.
+type ArchiveFile struct {
+	// LocalAbsolutePath is the location of the file to upload include in the archive on the local OS.
+	LocalAbsolutePath string
+	// ArchiveFilePath is the location of the file within the archive in which the file is to be stored.
+	ArchiveFilePath string
+}
+
+// MakeCRDBBinaryArchiveFile generates the ArchiveFile object for a CRDB binary.
+func MakeCRDBBinaryArchiveFile(base string, localAbsolutePath string) ArchiveFile {
+	_, hasExe := TrimDotExe(base)
+	path := "cockroach"
+	if hasExe {
+		path += ".exe"
+	}
+	return ArchiveFile{
+		LocalAbsolutePath: localAbsolutePath,
+		ArchiveFilePath:   path,
+	}
+}
+
+// PutReleaseOptions are options to for the PutRelease function.
+type PutReleaseOptions struct {
+	// BucketName is the bucket to upload the files to.
+	BucketName string
+	// NoCache is true if we should set the NoCache option to S3.
+	NoCache bool
+	// Suffix is the suffix of the main CRDB binary.
+	Suffix string
+	// BuildType is the build type of the release.
+	BuildType string
+	// VersionStr is the version (SHA/branch name) of the release.
+	VersionStr string
+
+	// Files are all the files to be included in the archive.
+	Files []ArchiveFile
+}
+
+// PutRelease uploads a compressed archive containing the release
+// files to S3.
+func PutRelease(svc S3Putter, o PutReleaseOptions) {
+	targetArchiveBase, targetArchive := S3KeyRelease(o.Suffix, o.BuildType, o.VersionStr)
+	var body bytes.Buffer
+
+	if strings.HasSuffix(targetArchive, ".zip") {
+		zw := zip.NewWriter(&body)
+
+		for _, f := range o.Files {
+			file, err := os.Open(f.LocalAbsolutePath)
+			if err != nil {
+				log.Fatalf("failed to open file: %s", f.LocalAbsolutePath)
+			}
+			defer func() { _ = file.Close() }()
+
+			stat, err := file.Stat()
+			if err != nil {
+				log.Fatalf("failed to stat: %s", f.LocalAbsolutePath)
+			}
+
+			zipHeader, err := zip.FileInfoHeader(stat)
+			if err != nil {
+				log.Fatal(err)
+			}
+			zipHeader.Name = filepath.Join(targetArchiveBase, f.ArchiveFilePath)
+
+			zfw, err := zw.CreateHeader(zipHeader)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if _, err := io.Copy(zfw, file); err != nil {
+				log.Fatal(err)
+			}
+		}
+		if err := zw.Close(); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		gzw := gzip.NewWriter(&body)
+		for _, f := range o.Files {
+			tw := tar.NewWriter(gzw)
+
+			file, err := os.Open(f.LocalAbsolutePath)
+			if err != nil {
+				log.Fatalf("failed to open file: %s", f.LocalAbsolutePath)
+			}
+			defer func() { _ = file.Close() }()
+
+			stat, err := file.Stat()
+			if err != nil {
+				log.Fatalf("failed to stat: %s", f.LocalAbsolutePath)
+			}
+
+			// Set the tar header from the file info. Overwrite name.
+			tarHeader, err := tar.FileInfoHeader(stat, "")
+			if err != nil {
+				log.Fatal(err)
+			}
+			tarHeader.Name = filepath.Join(targetArchiveBase, f.ArchiveFilePath)
+			if err := tw.WriteHeader(tarHeader); err != nil {
+				log.Fatal(err)
+			}
+
+			if _, err := io.Copy(tw, file); err != nil {
+				log.Fatal(err)
+			}
+			if err := tw.Close(); err != nil {
+				log.Fatal(err)
+			}
+		}
+		if err := gzw.Close(); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	putObjectInput := s3.PutObjectInput{
+		Bucket: &o.BucketName,
+		Key:    &targetArchive,
+		Body:   bytes.NewReader(body.Bytes()),
+	}
+	if o.NoCache {
+		putObjectInput.CacheControl = &NoCache
+	}
+	if _, err := svc.PutObject(&putObjectInput); err != nil {
+		log.Fatalf("s3 upload %s: %s", targetArchive, err)
+	}
 }


### PR DESCRIPTION
The `putRelease` / `putNonRelease` functionality of `publish-artifacts`
and `publish-provisional-artifacts` are almost exactly the same. I've
merged this to one implementation in the `release` package. This change
should have no functional difference to what is being published /
archived today.

I've also added the ability to put multiple files into a release archive
/ to be sent as part of a non release. This is relevant for a future
change, but getting that work bootstrapped here.

Release note: None