### PR TITLE
sql: add sort and virtual scan support in the new factory

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -113,7 +113,7 @@ func distChangefeedFlow(
 	}
 	dsp := phs.DistSQLPlanner()
 	evalCtx := phs.ExtendedEvalContext()
-	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, noTxn, true /* distribute */)
+	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil /* planner */, noTxn, true /* distribute */)
 
 	var spanPartitions []sql.SpanPartition
 	if details.SinkURI == `` {

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -258,9 +258,10 @@ func runPlanInsidePlan(
 
 	// Make a copy of the EvalContext so it can be safely modified.
 	evalCtx := params.p.ExtendedEvalContextCopy()
-	planCtx := params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.NewPlanningCtx(params.ctx, evalCtx, params.p.txn, false /* distribute */)
 	plannerCopy := *params.p
-	planCtx.planner = &plannerCopy
+	planCtx := params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.NewPlanningCtx(
+		params.ctx, evalCtx, &plannerCopy, params.p.txn, false, /* distribute */
+	)
 	planCtx.planner.curPlan = *plan
 	planCtx.ExtendedEvalCtx.Planner = &plannerCopy
 	planCtx.stmtType = recv.stmtType

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -883,7 +883,7 @@ func (sc *SchemaChanger) distBackfill(
 			)
 			defer recv.Release()
 
-			planCtx := sc.distSQLPlanner.NewPlanningCtx(ctx, &evalCtx, txn, true /* distribute */)
+			planCtx := sc.distSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil /* planner */, txn, true /* distribute */)
 			plan, err := sc.distSQLPlanner.createBackfiller(
 				planCtx, backfillType, *tableDesc.TableDesc(), duration, chunkSize, todoSpans, readAsOf,
 			)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -875,8 +875,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	defer recv.Release()
 
 	evalCtx := planner.ExtendedEvalContext()
-	planCtx := ex.server.cfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, planner.txn, distribute)
-	planCtx.planner = planner
+	planCtx := ex.server.cfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute)
 	planCtx.stmtType = recv.stmtType
 	if planner.collectBundle {
 		planCtx.saveDiagram = func(diagram execinfrapb.FlowDiagram) {

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -434,8 +434,7 @@ func (r *createStatsResumer) Resume(
 			txn.SetFixedTimestamp(ctx, *details.AsOf)
 		}
 
-		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, txn, true /* distribute */)
-		planCtx.planner = p
+		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, p, txn, true /* distribute */)
 		if err := dsp.planAndRunCreateStats(
 			ctx, evalCtx, planCtx, txn, r.job, NewRowResultWriter(rows),
 		); err != nil {

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -439,8 +439,9 @@ func (ds *ServerImpl) SetupSyncFlow(
 	req *execinfrapb.SetupFlowRequest,
 	output execinfra.RowReceiver,
 ) (context.Context, flowinfra.Flow, error) {
-	ctx, f, err := ds.setupFlow(ds.AnnotateCtx(ctx), opentracing.SpanFromContext(ctx), parentMonitor,
-		req, output, LocalState{})
+	ctx, f, err := ds.setupFlow(
+		ds.AnnotateCtx(ctx), opentracing.SpanFromContext(ctx), parentMonitor, req, output, LocalState{},
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -461,10 +462,6 @@ type LocalState struct {
 	// If there is concurrency, a LeafTxn will be created.
 	Txn *kv.Txn
 
-	/////////////////////////////////////////////
-	// Fields below are empty if IsLocal == false
-	/////////////////////////////////////////////
-
 	// LocalProcs is an array of planNodeToRowSource processors. It's in order and
 	// will be indexed into by the RowSourceIdx field in LocalPlanNodeSpec.
 	LocalProcs []execinfra.LocalProcessor
@@ -480,8 +477,9 @@ func (ds *ServerImpl) SetupLocalSyncFlow(
 	output execinfra.RowReceiver,
 	localState LocalState,
 ) (context.Context, flowinfra.Flow, error) {
-	ctx, f, err := ds.setupFlow(ctx, opentracing.SpanFromContext(ctx), parentMonitor, req, output,
-		localState)
+	ctx, f, err := ds.setupFlow(
+		ctx, opentracing.SpanFromContext(ctx), parentMonitor, req, output, localState,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1273,22 +1273,25 @@ func (dsp *DistSQLPlanner) selectRenders(
 	return nil
 }
 
-// addSorters adds sorters corresponding to a sortNode and updates the plan to
-// reflect the sort node.
-func (dsp *DistSQLPlanner) addSorters(p *PhysicalPlan, n *sortNode) {
+// addSorters adds sorters corresponding to the ordering and updates the plan
+// accordingly. When alreadyOrderedPrefix is non-zero, the input is already
+// ordered on the prefix ordering[:alreadyOrderedPrefix].
+func (dsp *DistSQLPlanner) addSorters(
+	p *PhysicalPlan, ordering sqlbase.ColumnOrdering, alreadyOrderedPrefix int,
+) {
 	// Sorting is needed; we add a stage of sorting processors.
-	ordering := execinfrapb.ConvertToMappedSpecOrdering(n.ordering, p.PlanToStreamColMap)
+	outputOrdering := execinfrapb.ConvertToMappedSpecOrdering(ordering, p.PlanToStreamColMap)
 
 	p.AddNoGroupingStage(
 		execinfrapb.ProcessorCoreUnion{
 			Sorter: &execinfrapb.SorterSpec{
-				OutputOrdering:   ordering,
-				OrderingMatchLen: uint32(n.alreadyOrderedPrefix),
+				OutputOrdering:   outputOrdering,
+				OrderingMatchLen: uint32(alreadyOrderedPrefix),
 			},
 		},
 		execinfrapb.PostProcessSpec{},
 		p.ResultTypes,
-		ordering,
+		outputOrdering,
 	)
 }
 
@@ -2572,7 +2575,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 			return nil, err
 		}
 
-		dsp.addSorters(plan, n)
+		dsp.addSorters(plan, n.ordering, n.alreadyOrderedPrefix)
 
 	case *unaryNode:
 		plan, err = dsp.createPlanForUnary(planCtx, n)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3425,9 +3425,9 @@ func (dsp *DistSQLPlanner) createPlanForExport(
 // lightweight version PlanningCtx is returned that can be used when the caller
 // knows plans will only be run on one node. It is coerced to false on SQL
 // SQL tenants (in which case only local planning is supported), regardless of
-// the passed-in value.
+// the passed-in value. planner argument can be left nil.
 func (dsp *DistSQLPlanner) NewPlanningCtx(
-	ctx context.Context, evalCtx *extendedEvalContext, txn *kv.Txn, distribute bool,
+	ctx context.Context, evalCtx *extendedEvalContext, planner *planner, txn *kv.Txn, distribute bool,
 ) *PlanningCtx {
 	// Tenants can not distribute plans.
 	distribute = distribute && evalCtx.Codec.ForSystemTenant()
@@ -3435,6 +3435,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 		ctx:             ctx,
 		ExtendedEvalCtx: evalCtx,
 		isLocal:         !distribute,
+		planner:         planner,
 	}
 	if !distribute {
 		return planCtx

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -845,7 +845,7 @@ func TestPartitionSpans(t *testing.T) {
 
 			planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
 				EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
-			}, nil /* txn */, true /* distribute */)
+			}, nil /* planner */, nil /* txn */, true /* distribute */)
 			var spans []roachpb.Span
 			for _, s := range tc.spans {
 				spans = append(spans, roachpb.Span{Key: roachpb.Key(s[0]), EndKey: roachpb.Key(s[1])})
@@ -1029,7 +1029,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 
 			planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
 				EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
-			}, nil /* txn */, true /* distribute */)
+			}, nil /* planner */, nil /* txn */, true /* distribute */)
 			partitions, err := dsp.PartitionSpans(planCtx, roachpb.Spans{span})
 			if err != nil {
 				t.Fatal(err)
@@ -1128,7 +1128,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 
 	planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
 		EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
-	}, nil /* txn */, true /* distribute */)
+	}, nil /* planner */, nil /* txn */, true /* distribute */)
 	partitions, err := dsp.PartitionSpans(planCtx, roachpb.Spans{span})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -23,7 +23,7 @@ import (
 func (dsp *DistSQLPlanner) SetupAllNodesPlanning(
 	ctx context.Context, evalCtx *extendedEvalContext, execCfg *ExecutorConfig,
 ) (*PlanningCtx, []roachpb.NodeID, error) {
-	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil /* txn */, true /* distribute */)
+	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil /* planner */, nil /* txn */, true /* distribute */)
 
 	ss, err := execCfg.StatusServer.OptionalErr(47900)
 	if err != nil {

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -31,8 +31,7 @@ func PlanAndRunCTAS(
 	out execinfrapb.ProcessorCoreUnion,
 	recv *DistSQLReceiver,
 ) {
-	planCtx := dsp.NewPlanningCtx(ctx, planner.ExtendedEvalContext(), txn, !isLocal)
-	planCtx.planner = planner
+	planCtx := dsp.NewPlanningCtx(ctx, planner.ExtendedEvalContext(), planner, txn, !isLocal)
 	planCtx.stmtType = tree.Rows
 
 	physPlan, err := dsp.createPhysPlan(planCtx, in)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -305,9 +305,9 @@ func (dsp *DistSQLPlanner) Run(
 	// the line.
 	localState.EvalContext = &evalCtx.EvalContext
 	localState.Txn = txn
+	localState.LocalProcs = plan.LocalProcessors
 	if planCtx.isLocal {
 		localState.IsLocal = true
-		localState.LocalProcs = plan.LocalProcessors
 	} else if txn != nil {
 		// If the plan is not local, we will have to set up leaf txns using the
 		// txnCoordMeta.
@@ -855,8 +855,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, subqueryPlan.plan,
 		).WillDistribute()
 	}
-	subqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner.txn, distributeSubquery)
-	subqueryPlanCtx.planner = planner
+	subqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distributeSubquery)
 	subqueryPlanCtx.stmtType = tree.Rows
 	if planner.collectBundle {
 		subqueryPlanCtx.saveDiagram = func(diagram execinfrapb.FlowDiagram) {
@@ -1149,8 +1148,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, postqueryPlan,
 		).WillDistribute()
 	}
