### PR TITLE
colexec: shorten benchmark of projection operators

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -414,8 +414,6 @@ func (r opResult) createAndWrapRowSource(
 	factory coldata.ColumnFactory,
 ) error {
 	if processorConstructor == nil {
-		// TODO(yuzefovich): update unit tests to remove panic-catcher when
-		// fallback to rowexec is not allowed.
 		return errors.New("processorConstructor is nil")
 	}
 	if flowCtx.EvalCtx.SessionData.VectorizeMode == sessiondata.Vectorize201Auto &&

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -1614,20 +1614,6 @@ func createTestProjectingOperator(
 	}
 	if canFallbackToRowexec {
 		args.ProcessorConstructor = rowexec.NewProcessor
-	} else {
-		// It is possible that there is a valid projecting operator with the
-		// given input types, but the vectorized engine doesn't support it. In
-		// such case in the production code we fall back to row-by-row engine,
-		// but the caller of this method doesn't want such behavior. In order
-		// to avoid a nil-pointer exception we mock out the processor
-		// constructor.
-		args.ProcessorConstructor = func(
-			context.Context, *execinfra.FlowCtx, int32,
-			*execinfrapb.ProcessorCoreUnion, *execinfrapb.PostProcessSpec,
-			[]execinfra.RowSource, []execinfra.RowReceiver,
-			[]execinfra.LocalProcessor) (execinfra.Processor, error) {
-			return nil, errors.Errorf("fallback to rowexec is disabled")
-		}
 	}
 	args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 	result, err := TestNewColOperator(ctx, flowCtx, args)

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -268,21 +268,14 @@ func (a *Allocator) ReleaseMemory(size int64) {
 }
 
 const (
-	// SizeOfBool is the size of a single bool value.
-	SizeOfBool = int(unsafe.Sizeof(true))
-	sizeOfInt  = int(unsafe.Sizeof(int(0)))
-	// SizeOfInt16 is the size of a single int16 value.
-	SizeOfInt16 = int(unsafe.Sizeof(int16(0)))
-	// SizeOfInt32 is the size of a single int32 value.
-	SizeOfInt32 = int(unsafe.Sizeof(int32(0)))
-	// SizeOfInt64 is the size of a single int64 value.
-	SizeOfInt64 = int(unsafe.Sizeof(int64(0)))
-	// SizeOfFloat64 is the size of a single float64 value.
-	SizeOfFloat64 = int(unsafe.Sizeof(float64(0)))
-	// SizeOfTime is the size of a single time.Time value.
-	SizeOfTime = int(unsafe.Sizeof(time.Time{}))
-	// SizeOfDuration is the size of a single duration.Duration value.
-	SizeOfDuration = int(unsafe.Sizeof(duration.Duration{}))
+	sizeOfBool     = int(unsafe.Sizeof(true))
+	sizeOfInt      = int(unsafe.Sizeof(int(0)))
+	sizeOfInt16    = int(unsafe.Sizeof(int16(0)))
+	sizeOfInt32    = int(unsafe.Sizeof(int32(0)))
+	sizeOfInt64    = int(unsafe.Sizeof(int64(0)))
+	sizeOfFloat64  = int(unsafe.Sizeof(float64(0)))
+	sizeOfTime     = int(unsafe.Sizeof(time.Time{}))
+	sizeOfDuration = int(unsafe.Sizeof(duration.Duration{}))
 	sizeOfDatum    = int(unsafe.Sizeof(tree.Datum(nil)))
 )
 
@@ -301,7 +294,7 @@ func EstimateBatchSizeBytes(vecTypes []*types.T, batchLength int) int {
 	for _, t := range vecTypes {
 		switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 		case types.BoolFamily:
-			acc += SizeOfBool
+			acc += sizeOfBool
 		case types.BytesFamily:
 			// For byte arrays, we initially allocate BytesInitialAllocationFactor
 			// number of bytes (plus an int32 for the offset) for each row, so we use
@@ -309,18 +302,18 @@ func EstimateBatchSizeBytes(vecTypes []*types.T, batchLength int) int {
 			// memory footprint will be used: whenever a modification of Bytes takes
 			// place, the Allocator will measure the old footprint and the updated
 			// one and will update the memory account accordingly.
-			acc += coldata.BytesInitialAllocationFactor + SizeOfInt32
+			acc += coldata.BytesInitialAllocationFactor + sizeOfInt32
 		case types.IntFamily:
 			switch t.Width() {
 			case 16:
-				acc += SizeOfInt16
+				acc += sizeOfInt16
 			case 32:
-				acc += SizeOfInt32
+				acc += sizeOfInt32
 			default:
-				acc += SizeOfInt64
+				acc += sizeOfInt64
 			}
 		case types.FloatFamily:
-			acc += SizeOfFloat64
+			acc += sizeOfFloat64
 		case types.DecimalFamily:
 			// Similar to byte arrays, we can't tell how much space is used
 			// to hold the arbitrary precision decimal objects.
@@ -333,9 +326,9 @@ func EstimateBatchSizeBytes(vecTypes []*types.T, batchLength int) int {
 			// timestamps, so if we were to include that in the estimation, we would
 			// significantly overestimate.
 			// TODO(yuzefovich): figure out whether the caching does take place.
-			acc += SizeOfTime
+			acc += sizeOfTime
 		case types.IntervalFamily:
-			acc += SizeOfDuration
+			acc += sizeOfDuration
 		case typeconv.DatumVecCanonicalTypeFamily:
 			// In datum vec we need to account for memory underlying the struct
 			// that is the implementation of tree.Datum interface (for example,


### PR DESCRIPTION
A couple of months ago I introduced a "comprehensive" benchmark of
projection operators that attempted to evaluate projection expressions
for 10 operations for many different combination of types of the
arguments. This benchmark takes forever to run, but also it doesn't
provide much benefit on top of us running the benchmark on ints. This
commit reduces the benchmark to only run on ints but also adds a variant
with a constant on the right.

Release note: None