### PR TITLE
util/tracing: fix String() for recordings of child spans 

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -15,7 +15,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"math/rand"
-	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -43,10 +43,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
-	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1276,11 +1274,19 @@ func TestDropIndexHandlesRetriableErrors(t *testing.T) {
 
 	ctx := context.Background()
 	rf := newDynamicRequestFilter()
+	dropIndexPlanningDoneCh := make(chan struct{})
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
 					TestingRequestFilter: rf.filter,
+				},
+				SQLExecutor: &sql.ExecutorTestingKnobs{
+					BeforeExecute: func(ctx context.Context, stmt string) {
+						if strings.Contains(stmt, "DROP INDEX") {
+							close(dropIndexPlanningDoneCh)
+						}
+					},
 				},
 			},
 		},
@@ -1306,11 +1312,7 @@ WHERE
     name = $1 AND database_name = current_database();`,
 		"foo").Scan(&tableID)
 
-	// Start the user transaction and enable tracing as we'll use the trace
-	// to determine when planning has concluded.
 	txn, err := tc.ServerConn(0).Begin()
-	require.NoError(t, err)
-	_, err = txn.Exec("SET TRACING = on")
 	require.NoError(t, err)
 	// Let's find out our transaction ID for our transaction by running a query.
 	// We'll also use this query to install a refresh span over the table data.
@@ -1363,12 +1365,11 @@ WHERE
 	afterInsert, err := sql.ParseHLC(afterInsertStr)
 	require.NoError(t, err)
 
-	// Now set up a filter to detect when the DROP INDEX execution will begin
-	// and inject an error forcing a refresh above the conflicting write which
-	// will fail. We'll want to ensure that we get a retriable error.
-	// Use the below pattern to detect when the user transaction has finished
-	// planning and is now executing.
-	dropIndexPlanningEndsRE := regexp.MustCompile("(?s)planning starts: DROP INDEX.*planning ends")
+	// Now set up a filter to detect when the DROP INDEX execution will begin and
+	// inject an error forcing a refresh above the conflicting write which will
+	// fail. We'll want to ensure that we get a retriable error. Use the below
+	// pattern to detect when the user transaction has finished planning and is
+	// now executing: we don't want to inject the error during planning.
 	rf.setFilter(func(ctx context.Context, request roachpb.BatchRequest) *roachpb.Error {
 		if request.Txn == nil {
 			return nil
@@ -1378,9 +1379,9 @@ WHERE
 		if filterState.txnID != request.Txn.ID {
 			return nil
 		}
-		sp := opentracing.SpanFromContext(ctx)
-		rec := tracing.GetRecording(sp)
-		if !dropIndexPlanningEndsRE.MatchString(rec.String()) {
+		select {
+		case <-dropIndexPlanningDoneCh:
+		default:
 			return nil
 		}
 		if getRequest, ok := request.GetArg(roachpb.Get); ok {

--- a/pkg/sql/testdata/ddl_analysis/ddl_analysis
+++ b/pkg/sql/testdata/ddl_analysis/ddl_analysis
@@ -17,7 +17,7 @@ CREATE TABLE t0()
 count
 GRANT ALL ON * TO TEST
 ----
-10
+13
 
 
 exec
@@ -36,9 +36,9 @@ CREATE TABLE t10();
 count
 GRANT ALL ON * TO TEST
 ----
-50
+53
 
 count
 CREATE ROLE rolea
 ----
-6
+16

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -49,9 +49,14 @@ type spanContext struct {
 	shadowTr  *shadowTracer
 	shadowCtx opentracing.SpanContext
 
-	// If set, all spans derived from this context are being recorded as a group.
-	recordingGroup *spanGroup
-	recordingType  RecordingType
+	// If set, all spans derived from this context are being recorded.
+	recordingType RecordingType
+	// span is set if this context corresponds to a local span. If so, pointing
+	// back to the span is used for registering child spans with their parent.
+	// Children of remote spans act as roots when it comes to recordings - someone
+	// is responsible for calling GetRecording() on them and marshaling the
+	// recording back to the parent (generally an RPC handler does this).
+	span *span
 
 	// The span's associated baggage.
 	Baggage map[string]string
@@ -130,9 +135,17 @@ type span struct {
 		// duration is initialized to -1 and set on Finish().
 		duration time.Duration
 
-		recordingGroup *spanGroup
-		recordingType  RecordingType
-		recordedLogs   []opentracing.LogRecord
+		// recording maintains state once StartRecording() is called.
+		recording struct {
+			recordingType RecordingType
+			recordedLogs  []opentracing.LogRecord
+			// children contains the list of child spans started after this span
+			// started recording.
+			children []*span
+			// remoteSpan contains the list of remote child spans manually imported.
+			remoteSpans []RecordedSpan
+		}
+
 		// tags are only set when recording. These are tags that have been added to
 		// this span, and will be appended to the tags in logTags when someone
 		// needs to actually observe the total set of tags that is a part of this
@@ -162,22 +175,30 @@ func IsRecording(s opentracing.Span) bool {
 	return s.(*span).isRecording()
 }
 
-func (s *span) enableRecording(group *spanGroup, recType RecordingType) {
-	if group == nil {
-		panic("no spanGroup")
-	}
+// enableRecording start recording on the span. From now on, log events and child spans
+// will be stored.
+//
+// If parent != nil, the span will be registered as a child of the respective
+// parent.
+// If separate recording is specified, the child is not registered with the
+// parent. Thus, the parent's recording will not include this child.
+func (s *span) enableRecording(parent *span, recType RecordingType, separateRecording bool) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	atomic.StoreInt32(&s.recording, 1)
-	s.mu.recordingGroup = group
-	s.mu.recordingType = recType
+	s.mu.recording.recordingType = recType
+	if parent != nil && !separateRecording {
+		parent.addChild(s)
+	}
 	if recType == SnowballRecording {
 		s.setBaggageItemLocked(Snowball, "1")
 	}
-	// Clear any previously recorded logs.
-	s.mu.recordedLogs = nil
-	s.mu.Unlock()
-
-	group.addSpan(s)
+	// Clear any previously recorded info. This is needed by SQL SessionTracing,
+	// who likes to start and stop recording repeatedly on the same span, and
+	// collect the (separate) recordings every time.
+	s.mu.recording.recordedLogs = nil
+	s.mu.recording.children = nil
+	s.mu.recording.remoteSpans = nil
 }
 
 // StartRecording enables recording on the span. Events from this point forward
@@ -196,7 +217,12 @@ func StartRecording(os opentracing.Span, recType RecordingType) {
 	if _, noop := os.(*noopSpan); noop {
 		panic("StartRecording called on NoopSpan; use the Recordable option for StartSpan")
 	}
-	os.(*span).enableRecording(new(spanGroup), recType)
+
+	// If we're already recording (perhaps because the parent was recording when
+	// this span was created), there's nothing to do.
+	if sp := os.(*span); !sp.isRecording() {
+		sp.enableRecording(nil /* parent */, recType, false /* separateRecording */)
+	}
 }
 
 // StopRecording disables recording on this span. Child spans that were created
@@ -213,11 +239,10 @@ func StopRecording(os opentracing.Span) {
 func (s *span) disableRecording() {
 	s.mu.Lock()
 	atomic.StoreInt32(&s.recording, 0)
-	s.mu.recordingGroup = nil
 	// We test the duration as a way to check if the span has been finished. If it
 	// has, we don't want to do the call below as it might crash (at least if
 	// there's a netTr).
-	if (s.mu.duration == -1) && (s.mu.recordingType == SnowballRecording) {
+	if (s.mu.duration == -1) && (s.mu.recording.recordingType == SnowballRecording) {
 		// Clear the Snowball baggage item, assuming that it was set by
 		// enableRecording().
 		s.setBaggageItemLocked(Snowball, "")
@@ -240,7 +265,7 @@ func IsRecordable(os opentracing.Span) bool {
 type Recording []RecordedSpan
 
 // GetRecording retrieves the current recording, if the span has recording
-// enabled. This can be called while spans that are part of the record are
+// enabled. This can be called while spans that are part of the recording are
 // still open; it can run concurrently with operations on those spans.
 func GetRecording(os opentracing.Span) Recording {
 	if _, noop := os.(*noopSpan); noop {
@@ -251,12 +276,26 @@ func GetRecording(os opentracing.Span) Recording {
 		return nil
 	}
 	s.mu.Lock()
-	group := s.mu.recordingGroup
+	// The capacity here is approximate since we don't know how many grandchildren
+	// there are.
+	result := make(Recording, 0, 1+len(s.mu.recording.children)+len(s.mu.recording.remoteSpans))
+	// Shallow-copy the children so we can process them without the lock.
+	children := s.mu.recording.children
+	result = append(result, s.getRecordingLocked())
+	result = append(result, s.mu.recording.remoteSpans...)
 	s.mu.Unlock()
-	if group == nil {
-		return nil
+
+	for _, child := range children {
+		result = append(result, GetRecording(child)...)
 	}
-	return group.getSpans()
+
+	// Sort the spans by StartTime, except the first span (the root of this
+	// recording) which stays in place.
+	toSort := result[1:]
+	sort.Slice(toSort, func(i, j int) bool {
+		return toSort[i].StartTime.Before(toSort[j].StartTime)
+	})
+	return result
 }
 
 type traceLogData struct {
@@ -552,15 +591,12 @@ type TraceCollection struct {
 // recorded traces from other nodes.
 func ImportRemoteSpans(os opentracing.Span, remoteSpans []RecordedSpan) error {
 	s := os.(*span)
-	s.mu.Lock()
-	group := s.mu.recordingGroup
-	s.mu.Unlock()
-	if group == nil {
+	if !s.isRecording() {
 		return errors.New("adding Raw Spans to a span that isn't recording")
 	}
-	group.Lock()
-	group.remoteSpans = append(group.remoteSpans, remoteSpans...)
-	group.Unlock()
+	s.mu.Lock()
+	s.mu.recording.remoteSpans = append(s.mu.recording.remoteSpans, remoteSpans...)
+	s.mu.Unlock()
 	return nil
 }
 
@@ -633,6 +669,7 @@ func (s *span) Context() opentracing.SpanContext {
 	}
 	sc := &spanContext{
 		spanMeta: s.spanMeta,
+		span:     s,
 		Baggage:  baggageCopy,
 	}
 	if s.shadowTr != nil {
@@ -641,8 +678,7 @@ func (s *span) Context() opentracing.SpanContext {
 	}
 
 	if s.isRecording() {
-		sc.recordingGroup = s.mu.recordingGroup
-		sc.recordingType = s.mu.recordingType
+		sc.recordingType = s.mu.recording.recordingType
 	}
 	return sc
 }
@@ -707,8 +743,8 @@ func (s *span) LogFields(fields ...otlog.Field) {
 	}
 	if s.isRecording() {
 		s.mu.Lock()
-		if len(s.mu.recordedLogs) < maxLogsPerSpan {
-			s.mu.recordedLogs = append(s.mu.recordedLogs, opentracing.LogRecord{
+		if len(s.mu.recording.recordedLogs) < maxLogsPerSpan {
+			s.mu.recording.recordedLogs = append(s.mu.recording.recordedLogs, opentracing.LogRecord{
 				Timestamp: time.Now(),
 				Fields:    fields,
 			})
@@ -779,11 +815,9 @@ func (s *span) Log(data opentracing.LogData) {
 	panic("unimplemented")
 }
 
-// getRecording returns the span's recording.
-func (s *span) getRecording() RecordedSpan {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
+// getRecordingLocked returns the span's recording. This does not include
+// children.
+func (s *span) getRecordingLocked() RecordedSpan {
 	rs := RecordedSpan{
 		TraceID:      s.TraceID,
 		SpanID:       s.SpanID,
@@ -836,8 +870,8 @@ func (s *span) getRecording() RecordedSpan {
 			addTag(k, fmt.Sprint(v))
 		}
 	}
-	rs.Logs = make([]LogRecord, len(s.mu.recordedLogs))
-	for i, r := range s.mu.recordedLogs {
+	rs.Logs = make([]LogRecord, len(s.mu.recording.recordedLogs))
+	for i, r := range s.mu.recording.recordedLogs {
 		rs.Logs[i].Time = r.Timestamp
 		rs.Logs[i].Fields = make([]LogRecord_Field, len(r.Fields))
 		for j, f := range r.Fields {
@@ -851,47 +885,10 @@ func (s *span) getRecording() RecordedSpan {
 	return rs
 }
 
-// spanGroup keeps track of all the spans that are being recorded as a group (i.e.
-// the span for which recording was enabled and all direct or indirect child
-// spans since then).
-type spanGroup struct {
-	syncutil.Mutex
-	// spans keeps track of all the local spans. A span is inserted in this slice
-	// as soon as it is opened; the first element is the span passed to
-	// StartRecording().
-	spans []*span
-	// remoteSpans stores spans obtained from another host that we want to associate
-	// with the record for this group.
-	remoteSpans Recording
-}
-
-func (ss *spanGroup) addSpan(s *span) {
-	ss.Lock()
-	ss.spans = append(ss.spans, s)
-	ss.Unlock()
-}
-
-// getSpans returns all the local and remote spans accumulated in this group.
-// The spans are sorted by StartTime; the first result is naturally the first
-// local span - i.e. the span originally passed to StartRecording().
-func (ss *spanGroup) getSpans() Recording {
-	ss.Lock()
-	spans := ss.spans
-	remoteSpans := ss.remoteSpans
-	ss.Unlock()
-
-	result := make([]RecordedSpan, 0, len(spans)+len(remoteSpans))
-	for _, s := range spans {
-		rs := s.getRecording()
-		result = append(result, rs)
-	}
-	result = append(result, remoteSpans...)
-	// Sort the spans by StartTime. ss.spans were already naturally sorted, but
-	// ss.remoteSpans weren't.
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].StartTime.Before(result[j].StartTime)
-	})
-	return result
+func (s *span) addChild(child *span) {
+	s.mu.Lock()
+	s.mu.recording.children = append(s.mu.recording.children, child)
+	s.mu.Unlock()
 }
 
 type noopSpanContext struct{}

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -331,17 +331,12 @@ type traceLogData struct {
 // TODO(andrei): this should be unified with
 // SessionTracing.generateSessionTraceVTable().
 func (r Recording) String() string {
-	var logs []traceLogData
-	var start time.Time
-	for _, sp := range r {
-		if sp.ParentSpanID == 0 {
-			if start == (time.Time{}) {
-				start = sp.StartTime
-			}
-			logs = append(logs, r.visitSpan(sp, 0 /* depth */)...)
-		}
+	if len(r) == 0 {
+		return "<empty recording>"
 	}
+	logs := r.visitSpan(r[0], 0 /* depth */)
 
+	start := r[0].StartTime
 	var buf strings.Builder
 	for _, entry := range logs {
 		fmt.Fprintf(&buf, "% 10.3fms % 10.3fms%s",

--- a/pkg/util/tracing/tracer_span_test.go
+++ b/pkg/util/tracing/tracer_span_test.go
@@ -70,14 +70,6 @@ span local child:
 `)
 	require.NoError(t, err)
 
