### PR TITLE
opt: calculate partial index scan statistics

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -576,6 +576,15 @@ func (s *ScanPrivate) UsesPartialIndex(md *opt.Metadata) bool {
 	return IsPartialIndex(tabMeta, s.Index)
 }
 
+// PartialIndexPredicate returns the FiltersExpr representing the predicate of
+// the partial index that the scan uses. If the scan does not use a partial
+// index, this function panics. UsesPartialIndex should be called first to
+// determine if the scan operates over a partial index.
+func (s *ScanPrivate) PartialIndexPredicate(md *opt.Metadata) FiltersExpr {
+	tabMeta := md.TableMeta(s.Table)
+	return PartialIndexPredicate(tabMeta, s.Index)
+}
+
 // NeedResults returns true if the mutation operator can return the rows that
 // were mutated.
 func (m *MutationPrivate) NeedResults() bool {

--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -1,0 +1,226 @@
+# ------------------------
+# Tests without Histograms
+# TODO(mgartner): Add more interesting tests for constrained partial index
+# scans, with and without histograms.
+# ------------------------
+
+exec-ddl
+CREATE TABLE a (
+  k INT PRIMARY KEY,
+  i INT,
+  s STRING,
+  t STRING,
+  INDEX idx_s_foo (i) WHERE s = 'foo',
+  INDEX idx_i_0_to_100 (s) WHERE i > 0 AND i < 100,
+  INDEX idx_not_tight (i) WHERE i < k AND i % 3 = 0,
+  INDEX idx_equiv (s, t) WHERE s = t,
+  INDEX idx_s_null (i) WHERE s IS NULL,
+  INDEX idx_i_200_to_250 (i) WHERE i > 200 AND i < 250
+)
+----
+
+exec-ddl
+ALTER TABLE a INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 5000
+  },
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 500
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 50,
+    "null_count": 275
+  },
+  {
+    "columns": ["t"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 500,
+    "null_count": 50
+  }
+]'
+----
+
+# Distinct and null counts are updated based on the partial index predicate.
+opt
+SELECT * FROM a WHERE s = 'foo'
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int) s:3(string!null) t:4(string)
+ ├── stats: [rows=96.4285714, distinct(3)=1, null(3)=0]
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,4)
+ └── scan a@idx_s_foo,partial
+      ├── columns: k:1(int!null) i:2(int)
+      ├── stats: [rows=96.4285714, distinct(3)=1, null(3)=0]
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+# Test for Select filter applied after partial index scan.
+opt
+SELECT * FROM a WHERE i > 25 AND i < 50
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string) t:4(string)
+ ├── stats: [rows=240, distinct(2)=24, null(2)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── index-join a
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string) t:4(string)
+ │    ├── stats: [rows=990]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── scan a@idx_i_0_to_100,partial
+ │         ├── columns: k:1(int!null) s:3(string)
+ │         ├── stats: [rows=990, distinct(2)=99, null(2)=0]
+ │         ├── key: (1)
+ │         └── fd: (1)-->(3)
+ └── filters
+      └── (i:2 > 25) AND (i:2 < 50) [type=bool, outer=(2), constraints=(/2: [/26 - /49]; tight)]
+
+# Test for multiple unapplied conjunctions due to non-tight constraints.
+opt
+SELECT * FROM a WHERE i < k AND i % 3 = 0
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string) t:4(string)
+ ├── immutable
+ ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0, distinct(2)=500, null(2)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan a@idx_not_tight,partial
+      ├── columns: k:1(int!null) i:2(int)
+      ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0, distinct(2)=500, null(2)=0]
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+# Test for an indexed column that is also constrained by partial index predicate.
+opt
+SELECT * FROM a WHERE i > 215 AND i < 230
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string) t:4(string)
+ ├── stats: [rows=140, distinct(2)=14, null(2)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── select
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── stats: [rows=140, distinct(2)=14, null(2)=0]
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan a@idx_i_200_to_250,partial
+      │    ├── columns: k:1(int!null) i:2(int)
+      │    ├── stats: [rows=490, distinct(1)=490, null(1)=0, distinct(2)=49, null(2)=0]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── (i:2 > 215) AND (i:2 < 230) [type=bool, outer=(2), constraints=(/2: [/216 - /229]; tight)]
+
+# Test for FuncDep equivalencies.
+opt
+SELECT * FROM a WHERE s = t AND s LIKE '%foo%' AND t LIKE '%bar%'
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int) s:3(string!null) t:4(string!null)
+ ├── stats: [rows=1.04895, distinct(3)=1.04895, null(3)=0, distinct(4)=1.04895, null(4)=0, distinct(3,4)=1.04895, null(3,4)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)==(4), (4)==(3)
+ └── select
+      ├── columns: k:1(int!null) s:3(string!null) t:4(string!null)
+      ├── stats: [rows=1.0395, distinct(3)=1.0395, null(3)=0, distinct(4)=1.0395, null(4)=0]
+      ├── key: (1)
+      ├── fd: (1)-->(3,4)
+      ├── scan a@idx_equiv,partial
+      │    ├── columns: k:1(int!null) s:3(string) t:4(string)
+      │    ├── stats: [rows=9.3555, distinct(1)=9.3555, null(1)=0, distinct(3)=9.3555, null(3)=0, distinct(4)=9.3555, null(4)=0]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(3,4)
+      └── filters
+           ├── s:3 LIKE '%foo%' [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
+           └── t:4 LIKE '%bar%' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+
+# Test for null predicate.
+opt
+SELECT * FROM a WHERE s IS NULL
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int) s:3(string) t:4(string)
+ ├── stats: [rows=275, distinct(3)=1, null(3)=275]
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,4)
+ └── scan a@idx_s_null,partial
+      ├── columns: k:1(int!null) i:2(int)
+      ├── stats: [rows=275, distinct(3)=1, null(3)=275]
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+# ---------------------
+# Tests with Histograms
+# ---------------------
+
+exec-ddl
+CREATE TABLE hist (
+  k INT PRIMARY KEY,
+  i INT,
+  s STRING,
+  INDEX idx_i (s) WHERE i > 100 AND i <= 200
+)
+----
+
+exec-ddl
+ALTER TABLE hist INJECT STATISTICS '[
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 41,
+    "null_count": 30,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 10, "num_range": 90, "distinct_range": 9, "upper_bound": "100"},
+      {"num_eq": 10, "num_range": 180, "distinct_range": 9, "upper_bound": "200"},
+      {"num_eq": 20, "num_range": 270, "distinct_range": 9, "upper_bound": "300"},
+      {"num_eq": 30, "num_range": 360, "distinct_range": 9, "upper_bound": "400"}
+    ]
+  }
+]'
+----
+
+# TODO(mgartner): The distinct(2) stat for the partial index scan should be 10
+# not 11. It is currently one more than it should be because
+# updateDistinctCountFromHistogram increments the distinct count before the null
+# count has been set to zero.
+opt
+SELECT * FROM hist WHERE i > 125 AND i < 150
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string)
+ ├── stats: [rows=43.6363636, distinct(2)=4.09090909, null(2)=0]
+ │   histogram(2)=  0   0   41.818 1.8182
+ │                <--- 125 -------- 149 -
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join hist
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=190]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan hist@idx_i,partial
+ │         ├── columns: k:1(int!null) s:3(string)
+ │         ├── stats: [rows=190, distinct(2)=11, null(2)=0]
+ │         │   histogram(2)=  0   0   180  10
+ │         │                <--- 100 ----- 200
+ │         ├── key: (1)
+ │         └── fd: (1)-->(3)
+ └── filters
+      └── (i:2 > 125) AND (i:2 < 150) [type=bool, outer=(2), constraints=(/2: [/126 - /149]; tight)]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -146,160 +146,87 @@ project
 
 # Generate a partial index scan inside an index-join when the index is not
 # covering and there no remaining filters.
