### PR TITLE
Revert "Makefile: change GEOS symlink to a copy"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -772,7 +772,7 @@ $(LIBGEOS): $(GEOS_DIR)/Makefile bin/uptodate .ALWAYS_REBUILD
 	@uptodate $@ $(GEOS_SRC_DIR) || $(MAKE) --no-print-directory -C $(GEOS_DIR) geos_c
 	mkdir -p $(DYN_LIB_DIR)
 	rm -f $(DYN_LIB_DIR)/lib{geos,geos_c}.$(DYN_EXT)
-	cp -L $(GEOS_DIR)/$(if $(target-is-windows),bin,lib)/lib{geos,geos_c}.$(DYN_EXT) $(DYN_LIB_DIR)
+	ln -sf $(GEOS_DIR)/lib/lib{geos,geos_c}.$(DYN_EXT) $(DYN_LIB_DIR)
 
 $(LIBPROJ): $(PROJ_DIR)/Makefile bin/uptodate .ALWAYS_REBUILD
 	@uptodate $@ $(PROJ_SRC_DIR) || $(MAKE) --no-print-directory -C $(PROJ_DIR) proj


### PR DESCRIPTION
This reverts commit 40f919aae6e590e96ba2192fc9a2bc0433caa680. This fails
publish bleeding edge as bin/workload tries to copy
/go/native/x86_64-pc-linux-gnu/geos/*.so which apparently doesn't exist.

Keep the delete in, as ln -sf may complain if the file is already there.

Release note: None