### PR TITLE
stmtdiagnostics: break into chunks

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"regexp"
 	"sort"
 	"strings"
@@ -42,6 +43,13 @@ func TestExplainAnalyzeDebug(t *testing.T) {
 
 	base := "statement.txt trace.json trace.txt trace-jaeger.json env.sql"
 	plans := "schema.sql opt.txt opt-v.txt opt-vv.txt plan.txt"
+
+	// Set a small chunk size to test splitting into chunks. The bundle files are
+	// on the order of 10KB.
+	r.Exec(t, fmt.Sprintf(
+		"SET CLUSTER SETTING sql.stmt_diagnostics.bundle_chunk_size = '%d'",
+		5000+rand.Intn(10000),
+	))
 
 	t.Run("basic", func(t *testing.T) {
 		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT * FROM abc WHERE c=1")


### PR DESCRIPTION
Implement breaking support bundles into chunks. The bundles contain
traces which can be large, resulting in "command is too large" errors.

Release note (bug fix): better support for large statement diagnostic
bundles.