-	recStr := rec.String()
-	// Strip the timing info, converting rows like:
-	//      0.007ms      0.007ms    event:root 1
-	// into:
-	//    event:root 1
-	re := regexp.MustCompile(`.*s.*s\s\s\s\s`)
-	stripped := string(re.ReplaceAll([]byte(recStr), nil))
-
 	exp := `=== operation:root sb:1
 event:root 1
     === operation:remote child sb:1
@@ -89,7 +81,18 @@ event:root 3
 event:root 4
 event:root 5
 `
-	require.Equal(t, exp, stripped)
+	require.Equal(t, exp, recToStrippedString(rec))
+}
+
+func recToStrippedString(r Recording) string {
+	s := r.String()
+	// Strip the timing info, converting rows like:
+	//      0.007ms      0.007ms    event:root 1
+	// into:
+	//    event:root 1
+	re := regexp.MustCompile(`.*s.*s\s\s\s\s`)
+	stripped := string(re.ReplaceAll([]byte(s), nil))
+	return stripped
 }
 
 func TestRecordingInRecording(t *testing.T) {
@@ -121,4 +124,9 @@ span child:
 span grandchild:
 	tags: sb=1
 `))
+
+	exp := `=== operation:child sb:1
+    === operation:grandchild sb:1
+`
+	require.Equal(t, exp, recToStrippedString(childRec))
 }

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -70,9 +70,6 @@ func TestTracerRecording(t *testing.T) {
 	}
 
 	if err := TestingCheckRecordedSpans(GetRecording(s2), `
-		span a:
-			tags: unfinished=
-			x: 2
 		span b:
 			tags: unfinished=
 			x: 3
@@ -120,11 +117,6 @@ func TestTracerRecording(t *testing.T) {
 	// The child span is still recording.
 	s3.LogKV("x", 5)
 	if err := TestingCheckRecordedSpans(GetRecording(s3), `
-		span a:
-			tags: unfinished=
-			x: 2
-		span b:
-			x: 3
 		span c:
 			tags: tag=val
 			x: 4


### PR DESCRIPTION
The String() method wasn't working for recordings of non-root spans,
because it was looking for a root span (parent id = 0). A recording for
a span that had a parent doesn't have a root span. Things mostly worked
in practice, though, as children of no-op spans had a parent id = 0, so
they looked like roots.

This patch switches to assuming that the first span in the recording is
the "root of that recording".

Release note (bug fix): Fixed a bug causing the raw trace file collected
inside a statement diagnostics bundle to be sometimes empty when the
cluster setting sql.trace.txn.enable_threshold was in use.