### PR TITLE
opt: fix error in case of NULL arguments to AddGeometryColumn

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
@@ -241,3 +241,10 @@ CREATE TABLE my_spatial_table (
    CONSTRAINT "primary" PRIMARY KEY (k ASC),
    FAMILY "primary" (k, geom1, geom2, geom3, geom4, geom5, geom6, geom8, geom9, geom10)
 )
+
+# Regression test for #50296. Using AddGeometryColumn with NULL arguments must
+# not panic.
+query T
+SELECT addgeometrycolumn('a', 'b', 3, NULL, 2);
+----
+NULL

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1255,6 +1255,9 @@ func (s *scope) replaceSQLFn(f *tree.FuncExpr, def *tree.FunctionDefinition) tre
 	if err != nil {
 		panic(err)
 	}
+	if typedFunc == tree.DNull {
+		return tree.DNull
+	}
 
 	f = typedFunc.(*tree.FuncExpr)
 	args := make(memo.ScalarListExpr, len(f.Exprs))


### PR DESCRIPTION
This commit fixes an error that occurred when `AddGeometryColumn` was
called with `NULL` arguments. The error was caused by an assertion that
the output of `TypeCheck` was a `tree.FuncExpr` when in fact it was
`tree.DNull`.

This commit fixes the error by adding an explicit check for `tree.DNull`
after calling `TypeCheck`.

Fixes #50296

Release note (bug fix): Fixed an internal error that occurred when
AddGeometryColumn was called with NULL arguments. This now results in
a no-op and returns NULL.