### PR TITLE
util/mon: don't crash when shrinking by too much

### DIFF
--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -571,8 +571,10 @@ func (b *BoundAccount) Grow(ctx context.Context, x int64) error {
 // Shrink releases part of the cumulated allocations by the specified size.
 func (b *BoundAccount) Shrink(ctx context.Context, delta int64) {
 	if b.used < delta {
-		panic(fmt.Sprintf("%s: no bytes in account to release, current %d, free %d",
-			b.mon.name, b.used, delta))
+		log.ReportOrPanic(ctx, &b.mon.settings.SV,
+			"%s: no bytes in account to release, current %d, free %d",
+			b.mon.name, b.used, delta)
+		delta = b.used
 	}
 	b.used -= delta
 	b.reserved += delta


### PR DESCRIPTION
Previously, we called `panic` when `Shrink`ing the memory account by
too much. Such scenario indicates that our memory accounting is off,
but we shouldn't be crashing - we should report an error instead, and
this commit does that.

Fixes: #50804.

Release note (bug fix): Previously, CockroachDB could crash when
internal memory accounting hit a discrepancy. Now it will report an
error instead.