-	postqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner.txn, distributePostquery)
-	postqueryPlanCtx.planner = planner
+	postqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distributePostquery)
 	postqueryPlanCtx.stmtType = tree.Rows
 	postqueryPlanCtx.ignoreClose = true
 	if planner.collectBundle {

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -158,8 +158,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		// We need distribute = true so that executing the plan involves marshaling
 		// the root txn meta to leaf txns. Local flows can start in aborted txns
 		// because they just use the root txn.
-		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, nil /* txn */, true /* distribute */)
-		planCtx.planner = p
+		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, nil /* txn */, true /* distribute */)
 		planCtx.stmtType = recv.stmtType
 
 		execCfg.DistSQLPlanner.PlanAndRun(

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -577,7 +577,11 @@ func (e *distSQLSpecExecFactory) ConstructSetOp(
 func (e *distSQLSpecExecFactory) ConstructSort(
 	input exec.Node, ordering sqlbase.ColumnOrdering, alreadyOrderedPrefix int,
 ) (exec.Node, error) {
-	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: sort")
+	physPlan, plan := getPhysPlan(input)
+	e.dsp.addSorters(physPlan, ordering, alreadyOrderedPrefix)
+	// Since addition of sorters doesn't change any properties of the physical
+	// plan, we don't need to update any of those.
+	return plan, nil
 }
 
 func (e *distSQLSpecExecFactory) ConstructOrdinality(

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -81,13 +81,13 @@ func (e *distSQLSpecExecFactory) getPlanCtx(recommendation distRecommendation) *
 	if distribute {
 		if e.planContexts.distPlanCtx == nil {
 			evalCtx := e.planner.ExtendedEvalContext()
-			e.planContexts.distPlanCtx = e.dsp.NewPlanningCtx(evalCtx.Context, evalCtx, e.planner.txn, distribute)
+			e.planContexts.distPlanCtx = e.dsp.NewPlanningCtx(evalCtx.Context, evalCtx, e.planner, e.planner.txn, distribute)
 		}
 		return e.planContexts.distPlanCtx
 	}
 	if e.planContexts.localPlanCtx == nil {
 		evalCtx := e.planner.ExtendedEvalContext()
-		e.planContexts.localPlanCtx = e.dsp.NewPlanningCtx(evalCtx.Context, evalCtx, e.planner.txn, distribute)
+		e.planContexts.localPlanCtx = e.dsp.NewPlanningCtx(evalCtx.Context, evalCtx, e.planner, e.planner.txn, distribute)
 	}
 	return e.planContexts.localPlanCtx
 }
@@ -170,7 +170,21 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	locking *tree.LockingItem,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
-		return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: virtual table scan")
+		return constructVirtualScan(
+			e, e.planner, table, index, needed, indexConstraint, hardLimit,
+			softLimit, reverse, reqOrdering, rowCount, locking,
+			func(d *delayedNode) (exec.Node, error) {
+				physPlan, err := e.dsp.wrapPlan(e.getPlanCtx(cannotDistribute), d)
+				if err != nil {
+					return nil, err
+				}
+				physPlan.ResultColumns = d.columns
+				return planMaybePhysical{physPlan: &physicalPlanTop{
+					PhysicalPlan:     physPlan,
+					planNodesToClose: []planNode{d},
+				}}, nil
+			},
+		)
 	}
 
 	p := MakePhysicalPlan(e.gatewayNodeID)

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -293,4 +294,83 @@ func hasDuplicates(cols []exec.NodeColumnOrdinal) bool {
 		set.Add(int(c))
 	}
 	return false
+}
+
+func constructVirtualScan(
+	ef exec.Factory,
+	p *planner,
+	table cat.Table,
+	index cat.Index,
+	needed exec.TableColumnOrdinalSet,
+	indexConstraint *constraint.Constraint,
+	hardLimit int64,
+	softLimit int64,
+	reverse bool,
+	reqOrdering exec.OutputOrdering,
+	rowCount float64,
+	locking *tree.LockingItem,
+	// delayedNodeCallback is a callback function that performs custom setup
+	// that varies by exec.Factory implementations.
+	delayedNodeCallback func(*delayedNode) (exec.Node, error),
+) (exec.Node, error) {
+	tn := &table.(*optVirtualTable).name
+	virtual, err := p.getVirtualTabler().getVirtualTableEntry(tn)
+	if err != nil {
+		return nil, err
+	}
+	indexDesc := index.(*optVirtualIndex).desc
+	columns, constructor := virtual.getPlanInfo(
+		table.(*optVirtualTable).desc.TableDesc(),
+		indexDesc, indexConstraint)
+
+	n, err := delayedNodeCallback(&delayedNode{
+		name:            fmt.Sprintf("%s@%s", table.Name(), index.Name()),
+		columns:         columns,
+		indexConstraint: indexConstraint,
+		constructor: func(ctx context.Context, p *planner) (planNode, error) {
+			return constructor(ctx, p, tn.Catalog())
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for explicit use of the dummy column.
+	if needed.Contains(0) {
+		return nil, errors.Errorf("use of %s column not allowed.", table.Column(0).ColName())
+	}
+	if locking != nil {
+		// We shouldn't have allowed SELECT FOR UPDATE for a virtual table.
+		return nil, errors.AssertionFailedf("locking cannot be used with virtual table")
+	}
+	if needed.Len() != len(columns) {
+		// We are selecting a subset of columns; we need a projection.
+		cols := make([]exec.NodeColumnOrdinal, 0, needed.Len())
+		colNames := make([]string, len(cols))
+		for ord, ok := needed.Next(0); ok; ord, ok = needed.Next(ord + 1) {
+			cols = append(cols, exec.NodeColumnOrdinal(ord-1))
+			colNames = append(colNames, columns[ord-1].Name)
+		}
+		n, err = ef.ConstructSimpleProject(n, cols, colNames, nil /* reqOrdering */)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if hardLimit != 0 {
+		n, err = ef.ConstructLimit(n, tree.NewDInt(tree.DInt(hardLimit)), nil /* offset */)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// reqOrdering will be set if the optimizer expects that the output of the
+	// exec.Node that we're returning will actually have a legitimate ordering.
+	// Virtual indexes never provide a legitimate ordering, so we have to make
+	// sure to sort if we have a required ordering.
+	if len(reqOrdering) != 0 {
+		n, err = ef.ConstructSort(n, sqlbase.ColumnOrdering(reqOrdering), 0)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return n, nil
 }

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -109,9 +109,8 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		params.extendedEvalCtx.SessionData.DistSQLMode, n.plan.main,
 	)
 	willDistribute := distribution.WillDistribute()
-	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn, willDistribute)
+	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p, params.p.txn, willDistribute)
 	planCtx.ignoreClose = true
-	planCtx.planner = params.p
 	planCtx.stmtType = n.stmtType
 
 	if n.analyze && len(n.plan.cascades) > 0 {

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -142,9 +142,8 @@ func newPlanningCtxForExplainPurposes(
 	subqueryPlans []subquery,
 	distribution physicalplan.PlanDistribution,
 ) *PlanningCtx {
-	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn, distribution.WillDistribute())
+	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p, params.p.txn, distribution.WillDistribute())
 	planCtx.ignoreClose = true
-	planCtx.planner = params.p
 	planCtx.stmtType = stmtType
 	planCtx.planner.curPlan.subqueryPlans = subqueryPlans
 	for i := range planCtx.planner.curPlan.subqueryPlans {

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
@@ -90,3 +90,13 @@ query I
 SELECT min(v) FROM kv
 ----
 1
+
+# Check that sort is supported.
+query I
+SELECT v FROM kv ORDER BY v DESC
+----
+3
+2
+1
+1
+NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -1,4 +1,7 @@
-# LogicTest: !3node-tenant
+# LogicTest: !local-spec-planning !fakedist-spec-planning !3node-tenant
+# Note that the new factory currently has limited support of EXPLAIN (PLAN)
+# statements, so spec-planning configurations are currently skipped.
+
 query TTT
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE oid = 50
 ----

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -157,64 +157,11 @@ func (ef *execFactory) constructVirtualScan(
 	rowCount float64,
 	locking *tree.LockingItem,
 ) (exec.Node, error) {
-	tn := &table.(*optVirtualTable).name
-	virtual, err := ef.planner.getVirtualTabler().getVirtualTableEntry(tn)
-	if err != nil {
-		return nil, err
-	}
-	indexDesc := index.(*optVirtualIndex).desc
-	columns, constructor := virtual.getPlanInfo(
-		table.(*optVirtualTable).desc.TableDesc(),
-		indexDesc, indexConstraint)
-
-	var n exec.Node
-	n = &delayedNode{
-		name:            fmt.Sprintf("%s@%s", table.Name(), index.Name()),
-		columns:         columns,
-		indexConstraint: indexConstraint,
-		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			return constructor(ctx, p, tn.Catalog())
-		},
-	}
-
-	// Check for explicit use of the dummy column.
-	if needed.Contains(0) {
-		return nil, errors.Errorf("use of %s column not allowed.", table.Column(0).ColName())
-	}
-	if locking != nil {
-		// We shouldn't have allowed SELECT FOR UPDATE for a virtual table.
-		return nil, errors.AssertionFailedf("locking cannot be used with virtual table")
-	}
-	if needed.Len() != len(columns) {
-		// We are selecting a subset of columns; we need a projection.
-		cols := make([]exec.NodeColumnOrdinal, 0, needed.Len())
-		colNames := make([]string, len(cols))
-		for ord, ok := needed.Next(0); ok; ord, ok = needed.Next(ord + 1) {
-			cols = append(cols, exec.NodeColumnOrdinal(ord-1))
-			colNames = append(colNames, columns[ord-1].Name)
-		}
-		n, err = ef.ConstructSimpleProject(n, cols, colNames, nil /* reqOrdering */)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if hardLimit != 0 {
-		n, err = ef.ConstructLimit(n, tree.NewDInt(tree.DInt(hardLimit)), nil /* offset */)
-		if err != nil {
-			return nil, err
-		}
-	}
-	// reqOrdering will be set if the optimizer expects that the output of the
-	// exec.Node that we're returning will actually have a legitimate ordering.
-	// Virtual indexes never provide a legitimate ordering, so we have to make
-	// sure to sort if we have a required ordering.
-	if len(reqOrdering) != 0 {
-		n, err = ef.ConstructSort(n, sqlbase.ColumnOrdering(reqOrdering), 0)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return n, nil
+	return constructVirtualScan(
+		ef, ef.planner, table, index, needed, indexConstraint, hardLimit,
+		softLimit, reverse, reqOrdering, rowCount, locking,
+		func(d *delayedNode) (exec.Node, error) { return d, nil },
+	)
 }
 
 func asDataSource(n exec.Node) planDataSource {

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -119,7 +119,11 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	}
 	scan.isFull = true
 
-	planCtx := params.extendedEvalCtx.DistSQLPlanner.NewPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn, true /* distribute */)
+	planCtx := params.extendedEvalCtx.DistSQLPlanner.NewPlanningCtx(ctx, params.extendedEvalCtx, params.p, params.p.txn, true /* distribute */)
+	// Since physicalCheckOperation might be only one of many check operations
+	// that scrubNode needs to perform, we need to make sure that scrubNode
+	// is not closed when this physical check operation is being cleaned up.
+	planCtx.ignoreClose = true
 	physPlan, err := params.extendedEvalCtx.DistSQLPlanner.createScrubPhysicalCheck(
 		planCtx, scan, *o.tableDesc.TableDesc(), *o.indexDesc, params.p.ExecCfg().Clock.Now())
 	if err != nil {

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -134,8 +134,7 @@ func (dsp *DistSQLPlanner) Exec(
 	defer recv.Release()
 
 	evalCtx := p.ExtendedEvalContext()
-	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p.txn, distribute)
-	planCtx.planner = p
+	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, p.txn, distribute)
 	planCtx.stmtType = recv.stmtType
 
 	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.main, recv)()


### PR DESCRIPTION
**sql: implement ConstructSort in the new factory**

Release note: None

**sql: add support of virtual scans in the new factory**

The support is added by sharing the same code with the old factory that
construct `delayedNode` with the rest of necessary methods already being
implemented in the new factory. That delayedNode is wrapped into the
physical plan via a callback.

Note that with the new factory it is possible to have a distributed plan
that contains an execinfra.LocalProcessor. This required to make
a change that distsql.LocalState, regardless of the plan distribution,
has always LocalProcs set when setting up a flow on the gateway.

Addresses: #47473.

Release note: None