### PR TITLE
release-20.1: sql: add cache for jobs to avoid querying system.jobs to find existing jobs

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -695,6 +695,10 @@ type ExecutorTestingKnobs struct {
 	// OnTempObjectsCleanupDone will trigger when the temporary objects cleanup
 	// job is done.
 	OnTempObjectsCleanupDone func()
+
+	// RunAfterSCJobsCacheLookup is called after the SchemaChangeJobCache is checked for
+	// a given table id.
+	RunAfterSCJobsCacheLookup func(*jobs.Job)
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -67,7 +67,13 @@ type extendedEvalContext struct {
 
 	TxnModesSetter txnModesSetter
 
+	// Jobs refers to jobs in extraTxnState. Jobs is a pointer to a jobsCollection
+	// which is a slice because we need calls to resetExtraTxnState to reset the
+	// jobsCollection.
 	Jobs *jobsCollection
+
+	// SchemaChangeJobCache refers to schemaChangeJobsCache in extraTxnState.
+	SchemaChangeJobCache map[sqlbase.ID]*jobs.Job
 
 	schemaAccessors *schemaInterface
 

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -930,24 +930,12 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 		}
 	}
 	var job *jobs.Job
-	// Iterate through the queued jobs to find an existing schema change job for
-	// this table, if it exists.
-	// TODO (lucy): Looking up each job to determine this is not ideal. Maybe
-	// we need some additional state in extraTxnState to help with lookups.
-	for _, jobID := range *p.extendedEvalCtx.Jobs {
-		var err error
-		j, err := p.ExecCfg().JobRegistry.LoadJobWithTxn(ctx, jobID, p.txn)
-		if err != nil {
-			return err
-		}
-		schemaDetails, ok := j.Details().(jobspb.SchemaChangeDetails)
-		if !ok {
-			continue
-		}
-		if schemaDetails.TableID == tableDesc.ID {
-			job = j
-			break
-		}
+	if cachedJob, ok := p.extendedEvalCtx.SchemaChangeJobCache[tableDesc.ID]; ok {
+		job = cachedJob
+	}
+
+	if p.extendedEvalCtx.ExecCfg.TestingKnobs.RunAfterSCJobsCacheLookup != nil {
+		p.extendedEvalCtx.ExecCfg.TestingKnobs.RunAfterSCJobsCacheLookup(job)
 	}
 
 	var spanList []jobspb.ResumeSpanList
@@ -982,6 +970,7 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 		if err != nil {
 			return err
 		}
+		p.extendedEvalCtx.SchemaChangeJobCache[tableDesc.ID] = newJob
 		// Only add a MutationJob if there's an associated mutation.
 		// TODO (lucy): get rid of this when we get rid of MutationJobs.
 		if mutationID != sqlbase.InvalidMutationID {

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -15,10 +15,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/assert"
 )
@@ -328,5 +331,72 @@ func TestPrimaryKeyUnspecified(t *testing.T) {
 	err = desc.ValidateTable()
 	if !testutils.IsError(err, sqlbase.ErrMissingPrimaryKey.Error()) {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestJobsCache verifies that a job for a given table gets cached and reused
+// for following schema changes in the same transaction.
+func TestJobsCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	foundInCache := false
+	runAfterSCJobsCacheLookup := func(job *jobs.Job) {
+		if job != nil {
+			foundInCache = true
+		}
+	}
+
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs.SQLExecutor = &ExecutorTestingKnobs{
+		RunAfterSCJobsCacheLookup: runAfterSCJobsCacheLookup,
+	}
+
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	// ALTER TABLE t1 ADD COLUMN x INT should have created a job for the table
+	// we're altering.
+	// Further schema changes to the table should have an existing cache
+	// entry for the job.
+	if _, err := sqlDB.Exec(`
+CREATE TABLE t1();
+BEGIN;
+ALTER TABLE t1 ADD COLUMN x INT;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqlDB.Exec(`
+ALTER TABLE t1 ADD COLUMN y INT;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	if !foundInCache {
+		t.Fatal("expected a job to be found in cache for table t1, " +
+			"but a job was not found")
+	}
+
+	// Verify that the cache is cleared once the transaction ends.
+	// Commit the old transaction.
+	if _, err := sqlDB.Exec(`
+COMMIT;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	foundInCache = false
+
+	if _, err := sqlDB.Exec(`
+BEGIN;
+ALTER TABLE t1 ADD COLUMN z INT;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	if foundInCache {
+		t.Fatal("expected a job to not be found in cache for table t1, " +
+			"but a job was found")
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #50848.

/cc @cockroachdb/release

---

Currently, we perform a loop through all existing jobs which involves
querying a system table to check if there is an existing job for the current
table undergoing a schema change. To avoid this query, we can use a cache
to map TableIDs to jobs.

Fixes #50165, #50783

Release note (bug fix): Fixed regression where granting privileges and dropping objects
would be slow when performed on a large number of objects due to unnecessary queries
for looking up jobs in the system.jobs.
Previously we did a quadratic number of queries based on the number of objects.
After this fix we do a linear number of queries based on the number of objects which
significantly improves the speed of dropping multiple objects or granting
multiple privileges to a user.