### PR TITLE
cli: add support for userfile upload CLI command

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -200,6 +200,7 @@ func init() {
 		nodeCmd,
 		dumpCmd,
 		nodeLocalCmd,
+		userFileCmd,
 
 		// Miscellaneous commands.
 		// TODO(pmattis): stats

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -297,7 +297,7 @@ func isSQLCommand(args []string) bool {
 		return false
 	}
 	switch args[0] {
-	case "sql", "dump", "workload", "nodelocal", "statement-diag":
+	case "sql", "dump", "workload", "nodelocal", "userfile", "statement-diag":
 		return true
 	case "node":
 		if len(args) == 0 {
@@ -1411,6 +1411,7 @@ Available Commands:
   dump              dump sql tables
 
   nodelocal         upload and delete nodelocal files
+  userfile          upload and delete user scoped files
   demo              open a demo sql shell
   gen               generate auxiliary files
   version           output version information

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -539,6 +539,7 @@ func init() {
 	clientCmds = append(clientCmds, nodeCmds...)
 	clientCmds = append(clientCmds, systemBenchCmds...)
 	clientCmds = append(clientCmds, nodeLocalCmds...)
+	clientCmds = append(clientCmds, userFileCmds...)
 	clientCmds = append(clientCmds, stmtDiagCmds...)
 	for _, cmd := range clientCmds {
 		f := cmd.PersistentFlags()
@@ -652,6 +653,7 @@ func init() {
 	sqlCmds = append(sqlCmds, demoCmd.Commands()...)
 	sqlCmds = append(sqlCmds, stmtDiagCmds...)
 	sqlCmds = append(sqlCmds, nodeLocalCmds...)
+	sqlCmds = append(sqlCmds, userFileCmds...)
 	for _, cmd := range sqlCmds {
 		f := cmd.Flags()
 		boolFlag(f, &sqlCtx.echo, cliflags.EchoSQL)

--- a/pkg/cli/nodelocal.go
+++ b/pkg/cli/nodelocal.go
@@ -11,9 +11,11 @@
 package cli
 
 import (
+	"context"
 	"database/sql/driver"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -50,7 +52,8 @@ func runUpload(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer reader.Close()
-	return uploadFile(conn, reader, destination)
+
+	return uploadFile(context.Background(), conn, reader, destination)
 }
 
 func openSourceFile(source string) (io.ReadCloser, error) {
@@ -68,16 +71,24 @@ func openSourceFile(source string) (io.ReadCloser, error) {
 	return f, nil
 }
 
-func uploadFile(conn *sqlConn, reader io.Reader, destination string) error {
+func uploadFile(ctx context.Context, conn *sqlConn, reader io.Reader, destination string) error {
 	if err := conn.ensureConn(); err != nil {
 		return err
 	}
 
-	if _, err := conn.conn.Exec(`BEGIN`, nil); err != nil {
+	ex := conn.conn.(driver.ExecerContext)
+	if _, err := ex.ExecContext(ctx, `BEGIN`, nil); err != nil {
 		return err
 	}
 
-	stmt, err := conn.conn.Prepare(sql.CopyInFileStmt(destination, "crdb_internal", "file_upload"))
+	// Construct the nodelocal URI as the destination for the CopyIn stmt.
+	nodelocalURL := url.URL{
+		Scheme: "nodelocal",
+		Host:   "self",
+		Path:   destination,
+	}
+	stmt, err := conn.conn.Prepare(sql.CopyInFileStmt(nodelocalURL.String(), sql.CrdbInternalName,
+		sql.NodelocalFileUploadTable))
 	if err != nil {
 		return err
 	}
@@ -85,7 +96,7 @@ func uploadFile(conn *sqlConn, reader io.Reader, destination string) error {
 	defer func() {
 		if stmt != nil {
 			_ = stmt.Close()
-			_, _ = conn.conn.Exec(`ROLLBACK`, nil)
+			_, _ = ex.ExecContext(ctx, `ROLLBACK`, nil)
 		}
 	}()
 
@@ -93,6 +104,8 @@ func uploadFile(conn *sqlConn, reader io.Reader, destination string) error {
 	for {
 		n, err := reader.Read(send)
 		if n > 0 {
+			// TODO(adityamaru): Switch to StmtExecContext once the copyin driver
+			// supports it.
 			_, err = stmt.Exec([]driver.Value{string(send[:n])})
 			if err != nil {
 				return err
@@ -108,7 +121,7 @@ func uploadFile(conn *sqlConn, reader io.Reader, destination string) error {
 	}
 	stmt = nil
 
-	if _, err := conn.conn.Exec(`COMMIT`, nil); err != nil {
+	if _, err := ex.ExecContext(ctx, `COMMIT`, nil); err != nil {
 		return err
 	}
 

--- a/pkg/cli/nodelocal_test.go
+++ b/pkg/cli/nodelocal_test.go
@@ -43,7 +43,7 @@ func Example_nodelocal() {
 	// nodelocal upload test.csv /test/file1.csv
 	// ERROR: destination file already exists for /test/file1.csv
 	// nodelocal upload test.csv /test/../../file1.csv
-	// ERROR: local file access to paths outside of external-io-dir is not allowed: /test/../../file1.csv
+	// ERROR: local file access to paths outside of external-io-dir is not allowed: ../file1.csv
 	// nodelocal upload notexist.csv /test/file1.csv
 	// ERROR: open notexist.csv: no such file or directory
 }

--- a/pkg/cli/userfile.go
+++ b/pkg/cli/userfile.go
@@ -1,0 +1,167 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+const defaultQualifiedDBSchemaName = "defaultdb.public."
+
+var userFileUploadCmd = &cobra.Command{
+	Use:   "upload <source> <destination>",
+	Short: "Upload file from source to destination",
+	Long: `
+Uploads a file to the user scoped file storage using a SQL connection.
+`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: maybeShoutError(runUserFileUpload),
+}
+
+func runUserFileUpload(cmd *cobra.Command, args []string) error {
+	conn, err := makeSQLClient("cockroach userfile", useDefaultDb)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	source := args[0]
+	destination := args[1]
+	reader, err := openUserFile(source)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	return uploadUserFile(context.Background(), conn, reader, destination)
+}
+
+func openUserFile(source string) (io.ReadCloser, error) {
+	f, err := os.Open(source)
+	if err != nil {
+		return nil, err
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get source file stats for %s", source)
+	}
+	if stat.IsDir() {
+		return nil, fmt.Errorf("source file %s is a directory, not a file", source)
+	}
+	return f, nil
+}
+
+func uploadUserFile(
+	ctx context.Context, conn *sqlConn, reader io.Reader, destination string,
+) error {
+	if err := conn.ensureConn(); err != nil {
+		return err
+	}
+
+	ex := conn.conn.(driver.ExecerContext)
+	if _, err := ex.ExecContext(ctx, `BEGIN`, nil); err != nil {
+		return err
+	}
+
+	// TODO(adityamaru): In the future we may want to allow users to specify a
+	// fully qualified db.schema.table where their underlying SQL file tables will
+	// be created. Enforcing the filepath to begin with a / allows for easy
+	// disambiguation between the qualified name and the filepath.
+	if !strings.HasPrefix(destination, "/") {
+		return errors.Newf("userfile upload destination path must begin with /")
+	}
+
+	connURL, err := url.Parse(conn.url)
+	if err != nil {
+		return err
+	}
+
+	// Construct the userfile URI as the destination for the CopyIn stmt.
+	// Currently we hardcode the db.schema prefix, in the future we might allow
+	// users to specify this.
+	userfileURL := url.URL{
+		Scheme: "userfile",
+		Host:   defaultQualifiedDBSchemaName + connURL.User.Username(),
+		Path:   destination,
+	}
+
+	// Accounts for filenames with arbitrary unicode characters. url.URL escapes
+	// these characters by default when setting the Path above.
+	unescapedUserfileURL, err := url.PathUnescape(userfileURL.String())
+	if err != nil {
+		return err
+	}
+	stmt, err := conn.conn.Prepare(sql.CopyInFileStmt(unescapedUserfileURL, sql.CrdbInternalName,
+		sql.UserFileUploadTable))
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if stmt != nil {
+			_ = stmt.Close()
+			_, _ = ex.ExecContext(ctx, `ROLLBACK`, nil)
+		}
+	}()
+
+	send := make([]byte, chunkSize)
+	for {
+		n, err := reader.Read(send)
+		if n > 0 {
+			// TODO(adityamaru): Switch to StmtExecContext once the copyin driver
+			// supports it.
+			_, err = stmt.Exec([]driver.Value{string(send[:n])})
+			if err != nil {
+				return err
+			}
+		} else if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+	}
+	if err := stmt.Close(); err != nil {
+		return err
+	}
+	stmt = nil
+
+	if _, err := ex.ExecContext(ctx, `COMMIT`, nil); err != nil {
+		return err
+	}
+
+	fmt.Printf("successfully uploaded to %s\n", unescapedUserfileURL)
+	return nil
+}
+
+var userFileCmds = []*cobra.Command{
+	userFileUploadCmd,
+}
+
+var userFileCmd = &cobra.Command{
+	Use:   "userfile [command]",
+	Short: "upload and delete user scoped files",
+	Long:  "Upload and delete files from the user scoped file storage.",
+	RunE:  usageAndErr,
+}
+
+func init() {
+	userFileCmd.AddCommand(userFileCmds...)
+}

--- a/pkg/cli/userfiletable_test.go
+++ b/pkg/cli/userfiletable_test.go
@@ -1,0 +1,137 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func Example_userfile() {
+	c := newCLITest(cliTestParams{})
+	defer c.cleanup()
+
+	file, cleanUp := createTestFile("test.csv", "content")
+	defer cleanUp()
+
+	c.Run(fmt.Sprintf("userfile upload %s /test/file1.csv", file))
+	c.Run(fmt.Sprintf("userfile upload %s /test/file2.csv", file))
+	c.Run(fmt.Sprintf("userfile upload %s /test/file1.csv", file))
+	c.Run(fmt.Sprintf("userfile upload %s /test/../../file1.csv", file))
+	c.Run(fmt.Sprintf("userfile upload %s /test/./file1.csv", file))
+	c.Run(fmt.Sprintf("userfile upload %s test/file1.csv", file))
+	c.Run(fmt.Sprintf("userfile upload notexist.csv /test/file1.csv"))
+	c.Run(fmt.Sprintf("userfile upload %s /test/À.csv", file))
+
+	// Output:
+	// userfile upload test.csv /test/file1.csv
+	// successfully uploaded to userfile://defaultdb.public.root/test/file1.csv
+	// userfile upload test.csv /test/file2.csv
+	// successfully uploaded to userfile://defaultdb.public.root/test/file2.csv
+	// userfile upload test.csv /test/file1.csv
+	// ERROR: destination file already exists for /test/file1.csv
+	// userfile upload test.csv /test/../../file1.csv
+	// ERROR: path /test/../../file1.csv changes after normalization to /file1.csv. userfile upload does not permit such path constructs
+	// userfile upload test.csv /test/./file1.csv
+	// ERROR: path /test/./file1.csv changes after normalization to /test/file1.csv. userfile upload does not permit such path constructs
+	// userfile upload test.csv test/file1.csv
+	// ERROR: userfile upload destination path must begin with /
+	// userfile upload notexist.csv /test/file1.csv
+	// ERROR: open notexist.csv: no such file or directory
+	// userfile upload test.csv /test/À.csv
+	// successfully uploaded to userfile://defaultdb.public.root/test/À.csv
+}
+
+func checkUserFileContent(
+	ctx context.Context,
+	t *testing.T,
+	execcCfg interface{},
+	user, filename string,
+	expectedContent []byte,
+) {
+	if !strings.HasPrefix(filename, "/") {
+		t.Fatal(errors.New("userfile destination must start with a /"))
+	}
+	uri := fmt.Sprintf("userfile://%s%s",
+		defaultQualifiedDBSchemaName+user, filename)
+	store, err := execcCfg.(sql.ExecutorConfig).DistSQLSrv.ExternalStorageFromURI(ctx, uri,
+		user)
+	require.NoError(t, err)
+	reader, err := store.ReadFile(ctx, "")
+	require.NoError(t, err)
+	got, err := ioutil.ReadAll(reader)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(got, expectedContent))
+}
+
+func TestUserFileUpload(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c := newCLITest(cliTestParams{t: t})
+	defer c.cleanup()
+
+	dir, cleanFn := testutils.TempDir(t)
+	defer cleanFn()
+	ctx := context.Background()
+
+	for i, tc := range []struct {
+		name        string
+		fileContent []byte
+	}{
+		{
+			"empty",
+			[]byte{},
+		},
+		{
+			"exactly-one-chunk",
+			make([]byte, chunkSize),
+		},
+		{
+			"exactly-five-chunks",
+			make([]byte, chunkSize*5),
+		},
+		{
+			"less-than-one-chunk",
+			make([]byte, chunkSize-100),
+		},
+		{
+			"more-than-one-chunk",
+			make([]byte, chunkSize+100),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			filePath := filepath.Join(dir, fmt.Sprintf("file%d.csv", i))
+			err := ioutil.WriteFile(filePath, tc.fileContent, 0666)
+			if err != nil {
+				t.Fatal(err)
+			}
+			destination := fmt.Sprintf("/test/file%d.csv", i)
+
+			_, err = c.RunWithCapture(fmt.Sprintf("userfile upload %s %s", filePath, destination))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			checkUserFileContent(ctx, t, c.ExecutorConfig(), security.RootUser, destination, tc.fileContent)
+		})
+	}
+}

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -14,9 +14,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"sync"
 
-	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -27,8 +27,13 @@ import (
 )
 
 const (
-	fileUploadTable = "file_upload"
-	copyOptionDest  = "destination"
+	// NodelocalFileUploadTable is used internally to identify a COPY initiated by
+	// nodelocal upload.
+	NodelocalFileUploadTable = "nodelocal_file_upload"
+	// UserFileUploadTable is used internally to identify a COPY initiated by
+	// userfile upload.
+	UserFileUploadTable = "user_file_upload"
+	copyOptionDest      = "destination"
 )
 
 var copyFileOptionExpectValues = map[string]KVStringOptValidate{
@@ -42,6 +47,16 @@ type fileUploadMachine struct {
 	writeToFile    *io.PipeWriter
 	wg             *sync.WaitGroup
 	failureCleanup func()
+}
+
+var _ io.ReadSeeker = &noopReadSeeker{}
+
+type noopReadSeeker struct {
+	*io.PipeReader
+}
+
+func (n *noopReadSeeker) Seek(int64, int) (int64, error) {
+	return 0, errors.New("illegal seek")
 }
 
 func newFileUploadMachine(
@@ -72,8 +87,10 @@ func newFileUploadMachine(
 	}()
 	c.parsingEvalCtx = c.p.EvalContext()
 
-	if err := c.p.RequireAdminRole(ctx, "upload to nodelocal"); err != nil {
-		return nil, err
+	if n.Table.Table() == NodelocalFileUploadTable {
+		if err := c.p.RequireAdminRole(ctx, "upload to nodelocal"); err != nil {
+			return nil, err
+		}
 	}
 
 	optsFn, err := f.c.p.TypeAsStringOpts(ctx, n.Options, copyFileOptionExpectValues)
@@ -86,18 +103,23 @@ func newFileUploadMachine(
 	}
 
 	pr, pw := io.Pipe()
-	localStorage, err := blobs.NewLocalStorage(c.p.execCfg.Settings.ExternalIODir)
+	store, err := c.p.execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, opts[copyOptionDest], c.p.User())
 	if err != nil {
 		return nil, err
 	}
+
 	// Check that the file does not already exist
-	_, err = localStorage.Stat(opts[copyOptionDest])
+	_, err = store.ReadFile(ctx, "")
 	if err == nil {
-		return nil, fmt.Errorf("destination file already exists for %s", opts[copyOptionDest])
+		// Can ignore this parse error as it would have been caught when creating a
+		// new ExternalStorage above and so we never expect it to non-nil.
+		uri, _ := url.Parse(opts[copyOptionDest])
+		return nil, errors.Newf("destination file already exists for %s", uri.Path)
 	}
+
 	f.wg.Add(1)
 	go func() {
-		err := localStorage.WriteFile(opts[copyOptionDest], pr)
+		err := store.WriteFile(ctx, "", &noopReadSeeker{pr})
 		if err != nil {
 			_ = pr.CloseWithError(err)
 		}
@@ -107,7 +129,7 @@ func newFileUploadMachine(
 	f.failureCleanup = func() {
 		// Ignoring this error because deletion would only fail
 		// if the file was not created in the first place.
-		_ = localStorage.Delete(opts[copyOptionDest])
+		_ = store.Delete(ctx, "")
 	}
 
 	c.resultColumns = make(sqlbase.ResultColumns, 1)

--- a/pkg/sql/copy_file_upload_test.go
+++ b/pkg/sql/copy_file_upload_test.go
@@ -14,23 +14,30 @@ import (
 	"bytes"
 	"context"
 	gosql "database/sql"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
+const defaultQualifiedDBSchemaName = "defaultdb.public."
 const filename = "/test/test_file_upload.csv"
+
+var fileUploadModes = []string{NodelocalFileUploadTable, UserFileUploadTable}
 
 func writeFile(t *testing.T, testSendFile string, fileContent []byte) {
 	err := os.MkdirAll(filepath.Dir(testSendFile), 0755)
@@ -43,7 +50,26 @@ func writeFile(t *testing.T, testSendFile string, fileContent []byte) {
 	}
 }
 
-func runCopyFile(t *testing.T, db *gosql.DB, testSendFile string) error {
+func prepareFileUploadURI(user, testSendFile, copyInternalTable string) (string, error) {
+	var uri string
+	switch copyInternalTable {
+	case NodelocalFileUploadTable:
+		testSendFile = strings.TrimPrefix(testSendFile, "/")
+		uri = fmt.Sprintf("nodelocal://self/%s", testSendFile)
+	case UserFileUploadTable:
+		if !strings.HasPrefix(testSendFile, "/") {
+			return "", errors.New("userfile destination must start with a /")
+		}
+		uri = fmt.Sprintf("userfile://%s%s",
+			defaultQualifiedDBSchemaName+user, testSendFile)
+	default:
+		return "", errors.New("unsupported upload destination")
+	}
+
+	return uri, nil
+}
+
+func runCopyFile(t *testing.T, db *gosql.DB, user, testSendFile, copyInternalTable string) error {
 	// Make sure we can open this file first
 	reader, err := os.Open(testSendFile)
 	if err != nil {
@@ -60,7 +86,11 @@ func runCopyFile(t *testing.T, db *gosql.DB, testSendFile string) error {
 		}
 	}()
 
-	stmt, err := txn.Prepare(CopyInFileStmt(filename, crdbInternalName, fileUploadTable))
+	fileUploadURI, err := prepareFileUploadURI(user, testSendFile, copyInternalTable)
+	if err != nil {
+		return err
+	}
+	stmt, err := txn.Prepare(CopyInFileStmt(fileUploadURI, CrdbInternalName, copyInternalTable))
 	if err != nil {
 		return err
 	}
@@ -87,10 +117,40 @@ func runCopyFile(t *testing.T, db *gosql.DB, testSendFile string) error {
 	return nil
 }
 
+func checkNodelocalContent(
+	t *testing.T, localExternalDir, filename string, expectedContent []byte,
+) {
+	content, err := ioutil.ReadFile(filepath.Join(localExternalDir, filename))
+	require.NoError(t, err)
+	if !bytes.Equal(expectedContent, content) {
+		t.Fatalf("content not the same. expected: %s got: %s", expectedContent, content)
+	}
+}
+
+func checkUserFileContent(
+	ctx context.Context,
+	t *testing.T,
+	s serverutils.TestServerInterface,
+	user, filename string,
+	expectedContent []byte,
+) {
+	uri, err := prepareFileUploadURI(user, filename, UserFileUploadTable)
+	require.NoError(t, err)
+	store, err := s.ExecutorConfig().(ExecutorConfig).DistSQLSrv.ExternalStorageFromURI(ctx, uri,
+		user)
+	require.NoError(t, err)
+	reader, err := store.ReadFile(ctx, "")
+	require.NoError(t, err)
+	got, err := ioutil.ReadAll(reader)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(got, expectedContent))
+}
+
 func TestFileUpload(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
 	localExternalDir, cleanup := testutils.TempDir(t)
 	defer cleanup()
@@ -105,24 +165,21 @@ func TestFileUpload(t *testing.T) {
 	fileContent := []byte("hello \n blah 1@#% some data hello \n @#%^&&*")
 	writeFile(t, testSendFile, fileContent)
 
-	err := runCopyFile(t, db, testSendFile)
-	if err != nil {
-		t.Fatal(err)
+	for _, table := range fileUploadModes {
+		err := runCopyFile(t, db, security.RootUser, testSendFile, table)
+		require.NoError(t, err)
 	}
 
-	content, err := ioutil.ReadFile(filepath.Join(localExternalDir, filename))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(fileContent, content) {
-		t.Fatalf("content not the same. expected: %s got: %s", fileContent, content)
-	}
+	// Verify contents of the uploaded file.
+	checkNodelocalContent(t, localExternalDir, testSendFile, fileContent)
+	checkUserFileContent(ctx, t, s, security.RootUser, testSendFile, fileContent)
 }
 
 func TestUploadEmptyFile(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
 	localExternalDir, cleanup := testutils.TempDir(t)
 	defer cleanup()
@@ -136,18 +193,14 @@ func TestUploadEmptyFile(t *testing.T) {
 	fileContent := []byte("")
 	writeFile(t, testSendFile, fileContent)
 
-	err := runCopyFile(t, db, testSendFile)
-	if err != nil {
-		t.Fatal(err)
+	for _, table := range fileUploadModes {
+		err := runCopyFile(t, db, security.RootUser, testSendFile, table)
+		require.NoError(t, err)
 	}
 
-	content, err := ioutil.ReadFile(filepath.Join(localExternalDir, filename))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(fileContent, content) {
-		t.Fatalf("content not the same. expected: %s got: %s", fileContent, content)
-	}
+	// Verify contents of the uploaded file.
+	checkNodelocalContent(t, localExternalDir, testSendFile, fileContent)
+	checkUserFileContent(ctx, t, s, security.RootUser, testSendFile, fileContent)
 }
 
 func TestFileNotExist(t *testing.T) {
@@ -161,10 +214,10 @@ func TestFileNotExist(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 
-	err := runCopyFile(t, db, filepath.Join(localExternalDir, filename))
 	expectedErr := "no such file"
-	if !testutils.IsError(err, expectedErr) {
-		t.Fatalf(`expected error: %s, got: %s`, expectedErr, err)
+	for _, table := range fileUploadModes {
+		err := runCopyFile(t, db, security.RootUser, filename, table)
+		require.True(t, testutils.IsError(err, expectedErr))
 	}
 }
 
@@ -179,17 +232,27 @@ func TestFileExist(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 
-	destination := filepath.Join(localExternalDir, filename)
-	writeFile(t, destination, []byte("file exists"))
+	testFileDir, cleanup2 := testutils.TempDir(t)
+	defer cleanup2()
+	testSendFile := filepath.Join(testFileDir, filename)
+	writeFile(t, testSendFile, []byte("file exists"))
 
-	err := runCopyFile(t, db, destination)
-	expectedErr := "file already exists"
-	if !testutils.IsError(err, expectedErr) {
-		t.Fatalf(`expected error: %s, got: %s`, expectedErr, err)
+	// Write successfully the first time.
+	for _, table := range fileUploadModes {
+		err := runCopyFile(t, db, security.RootUser, testSendFile, table)
+		require.NoError(t, err)
+	}
+
+	// Writes fail the second time.
+	for _, table := range fileUploadModes {
+		require.True(t, testutils.IsError(runCopyFile(t, db, security.RootUser, testSendFile,
+			table), "file already exists"))
 	}
 }
 
-func TestNotAdmin(t *testing.T) {
+// TestNodelocalNotAdmin ensures that non-admin users cannot interact with
+// nodelocal storage.
+func TestNodelocalNotAdmin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -219,9 +282,45 @@ func TestNotAdmin(t *testing.T) {
 	fileContent := []byte("hello \n blah 1@#% some data hello \n @#%^&&*")
 	writeFile(t, testSendFile, fileContent)
 
-	err = runCopyFile(t, userDB, testSendFile)
+	err = runCopyFile(t, userDB, "jsmith", testSendFile, NodelocalFileUploadTable)
 	expectedErr := "only users with the admin role are allowed to upload"
-	if !testutils.IsError(err, expectedErr) {
-		t.Fatalf(`expected error: %s, got: %s`, expectedErr, err)
-	}
+	require.True(t, testutils.IsError(err, expectedErr))
+}
+
+// TestUserfileNotAdmin ensures that non-admin users with CREATE privileges can
+// interact with the FileTable ExternalStorage.
+func TestUserfileNotAdmin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := tests.CreateTestServerParams()
+	localExternalDir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+	params.ExternalIODir = localExternalDir
+	params.Insecure = true
+	s, rootDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.Background())
+
+	_, err := rootDB.Exec("CREATE USER jsmith")
+	require.NoError(t, err)
+	_, err = rootDB.Exec("GRANT CREATE ON DATABASE defaultdb TO jsmith")
+	require.NoError(t, err)
+
+	pgURL, cleanupGoDB := sqlutils.PGUrlWithOptionalClientCerts(
+		t, s.ServingSQLAddr(), "notAdmin", url.User("jsmith"), false, /* withCerts */
+	)
+	defer cleanupGoDB()
+	pgURL.RawQuery = "sslmode=disable"
+	userDB, err := gosql.Open("postgres", pgURL.String())
+	require.NoError(t, err)
+	defer userDB.Close()
+
+	testFileDir, cleanup2 := testutils.TempDir(t)
+	defer cleanup2()
+	testSendFile := filepath.Join(testFileDir, filename)
+	fileContent := []byte("hello \n blah 1@#% some data hello \n @#%^&&*")
+	writeFile(t, testSendFile, fileContent)
+
+	err = runCopyFile(t, userDB, "jsmith", testSendFile, UserFileUploadTable)
+	require.NoError(t, err)
+	checkUserFileContent(context.Background(), t, s, "jsmith", testSendFile, fileContent)
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -52,7 +52,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-const crdbInternalName = sessiondata.CRDBInternalSchemaName
+// CrdbInternalName is the name of the crdb_internal schema.
+const CrdbInternalName = sessiondata.CRDBInternalSchemaName
 
 // Naming convention:
 // - if the response is served from memory, prefix with node_
@@ -66,7 +67,7 @@ const crdbInternalName = sessiondata.CRDBInternalSchemaName
 // Many existing tables don't follow the conventions above, but please apply
 // them to future additions.
 var crdbInternal = virtualSchema{
-	name: crdbInternalName,
+	name: CrdbInternalName,
 	tableDefs: map[sqlbase.ID]virtualSchemaDef{
 		sqlbase.CrdbInternalBackwardDependenciesTableID: crdbInternalBackwardDependenciesTable,
 		sqlbase.CrdbInternalBuildInfoTableID:            crdbInternalBuildInfoTable,

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1446,8 +1446,10 @@ func TestLint(t *testing.T) {
 				stream.GrepNot(`pkg/sql/pgwire/pgcode/codes.go:.* var .* is unused`),
 				// The methods in exprgen.customFuncs are used via reflection.
 				stream.GrepNot(`pkg/sql/opt/optgen/exprgen/custom_funcs.go:.* func .* is unused`),
-				// Using deprecated method to COPY.
+				// Using deprecated method to COPY because the copyin driver does not
+				// implement StmtExecContext as of 07/06/2020.
 				stream.GrepNot(`pkg/cli/nodelocal.go:.* stmt.Exec is deprecated: .*`),
+				stream.GrepNot(`pkg/cli/userfile.go:.* stmt.Exec is deprecated: .*`),
 				// Cause is a method used by pkg/cockroachdb/errors (through an unnamed
 				// interface).
 				stream.GrepNot(`pkg/.*.go:.* func .*\.Cause is unused`),


### PR DESCRIPTION
This change adds a CLI command allowing users to upload local files to
the user scoped file table ExternalStorage.  The command 
`userfile upload` uses the existing COPY protocol (similar to `nodelocal upload`)
to upload files and write them to the UserFileTableSystem. The
UserFileTableSystem is backed by two SQL tables which are currently
always created with `defaultdb.public.user` as the prefix of the
qualified name.  In the future we may allow users to specify the
`db.schema` they wish to store their tables in.

The command takes a source and destination path. The former is used to
find the file contents locally, the latter is used to reference the file
and its related metadata/payload in the SQL tables.

Known limitations:
- All destination paths must start with `/`, this is to help us
  disambiguate filepath from `db.schema` name when we allow users to
specify that in the future.

- Destination paths must not have a `..` in them. Since the
  UserFilTableSystem is not a "real" file system, storing SQL rows with
filenames such as /test/../test.csv seems strange. We will work on
enforcing a better naming scheme.

Informs: #47211

Release note (cli change): Adds a userfile upload command that can be
used to upload a file to the user scoped blob storage: `userfile upload
source/file /destination/of/file`