### PR TITLE
util/tracing: fix DistSQL trace collection

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -828,8 +828,6 @@ func (s *vectorizedFlowCreator) setupOutput(
 				metadataSourcesQueue,
 				execinfrapb.CallbackMetadataSource{
 					DrainMetaCb: func(ctx context.Context) []execinfrapb.ProducerMetadata {
-						// TODO(asubiotto): Who is responsible for the recording of the
-						// parent context?
 						// Start a separate recording so that GetRecording will return
 						// the recordings for only the child spans containing stats.
 						ctx, span := tracing.ChildSpanSeparateRecording(ctx, "")

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -334,24 +334,63 @@ func (r Recording) String() string {
 	if len(r) == 0 {
 		return "<empty recording>"
 	}
-	logs := r.visitSpan(r[0], 0 /* depth */)
 
-	start := r[0].StartTime
 	var buf strings.Builder
-	for _, entry := range logs {
-		fmt.Fprintf(&buf, "% 10.3fms % 10.3fms%s",
-			1000*entry.Timestamp.Sub(start).Seconds(),
-			1000*entry.timeSincePrev.Seconds(),
-			strings.Repeat("    ", entry.depth+1))
-		for i, f := range entry.Fields {
-			if i != 0 {
-				buf.WriteByte(' ')
+	var start time.Time
+	writeLogs := func(logs []traceLogData) {
+		for _, entry := range logs {
+			fmt.Fprintf(&buf, "% 10.3fms % 10.3fms%s",
+				1000*entry.Timestamp.Sub(start).Seconds(),
+				1000*entry.timeSincePrev.Seconds(),
+				strings.Repeat("    ", entry.depth+1))
+			for i, f := range entry.Fields {
+				if i != 0 {
+					buf.WriteByte(' ')
+				}
+				fmt.Fprintf(&buf, "%s:%v", f.Key(), f.Value())
 			}
-			fmt.Fprintf(&buf, "%s:%v", f.Key(), f.Value())
+			buf.WriteByte('\n')
 		}
-		buf.WriteByte('\n')
+	}
+
+	logs := r.visitSpan(r[0], 0 /* depth */)
+	writeLogs(logs)
+
+	// Check if there's any orphan spans (spans for which the parent is missing).
+	// This shouldn't happen, but we're protecting against incomplete traces. For
+	// example, ingesting of remote spans through DistSQL is complex. Orphan spans
+	// would not be reflected in the output string at all without this.
+	orphans := r.OrphanSpans()
+	if len(orphans) > 0 {
+		// This shouldn't happen.
+		buf.WriteString("orphan spans (trace is missing spans):\n")
+		for _, o := range orphans {
+			logs := r.visitSpan(o, 0 /* depth */)
+			writeLogs(logs)
+		}
 	}
 	return buf.String()
+}
+
+// OrphanSpans returns the spans with parents missing from the recording.
+func (r Recording) OrphanSpans() []RecordedSpan {
+	spanIDs := make(map[uint64]struct{})
+	for _, sp := range r {
+		spanIDs[sp.SpanID] = struct{}{}
+	}
+
+	var orphans []RecordedSpan
+	for i, sp := range r {
+		if i == 0 {
+			// The first span can be a root span. Note that any other root span will
+			// be considered an orphan.
+			continue
+		}
+		if _, ok := spanIDs[sp.ParentSpanID]; !ok {
+			orphans = append(orphans, sp)
+		}
+	}
+	return orphans
 }
 
 // FindLogMessage returns the first log message in the recording that matches
@@ -367,6 +406,17 @@ func (r Recording) FindLogMessage(pattern string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// FindSpan returns the span with the given operation. The bool retval is false
+// if the span is not found.
+func (r Recording) FindSpan(operation string) (RecordedSpan, bool) {
+	for _, sp := range r {
+		if sp.Operation == operation {
+			return sp, true
+		}
+	}
+	return RecordedSpan{}, false
 }
 
 // visitSpan returns the log messages for sp, and all of sp's children.
@@ -589,6 +639,12 @@ func ImportRemoteSpans(os opentracing.Span, remoteSpans []RecordedSpan) error {
 	if !s.isRecording() {
 		return errors.New("adding Raw Spans to a span that isn't recording")
 	}
+
+	// Change the root of the remote recording to be a child of this span. This is
+	// usually already the case, except with DistSQL traces where remote
+	// processors run in spans that FollowFrom an RPC span that we don't collect.
+	remoteSpans[0].ParentSpanID = s.SpanID
+
 	s.mu.Lock()
 	s.mu.recording.remoteSpans = append(s.mu.recording.remoteSpans, remoteSpans...)
 	s.mu.Unlock()


### PR DESCRIPTION
Before this patch, the collection of traces from remote DistSQL flows
was broken: the traces for the remote processors were collected as
orphans. The spans corresponding to each processor were collected with a
missing parent - the span corresponding to the SetupFlow RPC which
creates the processor (the relationship there is a FollowsFrom because
the execution of the processors is generally async wrt the RPC). This
was causing the Recording.String() method to ignore them - it was simply
skipping orphans.

Release note (bug fix): A bug causing traces collected through the
sql.trace.txn.enable_threshold setting to be sometimes incomplete was
fixed.