### PR TITLE
build: save artifacts for acceptance tests

### DIFF
--- a/build/teamcity-go-test-precompiled.sh
+++ b/build/teamcity-go-test-precompiled.sh
@@ -20,6 +20,9 @@ shift
 # Throw `go test`s binary away.
 shift
 
+# Ensure the artifacts still get saved to the artifacts directory.
+ln -s "$(dirname $0)/artifacts" artifacts
+
 # Following the example, invoke `./acceptance.test`.
 GOROOT=/home/agent/work/.go "./$(basename "$actual")" "$@"
 


### PR DESCRIPTION
I think we still need to symlink the artifacts with the artifacts in the
root directory.

Release note: None