### PR TITLE
backupccl,importccl: clear OfflineReason field when marking table active

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1197,6 +1197,7 @@ func (r *restoreResumer) publishTables(ctx context.Context) error {
 			newTableDesc := sqlbase.NewMutableExistingTableDescriptor(*tbl.TableDesc())
 			newTableDesc.Version++
 			newTableDesc.State = sqlbase.TableDescriptor_PUBLIC
+			newTableDesc.OfflineReason = ""
 			// Convert any mutations that were in progress on the table descriptor
 			// when the backup was taken, and convert them to schema change jobs.
 			newJobs, err := createSchemaChangeJobsFromMutations(ctx, r.execCfg.JobRegistry, r.execCfg.Codec, txn, r.job.Payload().Username, newTableDesc.TableDesc())

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1193,6 +1193,7 @@ func (r *importResumer) publishTables(ctx context.Context, execCfg *sql.Executor
 			tableDesc := sqlbase.NewMutableExistingTableDescriptor(*tbl.Desc)
 			tableDesc.Version++
 			tableDesc.State = sqlbase.TableDescriptor_PUBLIC
+			tableDesc.OfflineReason = ""
 
 			if !tbl.IsNew {
 				// NB: This is not using AllNonDropIndexes or directly mutating the


### PR DESCRIPTION
We only look at this field when the state is offline so it doesn't hurt anything,
but it can be confusing when debugging to see the residual offline reason still
set on an online table.

Release note: none.