-#
-# TODO(mgartner): The statistics builder does not consider the cardinality of
-# the partial index predicate. It does not know that scanning the partial index
-# will produce fewer results than scanning the primary index. Once the
-# statistics builder considers this, a scan over the partial index should be
-# selected here, and the test directive should be changed from "memo" to "opt".
-memo expect=GeneratePartialIndexScans
+opt expect=GeneratePartialIndexScans
 SELECT b FROM p WHERE s = 'foo'
 ----
-memo (optimized, ~7KB, required=[presentation: b:4])
- ├── G1: (project G2 G3 b)
- │    └── [presentation: b:4]
- │         ├── best: (project G2 G3 b)
- │         └── cost: 1080.15
- ├── G2: (select G4 G5) (index-join G6 p,cols=(3,4))
- │    └── []
- │         ├── best: (select G4 G5)
- │         └── cost: 1080.04
- ├── G3: (projections)
- ├── G4: (scan p,cols=(3,4))
- │    └── []
- │         ├── best: (scan p,cols=(3,4))
- │         └── cost: 1070.02
- ├── G5: (filters G7)
- ├── G6: (scan p@if_s,partial,cols=(3,5))
- │    └── []
- │         ├── best: (scan p@if_s,partial,cols=(3,5))
- │         └── cost: 1060.01
- ├── G7: (eq G8 G9)
- ├── G8: (variable s)
- └── G9: (const 'foo')
+project
+ ├── columns: b:4
+ └── index-join p
+      ├── columns: s:3!null b:4
+      ├── fd: ()-->(3)
+      └── scan p@if_s,partial
+           ├── columns: s:3 rowid:5!null
+           ├── key: (5)
+           └── fd: (5)-->(3)
 
 # Generate a partial index scan inside a select inside an index-join when the
 # index is not covering and there are remaining filters that are covered by the
 # index.
