### PR TITLE
partitionccl,kvserver: skip some flaky tests

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1174,6 +1174,9 @@ func setupPartitioningTestCluster(
 func TestInitialPartitioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	// Skipping as part of test-infra-team flaky test cleanup.
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/49909")
+
 	// This test configures many sub-tests and is too slow to run under nightly
 	// race stress.
 	if testutils.NightlyStress() && util.RaceEnabled {

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1932,6 +1932,10 @@ func TestStoreSplitGCThreshold(t *testing.T) {
 // and the uninitialized replica reacting to messages.
 func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	// Skipping as part of test-infra-team flaky test cleanup.
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/50809")
+
 	mtc := &multiTestContext{}
 	storeCfg := kvserver.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableMergeQueue = true


### PR DESCRIPTION
This commit skips 2 tests as part of the test-infra-team flaky
test cleanup:

TestInitialPartitioning
TestStoreRangeSplitRaceUninitializedRHS

Informs #49909
Informs #50809

Release note: None