### PR TITLE
colexec: clean up merge joiner in mismatched types case

### DIFF
--- a/pkg/sql/colexec/cast.eg.go
+++ b/pkg/sql/colexec/cast.eg.go
@@ -26,2304 +26,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
-	castPerformed := false
-	switch inputVec.CanonicalTypeFamily() {
-	case types.BoolFamily:
-		switch inputVec.Type().Width() {
-		case -1:
-		default:
-			switch outputVec.CanonicalTypeFamily() {
-			case types.BoolFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Bool()
-					outputCol := outputVec.Bool()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-									r = v
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-									r = v
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r bool
-								r = v
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r bool
-								r = v
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.FloatFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Bool()
-					outputCol := outputVec.Float64()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r float64
-
-									r = 0
-									if v {
-										r = 1
-									}
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r float64
-
-									r = 0
-									if v {
-										r = 1
-									}
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r float64
-
-								r = 0
-								if v {
-									r = 1
-								}
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r float64
-
-								r = 0
-								if v {
-									r = 1
-								}
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.IntFamily:
-				switch outputVec.Type().Width() {
-				case 16:
-					inputCol := inputVec.Bool()
-					outputCol := outputVec.Int16()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int16
-
-									r = 0
-									if v {
-										r = 1
-									}
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int16
-
-									r = 0
-									if v {
-										r = 1
-									}
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int16
-
-								r = 0
-								if v {
-									r = 1
-								}
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int16
-
-								r = 0
-								if v {
-									r = 1
-								}
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				case 32:
-					inputCol := inputVec.Bool()
-					outputCol := outputVec.Int32()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int32
-
-									r = 0
-									if v {
-										r = 1
-									}
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int32
-
-									r = 0
-									if v {
-										r = 1
-									}
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int32
-
-								r = 0
-								if v {
-									r = 1
-								}
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int32
-
-								r = 0
-								if v {
-									r = 1
-								}
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				case -1:
-				default:
-					inputCol := inputVec.Bool()
-					outputCol := outputVec.Int64()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int64
-
-									r = 0
-									if v {
-										r = 1
-									}
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int64
-
-									r = 0
-									if v {
-										r = 1
-									}
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int64
-
-								r = 0
-								if v {
-									r = 1
-								}
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int64
-
-								r = 0
-								if v {
-									r = 1
-								}
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			}
-		}
-	case types.DecimalFamily:
-		switch inputVec.Type().Width() {
-		case -1:
-		default:
-			switch outputVec.CanonicalTypeFamily() {
-			case types.DecimalFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Decimal()
-					outputCol := outputVec.Decimal()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r apd.Decimal
-									r = v
-									outputCol[i].Set(&r)
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r apd.Decimal
-									r = v
-									outputCol[i].Set(&r)
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r apd.Decimal
-								r = v
-								outputCol[i].Set(&r)
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r apd.Decimal
-								r = v
-								outputCol[i].Set(&r)
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.BoolFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Decimal()
-					outputCol := outputVec.Bool()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-									r = v.Sign() != 0
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-									r = v.Sign() != 0
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r bool
-								r = v.Sign() != 0
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r bool
-								r = v.Sign() != 0
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			}
-		}
-	case types.IntFamily:
-		switch inputVec.Type().Width() {
-		case 16:
-			switch outputVec.CanonicalTypeFamily() {
-			case types.IntFamily:
-				switch outputVec.Type().Width() {
-				case 16:
-					inputCol := inputVec.Int16()
-					outputCol := outputVec.Int16()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int16
-									r = v
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int16
-									r = v
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int16
-								r = v
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int16
-								r = v
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				case 32:
-					inputCol := inputVec.Int16()
-					outputCol := outputVec.Int32()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int32
-
-									r = int32(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int32
-
-									r = int32(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int32
-
-								r = int32(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int32
-
-								r = int32(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				case -1:
-				default:
-					inputCol := inputVec.Int16()
-					outputCol := outputVec.Int64()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int64
-
-									r = int64(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int64
-
-									r = int64(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int64
-
-								r = int64(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int64
-
-								r = int64(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.BoolFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Int16()
-					outputCol := outputVec.Bool()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-
-									r = v != 0
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-
-									r = v != 0
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r bool
-
-								r = v != 0
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r bool
-
-								r = v != 0
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.DecimalFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Int16()
-					outputCol := outputVec.Decimal()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r apd.Decimal
-
-									r = *apd.New(int64(v), 0)
-
-									outputCol[i].Set(&r)
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r apd.Decimal
-
-									r = *apd.New(int64(v), 0)
-
-									outputCol[i].Set(&r)
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r apd.Decimal
-
-								r = *apd.New(int64(v), 0)
-
-								outputCol[i].Set(&r)
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r apd.Decimal
-
-								r = *apd.New(int64(v), 0)
-
-								outputCol[i].Set(&r)
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.FloatFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Int16()
-					outputCol := outputVec.Float64()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r float64
-
-									r = float64(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r float64
-
-									r = float64(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r float64
-
-								r = float64(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r float64
-
-								r = float64(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			}
-		case 32:
-			switch outputVec.CanonicalTypeFamily() {
-			case types.IntFamily:
-				switch outputVec.Type().Width() {
-				case 16:
-					inputCol := inputVec.Int32()
-					outputCol := outputVec.Int16()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int16
-
-									r = int16(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int16
-
-									r = int16(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int16
-
-								r = int16(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int16
-
-								r = int16(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				case 32:
-					inputCol := inputVec.Int32()
-					outputCol := outputVec.Int32()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int32
-									r = v
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int32
-									r = v
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int32
-								r = v
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int32
-								r = v
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				case -1:
-				default:
-					inputCol := inputVec.Int32()
-					outputCol := outputVec.Int64()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int64
-
-									r = int64(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int64
-
-									r = int64(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int64
-
-								r = int64(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int64
-
-								r = int64(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.BoolFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Int32()
-					outputCol := outputVec.Bool()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-
-									r = v != 0
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-
-									r = v != 0
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r bool
-
-								r = v != 0
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r bool
-
-								r = v != 0
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.DecimalFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Int32()
-					outputCol := outputVec.Decimal()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r apd.Decimal
-
-									r = *apd.New(int64(v), 0)
-
-									outputCol[i].Set(&r)
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r apd.Decimal
-
-									r = *apd.New(int64(v), 0)
-
-									outputCol[i].Set(&r)
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r apd.Decimal
-
-								r = *apd.New(int64(v), 0)
-
-								outputCol[i].Set(&r)
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r apd.Decimal
-
-								r = *apd.New(int64(v), 0)
-
-								outputCol[i].Set(&r)
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.FloatFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Int32()
-					outputCol := outputVec.Float64()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r float64
-
-									r = float64(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r float64
-
-									r = float64(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r float64
-
-								r = float64(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r float64
-
-								r = float64(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			}
-		case -1:
-		default:
-			switch outputVec.CanonicalTypeFamily() {
-			case types.IntFamily:
-				switch outputVec.Type().Width() {
-				case 16:
-					inputCol := inputVec.Int64()
-					outputCol := outputVec.Int16()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int16
-
-									r = int16(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int16
-
-									r = int16(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int16
-
-								r = int16(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int16
-
-								r = int16(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				case 32:
-					inputCol := inputVec.Int64()
-					outputCol := outputVec.Int32()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int32
-
-									r = int32(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int32
-
-									r = int32(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int32
-
-								r = int32(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int32
-
-								r = int32(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				case -1:
-				default:
-					inputCol := inputVec.Int64()
-					outputCol := outputVec.Int64()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int64
-									r = v
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int64
-									r = v
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int64
-								r = v
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int64
-								r = v
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.BoolFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Int64()
-					outputCol := outputVec.Bool()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-
-									r = v != 0
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-
-									r = v != 0
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r bool
-
-								r = v != 0
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r bool
-
-								r = v != 0
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.DecimalFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Int64()
-					outputCol := outputVec.Decimal()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r apd.Decimal
-
-									r = *apd.New(int64(v), 0)
-
-									outputCol[i].Set(&r)
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r apd.Decimal
-
-									r = *apd.New(int64(v), 0)
-
-									outputCol[i].Set(&r)
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r apd.Decimal
-
-								r = *apd.New(int64(v), 0)
-
-								outputCol[i].Set(&r)
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r apd.Decimal
-
-								r = *apd.New(int64(v), 0)
-
-								outputCol[i].Set(&r)
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.FloatFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Int64()
-					outputCol := outputVec.Float64()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r float64
-
-									r = float64(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r float64
-
-									r = float64(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r float64
-
-								r = float64(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r float64
-
-								r = float64(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			}
-		}
-	case types.FloatFamily:
-		switch inputVec.Type().Width() {
-		case -1:
-		default:
-			switch outputVec.CanonicalTypeFamily() {
-			case types.FloatFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Float64()
-					outputCol := outputVec.Float64()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r float64
-									r = v
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r float64
-									r = v
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r float64
-								r = v
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r float64
-								r = v
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.BoolFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Float64()
-					outputCol := outputVec.Bool()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-
-									r = v != 0
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-
-									r = v != 0
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r bool
-
-								r = v != 0
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r bool
-
-								r = v != 0
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.DecimalFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Float64()
-					outputCol := outputVec.Decimal()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r apd.Decimal
-
-									{
-										var tmpDec apd.Decimal
-										_, tmpErr := tmpDec.SetFloat64(float64(v))
-										if tmpErr != nil {
-											colexecerror.ExpectedError(tmpErr)
-										}
-										r = tmpDec
-									}
-
-									outputCol[i].Set(&r)
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r apd.Decimal
-
-									{
-										var tmpDec apd.Decimal
-										_, tmpErr := tmpDec.SetFloat64(float64(v))
-										if tmpErr != nil {
-											colexecerror.ExpectedError(tmpErr)
-										}
-										r = tmpDec
-									}
-
-									outputCol[i].Set(&r)
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r apd.Decimal
-
-								{
-									var tmpDec apd.Decimal
-									_, tmpErr := tmpDec.SetFloat64(float64(v))
-									if tmpErr != nil {
-										colexecerror.ExpectedError(tmpErr)
-									}
-									r = tmpDec
-								}
-
-								outputCol[i].Set(&r)
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r apd.Decimal
-
-								{
-									var tmpDec apd.Decimal
-									_, tmpErr := tmpDec.SetFloat64(float64(v))
-									if tmpErr != nil {
-										colexecerror.ExpectedError(tmpErr)
-									}
-									r = tmpDec
-								}
-
-								outputCol[i].Set(&r)
-							}
-						}
-					}
-					castPerformed = true
-				}
-			case types.IntFamily:
-				switch outputVec.Type().Width() {
-				case 16:
-					inputCol := inputVec.Float64()
-					outputCol := outputVec.Int16()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int16
-
-									if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
-										colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-									}
-									r = int16(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int16
-
-									if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
-										colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-									}
-									r = int16(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int16
-
-								if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
-									colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-								}
-								r = int16(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int16
-
-								if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
-									colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-								}
-								r = int16(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				case 32:
-					inputCol := inputVec.Float64()
-					outputCol := outputVec.Int32()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int32
-
-									if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
-										colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-									}
-									r = int32(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int32
-
-									if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
-										colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-									}
-									r = int32(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int32
-
-								if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
-									colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-								}
-								r = int32(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int32
-
-								if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
-									colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-								}
-								r = int32(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				case -1:
-				default:
-					inputCol := inputVec.Float64()
-					outputCol := outputVec.Int64()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int64
-
-									if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
-										colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-									}
-									r = int64(v)
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r int64
-
-									if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
-										colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-									}
-									r = int64(v)
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r int64
-
-								if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
-									colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-								}
-								r = int64(v)
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r int64
-
-								if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
-									colexecerror.ExpectedError(tree.ErrIntOutOfRange)
-								}
-								r = int64(v)
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			}
-		}
-	case typeconv.DatumVecCanonicalTypeFamily:
-		switch inputVec.Type().Width() {
-		case -1:
-		default:
-			switch outputVec.CanonicalTypeFamily() {
-			case types.BoolFamily:
-				switch outputVec.Type().Width() {
-				case -1:
-				default:
-					inputCol := inputVec.Datum()
-					outputCol := outputVec.Bool()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-
-									{
-										_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, types.Bool)
-										if err != nil {
-											colexecerror.ExpectedError(err)
-										}
-										r = _castedDatum == tree.DBoolTrue
-									}
-
-									outputCol[i] = r
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol.Slice(0, n)
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r bool
-
-									{
-										_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, types.Bool)
-										if err != nil {
-											colexecerror.ExpectedError(err)
-										}
-										r = _castedDatum == tree.DBoolTrue
-									}
-
-									outputCol[i] = r
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r bool
-
-								{
-									_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, types.Bool)
-									if err != nil {
-										colexecerror.ExpectedError(err)
-									}
-									r = _castedDatum == tree.DBoolTrue
-								}
-
-								outputCol[i] = r
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = inputCol.Slice(0, n)
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r bool
-
-								{
-									_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, types.Bool)
-									if err != nil {
-										colexecerror.ExpectedError(err)
-									}
-									r = _castedDatum == tree.DBoolTrue
-								}
-
-								outputCol[i] = r
-							}
-						}
-					}
-					castPerformed = true
-				}
-			}
-		}
-	}
-	if !castPerformed {
-		colexecerror.InternalError(fmt.Sprintf("unhandled cast %s -> %s", inputVec.Type(), outputVec.Type()))
-	}
-}
-
 func GetCastOperator(
 	allocator *colmem.Allocator,
 	input colexecbase.Operator,
@@ -2335,10 +37,10 @@ func GetCastOperator(
 	input = newVectorTypeEnforcer(allocator, input, toType, resultIdx)
 	if fromType.Family() == types.UnknownFamily {
 		return &castOpNullAny{
-			OneInputNode: NewOneInputNode(input),
-			allocator:    allocator,
-			colIdx:       colIdx,
-			outputIdx:    resultIdx,
+			oneInputCloserHelper: makeOneInputCloserHelper(input),
+			allocator:            allocator,
+			colIdx:               colIdx,
+			outputIdx:            resultIdx,
 		}, nil
 	}
 	leftType, rightType := fromType, toType
@@ -2352,47 +54,47 @@ func GetCastOperator(
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castBoolBoolOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.FloatFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castBoolFloat64Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.IntFamily:
 				switch rightType.Width() {
 				case 16:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castBoolInt16Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				case 32:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castBoolInt32Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castBoolInt64Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			}
@@ -2406,22 +108,22 @@ func GetCastOperator(
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castDecimalDecimalOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.BoolFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castDecimalBoolOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			}
@@ -2433,59 +135,59 @@ func GetCastOperator(
 			case types.IntFamily:
 				switch rightType.Width() {
 				case 16:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt16Int16Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				case 32:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt16Int32Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt16Int64Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.BoolFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt16BoolOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.DecimalFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt16DecimalOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.FloatFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt16Float64Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			}
@@ -2494,59 +196,59 @@ func GetCastOperator(
 			case types.IntFamily:
 				switch rightType.Width() {
 				case 16:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt32Int16Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				case 32:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt32Int32Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt32Int64Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.BoolFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt32BoolOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.DecimalFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt32DecimalOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.FloatFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt32Float64Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			}
@@ -2556,59 +258,59 @@ func GetCastOperator(
 			case types.IntFamily:
 				switch rightType.Width() {
 				case 16:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt64Int16Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				case 32:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt64Int32Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt64Int64Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.BoolFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt64BoolOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.DecimalFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt64DecimalOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.FloatFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castInt64Float64Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			}
@@ -2622,58 +324,58 @@ func GetCastOperator(
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castFloat64Float64Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.BoolFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castFloat64BoolOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.DecimalFamily:
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castFloat64DecimalOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			case types.IntFamily:
 				switch rightType.Width() {
 				case 16:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castFloat64Int16Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				case 32:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castFloat64Int32Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castFloat64Int64Op{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			}
@@ -2687,11 +389,11 @@ func GetCastOperator(
 				switch rightType.Width() {
 				case -1:
 				default:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &castDatumBoolOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 				}
 			}
@@ -2701,13 +403,14 @@ func GetCastOperator(
 }
 
 type castOpNullAny struct {
-	OneInputNode
+	oneInputCloserHelper
+
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
 }
 
-var _ colexecbase.Operator = &castOpNullAny{}
+var _ closableOperator = &castOpNullAny{}
 
 func (c *castOpNullAny) Init() {
 	c.input.Init()
@@ -2749,34 +452,3446 @@ func (c *castOpNullAny) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-type castOp struct {
-	OneInputNode
+// TODO(yuzefovich): refactor castOp so that it is type-specific (meaning not
+// canonical type family specific, but actual type specific). This will
+// probably require changing the way we handle cast overloads as well.
+
+type castBoolBoolOp struct {
+	oneInputCloserHelper
+
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
 }
 
-var _ colexecbase.Operator = &castOp{}
+var _ ResettableOperator = &castBoolBoolOp{}
+var _ closableOperator = &castBoolBoolOp{}
 
-func (c *castOp) Init() {
+func (c *castBoolBoolOp) Init() {
 	c.input.Init()
 }
 
-func (c *castOp) Next(ctx context.Context) coldata.Batch {
+func (c *castBoolBoolOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	batch := c.input.Next(ctx)
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
 	}
-	vec := batch.ColVec(c.colIdx)
-	projVec := batch.ColVec(c.outputIdx)
-	if projVec.MaybeHasNulls() {
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
 		// We need to make sure that there are no left over null values in the
 		// output vector.
-		projVec.Nulls().UnsetNulls()
+		outputVec.Nulls().UnsetNulls()
 	}
 	c.allocator.PerformOperation(
-		[]coldata.Vec{projVec}, func() { cast(vec, projVec, n, batch.Selection()) },
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Bool()
+			outputCol := outputVec.Bool()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+							r = v
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+							r = v
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r bool
+						r = v
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r bool
+						r = v
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castBoolFloat64Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castBoolFloat64Op{}
+var _ closableOperator = &castBoolFloat64Op{}
+
+func (c *castBoolFloat64Op) Init() {
+	c.input.Init()
+}
+
+func (c *castBoolFloat64Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castBoolFloat64Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Bool()
+			outputCol := outputVec.Float64()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r float64
+
+							r = 0
+							if v {
+								r = 1
+							}
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r float64
+
+							r = 0
+							if v {
+								r = 1
+							}
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r float64
+
+						r = 0
+						if v {
+							r = 1
+						}
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r float64
+
+						r = 0
+						if v {
+							r = 1
+						}
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castBoolInt16Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castBoolInt16Op{}
+var _ closableOperator = &castBoolInt16Op{}
+
+func (c *castBoolInt16Op) Init() {
+	c.input.Init()
+}
+
+func (c *castBoolInt16Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castBoolInt16Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Bool()
+			outputCol := outputVec.Int16()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int16
+
+							r = 0
+							if v {
+								r = 1
+							}
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int16
+
+							r = 0
+							if v {
+								r = 1
+							}
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int16
+
+						r = 0
+						if v {
+							r = 1
+						}
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int16
+
+						r = 0
+						if v {
+							r = 1
+						}
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castBoolInt32Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castBoolInt32Op{}
+var _ closableOperator = &castBoolInt32Op{}
+
+func (c *castBoolInt32Op) Init() {
+	c.input.Init()
+}
+
+func (c *castBoolInt32Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castBoolInt32Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Bool()
+			outputCol := outputVec.Int32()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int32
+
+							r = 0
+							if v {
+								r = 1
+							}
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int32
+
+							r = 0
+							if v {
+								r = 1
+							}
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int32
+
+						r = 0
+						if v {
+							r = 1
+						}
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int32
+
+						r = 0
+						if v {
+							r = 1
+						}
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castBoolInt64Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castBoolInt64Op{}
+var _ closableOperator = &castBoolInt64Op{}
+
+func (c *castBoolInt64Op) Init() {
+	c.input.Init()
+}
+
+func (c *castBoolInt64Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castBoolInt64Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Bool()
+			outputCol := outputVec.Int64()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int64
+
+							r = 0
+							if v {
+								r = 1
+							}
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int64
+
+							r = 0
+							if v {
+								r = 1
+							}
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int64
+
+						r = 0
+						if v {
+							r = 1
+						}
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int64
+
+						r = 0
+						if v {
+							r = 1
+						}
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castDecimalDecimalOp struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castDecimalDecimalOp{}
+var _ closableOperator = &castDecimalDecimalOp{}
+
+func (c *castDecimalDecimalOp) Init() {
+	c.input.Init()
+}
+
+func (c *castDecimalDecimalOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Decimal()
+			outputCol := outputVec.Decimal()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r apd.Decimal
+							r = v
+							outputCol[i].Set(&r)
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r apd.Decimal
+							r = v
+							outputCol[i].Set(&r)
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r apd.Decimal
+						r = v
+						outputCol[i].Set(&r)
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r apd.Decimal
+						r = v
+						outputCol[i].Set(&r)
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castDecimalBoolOp struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castDecimalBoolOp{}
+var _ closableOperator = &castDecimalBoolOp{}
+
+func (c *castDecimalBoolOp) Init() {
+	c.input.Init()
+}
+
+func (c *castDecimalBoolOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castDecimalBoolOp) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Decimal()
+			outputCol := outputVec.Bool()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+							r = v.Sign() != 0
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+							r = v.Sign() != 0
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r bool
+						r = v.Sign() != 0
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r bool
+						r = v.Sign() != 0
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt16Int16Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt16Int16Op{}
+var _ closableOperator = &castInt16Int16Op{}
+
+func (c *castInt16Int16Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt16Int16Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int16()
+			outputCol := outputVec.Int16()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int16
+							r = v
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int16
+							r = v
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int16
+						r = v
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int16
+						r = v
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt16Int32Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt16Int32Op{}
+var _ closableOperator = &castInt16Int32Op{}
+
+func (c *castInt16Int32Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt16Int32Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int16()
+			outputCol := outputVec.Int32()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int32
+
+							r = int32(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int32
+
+							r = int32(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int32
+
+						r = int32(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int32
+
+						r = int32(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt16Int64Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt16Int64Op{}
+var _ closableOperator = &castInt16Int64Op{}
+
+func (c *castInt16Int64Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt16Int64Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int16()
+			outputCol := outputVec.Int64()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int64
+
+							r = int64(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int64
+
+							r = int64(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int64
+
+						r = int64(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int64
+
+						r = int64(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt16BoolOp struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt16BoolOp{}
+var _ closableOperator = &castInt16BoolOp{}
+
+func (c *castInt16BoolOp) Init() {
+	c.input.Init()
+}
+
+func (c *castInt16BoolOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt16BoolOp) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int16()
+			outputCol := outputVec.Bool()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+
+							r = v != 0
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+
+							r = v != 0
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r bool
+
+						r = v != 0
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r bool
+
+						r = v != 0
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt16DecimalOp struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt16DecimalOp{}
+var _ closableOperator = &castInt16DecimalOp{}
+
+func (c *castInt16DecimalOp) Init() {
+	c.input.Init()
+}
+
+func (c *castInt16DecimalOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int16()
+			outputCol := outputVec.Decimal()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r apd.Decimal
+
+							r = *apd.New(int64(v), 0)
+
+							outputCol[i].Set(&r)
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r apd.Decimal
+
+							r = *apd.New(int64(v), 0)
+
+							outputCol[i].Set(&r)
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r apd.Decimal
+
+						r = *apd.New(int64(v), 0)
+
+						outputCol[i].Set(&r)
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r apd.Decimal
+
+						r = *apd.New(int64(v), 0)
+
+						outputCol[i].Set(&r)
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt16Float64Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt16Float64Op{}
+var _ closableOperator = &castInt16Float64Op{}
+
+func (c *castInt16Float64Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt16Float64Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int16()
+			outputCol := outputVec.Float64()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r float64
+
+							r = float64(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r float64
+
+							r = float64(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r float64
+
+						r = float64(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r float64
+
+						r = float64(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt32Int16Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt32Int16Op{}
+var _ closableOperator = &castInt32Int16Op{}
+
+func (c *castInt32Int16Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt32Int16Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int32()
+			outputCol := outputVec.Int16()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int16
+
+							r = int16(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int16
+
+							r = int16(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int16
+
+						r = int16(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int16
+
+						r = int16(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt32Int32Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt32Int32Op{}
+var _ closableOperator = &castInt32Int32Op{}
+
+func (c *castInt32Int32Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt32Int32Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int32()
+			outputCol := outputVec.Int32()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int32
+							r = v
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int32
+							r = v
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int32
+						r = v
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int32
+						r = v
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt32Int64Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt32Int64Op{}
+var _ closableOperator = &castInt32Int64Op{}
+
+func (c *castInt32Int64Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt32Int64Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int32()
+			outputCol := outputVec.Int64()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int64
+
+							r = int64(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int64
+
+							r = int64(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int64
+
+						r = int64(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int64
+
+						r = int64(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt32BoolOp struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt32BoolOp{}
+var _ closableOperator = &castInt32BoolOp{}
+
+func (c *castInt32BoolOp) Init() {
+	c.input.Init()
+}
+
+func (c *castInt32BoolOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt32BoolOp) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int32()
+			outputCol := outputVec.Bool()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+
+							r = v != 0
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+
+							r = v != 0
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r bool
+
+						r = v != 0
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r bool
+
+						r = v != 0
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt32DecimalOp struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt32DecimalOp{}
+var _ closableOperator = &castInt32DecimalOp{}
+
+func (c *castInt32DecimalOp) Init() {
+	c.input.Init()
+}
+
+func (c *castInt32DecimalOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int32()
+			outputCol := outputVec.Decimal()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r apd.Decimal
+
+							r = *apd.New(int64(v), 0)
+
+							outputCol[i].Set(&r)
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r apd.Decimal
+
+							r = *apd.New(int64(v), 0)
+
+							outputCol[i].Set(&r)
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r apd.Decimal
+
+						r = *apd.New(int64(v), 0)
+
+						outputCol[i].Set(&r)
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r apd.Decimal
+
+						r = *apd.New(int64(v), 0)
+
+						outputCol[i].Set(&r)
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt32Float64Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt32Float64Op{}
+var _ closableOperator = &castInt32Float64Op{}
+
+func (c *castInt32Float64Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt32Float64Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int32()
+			outputCol := outputVec.Float64()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r float64
+
+							r = float64(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r float64
+
+							r = float64(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r float64
+
+						r = float64(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r float64
+
+						r = float64(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt64Int16Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt64Int16Op{}
+var _ closableOperator = &castInt64Int16Op{}
+
+func (c *castInt64Int16Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt64Int16Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int64()
+			outputCol := outputVec.Int16()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int16
+
+							r = int16(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int16
+
+							r = int16(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int16
+
+						r = int16(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int16
+
+						r = int16(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt64Int32Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt64Int32Op{}
+var _ closableOperator = &castInt64Int32Op{}
+
+func (c *castInt64Int32Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt64Int32Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int64()
+			outputCol := outputVec.Int32()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int32
+
+							r = int32(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int32
+
+							r = int32(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int32
+
+						r = int32(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int32
+
+						r = int32(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt64Int64Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt64Int64Op{}
+var _ closableOperator = &castInt64Int64Op{}
+
+func (c *castInt64Int64Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt64Int64Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int64()
+			outputCol := outputVec.Int64()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int64
+							r = v
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int64
+							r = v
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int64
+						r = v
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int64
+						r = v
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt64BoolOp struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt64BoolOp{}
+var _ closableOperator = &castInt64BoolOp{}
+
+func (c *castInt64BoolOp) Init() {
+	c.input.Init()
+}
+
+func (c *castInt64BoolOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt64BoolOp) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int64()
+			outputCol := outputVec.Bool()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+
+							r = v != 0
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+
+							r = v != 0
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r bool
+
+						r = v != 0
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r bool
+
+						r = v != 0
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt64DecimalOp struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt64DecimalOp{}
+var _ closableOperator = &castInt64DecimalOp{}
+
+func (c *castInt64DecimalOp) Init() {
+	c.input.Init()
+}
+
+func (c *castInt64DecimalOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int64()
+			outputCol := outputVec.Decimal()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r apd.Decimal
+
+							r = *apd.New(int64(v), 0)
+
+							outputCol[i].Set(&r)
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r apd.Decimal
+
+							r = *apd.New(int64(v), 0)
+
+							outputCol[i].Set(&r)
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r apd.Decimal
+
+						r = *apd.New(int64(v), 0)
+
+						outputCol[i].Set(&r)
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r apd.Decimal
+
+						r = *apd.New(int64(v), 0)
+
+						outputCol[i].Set(&r)
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castInt64Float64Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castInt64Float64Op{}
+var _ closableOperator = &castInt64Float64Op{}
+
+func (c *castInt64Float64Op) Init() {
+	c.input.Init()
+}
+
+func (c *castInt64Float64Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Int64()
+			outputCol := outputVec.Float64()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r float64
+
+							r = float64(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r float64
+
+							r = float64(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r float64
+
+						r = float64(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r float64
+
+						r = float64(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castFloat64Float64Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castFloat64Float64Op{}
+var _ closableOperator = &castFloat64Float64Op{}
+
+func (c *castFloat64Float64Op) Init() {
+	c.input.Init()
+}
+
+func (c *castFloat64Float64Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Float64()
+			outputCol := outputVec.Float64()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r float64
+							r = v
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r float64
+							r = v
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r float64
+						r = v
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r float64
+						r = v
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castFloat64BoolOp struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castFloat64BoolOp{}
+var _ closableOperator = &castFloat64BoolOp{}
+
+func (c *castFloat64BoolOp) Init() {
+	c.input.Init()
+}
+
+func (c *castFloat64BoolOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castFloat64BoolOp) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Float64()
+			outputCol := outputVec.Bool()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+
+							r = v != 0
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+
+							r = v != 0
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r bool
+
+						r = v != 0
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r bool
+
+						r = v != 0
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castFloat64DecimalOp struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castFloat64DecimalOp{}
+var _ closableOperator = &castFloat64DecimalOp{}
+
+func (c *castFloat64DecimalOp) Init() {
+	c.input.Init()
+}
+
+func (c *castFloat64DecimalOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Float64()
+			outputCol := outputVec.Decimal()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r apd.Decimal
+
+							{
+								var tmpDec apd.Decimal
+								_, tmpErr := tmpDec.SetFloat64(float64(v))
+								if tmpErr != nil {
+									colexecerror.ExpectedError(tmpErr)
+								}
+								r = tmpDec
+							}
+
+							outputCol[i].Set(&r)
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r apd.Decimal
+
+							{
+								var tmpDec apd.Decimal
+								_, tmpErr := tmpDec.SetFloat64(float64(v))
+								if tmpErr != nil {
+									colexecerror.ExpectedError(tmpErr)
+								}
+								r = tmpDec
+							}
+
+							outputCol[i].Set(&r)
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r apd.Decimal
+
+						{
+							var tmpDec apd.Decimal
+							_, tmpErr := tmpDec.SetFloat64(float64(v))
+							if tmpErr != nil {
+								colexecerror.ExpectedError(tmpErr)
+							}
+							r = tmpDec
+						}
+
+						outputCol[i].Set(&r)
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r apd.Decimal
+
+						{
+							var tmpDec apd.Decimal
+							_, tmpErr := tmpDec.SetFloat64(float64(v))
+							if tmpErr != nil {
+								colexecerror.ExpectedError(tmpErr)
+							}
+							r = tmpDec
+						}
+
+						outputCol[i].Set(&r)
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castFloat64Int16Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castFloat64Int16Op{}
+var _ closableOperator = &castFloat64Int16Op{}
+
+func (c *castFloat64Int16Op) Init() {
+	c.input.Init()
+}
+
+func (c *castFloat64Int16Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Float64()
+			outputCol := outputVec.Int16()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int16
+
+							if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
+								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+							}
+							r = int16(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int16
+
+							if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
+								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+							}
+							r = int16(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int16
+
+						if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
+							colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+						}
+						r = int16(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int16
+
+						if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
+							colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+						}
+						r = int16(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castFloat64Int32Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castFloat64Int32Op{}
+var _ closableOperator = &castFloat64Int32Op{}
+
+func (c *castFloat64Int32Op) Init() {
+	c.input.Init()
+}
+
+func (c *castFloat64Int32Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Float64()
+			outputCol := outputVec.Int32()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int32
+
+							if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
+								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+							}
+							r = int32(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int32
+
+							if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
+								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+							}
+							r = int32(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int32
+
+						if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
+							colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+						}
+						r = int32(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int32
+
+						if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
+							colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+						}
+						r = int32(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castFloat64Int64Op struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castFloat64Int64Op{}
+var _ closableOperator = &castFloat64Int64Op{}
+
+func (c *castFloat64Int64Op) Init() {
+	c.input.Init()
+}
+
+func (c *castFloat64Int64Op) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Float64()
+			outputCol := outputVec.Int64()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int64
+
+							if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
+								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+							}
+							r = int64(v)
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r int64
+
+							if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
+								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+							}
+							r = int64(v)
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r int64
+
+						if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
+							colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+						}
+						r = int64(v)
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol[0:n]
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r int64
+
+						if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
+							colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+						}
+						r = int64(v)
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
+	)
+	return batch
+}
+
+type castDatumBoolOp struct {
+	oneInputCloserHelper
+
+	allocator *colmem.Allocator
+	colIdx    int
+	outputIdx int
+}
+
+var _ ResettableOperator = &castDatumBoolOp{}
+var _ closableOperator = &castDatumBoolOp{}
+
+func (c *castDatumBoolOp) Init() {
+	c.input.Init()
+}
+
+func (c *castDatumBoolOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *castDatumBoolOp) Next(ctx context.Context) coldata.Batch {
+	batch := c.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
+	c.allocator.PerformOperation(
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec.Datum()
+			outputCol := outputVec.Bool()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+
+							{
+								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, types.Bool)
+								if err != nil {
+									colexecerror.ExpectedError(err)
+								}
+								r = _castedDatum == tree.DBoolTrue
+							}
+
+							outputCol[i] = r
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol.Slice(0, n)
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r bool
+
+							{
+								_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, types.Bool)
+								if err != nil {
+									colexecerror.ExpectedError(err)
+								}
+								r = _castedDatum == tree.DBoolTrue
+							}
+
+							outputCol[i] = r
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r bool
+
+						{
+							_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, types.Bool)
+							if err != nil {
+								colexecerror.ExpectedError(err)
+							}
+							r = _castedDatum == tree.DBoolTrue
+						}
+
+						outputCol[i] = r
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = inputCol.Slice(0, n)
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r bool
+
+						{
+							_castedDatum, err := v.(*coldataext.Datum).Cast(inputCol, types.Bool)
+							if err != nil {
+								colexecerror.ExpectedError(err)
+							}
+							r = _castedDatum == tree.DBoolTrue
+						}
+
+						outputCol[i] = r
+					}
+				}
+			}
+		},
 	)
 	return batch
 }

--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -71,89 +71,6 @@ func _L_SLICE(col, i, j interface{}) interface{} {
 
 // */}}
 
-func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
-	castPerformed := false
-	switch inputVec.CanonicalTypeFamily() {
-	// {{range .LeftFamilies}}
-	case _LEFT_CANONICAL_TYPE_FAMILY:
-		switch inputVec.Type().Width() {
-		// {{range .LeftWidths}}
-		case _LEFT_TYPE_WIDTH:
-			switch outputVec.CanonicalTypeFamily() {
-			// {{range .RightFamilies}}
-			case _RIGHT_CANONICAL_TYPE_FAMILY:
-				switch outputVec.Type().Width() {
-				// {{range .RightWidths}}
-				case _RIGHT_TYPE_WIDTH:
-					inputCol := inputVec._L_TYP()
-					outputCol := outputVec._R_TYP()
-					if inputVec.MaybeHasNulls() {
-						inputNulls := inputVec.Nulls()
-						outputNulls := outputVec.Nulls()
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r _R_GO_TYPE
-									_CAST(r, v, inputCol)
-									_R_SET(outputCol, i, r)
-								}
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = _L_SLICE(inputCol, 0, n)
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								if inputNulls.NullAt(i) {
-									outputNulls.SetNull(i)
-								} else {
-									v := inputCol.Get(i)
-									var r _R_GO_TYPE
-									_CAST(r, v, inputCol)
-									_R_SET(outputCol, i, r)
-								}
-							}
-						}
-					} else {
-						if sel != nil {
-							sel = sel[:n]
-							for _, i := range sel {
-								v := inputCol.Get(i)
-								var r _R_GO_TYPE
-								_CAST(r, v, inputCol)
-								_R_SET(outputCol, i, r)
-							}
-						} else {
-							// Remove bounds checks for inputCol[i] and outputCol[i].
-							inputCol = _L_SLICE(inputCol, 0, n)
-							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1)
-							for i := 0; i < n; i++ {
-								v := inputCol.Get(i)
-								var r _R_GO_TYPE
-								_CAST(r, v, inputCol)
-								_R_SET(outputCol, i, r)
-							}
-						}
-					}
-					castPerformed = true
-					// {{end}}
-				}
-				// {{end}}
-			}
-			// {{end}}
-		}
-		// {{end}}
-	}
-	if !castPerformed {
-		colexecerror.InternalError(fmt.Sprintf("unhandled cast %s -> %s", inputVec.Type(), outputVec.Type()))
-	}
-}
-
 func GetCastOperator(
 	allocator *colmem.Allocator,
 	input colexecbase.Operator,
@@ -165,10 +82,10 @@ func GetCastOperator(
 	input = newVectorTypeEnforcer(allocator, input, toType, resultIdx)
 	if fromType.Family() == types.UnknownFamily {
 		return &castOpNullAny{
-			OneInputNode: NewOneInputNode(input),
-			allocator:    allocator,
-			colIdx:       colIdx,
-			outputIdx:    resultIdx,
+			oneInputCloserHelper: makeOneInputCloserHelper(input),
+			allocator:            allocator,
+			colIdx:               colIdx,
+			outputIdx:            resultIdx,
 		}, nil
 	}
 	leftType, rightType := fromType, toType
@@ -184,11 +101,11 @@ func GetCastOperator(
 				switch rightType.Width() {
 				// {{range .RightWidths}}
 				case _RIGHT_TYPE_WIDTH:
-					return &castOp{
-						OneInputNode: NewOneInputNode(input),
-						allocator:    allocator,
-						colIdx:       colIdx,
-						outputIdx:    resultIdx,
+					return &cast_NAMEOp{
+						oneInputCloserHelper: makeOneInputCloserHelper(input),
+						allocator:            allocator,
+						colIdx:               colIdx,
+						outputIdx:            resultIdx,
 					}, nil
 					// {{end}}
 				}
@@ -202,13 +119,14 @@ func GetCastOperator(
 }
 
 type castOpNullAny struct {
-	OneInputNode
+	oneInputCloserHelper
+
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
 }
 
-var _ colexecbase.Operator = &castOpNullAny{}
+var _ closableOperator = &castOpNullAny{}
 
 func (c *castOpNullAny) Init() {
 	c.input.Init()
@@ -250,34 +168,113 @@ func (c *castOpNullAny) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-type castOp struct {
-	OneInputNode
+// TODO(yuzefovich): refactor castOp so that it is type-specific (meaning not
+// canonical type family specific, but actual type specific). This will
+// probably require changing the way we handle cast overloads as well.
+
+// {{range .LeftFamilies}}
+// {{range .LeftWidths}}
+// {{range .RightFamilies}}
+// {{range .RightWidths}}
+
+type cast_NAMEOp struct {
+	oneInputCloserHelper
+
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
 }
 
-var _ colexecbase.Operator = &castOp{}
+var _ ResettableOperator = &cast_NAMEOp{}
+var _ closableOperator = &cast_NAMEOp{}
 
-func (c *castOp) Init() {
+func (c *cast_NAMEOp) Init() {
 	c.input.Init()
 }
 
-func (c *castOp) Next(ctx context.Context) coldata.Batch {
+func (c *cast_NAMEOp) reset(ctx context.Context) {
+	if r, ok := c.input.(resetter); ok {
+		r.reset(ctx)
+	}
+}
+
+func (c *cast_NAMEOp) Next(ctx context.Context) coldata.Batch {
 	batch := c.input.Next(ctx)
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
 	}
-	vec := batch.ColVec(c.colIdx)
-	projVec := batch.ColVec(c.outputIdx)
-	if projVec.MaybeHasNulls() {
+	sel := batch.Selection()
+	inputVec := batch.ColVec(c.colIdx)
+	outputVec := batch.ColVec(c.outputIdx)
+	if outputVec.MaybeHasNulls() {
 		// We need to make sure that there are no left over null values in the
 		// output vector.
-		projVec.Nulls().UnsetNulls()
+		outputVec.Nulls().UnsetNulls()
 	}
 	c.allocator.PerformOperation(
-		[]coldata.Vec{projVec}, func() { cast(vec, projVec, n, batch.Selection()) },
+		[]coldata.Vec{outputVec}, func() {
+			inputCol := inputVec._L_TYP()
+			outputCol := outputVec._R_TYP()
+			if inputVec.MaybeHasNulls() {
+				inputNulls := inputVec.Nulls()
+				outputNulls := outputVec.Nulls()
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r _R_GO_TYPE
+							_CAST(r, v, inputCol)
+							_R_SET(outputCol, i, r)
+						}
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = _L_SLICE(inputCol, 0, n)
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						if inputNulls.NullAt(i) {
+							outputNulls.SetNull(i)
+						} else {
+							v := inputCol.Get(i)
+							var r _R_GO_TYPE
+							_CAST(r, v, inputCol)
+							_R_SET(outputCol, i, r)
+						}
+					}
+				}
+			} else {
+				if sel != nil {
+					sel = sel[:n]
+					for _, i := range sel {
+						v := inputCol.Get(i)
+						var r _R_GO_TYPE
+						_CAST(r, v, inputCol)
+						_R_SET(outputCol, i, r)
+					}
+				} else {
+					// Remove bounds checks for inputCol[i] and outputCol[i].
+					inputCol = _L_SLICE(inputCol, 0, n)
+					_ = inputCol.Get(n - 1)
+					_ = outputCol.Get(n - 1)
+					for i := 0; i < n; i++ {
+						v := inputCol.Get(i)
+						var r _R_GO_TYPE
+						_CAST(r, v, inputCol)
+						_R_SET(outputCol, i, r)
+					}
+				}
+			}
+		},
 	)
 	return batch
 }
+
+// {{end}}
+// {{end}}
+// {{end}}
+// {{end}}

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
@@ -27,6 +27,7 @@ func genCastOperators(inputFileContents string, wr io.Writer) error {
 		"_R_GO_TYPE", "{{.Right.GoType}}",
 		"_L_TYP", "{{.Left.VecMethod}}",
 		"_R_TYP", "{{.Right.VecMethod}}",
+		"_NAME", "{{.Left.VecMethod}}{{.Right.VecMethod}}",
 	)
 	s := r.Replace(inputFileContents)
 

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -713,10 +713,8 @@ func (hj *externalHashJoiner) Close(ctx context.Context) error {
 	if err := hj.rightPartitioner.Close(ctx); err != nil && retErr == nil {
 		retErr = err
 	}
-	if c, ok := hj.diskBackedSortMerge.(Closer); ok {
-		if err := c.Close(ctx); err != nil && retErr == nil {
-			retErr = err
-		}
+	if err := hj.diskBackedSortMerge.(Closer).Close(ctx); err != nil && retErr == nil {
+		retErr = err
 	}
 	if !hj.testingKnobs.delegateFDAcquisitions && hj.fdState.acquiredFDs > 0 {
 		hj.fdState.fdSemaphore.Release(hj.fdState.acquiredFDs)

--- a/pkg/sql/colexec/limit.go
+++ b/pkg/sql/colexec/limit.go
@@ -20,8 +20,7 @@ import (
 // limitOp is an operator that implements limit, returning only the first n
 // tuples from its input.
 type limitOp struct {
-	OneInputNode
-	closerHelper
+	oneInputCloserHelper
 
 	limit int
 
@@ -37,8 +36,8 @@ var _ closableOperator = &limitOp{}
 // NewLimitOp returns a new limit operator with the given limit.
 func NewLimitOp(input colexecbase.Operator, limit int) colexecbase.Operator {
 	c := &limitOp{
-		OneInputNode: NewOneInputNode(input),
-		limit:        limit,
+		oneInputCloserHelper: makeOneInputCloserHelper(input),
+		limit:                limit,
 	}
 	return c
 }
@@ -64,19 +63,4 @@ func (c *limitOp) Next(ctx context.Context) coldata.Batch {
 	}
 	c.seen = newSeen
 	return bat
-}
-
-// Close closes the limitOp's input.
-// TODO(asubiotto): Remove this method. It only exists so that we can call Close
-//  from some runTests subtests when not draining the input fully. The test
-//  should pass in the testing.T object used so that the caller can decide to
-//  explicitly close the input after checking the test.
-func (c *limitOp) Close(ctx context.Context) error {
-	if !c.close() {
-		return nil
-	}
-	if closer, ok := c.input.(Closer); ok {
-		return closer.Close(ctx)
-	}
-	return nil
 }

--- a/pkg/sql/colexec/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_exceptall.eg.go
@@ -42,67 +42,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -8965,67 +8905,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -17888,67 +17768,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -26811,67 +26631,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 

--- a/pkg/sql/colexec/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_fullouter.eg.go
@@ -42,67 +42,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -10511,67 +10451,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -20980,67 +20860,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -31449,67 +31269,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 

--- a/pkg/sql/colexec/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/mergejoiner_inner.eg.go
@@ -42,67 +42,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -6599,67 +6539,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -13156,67 +13036,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -19713,67 +19533,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 

--- a/pkg/sql/colexec/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_intersectall.eg.go
@@ -42,67 +42,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -6849,67 +6789,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -13656,67 +13536,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -20463,67 +20283,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 

--- a/pkg/sql/colexec/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftanti.eg.go
@@ -42,67 +42,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -8555,67 +8495,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -17068,67 +16948,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -25581,67 +25401,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 

--- a/pkg/sql/colexec/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftouter.eg.go
@@ -42,67 +42,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -8595,67 +8535,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -17148,67 +17028,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -25701,67 +25521,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 

--- a/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
@@ -42,67 +42,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -6559,67 +6499,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -13076,67 +12956,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -19593,67 +19413,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 

--- a/pkg/sql/colexec/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_rightouter.eg.go
@@ -42,67 +42,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -8515,67 +8455,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -16988,67 +16868,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 
@@ -25461,67 +25281,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1609,6 +1609,30 @@ var mjTestCases = []*joinTestCase{
 		rightEqCols:  []uint32{0},
 		expected:     tuples{{nil}, {true}, {true}},
 	},
+	{
+		description: "FULL OUTER join on mixed-type equality columns",
+		joinType:    sqlbase.FullOuterJoin,
+		leftTuples: tuples{
+			{8398534516657654136},
+			{932352552525192296},
+		},
+		leftTypes:   []*types.T{types.Int},
+		leftOutCols: []uint32{0},
+		leftEqCols:  []uint32{0},
+		rightTuples: tuples{
+			{-20041},
+			{23918},
+		},
+		rightTypes:   []*types.T{types.Int2},
+		rightOutCols: []uint32{0},
+		rightEqCols:  []uint32{0},
+		expected: tuples{
+			{8398534516657654136, nil},
+			{932352552525192296, nil},
+			{nil, -20041},
+			{nil, 23918},
+		},
+	},
 }
 
 func TestMergeJoiner(t *testing.T) {
@@ -1647,7 +1671,7 @@ func TestMergeJoiner(t *testing.T) {
 					output.input.Init()
 				}
 				verify := output.Verify
-				if _, isFullOuter := output.input.(*mergeJoinFullOuterOp); isFullOuter {
+				if tc.joinType == sqlbase.FullOuterJoin {
 					// FULL OUTER JOIN doesn't guarantee any ordering on its output (since
 					// it is ambiguous), so we're comparing the outputs as sets.
 					verify = output.VerifyAnyOrder

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -678,67 +678,7 @@ EqLoop:
 		rightColIdx := o.right.eqCols[eqColIdx]
 		lVec := o.proberState.lBatch.ColVec(int(leftColIdx))
 		rVec := o.proberState.rBatch.ColVec(int(rightColIdx))
-		leftType := o.left.sourceTypes[leftColIdx]
-		rightType := o.right.sourceTypes[rightColIdx]
-		colType := leftType
-		// Merge joiner only supports the case when the physical types in the
-		// equality columns in both inputs are the same. If that is not the case,
-		// we need to cast one of the vectors to another's physical type putting
-		// the result of the cast into a temporary vector that is used instead of
-		// the original.
-		leftCanonicalTypeFamily := o.left.canonicalTypeFamilies[leftColIdx]
-		isNumeric := leftCanonicalTypeFamily == types.IntFamily ||
-			leftCanonicalTypeFamily == types.FloatFamily ||
-			leftCanonicalTypeFamily == types.DecimalFamily
-		if isNumeric && !leftType.Identical(rightType) {
-			castLeftToRight := false
-			// There is a hierarchy of valid casts:
-			//   Int16 -> Int32 -> Int64 -> Float64 -> Decimal
-			// and the cast is valid if 'fromType' is mentioned before 'toType'
-			// in this chain.
-			switch leftCanonicalTypeFamily {
-			case types.IntFamily:
-				switch leftType.Width() {
-				case 16:
-					castLeftToRight = true
-				case 32:
-					castLeftToRight = !rightType.Identical(types.Int2)
-				case 64:
-					castLeftToRight = !rightType.Identical(types.Int2) && !rightType.Identical(types.Int4)
-				}
-			case types.FloatFamily:
-				castLeftToRight = o.right.canonicalTypeFamilies[rightColIdx] == types.DecimalFamily
-			}
-
-			toType := leftType
-			if castLeftToRight {
-				toType = rightType
-			}
-			var tempVec coldata.Vec
-			for _, vec := range o.scratch.tempVecs {
-				if vec.Type().Identical(toType) {
-					tempVec = vec
-					break
-				}
-			}
-			if tempVec == nil {
-				tempVec = o.unlimitedAllocator.NewMemColumn(toType, coldata.BatchSize())
-				o.scratch.tempVecs = append(o.scratch.tempVecs, tempVec)
-			} else {
-				tempVec.Nulls().UnsetNulls()
-				if tempVec.CanonicalTypeFamily() == types.BytesFamily {
-					tempVec.Bytes().Reset()
-				}
-			}
-			if castLeftToRight {
-				cast(lVec, tempVec, o.proberState.lBatch.Length(), lSel)
-				lVec = tempVec
-				colType = rightType
-			} else {
-				cast(rVec, tempVec, o.proberState.rBatch.Length(), rSel)
-				rVec = tempVec
-			}
-		}
+		colType := o.left.sourceTypes[leftColIdx]
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 				_PROBE_SWITCH(_JOIN_TYPE, _SEL_ARG, true, true)

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning_5node
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning_5node
@@ -73,7 +73,7 @@ EXPLAIN (VEC) SELECT * FROM kv WHERE k::REGCLASS IS NOT NULL
 │
 ├ Node 1
 │ └ *colexec.isNullSelOp
-│   └ *colexec.castOp
+│   └ *colexec.castInt64Int64Op
 │     └ *colexec.ParallelUnorderedSynchronizer
 │       ├ *colfetcher.colBatchScan
 │       ├ *colrpc.Inbox
@@ -103,7 +103,7 @@ EXPLAIN (VEC) SELECT * FROM kv WHERE k::REGCLASS IS NOT NULL
 │
 └ Node 1
   └ *colexec.isNullSelOp
-    └ *colexec.castOp
+    └ *colexec.castInt64Int64Op
       └ *colfetcher.colBatchScan
 
 statement ok
@@ -116,7 +116,7 @@ EXPLAIN (VEC) SELECT k::REGCLASS FROM kv
 ----
 │
 ├ Node 1
-│ └ *colexec.castOp
+│ └ *colexec.castInt64Int64Op
 │   └ *colexec.ParallelUnorderedSynchronizer
 │     ├ *colfetcher.colBatchScan
 │     ├ *colrpc.Inbox
@@ -172,7 +172,7 @@ EXPLAIN (VEC) SELECT k::REGCLASS FROM kv
 ----
 │
 └ Node 1
-  └ *colexec.castOp
+  └ *colexec.castInt64Int64Op
     └ *colfetcher.colBatchScan
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/merge_join_dist_vec
+++ b/pkg/sql/logictest/testdata/logic_test/merge_join_dist_vec
@@ -46,3 +46,47 @@ query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 2]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzEk9GPk0AQxt_9KzbjS6t7gaX4ssklGOWUSw9O4KLJhYe9MrYkHIu7S2LT9H83wCUV5Gobjb6xu_P7Zub7wg70txI4JP7Sf5eSRpXkKo5uyL3_5Xb5NgjJ7H2QpMmn5Zw8lbzqC0qy9K9Sch0FIVHkLgnCD2Qm5uTzRz_2iSCXxMmAQiVzDMUjauD3wICCAxmFWskVai1Ve73rioL8O3CbQlHVjWmvMworqRD4DkxhSgQOqXgoMUaRo7JarRyNKMpOulbFo1BbTwGFpBaV5sRyLizHegnZnoJszJPsQe1hSzZCb4Y6HoNsn1HQRqwRuLOnz4x30GkqqXJUmA-Uspb8XcnEjjeo1ngtiwqVtRjOlm5r5L3t0V3qx535QKHEr2bmsdfzS1WsN_0nUIgaw4nHqOdQzx25cNhw8QcbTowfygtZW-7YisnW7qA1Oz17ezr78u9mz54d719k7_zX7CeGi1HXstJ4UrR2ux7ma-zt0rJRK7xVctW16Y9Rx3XO5qhN_-r2h6Dqnrrf73SYHYfZGLZ_hp0BzMawcxR-M4DtMbw4Y-dfOh-H2XHYPWvnbP_iRwAAAP__W2L0nA==
+
+# Test that we can handle merge joins with equality columns of integers with
+# different widths.
+statement ok
+CREATE TABLE numbers (_int2 INT2, _int4 INT4, _int8 INT8, _float FLOAT, _decimal DECIMAL);
+INSERT INTO numbers VALUES (1, 1, 1, 1, 1)
+
+# Place the single range on node 1 for determinism.
+statement ok
+ALTER TABLE numbers EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 1)
+
+query T
+EXPLAIN (VEC) SELECT * FROM numbers AS t1 INNER MERGE JOIN numbers AS t2 ON t1._int2 = t2._int4
+----
+│
+└ Node 1
+  └ *colexec.mergeJoinInnerOp
+    ├ *colexec.castInt16Int32Op
+    │ └ *colexec.sortOp
+    │   └ *colfetcher.colBatchScan
+    └ *colexec.sortOp
+      └ *colfetcher.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT * FROM numbers AS t1 INNER MERGE JOIN numbers AS t2 ON t1._int8 = t2._int2
+----
+│
+└ Node 1
+  └ *colexec.mergeJoinInnerOp
+    ├ *colexec.sortOp
+    │ └ *colfetcher.colBatchScan
+    └ *colexec.castInt16Int64Op
+      └ *colexec.sortOp
+        └ *colfetcher.colBatchScan
+
+# Also check that we cannot plan a merge join with other numeric types.
+statement error could not produce a query plan conforming to the MERGE JOIN hint
+EXPLAIN SELECT * FROM numbers AS t1 INNER MERGE JOIN numbers AS t2 ON t1._int8 = t2._float
+
+statement error could not produce a query plan conforming to the MERGE JOIN hint
+EXPLAIN SELECT * FROM numbers AS t1 INNER MERGE JOIN numbers AS t2 ON t1._int8 = t2._decimal
+
+statement error could not produce a query plan conforming to the MERGE JOIN hint
+EXPLAIN SELECT * FROM numbers AS t1 INNER MERGE JOIN numbers AS t2 ON t1._float = t2._decimal

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -180,13 +180,13 @@ EXPLAIN (VEC) SELECT _int2 * _int2 FROM ints WHERE _int4 + _int4 = _int8 + 2
 │
 └ Node 1
   └ *colexec.projMultInt64Int64Op
-    └ *colexec.castOp
-      └ *colexec.castOp
+    └ *colexec.castInt16Int64Op
+      └ *colexec.castInt16Int64Op
         └ *colexec.selEQInt64Int64Op
           └ *colexec.projPlusInt64Int64ConstOp
             └ *colexec.projPlusInt64Int64Op
-              └ *colexec.castOp
-                └ *colexec.castOp
+              └ *colexec.castInt32Int64Op
+                └ *colexec.castInt32Int64Op
                   └ *colfetcher.colBatchScan
 
 query I

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -128,7 +128,7 @@ EXPLAIN (VEC) SELECT _inet - _int2 FROM many_types
 │
 └ Node 1
   └ *colexec.projMinusDatumInt64Op
-    └ *colexec.castOp
+    └ *colexec.castInt16Int64Op
       └ *colfetcher.colBatchScan
 
 query T
@@ -137,8 +137,8 @@ EXPLAIN (VEC) SELECT _int2^_int4 FROM many_types
 │
 └ Node 1
   └ *colexec.projPowInt64Int64Op
-    └ *colexec.castOp
-      └ *colexec.castOp
+    └ *colexec.castInt32Int64Op
+      └ *colexec.castInt16Int64Op
         └ *colfetcher.colBatchScan
 
 query T
@@ -147,7 +147,7 @@ EXPLAIN (VEC) SELECT _int2^_int FROM many_types
 │
 └ Node 1
   └ *colexec.projPowInt64Int64Op
-    └ *colexec.castOp
+    └ *colexec.castInt16Int64Op
       └ *colfetcher.colBatchScan
 
 query T
@@ -164,7 +164,7 @@ EXPLAIN (VEC) SELECT _decimal^_int4 FROM many_types
 │
 └ Node 1
   └ *colexec.projPowDecimalInt64Op
-    └ *colexec.castOp
+    └ *colexec.castInt32Int64Op
       └ *colfetcher.colBatchScan
 
 query R rowsort
@@ -213,7 +213,7 @@ EXPLAIN (VEC) SELECT _int4 + _inet FROM many_types
 │
 └ Node 1
   └ *colexec.projPlusDatumInt64Op
-    └ *colexec.castOp
+    └ *colexec.castInt32Int64Op
       └ *colfetcher.colBatchScan
 
 query T rowsort
@@ -396,7 +396,7 @@ EXPLAIN (VEC) SELECT _varbit << _int2 FROM many_types
 │
 └ Node 1
   └ *colexec.projLShiftDatumInt64Op
-    └ *colexec.castOp
+    └ *colexec.castInt16Int64Op
       └ *colfetcher.colBatchScan
 
 query T
@@ -405,7 +405,7 @@ EXPLAIN (VEC) SELECT _varbit << _int4 FROM many_types
 │
 └ Node 1
   └ *colexec.projLShiftDatumInt64Op
-    └ *colexec.castOp
+    └ *colexec.castInt32Int64Op
       └ *colfetcher.colBatchScan
 
 query T
@@ -431,7 +431,7 @@ EXPLAIN (VEC) SELECT _varbit >> _int2 FROM many_types
 │
 └ Node 1
   └ *colexec.projRShiftDatumInt64Op
-    └ *colexec.castOp
+    └ *colexec.castInt16Int64Op
       └ *colfetcher.colBatchScan
 
 query T
@@ -440,7 +440,7 @@ EXPLAIN (VEC) SELECT _varbit >> _int4 FROM many_types
 │
 └ Node 1
   └ *colexec.projRShiftDatumInt64Op
-    └ *colexec.castOp
+    └ *colexec.castInt32Int64Op
       └ *colfetcher.colBatchScan
 
 query T
@@ -481,7 +481,7 @@ EXPLAIN (VEC) SELECT _json -> _int2 FROM many_types
 │
 └ Node 1
   └ *colexec.projJSONFetchValDatumInt64Op
-    └ *colexec.castOp
+    └ *colexec.castInt16Int64Op
       └ *colfetcher.colBatchScan
 
 query I rowsort
@@ -513,7 +513,7 @@ EXPLAIN (VEC) SELECT _json -> _int4 FROM many_types
 │
 └ Node 1
   └ *colexec.projJSONFetchValDatumInt64Op
-    └ *colexec.castOp
+    └ *colexec.castInt32Int64Op
       └ *colfetcher.colBatchScan
 
 query T
@@ -629,7 +629,7 @@ EXPLAIN (VEC) SELECT _int4 // _int FROM many_types WHERE _int <> 0
 │
 └ Node 1
   └ *colexec.projFloorDivInt64Int64Op
-    └ *colexec.castOp
+    └ *colexec.castInt32Int64Op
       └ *colexec.selNEInt64Int64ConstOp
         └ *colfetcher.colBatchScan
 


### PR DESCRIPTION
Merge joiner only supports the case when the physical types in the
equality columns in both inputs are the same. We, however, also need to
support joining on numeric columns of different widths. If we encounter
type or width mismatch, we need to cast one of the vectors to another
and use the cast vector for equality check.

Previously this was done at the runtime by using `cast` function which
is the meat of the cast operator. This commit changes that approach so
that we, instead, plan the cast operator itself when needed during the
planning time. That `cast` function is now moved into the cast operator
itself, and the operator is refactored to remove the runtime type
switching logic.

Release note: None