### PR TITLE
roachtest/schemachange: add MinVersion of 20.1

### DIFF
--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -24,9 +24,10 @@ type randomLoadBenchSpec struct {
 
 func registerSchemaChangeRandomLoad(r *testRegistry) {
 	r.Add(testSpec{
-		Name:    "schemachange/random-load",
-		Owner:   OwnerSQLSchema,
-		Cluster: makeClusterSpec(3),
+		Name:       "schemachange/random-load",
+		Owner:      OwnerSQLSchema,
+		Cluster:    makeClusterSpec(3),
+		MinVersion: "v20.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			maxOps := 5000
 			concurrency := 20


### PR DESCRIPTION
Release note (bug fix):
I have forgotten to add the MinVersion setting when creating the test.

Fixes #50594.