### PR TITLE
config,sql: do not split on public schema ID

### DIFF
--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -298,7 +298,7 @@ func DecodeKeyIntoZoneIDAndSuffix(key roachpb.RKey) (id SystemTenantObjectID, ke
 	if !ok {
 		// Not in the structured data namespace.
 		objectID = keys.RootNamespaceID
-	} else if objectID <= keys.MaxSystemConfigDescID || isPseudoTableID(uint32(objectID)) {
+	} else if objectID <= keys.MaxSystemConfigDescID {
 		// For now, you cannot set the zone config on gossiped tables. The only
 		// way to set a zone config on these tables is to modify config for the
 		// system database as a whole. This is largely because all the
@@ -324,16 +324,6 @@ func DecodeKeyIntoZoneIDAndSuffix(key roachpb.RKey) (id SystemTenantObjectID, ke
 		objectID = keys.TenantsRangesID
 	}
 	return objectID, keySuffix
-}
-
-// isPseudoTableID returns true if id is in keys.PseudoTableIDs.
-func isPseudoTableID(id uint32) bool {
-	for _, pseudoTableID := range keys.PseudoTableIDs {
-		if id == pseudoTableID {
-			return true
-		}
-	}
-	return false
 }
 
 // GetZoneConfigForObject returns the combined zone config for the given object

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -571,12 +571,6 @@ func TestGetZoneConfigForKey(t *testing.T) {
 		{tkey(keys.LocationsTableID), keys.LocationsTableID},
 		{tkey(keys.NamespaceTableID), keys.NamespaceTableID},
 
-		// Pseudo-tables should refer to the SystemDatabaseID.
-		{tkey(keys.MetaRangesID), keys.SystemDatabaseID},
-		{tkey(keys.SystemRangesID), keys.SystemDatabaseID},
-		{tkey(keys.TimeseriesRangesID), keys.SystemDatabaseID},
-		{tkey(keys.LivenessRangesID), keys.SystemDatabaseID},
-
 		// User tables should refer to themselves.
 		{tkey(keys.MinUserDescID), keys.MinUserDescID},
 		{tkey(keys.MinUserDescID + 22), keys.MinUserDescID + 22},

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -405,7 +405,6 @@ var PseudoTableIDs = []uint32{
 	SystemRangesID,
 	TimeseriesRangesID,
 	LivenessRangesID,
-	PublicSchemaID,
 	TenantsRangesID,
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -298,8 +298,7 @@ start_key                          start_pretty                   end_key       
 [161]                              /Table/25                      [162]                              /Table/26                      system         replication_constraint_stats     ·           {1}       1
 [162]                              /Table/26                      [163]                              /Table/27                      system         replication_critical_localities  ·           {1}       1
 [163]                              /Table/27                      [164]                              /Table/28                      system         replication_stats                ·           {1}       1
-[164]                              /Table/28                      [165]                              /Table/29                      system         reports_meta                     ·           {1}       1
-[165]                              /Table/29                      [166]                              /NamespaceTable/30             ·              ·                                ·           {1}       1
+[164]                              /Table/28                      [166]                              /NamespaceTable/30             system         reports_meta                     ·           {1}       1
 [166]                              /NamespaceTable/30             [167]                              /NamespaceTable/Max            system         namespace2                       ·           {1}       1
 [167]                              /NamespaceTable/Max            [168]                              /Table/32                      system         protected_ts_meta                ·           {1}       1
 [168]                              /Table/32                      [169]                              /Table/33                      system         protected_ts_records             ·           {1}       1
@@ -355,8 +354,7 @@ start_key                          start_pretty                   end_key       
 [161]                              /Table/25                      [162]                              /Table/26                      system         replication_constraint_stats     ·           {1}       1
 [162]                              /Table/26                      [163]                              /Table/27                      system         replication_critical_localities  ·           {1}       1
 [163]                              /Table/27                      [164]                              /Table/28                      system         replication_stats                ·           {1}       1
-[164]                              /Table/28                      [165]                              /Table/29                      system         reports_meta                     ·           {1}       1
-[165]                              /Table/29                      [166]                              /NamespaceTable/30             ·              ·                                ·           {1}       1
+[164]                              /Table/28                      [166]                              /NamespaceTable/30             system         reports_meta                     ·           {1}       1
 [166]                              /NamespaceTable/30             [167]                              /NamespaceTable/Max            system         namespace2                       ·           {1}       1
 [167]                              /NamespaceTable/Max            [168]                              /Table/32                      system         protected_ts_meta                ·           {1}       1
 [168]                              /Table/32                      [169]                              /Table/33                      system         protected_ts_records             ·           {1}       1

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -41,7 +41,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 
 # Multi-row insert should auto-commit.
 query B
@@ -62,7 +62,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 
 # No auto-commit inside a transaction.
 statement ok
@@ -86,7 +86,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 2 CPut to (n1,s1):1
+dist sender send  r33: sending batch 2 CPut to (n1,s1):1
 
 statement ok
 ROLLBACK
@@ -110,7 +110,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 
 # TODO(radu): allow non-side-effecting projections.
 query B
@@ -132,8 +132,8 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 2 CPut to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 2 CPut to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 # Insert with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
@@ -156,8 +156,8 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 2 CPut to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 2 CPut to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 # Another way to test the scenario above: generate an error and ensure that the
 # mutation was not committed.
@@ -192,7 +192,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 1 Put, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 Put, 1 EndTxn to (n1,s1):1
 
 # Multi-row upsert should auto-commit.
 query B
@@ -213,7 +213,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 2 Put, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # No auto-commit inside a transaction.
 statement ok
@@ -237,7 +237,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 2 Put to (n1,s1):1
+dist sender send  r33: sending batch 2 Put to (n1,s1):1
 
 statement ok
 ROLLBACK
@@ -261,7 +261,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 2 Put, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # TODO(radu): allow non-side-effecting projections.
 query B
@@ -283,8 +283,8 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 2 Put to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 2 Put to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 # Upsert with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
@@ -307,8 +307,8 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 2 Put to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 2 Put to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 # Another way to test the scenario above: generate an error and ensure that the
 # mutation was not committed.
@@ -343,8 +343,8 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 2 Put, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # No auto-commit inside a transaction.
 statement ok
@@ -368,8 +368,8 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 2 Put to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 2 Put to (n1,s1):1
 
 statement ok
 ROLLBACK
@@ -393,8 +393,8 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 2 Put, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # TODO(radu): allow non-side-effecting projections.
 query B
@@ -416,9 +416,9 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 2 Put to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 2 Put to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 # Update with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
@@ -441,9 +441,9 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 2 Put to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 2 Put to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 # Another way to test the scenario above: generate an error and ensure that the
 # mutation was not committed.
@@ -478,7 +478,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 
 # Multi-row delete should auto-commit.
 query B
@@ -499,7 +499,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 
 # No auto-commit inside a transaction.
 statement ok
@@ -523,7 +523,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 1 DelRng to (n1,s1):1
+dist sender send  r33: sending batch 1 DelRng to (n1,s1):1
 
 statement ok
 ROLLBACK
@@ -547,8 +547,8 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 2 Del, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 
 # TODO(radu): allow non-side-effecting projections.
 query B
@@ -570,9 +570,9 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 2 Del to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 2 Del to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 # Insert with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
@@ -595,9 +595,9 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 2 Del to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 2 Del to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 statement ok
 INSERT INTO ab VALUES (12, 0);
@@ -644,9 +644,9 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 2 CPut, 2 InitPut to (n1,s1):1
-dist sender send  r34: sending batch 2 Scan to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 2 CPut, 2 InitPut to (n1,s1):1
+dist sender send  r33: sending batch 2 Scan to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 query B
 SELECT count(*) > 0 FROM [
@@ -667,10 +667,10 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 1 Put, 1 CPut, 1 Del to (n1,s1):1
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 1 Put, 1 CPut, 1 Del to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 query B
 SELECT count(*) > 0 FROM [
@@ -692,10 +692,10 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 1 Del to (n1,s1):1
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 1 Del to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 # Test with a single cascade, which should use autocommit.
 statement ok
@@ -719,10 +719,10 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 1 Del to (n1,s1):1
-dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 2 Del, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 1 Del to (n1,s1):1
+dist sender send  r33: sending batch 1 Scan to (n1,s1):1
+dist sender send  r33: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 
 # -----------------------
 # Multiple mutation tests
@@ -750,9 +750,9 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 2 CPut to (n1,s1):1
-dist sender send  r34: sending batch 2 CPut to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 2 CPut to (n1,s1):1
+dist sender send  r33: sending batch 2 CPut to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1
 
 query B
 SELECT count(*) > 0 FROM [
@@ -775,6 +775,6 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 2 CPut to (n1,s1):1
-dist sender send  r34: sending batch 2 CPut to (n1,s1):1
-dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 2 CPut to (n1,s1):1
+dist sender send  r33: sending batch 2 CPut to (n1,s1):1
+dist sender send  r33: sending batch 1 EndTxn to (n1,s1):1

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -216,9 +216,9 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message LIKE '%DelRange%' OR message LIKE '%DelRng%'
 ----
 flow              DelRange /Table/57/1 - /Table/57/2
-dist sender send  r34: sending batch 1 DelRng to (n1,s1):1
+dist sender send  r33: sending batch 1 DelRng to (n1,s1):1
 flow              DelRange /Table/57/1/601/0 - /Table/57/2
-dist sender send  r34: sending batch 1 DelRng to (n1,s1):1
+dist sender send  r33: sending batch 1 DelRng to (n1,s1):1
 
 # Ensure that DelRange requests are autocommitted when DELETE FROM happens on a
 # chunk of fewer than 600 keys.
@@ -234,7 +234,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message LIKE '%DelRange%' OR message LIKE '%sending batch%'
 ----
 flow              DelRange /Table/57/1/5 - /Table/57/1/5/#
-dist sender send  r34: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+dist sender send  r33: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 
 # Test use of fast path when there are interleaved tables.
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -255,7 +255,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 table reader                          Scan /Table/57/1/2{-/#}
 flow                                  CPut /Table/57/1/2/0 -> /TUPLE/2:2:Int/3
 flow                                  InitPut /Table/57/2/3/0 -> /BYTES/0x8a
-kv.DistSender: sending partial batch  r34: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
+kv.DistSender: sending partial batch  r33: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
 exec stmt                             rows affected: 1
 
@@ -269,7 +269,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 table reader                          Scan /Table/57/1/1{-/#}
 flow                                  CPut /Table/57/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/57/2/2/0 -> /BYTES/0x89
-kv.DistSender: sending partial batch  r34: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
+kv.DistSender: sending partial batch  r33: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
 exec stmt                             rows affected: 1
 
@@ -286,7 +286,7 @@ table reader                          fetched: /kv/primary/2/v -> /3
 flow                                  Put /Table/57/1/2/0 -> /TUPLE/2:2:Int/2
 flow                                  Del /Table/57/2/3/0
 flow                                  CPut /Table/57/2/2/0 -> /BYTES/0x8a (expecting does not exist)
-kv.DistSender: sending partial batch  r34: sending batch 1 Put, 1 EndTxn to (n1,s1):1
+kv.DistSender: sending partial batch  r33: sending batch 1 Put, 1 EndTxn to (n1,s1):1
 exec stmt                             execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 

--- a/pkg/sql/tests/testdata/initial_keys
+++ b/pkg/sql/tests/testdata/initial_keys
@@ -68,7 +68,7 @@ initial-keys tenant=system
  /NamespaceTable/30/1/1/29/"users"/4/1
  /NamespaceTable/30/1/1/29/"web_sessions"/4/1
  /NamespaceTable/30/1/1/29/"zones"/4/1
-28 splits:
+27 splits:
  /Table/11
  /Table/12
  /Table/13
@@ -87,7 +87,6 @@ initial-keys tenant=system
  /Table/26
  /Table/27
  /Table/28
- /Table/29
  /NamespaceTable/30
  /NamespaceTable/Max
  /Table/32


### PR DESCRIPTION
The PublicSchemaID was introduced during the work for temp tables and the
associated migration of the namespace table. The chosen constantly was
erroneously put into the PseudoTableIDs which is used to create split
points and control zone configs for low-level constructs like meta ranges,
liveness range, timeseries, etc.

This commit also fixed non-sense I introduced in #39638 while trying to
enable real system tables to have their own zone configs (as opposed to
just being controlled by the system zone config). All of the pseudo-table
ids had corresponding filters below.

This change should get backported as far back as 19.2.

Release note (bug fix): Fix bug where an extra split was created in the
keyspace which does not correspond to user data that could appear to
be under-replicated in mixed-version clusters due to conflicting
default zone configrations.