-#
-# TODO(mgartner): Change "memo" to "opt".
-memo expect=GeneratePartialIndexScans
+opt expect=GeneratePartialIndexScans
 SELECT b FROM p WHERE s = 'foo' AND (i = 1 OR f = 2.0)
 ----
-memo (optimized, ~8KB, required=[presentation: b:4])
- ├── G1: (project G2 G3 b)
- │    └── [presentation: b:4]
- │         ├── best: (project G2 G3 b)
- │         └── cost: 1100.09
- ├── G2: (select G4 G5) (index-join G6 p,cols=(1-4))
- │    └── []
- │         ├── best: (select G4 G5)
- │         └── cost: 1100.05
- ├── G3: (projections)
- ├── G4: (scan p,cols=(1-4))
- │    └── []
- │         ├── best: (scan p,cols=(1-4))
- │         └── cost: 1090.02
- ├── G5: (filters G7 G8)
- ├── G6: (select G9 G10)
- │    └── []
- │         ├── best: (select G9 G10)
- │         └── cost: 1090.03
- ├── G7: (eq G11 G12)
- ├── G8: (or G13 G14)
- ├── G9: (scan p@if_s,partial,cols=(1-3,5))
- │    └── []
- │         ├── best: (scan p@if_s,partial,cols=(1-3,5))
- │         └── cost: 1080.01
- ├── G10: (filters G8)
- ├── G11: (variable s)
- ├── G12: (const 'foo')
- ├── G13: (eq G15 G16)
- ├── G14: (eq G17 G18)
- ├── G15: (variable i)
- ├── G16: (const 1)
- ├── G17: (variable f)
- └── G18: (const 2.0)
+project
+ ├── columns: b:4
+ └── index-join p
+      ├── columns: i:1 f:2 s:3!null b:4
+      ├── fd: ()-->(3)
+      └── select
+           ├── columns: i:1 f:2 s:3 rowid:5!null
+           ├── key: (5)
+           ├── fd: (5)-->(1-3)
+           ├── scan p@if_s,partial
+           │    ├── columns: i:1 f:2 s:3 rowid:5!null
+           │    ├── key: (5)
+           │    └── fd: (5)-->(1-3)
+           └── filters
+                └── (i:1 = 1) OR (f:2 = 2.0) [outer=(1,2)]
 
 # Generate a partial index scan inside an index-join inside a select when the
 # index is not covering and the remaining filters are not covered by the index.
-#
-# TODO(mgartner): Change "memo" to "opt".
-memo expect=GeneratePartialIndexScans
+opt expect=GeneratePartialIndexScans
 SELECT b FROM p WHERE s = 'foo' AND b
 ----
-memo (optimized, ~8KB, required=[presentation: b:4])
- ├── G1: (project G2 G3 b)
- │    └── [presentation: b:4]
- │         ├── best: (project G2 G3 b)
- │         └── cost: 1080.10
- ├── G2: (select G4 G5) (select G6 G7)
- │    └── []
- │         ├── best: (select G4 G5)
- │         └── cost: 1080.05
- ├── G3: (projections)
- ├── G4: (scan p,cols=(3,4))
- │    └── []
- │         ├── best: (scan p,cols=(3,4))
- │         └── cost: 1070.02
- ├── G5: (filters G8 G9)
- ├── G6: (index-join G10 p,cols=(3,4))
- │    └── []
- │         ├── best: (index-join G10 p,cols=(3,4))
- │         └── cost: 5140.02
- ├── G7: (filters G9)
- ├── G8: (eq G11 G12)
- ├── G9: (variable b)
- ├── G10: (scan p@if_s,partial,cols=(3,5))
- │    └── []
- │         ├── best: (scan p@if_s,partial,cols=(3,5))
- │         └── cost: 1060.01
- ├── G11: (variable s)
- └── G12: (const 'foo')
+project
+ ├── columns: b:4!null
+ ├── fd: ()-->(4)
+ └── select
+      ├── columns: s:3!null b:4!null
+      ├── fd: ()-->(3,4)
+      ├── index-join p
+      │    ├── columns: s:3 b:4
+      │    └── scan p@if_s,partial
+      │         ├── columns: s:3 rowid:5!null
+      │         ├── key: (5)
+      │         └── fd: (5)-->(3)
+      └── filters
+           └── b:4 [outer=(4), constraints=(/4: [/true - /true]; tight), fd=()-->(4)]
 
 # Generate a partial index scan inside a Select/IndexJoin/Select when the index
 # is not covering and the remaining filters are partially covered by the index.
