### PR TITLE
opt: fix bug when execbuilding lookup semi/anti join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -650,3 +650,14 @@ query T
 SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'Scan /Table/72/1/1/{0-1}, /Table/72/1/1/2/{1-2}'
 ----
 Scan /Table/72/1/1/{0-1}, /Table/72/1/1/2/{1-2}
+
+# Regression test for #50964.
+statement ok
+CREATE TABLE tab4 (
+  pk INT8 PRIMARY KEY, col0 INT8, col1 FLOAT8, col2 STRING, col3 INT8, col4 FLOAT8, col5 STRING,
+  UNIQUE (col3 DESC, col4 DESC)
+)
+
+query I
+SELECT pk FROM tab4 WHERE col0 IN (SELECT col3 FROM tab4 WHERE col4 = 495.6) AND (col3 IS NULL)
+----

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1378,7 +1378,11 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 
 	// Apply a post-projection if Cols doesn't contain all input columns.
 	if !inputCols.SubsetOf(join.Cols) {
-		return b.applySimpleProject(res, join.Cols, join.ProvidedPhysical().Ordering)
+		outCols := join.Cols
+		if join.JoinType == opt.SemiJoinOp || join.JoinType == opt.AntiJoinOp {
+			outCols = join.Cols.Intersection(inputCols)
+		}
+		return b.applySimpleProject(res, outCols, join.ProvidedPhysical().Ordering)
 	}
 	return res, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -1470,3 +1470,36 @@ limit                                               ·                      ·
 ·                                                   table                  lineitem@primary
 ·                                                   spans                  FULL SCAN
 ·                                                   filter                 l_receiptdate > l_commitdate
+
+# Regression test for #50964.
+statement ok
+CREATE TABLE tab4 (
+  pk INT8 PRIMARY KEY, col0 INT8, col1 FLOAT8, col2 STRING, col3 INT8, col4 FLOAT8, col5 STRING,
+  UNIQUE (col3 DESC, col4 DESC)
+)
+
+query TTTTT
+EXPLAIN (VERBOSE)
+  SELECT pk FROM tab4 WHERE col0 IN (SELECT col3 FROM tab4 WHERE col4 = 495.6) AND (col3 IS NULL)
+----
+·                          distribution           full                                          ·                                          ·
+·                          vectorized             true                                          ·                                          ·
+render                     ·                      ·                                             (pk)                                       ·
+ │                         render 0               pk                                            ·                                          ·
+ └── lookup-join           ·                      ·                                             ("project_const_col_@13", pk, col0, col3)  ·
+      │                    table                  tab4@tab4_col3_col4_key                       ·                                          ·
+      │                    type                   semi                                          ·                                          ·
+      │                    equality               (col0, project_const_col_@13) = (col3, col4)  ·                                          ·
+      │                    equality cols are key  ·                                             ·                                          ·
+      │                    parallel               ·                                             ·                                          ·
+      └── render           ·                      ·                                             ("project_const_col_@13", pk, col0, col3)  ·
+           │               render 0               495.6                                         ·                                          ·
+           │               render 1               pk                                            ·                                          ·
+           │               render 2               col0                                          ·                                          ·
+           │               render 3               col3                                          ·                                          ·
+           └── index-join  ·                      ·                                             (pk, col0, col3)                           ·
+                │          table                  tab4@primary                                  ·                                          ·
+                │          key columns            pk                                            ·                                          ·
+                └── scan   ·                      ·                                             (pk, col3)                                 ·
+·                          table                  tab4@tab4_col3_col4_key                       ·                                          ·
+·                          spans                  /NULL-                                        ·                                          ·

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -305,10 +305,16 @@ define LookupJoinPrivate {
     # index columns (or a prefix of them).
     KeyCols ColList
 
-    # Cols is the set of columns produced by the lookup join. This set can
-    # contain columns from the input and columns from the index. Any columns not
-    # in the input are retrieved from the index. Cols may not contain some or
-    # all of the KeyCols, if they are not output columns for the join.
+    # Cols is the union between the set of input columns that are returned by
+    # the lookup join and the set of lookup columns retrieved through lookup.
+    #
+    # For inner/left join, this is the set of columns produced by the LookupJoin
+    # operator.
+    # For semi/anti-join, this contains the semi-join output columns (from the
+    # input) plus the columns that we need to look up for the ON condition.
+    #
+    # Cols may not contain some or all of the KeyCols, if they are not output
+    # columns for the join.
     #
     # TODO(radu): this effectively allows an arbitrary projection; it should be
     # just a LookupCols set indicating which columns we should add from the


### PR DESCRIPTION
This change clarifies the semantics of `LookupJoinPrivate.Cols` for
semi/anti join and fixes the execbuilder code to handle these columns
correctly. Fixes an internal error exposed by a recent change that
generates semi joins in more cases.

Fixes #50964.

Release note (bug fix): fixed "column not in input" internal error in
cases involving lookup semi/anti joins.