### PR TITLE
sql: handle UPDATEs for partial indexes

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -281,8 +281,11 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 				oldValues[j] = tree.DNull
 			}
 		}
+		// TODO(mgartner): Add partial index IDs to ignoreIndexes that we should
+		// not add entries to or delete entries from.
+		var ignoreIndexes util.FastIntSet
 		if _, err := ru.UpdateRow(
-			ctx, b, oldValues, updateValues, traceKV,
+			ctx, b, oldValues, updateValues, ignoreIndexes, ignoreIndexes, traceKV,
 		); err != nil {
 			return roachpb.Key{}, err
 		}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -179,27 +179,27 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// the predicate and therefore do not exist in the partial index. This
 	// set is passed as a argument to tableDeleter.row below.
 	var ignoreIndexes util.FastIntSet
-	partialIndexDelVals := sourceVals[d.run.partialIndexDelValsOffset:]
-	colIdx := 0
-	indexes := d.run.td.tableDesc().Indexes
-	for i := range indexes {
-		index := &indexes[i]
-		if index.IsPartial() {
-			val, err := tree.GetBool(partialIndexDelVals[colIdx])
-			if err != nil {
-				return err
-			}
+	partialIndexOrds := d.run.td.tableDesc().PartialIndexOrds()
+	if !partialIndexOrds.Empty() {
+		partialIndexDelVals := sourceVals[d.run.partialIndexDelValsOffset:]
+		colIdx := 0
+		indexes := d.run.td.tableDesc().Indexes
+		for i, ok := partialIndexOrds.Next(0); ok; i, ok = partialIndexOrds.Next(i + 1) {
+			index := &indexes[i]
+			if index.IsPartial() {
+				val, err := tree.GetBool(partialIndexDelVals[colIdx])
+				if err != nil {
+					return err
+				}
 
-			if !val {
-				// If the value of the column for the index predicate expression
-				// is false, the row should not be removed from the partial
-				// index because it does not exist.
-				ignoreIndexes.Add(int(index.ID))
-			}
+				if !val {
+					// If the value of the column for the index predicate expression
+					// is false, the row should not be removed from the partial
+					// index because it does not exist.
+					ignoreIndexes.Add(int(index.ID))
+				}
 
-			colIdx++
-			if colIdx >= len(partialIndexDelVals) {
-				break
+				colIdx++
 			}
 		}
 	}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -183,7 +183,7 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	colIdx := 0
 	indexes := d.run.td.tableDesc().Indexes
 	for i := range indexes {
-		index := indexes[i]
+		index := &indexes[i]
 		if index.IsPartial() {
 			val, err := tree.GetBool(partialIndexDelVals[colIdx])
 			if err != nil {
@@ -193,7 +193,7 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 			if !val {
 				// If the value of the column for the index predicate expression
 				// is false, the row should not be removed from the partial
-				// index.
+				// index because it does not exist.
 				ignoreIndexes.Add(int(index.ID))
 			}
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -147,7 +147,7 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 	colIdx := 0
 	indexes := r.ti.tableDesc().Indexes
 	for i := range indexes {
-		index := indexes[i]
+		index := &indexes[i]
 		if index.IsPartial() {
 			val, err := tree.GetBool(partialIndexPutVals[colIdx])
 			if err != nil {
@@ -164,7 +164,6 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 			if colIdx >= len(partialIndexPutVals) {
 				break
 			}
-
 		}
 	}
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -143,26 +143,26 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 	// to when they are partial indexes and the row does not satisfy the
 	// predicate. This set is passed as a parameter to tableInserter.row below.
 	var ignoreIndexes util.FastIntSet
-	partialIndexPutVals := rowVals[len(r.insertCols)+r.checkOrds.Len():]
-	colIdx := 0
-	indexes := r.ti.tableDesc().Indexes
-	for i := range indexes {
-		index := &indexes[i]
-		if index.IsPartial() {
-			val, err := tree.GetBool(partialIndexPutVals[colIdx])
-			if err != nil {
-				return err
-			}
+	partialIndexOrds := r.ti.tableDesc().PartialIndexOrds()
+	if !partialIndexOrds.Empty() {
+		partialIndexPutVals := rowVals[len(r.insertCols)+r.checkOrds.Len():]
+		colIdx := 0
+		indexes := r.ti.tableDesc().Indexes
+		for i, ok := partialIndexOrds.Next(0); ok; i, ok = partialIndexOrds.Next(i + 1) {
+			index := &indexes[i]
+			if index.IsPartial() {
+				val, err := tree.GetBool(partialIndexPutVals[colIdx])
+				if err != nil {
+					return err
+				}
 
-			if !val {
-				// If the value of the column for the index predicate expression
-				// is false, the row should not be added to the partial index.
-				ignoreIndexes.Add(int(index.ID))
-			}
+				if !val {
+					// If the value of the column for the index predicate expression
+					// is false, the row should not be added to the partial index.
+					ignoreIndexes.Add(int(index.ID))
+				}
 
-			colIdx++
-			if colIdx >= len(partialIndexPutVals) {
-				break
+				colIdx++
 			}
 		}
 	}

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -274,7 +274,8 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {
 	//
 	// TODO(andyk): Using ensureColumns here can result in an extra Render.
 	// Upgrade execution engine to not require this.
-	cnt := len(upd.FetchCols) + len(upd.UpdateCols) + len(upd.PassthroughCols) + len(upd.CheckCols)
+	cnt := len(upd.FetchCols) + len(upd.UpdateCols) + len(upd.PassthroughCols) +
+		len(upd.CheckCols) + len(upd.PartialIndexPutCols) + len(upd.PartialIndexDelCols)
 	colList := make(opt.ColList, 0, cnt)
 	colList = appendColsWhenPresent(colList, upd.FetchCols)
 	colList = appendColsWhenPresent(colList, upd.UpdateCols)
@@ -286,6 +287,8 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {
 		colList = appendColsWhenPresent(colList, upd.PassthroughCols)
 	}
 	colList = appendColsWhenPresent(colList, upd.CheckCols)
+	colList = appendColsWhenPresent(colList, upd.PartialIndexPutCols)
+	colList = appendColsWhenPresent(colList, upd.PartialIndexDelCols)
 
 	input, err := b.buildMutationInput(upd, upd.Input, colList, &upd.MutationPrivate)
 	if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -10,15 +10,21 @@ CREATE TABLE t (
     b INT,
     c STRING,
     FAMILY (a, b, c),
-    INDEX (b) WHERE b > 10,
-    INDEX (c) WHERE a > b AND c = 'foo'
+    INDEX b_full (b),
+    INDEX b_partial (b) WHERE b > 10,
+    INDEX c_partial (c) WHERE a > b AND c = 'foo'
 )
+
+# ---------------------------------------------------------
+# INSERT
+# ---------------------------------------------------------
 
 # Inserted row matches no partial index.
 query T kvtrace
 INSERT INTO t VALUES(5, 4, 'bar')
 ----
 CPut /Table/53/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+InitPut /Table/53/2/4/5/0 -> /BYTES/
 
 # Inserted row matches the first partial index.
 query T kvtrace
@@ -26,6 +32,7 @@ INSERT INTO t VALUES(6, 11, 'bar')
 ----
 CPut /Table/53/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
 InitPut /Table/53/2/11/6/0 -> /BYTES/
+InitPut /Table/53/3/11/6/0 -> /BYTES/
 
 # Inserted row matches both partial indexes.
 query T kvtrace
@@ -33,13 +40,19 @@ INSERT INTO t VALUES(12, 11, 'foo')
 ----
 CPut /Table/53/1/12/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
 InitPut /Table/53/2/11/12/0 -> /BYTES/
-InitPut /Table/53/3/"foo"/12/0 -> /BYTES/
+InitPut /Table/53/3/11/12/0 -> /BYTES/
+InitPut /Table/53/4/"foo"/12/0 -> /BYTES/
+
+# ---------------------------------------------------------
+# DELETE
+# ---------------------------------------------------------
 
 # Deleted row matches no partial index.
 query T kvtrace
 DELETE FROM t WHERE a = 5
 ----
 Scan /Table/53/1/5{-/#}
+Del /Table/53/2/4/5/0
 Del /Table/53/1/5/0
 
 # Deleted row matches the first partial index.
@@ -48,6 +61,7 @@ DELETE FROM t WHERE a = 6
 ----
 Scan /Table/53/1/6{-/#}
 Del /Table/53/2/11/6/0
+Del /Table/53/3/11/6/0
 Del /Table/53/1/6/0
 
 # Deleted row matches both partial indexes.
@@ -56,8 +70,138 @@ DELETE FROM t WHERE a = 12
 ----
 Scan /Table/53/1/12{-/#}
 Del /Table/53/2/11/12/0
-Del /Table/53/3/"foo"/12/0
+Del /Table/53/3/11/12/0
+Del /Table/53/4/"foo"/12/0
 Del /Table/53/1/12/0
+
+# ---------------------------------------------------------
+# UPDATE
+# ---------------------------------------------------------
+
+# Insert a row that matches no partial index.
+statement ok
+INSERT INTO t VALUES(5, 4, 'bar')
+
+# Insert a row that matches the first partial index.
+statement ok
+INSERT INTO t VALUES(6, 11, 'bar')
+
+# Insert a row that matches both partial indexes.
+statement ok
+INSERT INTO t VALUES(13, 11, 'foo')
+
+# Update a row that matches no partial indexes before or after the update.
+query T kvtrace
+UPDATE t SET c = 'baz' WHERE a = 5
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/baz
+
+# Update a row that matches no partial indexes before the update, but does match
+# after the update.
+query T kvtrace
+UPDATE t SET b = 11 WHERE a = 5
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
+Del /Table/53/2/4/5/0
+CPut /Table/53/2/11/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/53/3/11/5/0 -> /BYTES/ (expecting does not exist)
+
+# Update a row that matches the first partial index before and after the update
+# and the index entry does not change.
+query T kvtrace
+UPDATE t SET c = 'baz' WHERE a = 6
+----
+Scan /Table/53/1/6{-/#}
+Put /Table/53/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
+
+# Update a row that matches the first partial index before and after the update
+# and the index entry changes.
+query T kvtrace
+UPDATE t SET b = 12 WHERE a = 6
+----
+Scan /Table/53/1/6{-/#}
+Put /Table/53/1/6/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
+Del /Table/53/2/11/6/0
+CPut /Table/53/2/12/6/0 -> /BYTES/ (expecting does not exist)
+Del /Table/53/3/11/6/0
+CPut /Table/53/3/12/6/0 -> /BYTES/ (expecting does not exist)
+
+# Update a row that matches the first partial index before the update, but does
+# not match after the update.
+query T kvtrace
+UPDATE t SET b = 9 WHERE a = 6
+----
+Scan /Table/53/1/6{-/#}
+Put /Table/53/1/6/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/baz
+Del /Table/53/2/12/6/0
+CPut /Table/53/2/9/6/0 -> /BYTES/ (expecting does not exist)
+Del /Table/53/3/12/6/0
+
+# Update a row that matches both partial indexes before the update, the first
+# partial index entry needs to be updated, and the second needs to be deleted.
+query T kvtrace
+UPDATE t SET c = 'baz', b = 12 WHERE a = 13
+----
+Scan /Table/53/1/13{-/#}
+Put /Table/53/1/13/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
+Del /Table/53/2/11/13/0
+CPut /Table/53/2/12/13/0 -> /BYTES/ (expecting does not exist)
+Del /Table/53/3/11/13/0
+CPut /Table/53/3/12/13/0 -> /BYTES/ (expecting does not exist)
+Del /Table/53/4/"foo"/13/0
+
+# Reversing the previous update should reverse the partial index changes.
+query T kvtrace
+UPDATE t SET c = 'foo', b = 11 WHERE a = 13
+----
+Scan /Table/53/1/13{-/#}
+Put /Table/53/1/13/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
+Del /Table/53/2/12/13/0
+CPut /Table/53/2/11/13/0 -> /BYTES/ (expecting does not exist)
+Del /Table/53/3/12/13/0
+CPut /Table/53/3/11/13/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/53/4/"foo"/13/0 -> /BYTES/ (expecting does not exist)
+
+# ---------------------------------------------------------
+# UPDATE primary key
+# ---------------------------------------------------------
+
+# Insert a row that matches the first partial index.
+statement ok
+INSERT INTO t VALUES(20, 11, 'bar')
+
+# Update the primary key of a row that matches the first partial index but not
+# the second.
+query T kvtrace
+UPDATE t SET a = 21 WHERE a = 20
+----
+Scan /Table/53/1/20{-/#}
+Del /Table/53/2/11/20/0
+Del /Table/53/3/11/20/0
+Del /Table/53/1/20/0
+CPut /Table/53/1/21/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
+InitPut /Table/53/2/11/21/0 -> /BYTES/
+InitPut /Table/53/3/11/21/0 -> /BYTES/
+
+# Update the primary key of a row that currently matches the first partial
+# index. Also update the row so that the row no longer matches the first partial
+# index, but now matches the second.
+query T kvtrace
+UPDATE t SET a = 22, b = 9, c = 'foo' WHERE a = 21
+----
+Scan /Table/53/1/21{-/#}
+Del /Table/53/2/11/21/0
+Del /Table/53/3/11/21/0
+Del /Table/53/1/21/0
+CPut /Table/53/1/22/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/foo
+InitPut /Table/53/2/9/22/0 -> /BYTES/
+InitPut /Table/53/4/"foo"/22/0 -> /BYTES/
+
+# ---------------------------------------------------------
+# EXPLAIN
+# ---------------------------------------------------------
 
 # EXPLAIN output shows the partial index label on scans over partial indexes.
 query TTT
@@ -66,6 +210,6 @@ EXPLAIN SELECT b FROM t WHERE b > 10
 ·     distribution   local
 ·     vectorized     true
 scan  ·              ·
-·     table          t@t_b_idx
+·     table          t@b_partial
 ·     spans          FULL SCAN
 ·     partial index  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -10,6 +10,7 @@ CREATE TABLE t (
     b INT,
     c STRING,
     FAMILY (a, b, c),
+    CHECK (b > 0),
     INDEX b_full (b),
     INDEX b_partial (b) WHERE b > 10,
     INDEX c_partial (c) WHERE a > b AND c = 'foo'

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -499,7 +499,6 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.formatMutationCols(e, tp, "insert-mapping:", t.InsertCols, t.Table)
 			f.formatColList(e, tp, "check columns:", t.CheckCols)
 			f.formatColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
-			f.formatColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
 
@@ -511,6 +510,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.formatColList(e, tp, "fetch columns:", t.FetchCols)
 			f.formatMutationCols(e, tp, "update-mapping:", t.UpdateCols, t.Table)
 			f.formatColList(e, tp, "check columns:", t.CheckCols)
+			f.formatColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
+			f.formatColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
 
@@ -538,6 +539,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				tp.Child("columns: <none>")
 			}
 			f.formatColList(e, tp, "fetch columns:", t.FetchCols)
+			f.formatColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
 

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1942,17 +1942,21 @@ delete a
 # Do not prune columns that are required for evaluating partial index
 # predicates.
 norm expect-not=(PruneMutationFetchCols,PruneMutationInputCols)
-DELETE FROM partial_indexes RETURNING a
+UPDATE partial_indexes SET c = 'bar' RETURNING a
 ----
-delete partial_indexes
+update partial_indexes
  ├── columns: a:1!null
  ├── fetch columns: a:4 b:5 c:6
+ ├── update-mapping:
+ │    └── c_new:9 => c:3
+ ├── partial index put columns: partial_index_put1:10 partial_index_put2:11
+ ├── partial index del columns: partial_index_del1:7 partial_index_del2:8
  ├── volatile, mutations
  ├── key: (1)
  └── project
-      ├── columns: partial_index_del1:7 partial_index_del2:8 a:4!null b:5 c:6
+      ├── columns: partial_index_put1:10!null partial_index_put2:11 c_new:9!null partial_index_del1:7 partial_index_del2:8 a:4!null b:5 c:6
       ├── key: (4)
-      ├── fd: (4)-->(5,6,8), (6)-->(7)
+      ├── fd: ()-->(9,10), (4)-->(5,6,8,11), (6)-->(7)
       ├── scan partial_indexes
       │    ├── columns: a:4!null b:5 c:6
       │    ├── partial index predicates
@@ -1964,6 +1968,9 @@ delete partial_indexes
       │    ├── key: (4)
       │    └── fd: (4)-->(5,6)
       └── projections
+           ├── false [as=partial_index_put1:10]
+           ├── a:4 > b:5 [as=partial_index_put2:11, outer=(4,5)]
+           ├── 'bar' [as=c_new:9]
            ├── c:6 = 'foo' [as=partial_index_del1:7, outer=(6)]
            └── (a:4 > b:5) AND (c:6 = 'bar') [as=partial_index_del2:8, outer=(4-6)]
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -742,7 +742,7 @@ func (mb *mutationBuilder) addPartialIndexCols(aliasPrefix string, ords []scopeO
 		projectionsScope.appendColumnsFromScope(mb.outScope)
 
 		ord := 0
-		for i, n := 0, mb.tab.IndexCount(); i < n; i++ {
+		for i, n := 0, mb.tab.DeletableIndexCount(); i < n; i++ {
 			index := mb.tab.Index(i)
 			predicate, ok := index.Predicate()
 			if !ok {

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -449,7 +449,9 @@ CREATE TABLE partial_indexes (
     c STRING,
     INDEX (b),
     INDEX (b) WHERE c = 'foo',
-    INDEX (c) WHERE a > b AND c = 'bar'
+    INDEX (c) WHERE a > b AND c = 'bar',
+    INDEX "b:delete-only" (b) WHERE c = 'delete-only',
+    INDEX "b:write-only" (b) WHERE c = 'write-only'
 )
 ----
 
@@ -459,8 +461,9 @@ DELETE FROM partial_indexes
 delete partial_indexes
  ├── columns: <none>
  ├── fetch columns: a:4 b:5 c:6
+ ├── partial index del columns: partial_index_del1:7 partial_index_del2:8 partial_index_del3:9 partial_index_del4:10
  └── project
-      ├── columns: partial_index_del1:7 partial_index_del2:8 a:4!null b:5 c:6
+      ├── columns: partial_index_del1:7 partial_index_del2:8 partial_index_del3:9 partial_index_del4:10 a:4!null b:5 c:6
       ├── scan partial_indexes
       │    ├── columns: a:4!null b:5 c:6
       │    └── partial index predicates
@@ -471,4 +474,6 @@ delete partial_indexes
       │              └── c:6 = 'bar'
       └── projections
            ├── c:6 = 'foo' [as=partial_index_del1:7]
-           └── (a:4 > b:5) AND (c:6 = 'bar') [as=partial_index_del2:8]
+           ├── (a:4 > b:5) AND (c:6 = 'bar') [as=partial_index_del2:8]
+           ├── c:6 = 'delete-only' [as=partial_index_del3:9]
+           └── c:6 = 'write-only' [as=partial_index_del4:10]

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1245,7 +1245,9 @@ CREATE TABLE partial_indexes (
     c STRING,
     INDEX (b),
     INDEX (b) WHERE c = 'foo',
-    INDEX (c) WHERE a > b AND c = 'bar'
+    INDEX (c) WHERE a > b AND c = 'bar',
+    INDEX "b:delete-only" (b) WHERE c = 'delete-only',
+    INDEX "b:write-only" (b) WHERE c = 'write-only'
 )
 ----
 
@@ -1258,12 +1260,14 @@ insert partial_indexes
  │    ├── column1:4 => a:1
  │    ├── column2:5 => b:2
  │    └── column3:6 => c:3
- ├── partial index put columns: partial_index_put1:7 partial_index_put2:8
+ ├── partial index put columns: partial_index_put1:7 partial_index_put2:8 partial_index_put3:9 partial_index_put4:10
  └── project
-      ├── columns: partial_index_put1:7!null partial_index_put2:8!null column1:4!null column2:5!null column3:6!null
+      ├── columns: partial_index_put1:7!null partial_index_put2:8!null partial_index_put3:9!null partial_index_put4:10!null column1:4!null column2:5!null column3:6!null
       ├── values
       │    ├── columns: column1:4!null column2:5!null column3:6!null
       │    └── (2, 1, 'bar')
       └── projections
            ├── column3:6 = 'foo' [as=partial_index_put1:7]
-           └── (column1:4 > column2:5) AND (column3:6 = 'bar') [as=partial_index_put2:8]
+           ├── (column1:4 > column2:5) AND (column3:6 = 'bar') [as=partial_index_put2:8]
+           ├── column3:6 = 'delete-only' [as=partial_index_put3:9]
+           └── column3:6 = 'write-only' [as=partial_index_put4:10]

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1697,8 +1697,11 @@ update partial_indexes
       │    │    ├── scan partial_indexes
       │    │    │    ├── columns: a:4!null b:5 c:6
       │    │    │    └── partial index predicates
-      │    │    │         ├── secondary: c:6 = 'foo'
-      │    │    │         └── secondary: (a:4 > b:5) AND (c:6 = 'bar')
+      │    │    │         ├── secondary: filters
+      │    │    │         │    └── c:6 = 'foo'
+      │    │    │         └── secondary: filters
+      │    │    │              ├── a:4 > b:5
+      │    │    │              └── c:6 = 'bar'
       │    │    └── projections
       │    │         ├── c:6 = 'foo' [as=partial_index_del1:7]
       │    │         ├── (a:4 > b:5) AND (c:6 = 'bar') [as=partial_index_del2:8]

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1660,3 +1660,51 @@ update decimals
       └── projections
            ├── round(a:11) = a:11 [as=check1:15]
            └── b:12[0] > 1 [as=check2:16]
+
+# ------------------------------------------------------------------------------
+# Test partial index column values.
+# ------------------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE partial_indexes (
+    a INT PRIMARY KEY,
+    b INT,
+    c STRING,
+    INDEX (b),
+    INDEX (b) WHERE c = 'foo',
+    INDEX (c) WHERE a > b AND c = 'bar',
+    INDEX "b:delete-only" (b) WHERE c = 'delete-only',
+    INDEX "b:write-only" (b) WHERE c = 'write-only'
+)
+----
+
+build
+UPDATE partial_indexes SET a = 1
+----
+update partial_indexes
+ ├── columns: <none>
+ ├── fetch columns: a:4 b:5 c:6
+ ├── update-mapping:
+ │    └── a_new:11 => a:1
+ ├── partial index put columns: partial_index_del1:7 partial_index_put2:12 partial_index_del3:9 partial_index_del4:10
+ ├── partial index del columns: partial_index_del1:7 partial_index_del2:8 partial_index_del3:9 partial_index_del4:10
+ └── project
+      ├── columns: partial_index_put2:12 a:4!null b:5 c:6 partial_index_del1:7 partial_index_del2:8 partial_index_del3:9 partial_index_del4:10 a_new:11!null
+      ├── project
+      │    ├── columns: a_new:11!null a:4!null b:5 c:6 partial_index_del1:7 partial_index_del2:8 partial_index_del3:9 partial_index_del4:10
+      │    ├── project
+      │    │    ├── columns: partial_index_del1:7 partial_index_del2:8 partial_index_del3:9 partial_index_del4:10 a:4!null b:5 c:6
+      │    │    ├── scan partial_indexes
+      │    │    │    ├── columns: a:4!null b:5 c:6
+      │    │    │    └── partial index predicates
+      │    │    │         ├── secondary: c:6 = 'foo'
+      │    │    │         └── secondary: (a:4 > b:5) AND (c:6 = 'bar')
+      │    │    └── projections
+      │    │         ├── c:6 = 'foo' [as=partial_index_del1:7]
+      │    │         ├── (a:4 > b:5) AND (c:6 = 'bar') [as=partial_index_del2:8]
+      │    │         ├── c:6 = 'delete-only' [as=partial_index_del3:9]
+      │    │         └── c:6 = 'write-only' [as=partial_index_del4:10]
+      │    └── projections
+      │         └── 1 [as=a_new:11]
+      └── projections
+           └── (a_new:11 > b:5) AND (c:6 = 'bar') [as=partial_index_put2:12]

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -97,6 +97,9 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	// All columns from the update table will be projected.
 	mb.buildInputForUpdate(inScope, upd.Table, upd.From, upd.Where, upd.Limit, upd.OrderBy)
 
+	// Add partial index del boolean columns to the input.
+	mb.addPartialIndexDelCols()
+
 	// Derive the columns that will be updated from the SET expressions.
 	mb.addTargetColsForUpdate(upd.Exprs)
 
@@ -326,6 +329,9 @@ func (mb *mutationBuilder) buildUpdate(returning tree.ReturningExprs) {
 	mb.disambiguateColumns()
 
 	mb.addCheckConstraintCols()
+
+	// Add partial index put boolean columns to the input.
+	mb.addPartialIndexPutCols()
 
 	mb.buildFKChecksForUpdate()
 

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -257,6 +257,8 @@ func (ru *Updater) UpdateRow(
 	batch *kv.Batch,
 	oldValues []tree.Datum,
 	updateValues []tree.Datum,
+	ignoreIndexesForPut util.FastIntSet,
+	ignoreIndexesForDel util.FastIntSet,
 	traceKV bool,
 ) ([]tree.Datum, error) {
 	if len(oldValues) != len(ru.FetchCols) {
@@ -317,6 +319,7 @@ func (ru *Updater) UpdateRow(
 	}
 
 	for i := range ru.Helper.Indexes {
+		index := &ru.Helper.Indexes[i]
 		// We don't want to insert any empty k/v's, so set includeEmpty to false.
 		// Consider the following case:
 		// TABLE t (
@@ -324,34 +327,42 @@ func (ru *Updater) UpdateRow(
 		//   INDEX (y) STORING (z, w),
 		//   FAMILY (x), FAMILY (y), FAMILY (z), FAMILY (w)
 		//)
-		// If we are to perform an update on row (1, 2, 3, NULL),
-		// the k/v pair for index i that encodes column w would have
-		// an empty value because w is null and the sole resident
-		// of that family. We want to ensure that we don't insert
-		// empty k/v pairs during the process of the update, so
-		// set includeEmpty to false while generating the old
-		// and new index entries.
-		ru.oldIndexEntries[i], err = sqlbase.EncodeSecondaryIndex(
-			ru.Helper.Codec,
-			ru.Helper.TableDesc.TableDesc(),
-			&ru.Helper.Indexes[i],
-			ru.FetchColIDtoRowIndex,
-			oldValues,
-			false, /* includeEmpty */
-		)
-		if err != nil {
-			return nil, err
+		// If we are to perform an update on row (1, 2, 3, NULL), the k/v pair
+		// for index i that encodes column w would have an empty value because w
+		// is null and the sole resident of that family. We want to ensure that
+		// we don't insert empty k/v pairs during the process of the update, so
+		// set includeEmpty to false while generating the old and new index
+		// entries.
+		//
+		// Also, we don't build entries for old and new values if the index
+		// exists in ignoreIndexesForDel and ignoreIndexesForPut, respectively.
+		// Index IDs in these sets indicate that old and new values for the row
+		// do not satisfy a partial index's predicate expression.
+		if !ignoreIndexesForDel.Contains(int(index.ID)) {
+			ru.oldIndexEntries[i], err = sqlbase.EncodeSecondaryIndex(
+				ru.Helper.Codec,
+				ru.Helper.TableDesc.TableDesc(),
+				index,
+				ru.FetchColIDtoRowIndex,
+				oldValues,
+				false, /* includeEmpty */
+			)
+			if err != nil {
+				return nil, err
+			}
 		}
-		ru.newIndexEntries[i], err = sqlbase.EncodeSecondaryIndex(
-			ru.Helper.Codec,
-			ru.Helper.TableDesc.TableDesc(),
-			&ru.Helper.Indexes[i],
-			ru.FetchColIDtoRowIndex,
-			ru.newValues,
-			false, /* includeEmpty */
-		)
-		if err != nil {
-			return nil, err
+		if !ignoreIndexesForPut.Contains(int(index.ID)) {
+			ru.newIndexEntries[i], err = sqlbase.EncodeSecondaryIndex(
+				ru.Helper.Codec,
+				ru.Helper.TableDesc.TableDesc(),
+				index,
+				ru.FetchColIDtoRowIndex,
+				ru.newValues,
+				false, /* includeEmpty */
+			)
+			if err != nil {
+				return nil, err
+			}
 		}
 		if ru.Helper.Indexes[i].Type == sqlbase.IndexDescriptor_INVERTED {
 			// Deduplicate the keys we're adding and removing if we're updating an
@@ -390,14 +401,11 @@ func (ru *Updater) UpdateRow(
 	}
 
 	if rowPrimaryKeyChanged {
-		// TODO(mgartner): Add partial index IDs to ignoreIndexes that we should
-		// not write entries to.
-		var ignoreIndexes util.FastIntSet
-		if err := ru.rd.DeleteRow(ctx, batch, oldValues, ignoreIndexes, traceKV); err != nil {
+		if err := ru.rd.DeleteRow(ctx, batch, oldValues, ignoreIndexesForDel, traceKV); err != nil {
 			return nil, err
 		}
 		if err := ru.ri.InsertRow(
-			ctx, batch, ru.newValues, ignoreIndexes, false /* ignoreConflicts */, traceKV,
+			ctx, batch, ru.newValues, ignoreIndexesForPut, false /* ignoreConflicts */, traceKV,
 		); err != nil {
 			return nil, err
 		}
@@ -499,14 +507,11 @@ func (ru *Updater) UpdateRow(
 				}
 			}
 			for oldIdx < len(oldEntries) {
-				// Delete any remaining old entries that are not matched by new entries in this row.
+				// Delete any remaining old entries that are not matched by new
+				// entries in this row because 1) the family does not exist in
+				// the new set of k/v's or 2) the index is a partial index and
+				// the new row values do not match the partial index predicate.
 				oldEntry := &oldEntries[oldIdx]
-				if oldEntry.Family == sqlbase.FamilyID(0) {
-					return nil, errors.AssertionFailedf(
-						"index entry for family 0 for table %s, index %s was not generated",
-						ru.Helper.TableDesc.Name, index.Name,
-					)
-				}
 				if traceKV {
 					log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(ru.Helper.secIndexValDirs[i], oldEntry.Key))
 				}
@@ -514,14 +519,13 @@ func (ru *Updater) UpdateRow(
 				oldIdx++
 			}
 			for newIdx < len(newEntries) {
-				// Insert any remaining new entries that are not present in the old row.
+				// Insert any remaining new entries that are not present in the
+				// old row. Insert any remaining new entries that are not
+				// present in the old row because 1) the family does not exist
+				// in the old set of k/v's or 2) the index is a partial index
+				// and the old row values do not match the partial index
+				// predicate.
 				newEntry := &newEntries[newIdx]
-				if newEntry.Family == sqlbase.FamilyID(0) {
-					return nil, errors.AssertionFailedf(
-						"index entry for family 0 for table %s, index %s was not generated",
-						ru.Helper.TableDesc.Name, index.Name,
-					)
-				}
 				if traceKV {
 					k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
 					v := newEntry.Value.PrettyPrint()

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -206,6 +207,9 @@ type ImmutableTableDescriptor struct {
 
 	allChecks []TableDescriptor_CheckConstraint
 
+	// partialIndexOrds contains the ordinal of each partial index.
+	partialIndexOrds util.FastIntSet
+
 	// ReadableColumns is a list of columns (including those undergoing a schema change)
 	// which can be scanned. Columns in the process of a schema change
 	// are all set to nullable while column backfilling is still in
@@ -343,6 +347,13 @@ func NewImmutableTableDescriptor(tbl TableDescriptor) *ImmutableTableDescriptor 
 	desc.allChecks = make([]TableDescriptor_CheckConstraint, len(tbl.Checks))
 	for i, c := range tbl.Checks {
 		desc.allChecks[i] = *c
+	}
+
+	// Track partial index ordinals.
+	for i := range publicAndNonPublicIndexes {
+		if publicAndNonPublicIndexes[i].IsPartial() {
+			desc.partialIndexOrds.Add(i)
+		}
 	}
 
 	// Remember what columns have user defined types.
@@ -4375,6 +4386,12 @@ func (desc *ImmutableTableDescriptor) DeletableIndexes() []IndexDescriptor {
 // DeleteOnlyIndexes returns a list of delete-only mutation indexes.
 func (desc *ImmutableTableDescriptor) DeleteOnlyIndexes() []IndexDescriptor {
 	return desc.publicAndNonPublicIndexes[len(desc.Indexes)+desc.writeOnlyIndexCount:]
+}
+
+// PartialIndexOrds returns a set containing the ordinal of each partial index
+// defined on the table.
+func (desc *ImmutableTableDescriptor) PartialIndexOrds() util.FastIntSet {
+	return desc.partialIndexOrds
 }
 
 // DatabaseDesc implements the ObjectDescriptor interface.

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -48,10 +48,14 @@ func (tu *tableUpdater) row(context.Context, tree.Datums, util.FastIntSet, bool)
 
 // rowForUpdate extends row() from the tableWriter interface.
 func (tu *tableUpdater) rowForUpdate(
-	ctx context.Context, oldValues, updateValues tree.Datums, traceKV bool,
+	ctx context.Context,
+	oldValues, updateValues tree.Datums,
+	ignoreIndexesForPut util.FastIntSet,
+	ignoreIndexesForDel util.FastIntSet,
+	traceKV bool,
 ) (tree.Datums, error) {
 	tu.batchSize++
-	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, traceKV)
+	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, ignoreIndexesForPut, ignoreIndexesForDel, traceKV)
 }
 
 // atBatchEnd is part of the tableWriter interface.

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -367,7 +367,10 @@ func (tu *optTableUpserter) updateConflictingRow(
 	// Queue the update in KV. This also returns an "update row"
 	// containing the updated values for every column in the
 	// table. This is useful for RETURNING, which we collect below.
-	_, err := tu.ru.UpdateRow(ctx, b, fetchRow, updateValues, traceKV)
+	// TODO(mgartner): Add partial index IDs to ignoreIndexes that we should
+	// not add entries to or delete entries from.
+	var ignoreIndexes util.FastIntSet
+	_, err := tu.ru.UpdateRow(ctx, b, fetchRow, updateValues, ignoreIndexes, ignoreIndexes, traceKV)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -310,39 +310,39 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// entries from.
 	var ignoreIndexesForPut util.FastIntSet
 	var ignoreIndexesForDel util.FastIntSet
-	partialIndexValOffset := len(u.run.tu.ru.FetchCols) + len(u.run.tu.ru.UpdateCols) + u.run.numPassthrough
-	partialIndexVals := sourceVals[partialIndexValOffset:]
-	colIdx := 0
-	delColOffset := len(partialIndexVals) / 2
-	indexes := u.run.tu.tableDesc().Indexes
-	for i := range indexes {
-		index := &indexes[i]
-		if index.IsPartial() {
-			// Check the boolean partial index put column.
-			val, err := tree.GetBool(partialIndexVals[colIdx])
-			if err != nil {
-				return err
-			}
-			if !val {
-				// If the value of the column for the index predicate expression
-				// is false, the row should not be added to the partial index.
-				ignoreIndexesForPut.Add(int(index.ID))
-			}
+	partialIndexOrds := u.run.tu.tableDesc().PartialIndexOrds()
+	if !partialIndexOrds.Empty() {
+		partialIndexValOffset := len(u.run.tu.ru.FetchCols) + len(u.run.tu.ru.UpdateCols) + u.run.checkOrds.Len() + u.run.numPassthrough
+		partialIndexVals := sourceVals[partialIndexValOffset:]
+		colIdx := 0
+		delColOffset := len(partialIndexVals) / 2
+		indexes := u.run.tu.tableDesc().Indexes
+		for i, ok := partialIndexOrds.Next(0); ok; i, ok = partialIndexOrds.Next(i + 1) {
+			index := &indexes[i]
+			if index.IsPartial() {
+				// Check the boolean partial index put column.
+				val, err := tree.GetBool(partialIndexVals[colIdx])
+				if err != nil {
+					return err
+				}
+				if !val {
+					// If the value of the column for the index predicate expression
+					// is false, the row should not be added to the partial index.
+					ignoreIndexesForPut.Add(int(index.ID))
+				}
 
-			// Check the boolean partial index del column.
-			val, err = tree.GetBool(partialIndexVals[colIdx+delColOffset])
-			if err != nil {
-				return err
-			}
-			if !val {
-				// If the value of the column for the index predicate expression
-				// is false, the row should not be added to the partial index.
-				ignoreIndexesForDel.Add(int(index.ID))
-			}
+				// Check the boolean partial index del column.
+				val, err = tree.GetBool(partialIndexVals[colIdx+delColOffset])
+				if err != nil {
+					return err
+				}
+				if !val {
+					// If the value of the column for the index predicate expression
+					// is false, the row should not be added to the partial index.
+					ignoreIndexesForDel.Add(int(index.ID))
+				}
 
-			colIdx++
-			if colIdx+delColOffset >= len(partialIndexVals) {
-				break
+				colIdx++
 			}
 		}
 	}


### PR DESCRIPTION
#### sql: handle UPDATEs for partial indexes

This commit enhances the behavoir of `UPDATE` so that the state of
partial indexes is correctly maintained. Two boolean columns are
synthesized for each partial index defined on the table. These two
columns indicate whether the old rows and new rows satisfy the partial
index predicate, respectively. During execution, these columns are
accessed when deciding whether to delete or put entries in the partial
index.

Note that `UPDATE`s to partial inverted indexes are not yet supported or
tested.

Fixes #50221

Release note: None

#### sql: shortcut logic in mutations for tables without partial indexes

This commit avoids a loop through a table's indexes for every row
processed in a mutation when the table contains no partial indexes. By
caching the set of ordinals of the partial indexes defined on the table,
we can avoid partial-index related logic in the case that the set is
empty. Also, this set allows iterating through just the partial indexes,
not all the indexes.

Release note: None