-#
-# TODO(mgartner): Change "memo" to "opt".
-memo expect=GeneratePartialIndexScans
+opt expect=GeneratePartialIndexScans
 SELECT b FROM p WHERE s = 'foo' AND i = 1 AND b
 ----
-memo (optimized, ~9KB, required=[presentation: b:4])
- ├── G1: (project G2 G3 b)
- │    └── [presentation: b:4]
- │         ├── best: (project G2 G3 b)
- │         └── cost: 1090.08
- ├── G2: (select G4 G5) (select G6 G7)
- │    └── []
- │         ├── best: (select G4 G5)
- │         └── cost: 1090.06
- ├── G3: (projections)
- ├── G4: (scan p,cols=(1,3,4))
- │    └── []
- │         ├── best: (scan p,cols=(1,3,4))
- │         └── cost: 1080.02
- ├── G5: (filters G8 G9 G10)
- ├── G6: (index-join G11 p,cols=(1,3,4))
- │    └── []
- │         ├── best: (index-join G11 p,cols=(1,3,4))
- │         └── cost: 1120.94
- ├── G7: (filters G10)
- ├── G8: (eq G12 G13)
- ├── G9: (eq G14 G15)
- ├── G10: (variable b)
- ├── G11: (select G16 G17)
- │    └── []
- │         ├── best: (select G16 G17)
- │         └── cost: 1080.03
- ├── G12: (variable s)
- ├── G13: (const 'foo')
- ├── G14: (variable i)
- ├── G15: (const 1)
- ├── G16: (scan p@if_s,partial,cols=(1,3,5))
- │    └── []
- │         ├── best: (scan p@if_s,partial,cols=(1,3,5))
- │         └── cost: 1070.01
- └── G17: (filters G9)
+project
+ ├── columns: b:4!null
+ ├── fd: ()-->(4)
+ └── select
+      ├── columns: i:1!null s:3!null b:4!null
+      ├── fd: ()-->(1,3,4)
+      ├── index-join p
+      │    ├── columns: i:1 s:3 b:4
+      │    ├── fd: ()-->(1)
+      │    └── select
+      │         ├── columns: i:1!null s:3 rowid:5!null
+      │         ├── key: (5)
+      │         ├── fd: ()-->(1), (5)-->(3)
+      │         ├── scan p@if_s,partial
+      │         │    ├── columns: i:1 s:3 rowid:5!null
+      │         │    ├── key: (5)
+      │         │    └── fd: (5)-->(1,3)
+      │         └── filters
+      │              └── i:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+      └── filters
+           └── b:4 [outer=(4), constraints=(/4: [/true - /true]; tight), fd=()-->(4)]
 
 # Generate multiple partial index scans when there are multiple partial indexes
 # that have predicates implied by the filters.
@@ -309,8 +236,8 @@ SELECT * FROM q WHERE i > 0 AND s = 'foo'
 memo (optimized, ~11KB, required=[presentation: i:1,s:2,b:3])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G5)
  │    └── [presentation: i:1,s:2,b:3]
- │         ├── best: (select G2 G3)
- │         └── cost: 1080.05
+ │         ├── best: (select G6 G7)
+ │         └── cost: 51.34
  ├── G2: (scan q,cols=(1-3))
  │    └── []
  │         ├── best: (scan q,cols=(1-3))
@@ -319,12 +246,12 @@ memo (optimized, ~11KB, required=[presentation: i:1,s:2,b:3])
  ├── G4: (index-join G11 q,cols=(1-3))
  │    └── []
  │         ├── best: (index-join G11 q,cols=(1-3))
- │         └── cost: 5120.02
+ │         └── cost: 1706.69
  ├── G5: (filters G10)
  ├── G6: (index-join G12 q,cols=(1-3))
  │    └── []
  │         ├── best: (index-join G12 q,cols=(1-3))
- │         └── cost: 5120.02
+ │         └── cost: 51.22
  ├── G7: (filters G9)
  ├── G8: (index-join G13 q,cols=(1-3))
  │    └── []
@@ -335,11 +262,11 @@ memo (optimized, ~11KB, required=[presentation: i:1,s:2,b:3])
  ├── G11: (scan q@i_gt_0,partial,cols=(1,4))
  │    └── []
  │         ├── best: (scan q@i_gt_0,partial,cols=(1,4))
- │         └── cost: 1040.01
+ │         └── cost: 346.68
  ├── G12: (scan q@s_eq_foo,partial,cols=(2,4))
  │    └── []
  │         ├── best: (scan q@s_eq_foo,partial,cols=(2,4))
- │         └── cost: 1040.01
+ │         └── cost: 10.41
  ├── G13: (scan q@i,cols=(1,4),constrained)
  │    └── []
  │         ├── best: (scan q@i,cols=(1,4),constrained)


### PR DESCRIPTION
This commit updates the statistics builder to account for the
selectivity of predicate expressions for scans over partial indexes.

Fixes #50220