### PR TITLE
colexec: remove UNSAFEGET

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/jaegertracing/jaeger v1.17.0
 	github.com/jcmturner/gofork v1.0.0 // indirect
-	github.com/jordanlewis/gcassert v0.0.0-20200630054945-8ff878e72753
+	github.com/jordanlewis/gcassert v0.0.0-20200706043056-bf61eb72ee48
 	github.com/kevinburke/go-bindata v3.13.0+incompatible
 	github.com/kisielk/errcheck v1.2.0
 	github.com/kisielk/gotool v1.0.0
@@ -154,7 +154,7 @@ require (
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-	golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f
+	golang.org/x/tools v0.0.0-20200702044944-0cc1aa72b347
 	google.golang.org/api v0.1.0
 	google.golang.org/genproto v0.0.0-20200218151345-dad8c97a84f5 // indirect
 	google.golang.org/grpc v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -374,8 +374,8 @@ github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/U
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jordanlewis/gcassert v0.0.0-20200630054945-8ff878e72753 h1:FXipXC++4uw5v41AxCRFoxoGnQJBuEsObAy9q3a8uww=
-github.com/jordanlewis/gcassert v0.0.0-20200630054945-8ff878e72753/go.mod h1:Qc93dJSt1iLNJCuG9Gy9ds0k/oh4ckhXGkD4AI3cEtM=
+github.com/jordanlewis/gcassert v0.0.0-20200706043056-bf61eb72ee48 h1:d1Ov7s7RbMdHcgE1Eh1CxR+yd2TTKYOCHZf92Tm/fLs=
+github.com/jordanlewis/gcassert v0.0.0-20200706043056-bf61eb72ee48/go.mod h1:Qc93dJSt1iLNJCuG9Gy9ds0k/oh4ckhXGkD4AI3cEtM=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -742,6 +742,8 @@ golang.org/x/tools v0.0.0-20200509030707-2212a7e161a5 h1:MeC2gMlMdkd67dn17MEby3r
 golang.org/x/tools v0.0.0-20200509030707-2212a7e161a5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f h1:JcoF/bowzCDI+MXu1yLqQGNO3ibqWsWq+Sk7pOT218w=
 golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200702044944-0cc1aa72b347 h1:/e4fNMHdLn7SQSxTrRZTma2xjQW6ELdxcnpqMhpo9X4=
+golang.org/x/tools v0.0.0-20200702044944-0cc1aa72b347/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -105,6 +105,7 @@ func (b *Bytes) maybeBackfillOffsets(i int) {
 // unsafe for reuse if any write operation happens.
 // NOTE: if ith element was never set in any way, the behavior of Get is
 // undefined.
+//gcassert:inline
 func (b *Bytes) Get(i int) []byte {
 	return b.data[b.offsets[i]:b.offsets[i+1]]
 }

--- a/pkg/col/coldata/datum_vec.go
+++ b/pkg/col/coldata/datum_vec.go
@@ -19,7 +19,8 @@ type Datum interface{}
 // tree.Datums in the vectorized engine. In order to avoid import of 'tree'
 // package the implementation of DatumVec lives in 'coldataext' package.
 type DatumVec interface {
-	// Get returns the datum at index i in the vector.
+	// Get returns the datum at index i in the vector. The datum cannot be used
+	// anymore once the vector is modified.
 	Get(i int) Datum
 	// Set sets the datum at index i in the vector. It must check whether the
 	// provided datum is compatible with the type that the DatumVec stores.

--- a/pkg/col/coldata/native_types.go
+++ b/pkg/col/coldata/native_types.go
@@ -41,28 +41,44 @@ type Times []time.Time
 // Durations is a slice of duration.Duration.
 type Durations []duration.Duration
 
-// Get returns the element at index idx of the vector.
+// Get returns the element at index idx of the vector. The element cannot be
+// used anymore once the vector is modified.
+//gcassert:inline
 func (c Bools) Get(idx int) bool { return c[idx] }
 
-// Get returns the element at index idx of the vector.
+// Get returns the element at index idx of the vector. The element cannot be
+// used anymore once the vector is modified.
+//gcassert:inline
 func (c Int16s) Get(idx int) int16 { return c[idx] }
 
-// Get returns the element at index idx of the vector.
+// Get returns the element at index idx of the vector. The element cannot be
+// used anymore once the vector is modified.
+//gcassert:inline
 func (c Int32s) Get(idx int) int32 { return c[idx] }
 
-// Get returns the element at index idx of the vector.
+// Get returns the element at index idx of the vector. The element cannot be
+// used anymore once the vector is modified.
+//gcassert:inline
 func (c Int64s) Get(idx int) int64 { return c[idx] }
 
-// Get returns the element at index idx of the vector.
+// Get returns the element at index idx of the vector. The element cannot be
+// used anymore once the vector is modified.
+//gcassert:inline
 func (c Float64s) Get(idx int) float64 { return c[idx] }
 
-// Get returns the element at index idx of the vector.
+// Get returns the element at index idx of the vector. The element cannot be
+// used anymore once the vector is modified.
+//gcassert:inline
 func (c Decimals) Get(idx int) apd.Decimal { return c[idx] }
 
-// Get returns the element at index idx of the vector.
+// Get returns the element at index idx of the vector. The element cannot be
+// used anymore once the vector is modified.
+//gcassert:inline
 func (c Times) Get(idx int) time.Time { return c[idx] }
 
-// Get returns the element at index idx of the vector.
+// Get returns the element at index idx of the vector. The element cannot be
+// used anymore once the vector is modified.
+//gcassert:inline
 func (c Durations) Get(idx int) duration.Duration { return c[idx] }
 
 // Len returns the length of the vector.

--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -37,7 +37,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
 				toCol = toCol[0:args.DestIdx]
 				for _, selIdx := range sel {
-					val := fromCol.Get(selIdx) //gcassert:inline
+					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
 				}
 			}
@@ -73,7 +73,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				}
 				fromCol.UpdateOffsetsToBeNonDecreasing(maxIdx + 1)
 				for _, selIdx := range sel {
-					val := fromCol.Get(selIdx) //gcassert:inline
+					val := fromCol.Get(selIdx)
 					toCol.AppendVal(val)
 				}
 			}
@@ -115,7 +115,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
 				toCol = toCol[0:args.DestIdx]
 				for _, selIdx := range sel {
-					val := fromCol.Get(selIdx) //gcassert:inline
+					val := fromCol.Get(selIdx)
 					toCol = append(toCol, apd.Decimal{})
 					toCol[len(toCol)-1].Set(&val)
 				}
@@ -138,7 +138,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
 				toCol = toCol[0:args.DestIdx]
 				for _, selIdx := range sel {
-					val := fromCol.Get(selIdx) //gcassert:inline
+					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
 				}
 			}
@@ -157,7 +157,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
 				toCol = toCol[0:args.DestIdx]
 				for _, selIdx := range sel {
-					val := fromCol.Get(selIdx) //gcassert:inline
+					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
 				}
 			}
@@ -177,7 +177,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
 				toCol = toCol[0:args.DestIdx]
 				for _, selIdx := range sel {
-					val := fromCol.Get(selIdx) //gcassert:inline
+					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
 				}
 			}
@@ -200,7 +200,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
 				toCol = toCol[0:args.DestIdx]
 				for _, selIdx := range sel {
-					val := fromCol.Get(selIdx) //gcassert:inline
+					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
 				}
 			}
@@ -223,7 +223,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
 				toCol = toCol[0:args.DestIdx]
 				for _, selIdx := range sel {
-					val := fromCol.Get(selIdx) //gcassert:inline
+					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
 				}
 			}
@@ -246,7 +246,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
 				toCol = toCol[0:args.DestIdx]
 				for _, selIdx := range sel {
-					val := fromCol.Get(selIdx) //gcassert:inline
+					val := fromCol.Get(selIdx)
 					toCol = append(toCol, val)
 				}
 			}
@@ -309,7 +309,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 								_ = i
 								m.nulls.SetNull(selIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
 								toCol[selIdx] = v
 							}
@@ -319,7 +319,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[selIdx] = v
 					}
 				} else {
@@ -329,7 +329,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							if nulls.NullAt(selIdx) {
 								m.nulls.SetNull(i + args.DestIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								toCol[i+args.DestIdx] = v
 							}
 						}
@@ -338,7 +338,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[i+args.DestIdx] = v
 					}
 				}
@@ -365,7 +365,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 								_ = i
 								m.nulls.SetNull(selIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
 								toCol.Set(selIdx, v)
 							}
@@ -375,7 +375,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol.Set(selIdx, v)
 					}
 				} else {
@@ -385,7 +385,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							if nulls.NullAt(selIdx) {
 								m.nulls.SetNull(i + args.DestIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								toCol.Set(i+args.DestIdx, v)
 							}
 						}
@@ -394,7 +394,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol.Set(i+args.DestIdx, v)
 					}
 				}
@@ -421,7 +421,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 								_ = i
 								m.nulls.SetNull(selIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
 								toCol[selIdx].Set(&v)
 							}
@@ -431,7 +431,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[selIdx].Set(&v)
 					}
 				} else {
@@ -441,7 +441,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							if nulls.NullAt(selIdx) {
 								m.nulls.SetNull(i + args.DestIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								toCol[i+args.DestIdx].Set(&v)
 							}
 						}
@@ -450,7 +450,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[i+args.DestIdx].Set(&v)
 					}
 				}
@@ -482,7 +482,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 								_ = i
 								m.nulls.SetNull(selIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
 								toCol[selIdx] = v
 							}
@@ -492,7 +492,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[selIdx] = v
 					}
 				} else {
@@ -502,7 +502,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							if nulls.NullAt(selIdx) {
 								m.nulls.SetNull(i + args.DestIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								toCol[i+args.DestIdx] = v
 							}
 						}
@@ -511,7 +511,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[i+args.DestIdx] = v
 					}
 				}
@@ -534,7 +534,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 								_ = i
 								m.nulls.SetNull(selIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
 								toCol[selIdx] = v
 							}
@@ -544,7 +544,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[selIdx] = v
 					}
 				} else {
@@ -554,7 +554,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							if nulls.NullAt(selIdx) {
 								m.nulls.SetNull(i + args.DestIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								toCol[i+args.DestIdx] = v
 							}
 						}
@@ -563,7 +563,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[i+args.DestIdx] = v
 					}
 				}
@@ -587,7 +587,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 								_ = i
 								m.nulls.SetNull(selIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
 								toCol[selIdx] = v
 							}
@@ -597,7 +597,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[selIdx] = v
 					}
 				} else {
@@ -607,7 +607,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							if nulls.NullAt(selIdx) {
 								m.nulls.SetNull(i + args.DestIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								toCol[i+args.DestIdx] = v
 							}
 						}
@@ -616,7 +616,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[i+args.DestIdx] = v
 					}
 				}
@@ -643,7 +643,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 								_ = i
 								m.nulls.SetNull(selIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
 								toCol[selIdx] = v
 							}
@@ -653,7 +653,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[selIdx] = v
 					}
 				} else {
@@ -663,7 +663,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							if nulls.NullAt(selIdx) {
 								m.nulls.SetNull(i + args.DestIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								toCol[i+args.DestIdx] = v
 							}
 						}
@@ -672,7 +672,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[i+args.DestIdx] = v
 					}
 				}
@@ -699,7 +699,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 								_ = i
 								m.nulls.SetNull(selIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
 								toCol[selIdx] = v
 							}
@@ -709,7 +709,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[selIdx] = v
 					}
 				} else {
@@ -719,7 +719,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							if nulls.NullAt(selIdx) {
 								m.nulls.SetNull(i + args.DestIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								toCol[i+args.DestIdx] = v
 							}
 						}
@@ -728,7 +728,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[i+args.DestIdx] = v
 					}
 				}
@@ -755,7 +755,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 								_ = i
 								m.nulls.SetNull(selIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								m.nulls.UnsetNull(selIdx)
 								toCol[selIdx] = v
 							}
@@ -765,7 +765,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[selIdx] = v
 					}
 				} else {
@@ -775,7 +775,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 							if nulls.NullAt(selIdx) {
 								m.nulls.SetNull(i + args.DestIdx)
 							} else {
-								v := fromCol.Get(selIdx) //gcassert:inline
+								v := fromCol.Get(selIdx)
 								toCol[i+args.DestIdx] = v
 							}
 						}
@@ -784,7 +784,7 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 					// No Nulls.
 					for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 						selIdx := sel[args.SrcStartIdx+i]
-						v := fromCol.Get(selIdx) //gcassert:inline
+						v := fromCol.Get(selIdx)
 						toCol[i+args.DestIdx] = v
 					}
 				}
@@ -1064,55 +1064,55 @@ func GetValueAt(v Vec, rowIdx int) interface{} {
 		case -1:
 		default:
 			target := v.Bool()
-			return target.Get(rowIdx) //gcassert:inline
+			return target.Get(rowIdx)
 		}
 	case types.BytesFamily:
 		switch t.Width() {
 		case -1:
 		default:
 			target := v.Bytes()
-			return target.Get(rowIdx) //gcassert:inline
+			return target.Get(rowIdx)
 		}
 	case types.DecimalFamily:
 		switch t.Width() {
 		case -1:
 		default:
 			target := v.Decimal()
-			return target.Get(rowIdx) //gcassert:inline
+			return target.Get(rowIdx)
 		}
 	case types.IntFamily:
 		switch t.Width() {
 		case 16:
 			target := v.Int16()
-			return target.Get(rowIdx) //gcassert:inline
+			return target.Get(rowIdx)
 		case 32:
 			target := v.Int32()
-			return target.Get(rowIdx) //gcassert:inline
+			return target.Get(rowIdx)
 		case -1:
 		default:
 			target := v.Int64()
-			return target.Get(rowIdx) //gcassert:inline
+			return target.Get(rowIdx)
 		}
 	case types.FloatFamily:
 		switch t.Width() {
 		case -1:
 		default:
 			target := v.Float64()
-			return target.Get(rowIdx) //gcassert:inline
+			return target.Get(rowIdx)
 		}
 	case types.TimestampTZFamily:
 		switch t.Width() {
 		case -1:
 		default:
 			target := v.Timestamp()
-			return target.Get(rowIdx) //gcassert:inline
+			return target.Get(rowIdx)
 		}
 	case types.IntervalFamily:
 		switch t.Width() {
 		case -1:
 		default:
 			target := v.Interval()
-			return target.Get(rowIdx) //gcassert:inline
+			return target.Get(rowIdx)
 		}
 	case typeconv.DatumVecCanonicalTypeFamily:
 		switch t.Width() {

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -75,7 +75,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				toCol = execgen.SLICE(toCol, 0, args.DestIdx)
 				// {{end}}
 				for _, selIdx := range sel {
-					val := execgen.UNSAFEGET(fromCol, selIdx)
+					val := fromCol.Get(selIdx)
 					execgen.APPENDVAL(toCol, val)
 				}
 			}
@@ -107,7 +107,7 @@ func _COPY_WITH_SEL(
 				// {{end}}
 			} else {
 				// {{with .Global}}
-				v := execgen.UNSAFEGET(fromCol, selIdx)
+				v := fromCol.Get(selIdx)
 				// {{end}}
 				// {{if .SelOnDest}}
 				m.nulls.UnsetNull(selIdx)
@@ -127,7 +127,7 @@ func _COPY_WITH_SEL(
 	for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 		selIdx := sel[args.SrcStartIdx+i]
 		// {{with .Global}}
-		v := execgen.UNSAFEGET(fromCol, selIdx)
+		v := fromCol.Get(selIdx)
 		// {{end}}
 		// {{if .SelOnDest}}
 		// {{with .Global}}
@@ -235,7 +235,7 @@ func GetValueAt(v Vec, rowIdx int) interface{} {
 		// {{range .WidthOverloads}}
 		case _TYPE_WIDTH:
 			target := v.TemplateType()
-			return execgen.UNSAFEGET(target, rowIdx)
+			return target.Get(rowIdx)
 			// {{end}}
 		}
 		// {{end}}

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -129,7 +129,7 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) Compute(b coldata.Batch, inputIdxs []uint32
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = execgen.UNSAFEGET(col, inputLen-1)
+			_ = col.Get(inputLen - 1)
 			// {{if eq "_AGGKIND" "Ordered"}}
 			groups := a.groups
 			// {{end}}
@@ -239,7 +239,7 @@ func _FIND_ANY_NOT_NULL(
 		// current value is non-null, then we can pick the current value to be
 		// the output.
 		// {{with .Global}}
-		val := execgen.UNSAFEGET(col, i)
+		val := col.Get(i)
 		execgen.COPYVAL(a.curAgg, val)
 		// {{end}}
 		a.foundNonNullForCurrentGroup = true

--- a/pkg/sql/colexec/cast.eg.go
+++ b/pkg/sql/colexec/cast.eg.go
@@ -49,7 +49,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 									r = v
 									outputCol[i] = r
@@ -58,13 +58,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 									r = v
 									outputCol[i] = r
@@ -75,7 +75,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 								r = v
 								outputCol[i] = r
@@ -83,10 +83,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 								r = v
 								outputCol[i] = r
@@ -110,7 +110,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r float64
 
 									r = 0
@@ -124,13 +124,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r float64
 
 									r = 0
@@ -146,7 +146,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r float64
 
 								r = 0
@@ -159,10 +159,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r float64
 
 								r = 0
@@ -190,7 +190,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int16
 
 									r = 0
@@ -204,13 +204,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int16
 
 									r = 0
@@ -226,7 +226,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int16
 
 								r = 0
@@ -239,10 +239,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int16
 
 								r = 0
@@ -267,7 +267,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int32
 
 									r = 0
@@ -281,13 +281,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int32
 
 									r = 0
@@ -303,7 +303,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int32
 
 								r = 0
@@ -316,10 +316,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int32
 
 								r = 0
@@ -345,7 +345,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int64
 
 									r = 0
@@ -359,13 +359,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int64
 
 									r = 0
@@ -381,7 +381,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int64
 
 								r = 0
@@ -394,10 +394,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int64
 
 								r = 0
@@ -433,7 +433,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r apd.Decimal
 									r = v
 									outputCol[i].Set(&r)
@@ -442,13 +442,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r apd.Decimal
 									r = v
 									outputCol[i].Set(&r)
@@ -459,7 +459,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r apd.Decimal
 								r = v
 								outputCol[i].Set(&r)
@@ -467,10 +467,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r apd.Decimal
 								r = v
 								outputCol[i].Set(&r)
@@ -494,7 +494,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 									r = v.Sign() != 0
 									outputCol[i] = r
@@ -503,13 +503,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 									r = v.Sign() != 0
 									outputCol[i] = r
@@ -520,7 +520,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 								r = v.Sign() != 0
 								outputCol[i] = r
@@ -528,10 +528,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 								r = v.Sign() != 0
 								outputCol[i] = r
@@ -560,7 +560,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int16
 									r = v
 									outputCol[i] = r
@@ -569,13 +569,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int16
 									r = v
 									outputCol[i] = r
@@ -586,7 +586,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int16
 								r = v
 								outputCol[i] = r
@@ -594,10 +594,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int16
 								r = v
 								outputCol[i] = r
@@ -617,7 +617,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int32
 
 									r = int32(v)
@@ -628,13 +628,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int32
 
 									r = int32(v)
@@ -647,7 +647,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int32
 
 								r = int32(v)
@@ -657,10 +657,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int32
 
 								r = int32(v)
@@ -683,7 +683,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int64
 
 									r = int64(v)
@@ -694,13 +694,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int64
 
 									r = int64(v)
@@ -713,7 +713,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int64
 
 								r = int64(v)
@@ -723,10 +723,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int64
 
 								r = int64(v)
@@ -752,7 +752,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 
 									r = v != 0
@@ -763,13 +763,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 
 									r = v != 0
@@ -782,7 +782,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 
 								r = v != 0
@@ -792,10 +792,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 
 								r = v != 0
@@ -821,7 +821,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r apd.Decimal
 
 									r = *apd.New(int64(v), 0)
@@ -832,13 +832,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r apd.Decimal
 
 									r = *apd.New(int64(v), 0)
@@ -851,7 +851,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r apd.Decimal
 
 								r = *apd.New(int64(v), 0)
@@ -861,10 +861,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r apd.Decimal
 
 								r = *apd.New(int64(v), 0)
@@ -890,7 +890,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r float64
 
 									r = float64(v)
@@ -901,13 +901,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r float64
 
 									r = float64(v)
@@ -920,7 +920,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r float64
 
 								r = float64(v)
@@ -930,10 +930,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r float64
 
 								r = float64(v)
@@ -961,7 +961,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int16
 
 									r = int16(v)
@@ -972,13 +972,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int16
 
 									r = int16(v)
@@ -991,7 +991,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int16
 
 								r = int16(v)
@@ -1001,10 +1001,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int16
 
 								r = int16(v)
@@ -1026,7 +1026,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int32
 									r = v
 									outputCol[i] = r
@@ -1035,13 +1035,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int32
 									r = v
 									outputCol[i] = r
@@ -1052,7 +1052,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int32
 								r = v
 								outputCol[i] = r
@@ -1060,10 +1060,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int32
 								r = v
 								outputCol[i] = r
@@ -1084,7 +1084,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int64
 
 									r = int64(v)
@@ -1095,13 +1095,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int64
 
 									r = int64(v)
@@ -1114,7 +1114,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int64
 
 								r = int64(v)
@@ -1124,10 +1124,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int64
 
 								r = int64(v)
@@ -1153,7 +1153,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 
 									r = v != 0
@@ -1164,13 +1164,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 
 									r = v != 0
@@ -1183,7 +1183,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 
 								r = v != 0
@@ -1193,10 +1193,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 
 								r = v != 0
@@ -1222,7 +1222,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r apd.Decimal
 
 									r = *apd.New(int64(v), 0)
@@ -1233,13 +1233,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r apd.Decimal
 
 									r = *apd.New(int64(v), 0)
@@ -1252,7 +1252,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r apd.Decimal
 
 								r = *apd.New(int64(v), 0)
@@ -1262,10 +1262,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r apd.Decimal
 
 								r = *apd.New(int64(v), 0)
@@ -1291,7 +1291,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r float64
 
 									r = float64(v)
@@ -1302,13 +1302,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r float64
 
 									r = float64(v)
@@ -1321,7 +1321,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r float64
 
 								r = float64(v)
@@ -1331,10 +1331,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r float64
 
 								r = float64(v)
@@ -1363,7 +1363,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int16
 
 									r = int16(v)
@@ -1374,13 +1374,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int16
 
 									r = int16(v)
@@ -1393,7 +1393,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int16
 
 								r = int16(v)
@@ -1403,10 +1403,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int16
 
 								r = int16(v)
@@ -1428,7 +1428,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int32
 
 									r = int32(v)
@@ -1439,13 +1439,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int32
 
 									r = int32(v)
@@ -1458,7 +1458,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int32
 
 								r = int32(v)
@@ -1468,10 +1468,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int32
 
 								r = int32(v)
@@ -1494,7 +1494,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int64
 									r = v
 									outputCol[i] = r
@@ -1503,13 +1503,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int64
 									r = v
 									outputCol[i] = r
@@ -1520,7 +1520,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int64
 								r = v
 								outputCol[i] = r
@@ -1528,10 +1528,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int64
 								r = v
 								outputCol[i] = r
@@ -1555,7 +1555,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 
 									r = v != 0
@@ -1566,13 +1566,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 
 									r = v != 0
@@ -1585,7 +1585,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 
 								r = v != 0
@@ -1595,10 +1595,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 
 								r = v != 0
@@ -1624,7 +1624,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r apd.Decimal
 
 									r = *apd.New(int64(v), 0)
@@ -1635,13 +1635,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r apd.Decimal
 
 									r = *apd.New(int64(v), 0)
@@ -1654,7 +1654,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r apd.Decimal
 
 								r = *apd.New(int64(v), 0)
@@ -1664,10 +1664,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r apd.Decimal
 
 								r = *apd.New(int64(v), 0)
@@ -1693,7 +1693,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r float64
 
 									r = float64(v)
@@ -1704,13 +1704,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r float64
 
 									r = float64(v)
@@ -1723,7 +1723,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r float64
 
 								r = float64(v)
@@ -1733,10 +1733,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r float64
 
 								r = float64(v)
@@ -1769,7 +1769,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r float64
 									r = v
 									outputCol[i] = r
@@ -1778,13 +1778,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r float64
 									r = v
 									outputCol[i] = r
@@ -1795,7 +1795,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r float64
 								r = v
 								outputCol[i] = r
@@ -1803,10 +1803,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r float64
 								r = v
 								outputCol[i] = r
@@ -1830,7 +1830,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 
 									r = v != 0
@@ -1841,13 +1841,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r bool
 
 									r = v != 0
@@ -1860,7 +1860,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 
 								r = v != 0
@@ -1870,10 +1870,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r bool
 
 								r = v != 0
@@ -1899,7 +1899,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r apd.Decimal
 
 									{
@@ -1917,13 +1917,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r apd.Decimal
 
 									{
@@ -1943,7 +1943,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r apd.Decimal
 
 								{
@@ -1960,10 +1960,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r apd.Decimal
 
 								{
@@ -1995,7 +1995,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int16
 
 									if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
@@ -2009,13 +2009,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int16
 
 									if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
@@ -2031,7 +2031,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int16
 
 								if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
@@ -2044,10 +2044,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int16
 
 								if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
@@ -2072,7 +2072,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int32
 
 									if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
@@ -2086,13 +2086,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int32
 
 									if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
@@ -2108,7 +2108,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int32
 
 								if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
@@ -2121,10 +2121,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int32
 
 								if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
@@ -2150,7 +2150,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int64
 
 									if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
@@ -2164,13 +2164,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := inputCol.Get(i) //gcassert:inline
+									v := inputCol.Get(i)
 									var r int64
 
 									if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
@@ -2186,7 +2186,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int64
 
 								if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
@@ -2199,10 +2199,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol[0:n]
-							_ = inputCol.Get(n - 1)  //gcassert:inline
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := inputCol.Get(i) //gcassert:inline
+								v := inputCol.Get(i)
 								var r int64
 
 								if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
@@ -2256,7 +2256,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol.Slice(0, n)
 							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
@@ -2297,7 +2297,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = inputCol.Slice(0, n)
 							_ = inputCol.Get(n - 1)
-							_ = outputCol.Get(n - 1) //gcassert:inline
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								v := inputCol.Get(i)
 								var r bool

--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -59,16 +59,6 @@ func _CAST(to, from, fromCol interface{}) {
 	colexecerror.InternalError("")
 }
 
-// This will be replaced with execgen.UNSAFEGET.
-func _L_UNSAFEGET(to, from interface{}) interface{} {
-	colexecerror.InternalError("")
-}
-
-// This will be replaced with execgen.UNSAFEGET.
-func _R_UNSAFEGET(to, from interface{}) interface{} {
-	colexecerror.InternalError("")
-}
-
 // This will be replaced with execgen.SET.
 func _R_SET(to, from interface{}) {
 	colexecerror.InternalError("")
@@ -106,7 +96,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := _L_UNSAFEGET(inputCol, i)
+									v := inputCol.Get(i)
 									var r _R_GO_TYPE
 									_CAST(r, v, inputCol)
 									_R_SET(outputCol, i, r)
@@ -115,13 +105,13 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = _L_SLICE(inputCol, 0, n)
-							_ = _L_UNSAFEGET(inputCol, n-1)
-							_ = _R_UNSAFEGET(outputCol, n-1)
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
-									v := _L_UNSAFEGET(inputCol, i)
+									v := inputCol.Get(i)
 									var r _R_GO_TYPE
 									_CAST(r, v, inputCol)
 									_R_SET(outputCol, i, r)
@@ -132,7 +122,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						if sel != nil {
 							sel = sel[:n]
 							for _, i := range sel {
-								v := _L_UNSAFEGET(inputCol, i)
+								v := inputCol.Get(i)
 								var r _R_GO_TYPE
 								_CAST(r, v, inputCol)
 								_R_SET(outputCol, i, r)
@@ -140,10 +130,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 						} else {
 							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = _L_SLICE(inputCol, 0, n)
-							_ = _L_UNSAFEGET(inputCol, n-1)
-							_ = _R_UNSAFEGET(outputCol, n-1)
+							_ = inputCol.Get(n - 1)
+							_ = outputCol.Get(n - 1)
 							for i := 0; i < n; i++ {
-								v := _L_UNSAFEGET(inputCol, i)
+								v := inputCol.Get(i)
 								var r _R_GO_TYPE
 								_CAST(r, v, inputCol)
 								_R_SET(outputCol, i, r)

--- a/pkg/sql/colexec/const.eg.go
+++ b/pkg/sql/colexec/const.eg.go
@@ -178,7 +178,7 @@ func (c constBoolOp) Next(ctx context.Context) coldata.Batch {
 				}
 			} else {
 				col = col[0:n]
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
 				}
@@ -228,7 +228,7 @@ func (c constBytesOp) Next(ctx context.Context) coldata.Batch {
 				col = col
 				_ = 0
 				_ = n
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col.Set(i, c.constVal)
 				}
@@ -276,7 +276,7 @@ func (c constDecimalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			} else {
 				col = col[0:n]
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i].Set(&c.constVal)
 				}
@@ -324,7 +324,7 @@ func (c constInt16Op) Next(ctx context.Context) coldata.Batch {
 				}
 			} else {
 				col = col[0:n]
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
 				}
@@ -372,7 +372,7 @@ func (c constInt32Op) Next(ctx context.Context) coldata.Batch {
 				}
 			} else {
 				col = col[0:n]
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
 				}
@@ -420,7 +420,7 @@ func (c constInt64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			} else {
 				col = col[0:n]
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
 				}
@@ -468,7 +468,7 @@ func (c constFloat64Op) Next(ctx context.Context) coldata.Batch {
 				}
 			} else {
 				col = col[0:n]
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
 				}
@@ -516,7 +516,7 @@ func (c constTimestampOp) Next(ctx context.Context) coldata.Batch {
 				}
 			} else {
 				col = col[0:n]
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
 				}
@@ -564,7 +564,7 @@ func (c constIntervalOp) Next(ctx context.Context) coldata.Batch {
 				}
 			} else {
 				col = col[0:n]
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					col[i] = c.constVal
 				}

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -116,7 +116,7 @@ func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
 				}
 			} else {
 				col = execgen.SLICE(col, 0, n)
-				_ = execgen.UNSAFEGET(col, n-1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					execgen.SET(col, i, c.constVal)
 				}

--- a/pkg/sql/colexec/distinct.eg.go
+++ b/pkg/sql/colexec/distinct.eg.go
@@ -347,7 +347,7 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -385,7 +385,7 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 bool
@@ -394,7 +394,7 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -441,7 +441,7 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -479,7 +479,7 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 bool
@@ -488,7 +488,7 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -545,7 +545,7 @@ func (p partitionerBool) partitionWithOrder(
 	// Eliminate bounds checks for outputcol[outputIdx].
 	_ = outputCol[len(order)-1]
 	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1) //gcassert:inline
+	_ = col.Get(len(order) - 1)
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx, checkIdx := range order {
@@ -562,7 +562,7 @@ func (p partitionerBool) partitionWithOrder(
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -601,7 +601,7 @@ func (p partitionerBool) partitionWithOrder(
 			{
 				var __retval_0 bool
 				{
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -641,7 +641,7 @@ func (p partitionerBool) partition(colVec coldata.Vec, outputCol []bool, n int) 
 	}
 
 	col := colVec.Bool()
-	_ = col.Get(n - 1) //gcassert:inline
+	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
@@ -663,7 +663,7 @@ func (p partitionerBool) partition(colVec coldata.Vec, outputCol []bool, n int) 
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -706,7 +706,7 @@ func (p partitionerBool) partition(colVec coldata.Vec, outputCol []bool, n int) 
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -826,7 +826,7 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -856,7 +856,7 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 []byte
@@ -865,7 +865,7 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -904,7 +904,7 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -934,7 +934,7 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 []byte
@@ -943,7 +943,7 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -994,7 +994,7 @@ func (p partitionerBytes) partitionWithOrder(
 	// Eliminate bounds checks for outputcol[outputIdx].
 	_ = outputCol[len(order)-1]
 	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1) //gcassert:inline
+	_ = col.Get(len(order) - 1)
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx, checkIdx := range order {
@@ -1011,7 +1011,7 @@ func (p partitionerBytes) partitionWithOrder(
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -1042,7 +1042,7 @@ func (p partitionerBytes) partitionWithOrder(
 			{
 				var __retval_0 []byte
 				{
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -1074,7 +1074,7 @@ func (p partitionerBytes) partition(colVec coldata.Vec, outputCol []bool, n int)
 	}
 
 	col := colVec.Bytes()
-	_ = col.Get(n - 1) //gcassert:inline
+	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
@@ -1096,7 +1096,7 @@ func (p partitionerBytes) partition(colVec coldata.Vec, outputCol []bool, n int)
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -1131,7 +1131,7 @@ func (p partitionerBytes) partition(colVec coldata.Vec, outputCol []bool, n int)
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -1243,7 +1243,7 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -1273,7 +1273,7 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 apd.Decimal
@@ -1282,7 +1282,7 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -1321,7 +1321,7 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -1351,7 +1351,7 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 apd.Decimal
@@ -1360,7 +1360,7 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -1409,7 +1409,7 @@ func (p partitionerDecimal) partitionWithOrder(
 	// Eliminate bounds checks for outputcol[outputIdx].
 	_ = outputCol[len(order)-1]
 	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1) //gcassert:inline
+	_ = col.Get(len(order) - 1)
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx, checkIdx := range order {
@@ -1426,7 +1426,7 @@ func (p partitionerDecimal) partitionWithOrder(
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -1457,7 +1457,7 @@ func (p partitionerDecimal) partitionWithOrder(
 			{
 				var __retval_0 apd.Decimal
 				{
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -1489,7 +1489,7 @@ func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n in
 	}
 
 	col := colVec.Decimal()
-	_ = col.Get(n - 1) //gcassert:inline
+	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
@@ -1511,7 +1511,7 @@ func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n in
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -1546,7 +1546,7 @@ func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n in
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -1658,7 +1658,7 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -1699,7 +1699,7 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 int16
@@ -1708,7 +1708,7 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -1758,7 +1758,7 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -1799,7 +1799,7 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 int16
@@ -1808,7 +1808,7 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -1868,7 +1868,7 @@ func (p partitionerInt16) partitionWithOrder(
 	// Eliminate bounds checks for outputcol[outputIdx].
 	_ = outputCol[len(order)-1]
 	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1) //gcassert:inline
+	_ = col.Get(len(order) - 1)
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx, checkIdx := range order {
@@ -1885,7 +1885,7 @@ func (p partitionerInt16) partitionWithOrder(
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -1927,7 +1927,7 @@ func (p partitionerInt16) partitionWithOrder(
 			{
 				var __retval_0 int16
 				{
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -1970,7 +1970,7 @@ func (p partitionerInt16) partition(colVec coldata.Vec, outputCol []bool, n int)
 	}
 
 	col := colVec.Int16()
-	_ = col.Get(n - 1) //gcassert:inline
+	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
@@ -1992,7 +1992,7 @@ func (p partitionerInt16) partition(colVec coldata.Vec, outputCol []bool, n int)
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -2038,7 +2038,7 @@ func (p partitionerInt16) partition(colVec coldata.Vec, outputCol []bool, n int)
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -2161,7 +2161,7 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -2202,7 +2202,7 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 int32
@@ -2211,7 +2211,7 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -2261,7 +2261,7 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -2302,7 +2302,7 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 int32
@@ -2311,7 +2311,7 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -2371,7 +2371,7 @@ func (p partitionerInt32) partitionWithOrder(
 	// Eliminate bounds checks for outputcol[outputIdx].
 	_ = outputCol[len(order)-1]
 	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1) //gcassert:inline
+	_ = col.Get(len(order) - 1)
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx, checkIdx := range order {
@@ -2388,7 +2388,7 @@ func (p partitionerInt32) partitionWithOrder(
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -2430,7 +2430,7 @@ func (p partitionerInt32) partitionWithOrder(
 			{
 				var __retval_0 int32
 				{
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -2473,7 +2473,7 @@ func (p partitionerInt32) partition(colVec coldata.Vec, outputCol []bool, n int)
 	}
 
 	col := colVec.Int32()
-	_ = col.Get(n - 1) //gcassert:inline
+	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
@@ -2495,7 +2495,7 @@ func (p partitionerInt32) partition(colVec coldata.Vec, outputCol []bool, n int)
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -2541,7 +2541,7 @@ func (p partitionerInt32) partition(colVec coldata.Vec, outputCol []bool, n int)
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -2664,7 +2664,7 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -2705,7 +2705,7 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 int64
@@ -2714,7 +2714,7 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -2764,7 +2764,7 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -2805,7 +2805,7 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 int64
@@ -2814,7 +2814,7 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -2874,7 +2874,7 @@ func (p partitionerInt64) partitionWithOrder(
 	// Eliminate bounds checks for outputcol[outputIdx].
 	_ = outputCol[len(order)-1]
 	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1) //gcassert:inline
+	_ = col.Get(len(order) - 1)
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx, checkIdx := range order {
@@ -2891,7 +2891,7 @@ func (p partitionerInt64) partitionWithOrder(
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -2933,7 +2933,7 @@ func (p partitionerInt64) partitionWithOrder(
 			{
 				var __retval_0 int64
 				{
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -2976,7 +2976,7 @@ func (p partitionerInt64) partition(colVec coldata.Vec, outputCol []bool, n int)
 	}
 
 	col := colVec.Int64()
-	_ = col.Get(n - 1) //gcassert:inline
+	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
@@ -2998,7 +2998,7 @@ func (p partitionerInt64) partition(colVec coldata.Vec, outputCol []bool, n int)
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -3044,7 +3044,7 @@ func (p partitionerInt64) partition(colVec coldata.Vec, outputCol []bool, n int)
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -3167,7 +3167,7 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -3216,7 +3216,7 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 float64
@@ -3225,7 +3225,7 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -3283,7 +3283,7 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -3332,7 +3332,7 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 float64
@@ -3341,7 +3341,7 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -3409,7 +3409,7 @@ func (p partitionerFloat64) partitionWithOrder(
 	// Eliminate bounds checks for outputcol[outputIdx].
 	_ = outputCol[len(order)-1]
 	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1) //gcassert:inline
+	_ = col.Get(len(order) - 1)
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx, checkIdx := range order {
@@ -3426,7 +3426,7 @@ func (p partitionerFloat64) partitionWithOrder(
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -3476,7 +3476,7 @@ func (p partitionerFloat64) partitionWithOrder(
 			{
 				var __retval_0 float64
 				{
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -3527,7 +3527,7 @@ func (p partitionerFloat64) partition(colVec coldata.Vec, outputCol []bool, n in
 	}
 
 	col := colVec.Float64()
-	_ = col.Get(n - 1) //gcassert:inline
+	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
@@ -3549,7 +3549,7 @@ func (p partitionerFloat64) partition(colVec coldata.Vec, outputCol []bool, n in
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -3603,7 +3603,7 @@ func (p partitionerFloat64) partition(colVec coldata.Vec, outputCol []bool, n in
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -3734,7 +3734,7 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -3771,7 +3771,7 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 time.Time
@@ -3780,7 +3780,7 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -3826,7 +3826,7 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -3863,7 +3863,7 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 time.Time
@@ -3872,7 +3872,7 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -3928,7 +3928,7 @@ func (p partitionerTimestamp) partitionWithOrder(
 	// Eliminate bounds checks for outputcol[outputIdx].
 	_ = outputCol[len(order)-1]
 	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1) //gcassert:inline
+	_ = col.Get(len(order) - 1)
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx, checkIdx := range order {
@@ -3945,7 +3945,7 @@ func (p partitionerTimestamp) partitionWithOrder(
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -3983,7 +3983,7 @@ func (p partitionerTimestamp) partitionWithOrder(
 			{
 				var __retval_0 time.Time
 				{
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -4022,7 +4022,7 @@ func (p partitionerTimestamp) partition(colVec coldata.Vec, outputCol []bool, n 
 	}
 
 	col := colVec.Timestamp()
-	_ = col.Get(n - 1) //gcassert:inline
+	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
@@ -4044,7 +4044,7 @@ func (p partitionerTimestamp) partition(colVec coldata.Vec, outputCol []bool, n 
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -4086,7 +4086,7 @@ func (p partitionerTimestamp) partition(colVec coldata.Vec, outputCol []bool, n 
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -4205,7 +4205,7 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -4235,7 +4235,7 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				{
 					var __retval_0 duration.Duration
@@ -4244,7 +4244,7 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -4283,7 +4283,7 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 								outputCol[outputIdx] = true
 							}
 						} else {
-							v := col.Get(checkIdx) //gcassert:inline
+							v := col.Get(checkIdx)
 							if lastValNull {
 								// The previous value was null while the current is not.
 								outputCol[outputIdx] = true
@@ -4313,7 +4313,7 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = col.Get(n - 1) //gcassert:inline
+			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				{
 					var __retval_0 duration.Duration
@@ -4322,7 +4322,7 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 							checkIdx  int = idx
 							outputIdx int = idx
 						)
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						var unique bool
 
 						{
@@ -4371,7 +4371,7 @@ func (p partitionerInterval) partitionWithOrder(
 	// Eliminate bounds checks for outputcol[outputIdx].
 	_ = outputCol[len(order)-1]
 	// Eliminate bounds checks for col[outputIdx].
-	_ = col.Get(len(order) - 1) //gcassert:inline
+	_ = col.Get(len(order) - 1)
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx, checkIdx := range order {
@@ -4388,7 +4388,7 @@ func (p partitionerInterval) partitionWithOrder(
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -4419,7 +4419,7 @@ func (p partitionerInterval) partitionWithOrder(
 			{
 				var __retval_0 duration.Duration
 				{
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{
@@ -4451,7 +4451,7 @@ func (p partitionerInterval) partition(colVec coldata.Vec, outputCol []bool, n i
 	}
 
 	col := colVec.Interval()
-	_ = col.Get(n - 1) //gcassert:inline
+	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
@@ -4473,7 +4473,7 @@ func (p partitionerInterval) partition(colVec coldata.Vec, outputCol []bool, n i
 							outputCol[outputIdx] = true
 						}
 					} else {
-						v := col.Get(checkIdx) //gcassert:inline
+						v := col.Get(checkIdx)
 						if lastValNull {
 							// The previous value was null while the current is not.
 							outputCol[outputIdx] = true
@@ -4508,7 +4508,7 @@ func (p partitionerInterval) partition(colVec coldata.Vec, outputCol []bool, n i
 						checkIdx  int = idx
 						outputIdx int = idx
 					)
-					v := col.Get(checkIdx) //gcassert:inline
+					v := col.Get(checkIdx)
 					var unique bool
 
 					{

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -245,7 +245,7 @@ func (p *distinct_TYPEOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = execgen.UNSAFEGET(col, n-1)
+			_ = col.Get(n - 1)
 			for _, idx := range sel {
 				lastVal = checkDistinct(idx, idx, lastVal, col, outputCol)
 			}
@@ -259,7 +259,7 @@ func (p *distinct_TYPEOp) Next(ctx context.Context) coldata.Batch {
 			// Eliminate bounds checks for outputCol[idx].
 			_ = outputCol[n-1]
 			// Eliminate bounds checks for col[idx].
-			_ = execgen.UNSAFEGET(col, n-1)
+			_ = col.Get(n - 1)
 			for idx := 0; idx < n; idx++ {
 				lastVal = checkDistinct(idx, idx, lastVal, col, outputCol)
 			}
@@ -294,7 +294,7 @@ func (p partitioner_TYPE) partitionWithOrder(
 	// Eliminate bounds checks for outputcol[outputIdx].
 	_ = outputCol[len(order)-1]
 	// Eliminate bounds checks for col[outputIdx].
-	_ = execgen.UNSAFEGET(col, len(order)-1)
+	_ = col.Get(len(order) - 1)
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx, checkIdx := range order {
@@ -318,7 +318,7 @@ func (p partitioner_TYPE) partition(colVec coldata.Vec, outputCol []bool, n int)
 	}
 
 	col := colVec.TemplateType()
-	_ = execgen.UNSAFEGET(col, n-1)
+	_ = col.Get(n - 1)
 	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
@@ -343,7 +343,7 @@ func (p partitioner_TYPE) partition(colVec coldata.Vec, outputCol []bool, n int)
 func checkDistinct(
 	checkIdx int, outputIdx int, lastVal _GOTYPE, col []_GOTYPE, outputCol []bool,
 ) _GOTYPE {
-	v := execgen.UNSAFEGET(col, checkIdx)
+	v := col.Get(checkIdx)
 	var unique bool
 	_ASSIGN_NE(unique, v, lastVal, _, col, _)
 	outputCol[outputIdx] = outputCol[outputIdx] || unique
@@ -371,7 +371,7 @@ func checkDistinctWithNulls(
 			outputCol[outputIdx] = true
 		}
 	} else {
-		v := execgen.UNSAFEGET(col, checkIdx)
+		v := col.Get(checkIdx)
 		if lastValNull {
 			// The previous value was null while the current is not.
 			outputCol[outputIdx] = true

--- a/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
@@ -25,16 +25,6 @@ type dataManipulationReplacementInfo struct {
 
 var dataManipulationReplacementInfos = []dataManipulationReplacementInfo{
 	{
-		templatePlaceholder: "execgen.UNSAFEGET",
-		numArgs:             2,
-		replaceWith:         "Get",
-	},
-	{
-		templatePlaceholder: "execgen.RETURNUNSAFEGET",
-		numArgs:             2,
-		replaceWith:         "ReturnGet",
-	},
-	{
 		templatePlaceholder: "execgen.COPYVAL",
 		numArgs:             2,
 		replaceWith:         "CopyVal",

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -450,26 +450,6 @@ func (b *argWidthOverloadBase) GoTypeSliceName() string {
 	return goTypeSliceName(b.CanonicalTypeFamily, b.Width)
 }
 
-func get(family types.Family, target, i string) string {
-	// Assert that the .Get call is inlined by Go, except in the case
-	// of the DatumVec .Get which isn't inlinable.
-	maybeInline := " //gcassert:inline"
-	if family == typeconv.DatumVecCanonicalTypeFamily {
-		maybeInline = ""
-	}
-	return fmt.Sprintf("%s.Get(%s)%s", target, i, maybeInline)
-}
-
-// Get is a function that should only be used in templates.
-func (b *argWidthOverloadBase) Get(target, i string) string {
-	return get(b.CanonicalTypeFamily, target, i)
-}
-
-// ReturnGet is a function that should only be used in templates.
-func (o *lastArgWidthOverload) ReturnGet(target, i string) string {
-	return get(typeconv.TypeFamilyToCanonicalTypeFamily(o.RetType.Family()), target, i)
-}
-
 func copyVal(canonicalTypeFamily types.Family, dest, src string) string {
 	switch canonicalTypeFamily {
 	case types.BytesFamily:
@@ -622,11 +602,9 @@ var (
 	_    = lawo.Compare
 	_    = lawo.Cast
 	_    = lawo.UnaryAssign
-	_    = lawo.ReturnGet
 
 	awob = &argWidthOverloadBase{}
 	_    = awob.GoTypeSliceName
-	_    = awob.Get
 	_    = awob.CopyVal
 	_    = awob.Set
 	_    = awob.Slice

--- a/pkg/sql/colexec/execgen/placeholders.go
+++ b/pkg/sql/colexec/execgen/placeholders.go
@@ -16,8 +16,6 @@ const nonTemplatePanic = "do not call from non-template code"
 
 // Remove unused warnings.
 var (
-	_ = UNSAFEGET
-	_ = RETURNUNSAFEGET
 	_ = COPYVAL
 	_ = SET
 	_ = SLICE
@@ -28,26 +26,6 @@ var (
 	_ = ZERO
 	_ = WINDOW
 )
-
-// UNSAFEGET is a template function. Use this if you are not keeping data
-// around (including passing it to SET).
-func UNSAFEGET(target, i interface{}) interface{} {
-	colexecerror.InternalError(nonTemplatePanic)
-	return nil
-}
-
-// RETURNUNSAFEGET is a template function. Use this if you are not keeping data
-// around (including passing it to SET).
-// This function is similar to UNSAFEGET with the only difference is that this
-// will be called on "return" type of an overload. For example, if we have an
-// overload like "a = b < c", "b" and "c" are arguments of the overload and can
-// be accessed via UNSAFEGET, but RETURNUNSAFEGET will operate on "a". At the
-// moment of this writing, it is used only for the purposes of bounds check
-// elimination in some templates.
-func RETURNUNSAFEGET(target, i interface{}) interface{} {
-	colexecerror.InternalError(nonTemplatePanic)
-	return nil
-}
 
 // COPYVAL is a template function that can be used to set a scalar to the value
 // of another scalar in such a way that the destination won't be modified if the

--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -126,7 +126,7 @@ func (v hashAggFuncs) match(
 					if lhsHasNull {
 						lhsNull := lhs.Nulls().NullAt(v.keyIdx)
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								rhsNull := rhs.Nulls().NullAt(rowIdx)
@@ -138,7 +138,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -160,7 +160,7 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								if lhsNull {
@@ -168,7 +168,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -192,11 +192,11 @@ func (v hashAggFuncs) match(
 						}
 					} else {
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -218,11 +218,11 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -255,7 +255,7 @@ func (v hashAggFuncs) match(
 					if lhsHasNull {
 						lhsNull := lhs.Nulls().NullAt(v.keyIdx)
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								rhsNull := rhs.Nulls().NullAt(rowIdx)
@@ -267,7 +267,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -281,7 +281,7 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								if lhsNull {
@@ -289,7 +289,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -305,11 +305,11 @@ func (v hashAggFuncs) match(
 						}
 					} else {
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -323,11 +323,11 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -352,7 +352,7 @@ func (v hashAggFuncs) match(
 					if lhsHasNull {
 						lhsNull := lhs.Nulls().NullAt(v.keyIdx)
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								rhsNull := rhs.Nulls().NullAt(rowIdx)
@@ -364,7 +364,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -378,7 +378,7 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								if lhsNull {
@@ -386,7 +386,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -402,11 +402,11 @@ func (v hashAggFuncs) match(
 						}
 					} else {
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -420,11 +420,11 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -448,7 +448,7 @@ func (v hashAggFuncs) match(
 					if lhsHasNull {
 						lhsNull := lhs.Nulls().NullAt(v.keyIdx)
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								rhsNull := rhs.Nulls().NullAt(rowIdx)
@@ -460,7 +460,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -485,7 +485,7 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								if lhsNull {
@@ -493,7 +493,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -520,11 +520,11 @@ func (v hashAggFuncs) match(
 						}
 					} else {
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -549,11 +549,11 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -585,7 +585,7 @@ func (v hashAggFuncs) match(
 					if lhsHasNull {
 						lhsNull := lhs.Nulls().NullAt(v.keyIdx)
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								rhsNull := rhs.Nulls().NullAt(rowIdx)
@@ -597,7 +597,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -622,7 +622,7 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								if lhsNull {
@@ -630,7 +630,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -657,11 +657,11 @@ func (v hashAggFuncs) match(
 						}
 					} else {
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -686,11 +686,11 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -723,7 +723,7 @@ func (v hashAggFuncs) match(
 					if lhsHasNull {
 						lhsNull := lhs.Nulls().NullAt(v.keyIdx)
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								rhsNull := rhs.Nulls().NullAt(rowIdx)
@@ -735,7 +735,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -760,7 +760,7 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								if lhsNull {
@@ -768,7 +768,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -795,11 +795,11 @@ func (v hashAggFuncs) match(
 						}
 					} else {
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -824,11 +824,11 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -864,7 +864,7 @@ func (v hashAggFuncs) match(
 					if lhsHasNull {
 						lhsNull := lhs.Nulls().NullAt(v.keyIdx)
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								rhsNull := rhs.Nulls().NullAt(rowIdx)
@@ -876,7 +876,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -909,7 +909,7 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								if lhsNull {
@@ -917,7 +917,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -952,11 +952,11 @@ func (v hashAggFuncs) match(
 						}
 					} else {
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -989,11 +989,11 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -1037,7 +1037,7 @@ func (v hashAggFuncs) match(
 					if lhsHasNull {
 						lhsNull := lhs.Nulls().NullAt(v.keyIdx)
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								rhsNull := rhs.Nulls().NullAt(rowIdx)
@@ -1049,7 +1049,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -1070,7 +1070,7 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								if lhsNull {
@@ -1078,7 +1078,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -1101,11 +1101,11 @@ func (v hashAggFuncs) match(
 						}
 					} else {
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -1126,11 +1126,11 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -1162,7 +1162,7 @@ func (v hashAggFuncs) match(
 					if lhsHasNull {
 						lhsNull := lhs.Nulls().NullAt(v.keyIdx)
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								rhsNull := rhs.Nulls().NullAt(rowIdx)
@@ -1174,7 +1174,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -1188,7 +1188,7 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 								if lhsNull {
@@ -1196,7 +1196,7 @@ func (v hashAggFuncs) match(
 									continue
 								}
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -1212,11 +1212,11 @@ func (v hashAggFuncs) match(
 						}
 					} else {
 						if rhsHasNull {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 
@@ -1230,11 +1230,11 @@ func (v hashAggFuncs) match(
 							}
 
 						} else {
-							lhsVal := lhsCol.Get(aggKeyIdx) //gcassert:inline
+							lhsVal := lhsCol.Get(aggKeyIdx)
 
 							for selIdx, rowIdx := range sel {
 
-								rhsVal := rhsCol.Get(rowIdx) //gcassert:inline
+								rhsVal := rhsCol.Get(rowIdx)
 
 								var cmp bool
 

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -103,7 +102,7 @@ func _MATCH_LOOP(
 ) { // */}}
 	// {{define "matchLoop" -}}
 
-	lhsVal := execgen.UNSAFEGET(lhsCol, aggKeyIdx)
+	lhsVal := lhsCol.Get(aggKeyIdx)
 
 	for selIdx, rowIdx := range sel {
 		// {{if .LhsMaybeHasNulls}}
@@ -124,7 +123,7 @@ func _MATCH_LOOP(
 		// {{end}}
 		// {{end}}
 
-		rhsVal := execgen.UNSAFEGET(rhsCol, rowIdx)
+		rhsVal := rhsCol.Get(rowIdx)
 
 		var cmp bool
 		_ASSIGN_NE(cmp, lhsVal, rhsVal, _, lhsCol, rhsCol)

--- a/pkg/sql/colexec/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/hash_any_not_null_agg.eg.go
@@ -138,7 +138,7 @@ func (a *anyNotNullBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
 					sel = sel[:inputLen]
@@ -150,7 +150,7 @@ func (a *anyNotNullBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -168,7 +168,7 @@ func (a *anyNotNullBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -189,7 +189,7 @@ func (a *anyNotNullBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -207,7 +207,7 @@ func (a *anyNotNullBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -310,7 +310,7 @@ func (a *anyNotNullBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
 					sel = sel[:inputLen]
@@ -322,7 +322,7 @@ func (a *anyNotNullBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = append(a.curAgg[:0], val...)
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -340,7 +340,7 @@ func (a *anyNotNullBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = append(a.curAgg[:0], val...)
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -361,7 +361,7 @@ func (a *anyNotNullBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = append(a.curAgg[:0], val...)
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -379,7 +379,7 @@ func (a *anyNotNullBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = append(a.curAgg[:0], val...)
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -482,7 +482,7 @@ func (a *anyNotNullDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
 					sel = sel[:inputLen]
@@ -494,7 +494,7 @@ func (a *anyNotNullDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg.Set(&val)
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -512,7 +512,7 @@ func (a *anyNotNullDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg.Set(&val)
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -533,7 +533,7 @@ func (a *anyNotNullDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg.Set(&val)
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -551,7 +551,7 @@ func (a *anyNotNullDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg.Set(&val)
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -654,7 +654,7 @@ func (a *anyNotNullInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
 					sel = sel[:inputLen]
@@ -666,7 +666,7 @@ func (a *anyNotNullInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -684,7 +684,7 @@ func (a *anyNotNullInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -705,7 +705,7 @@ func (a *anyNotNullInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -723,7 +723,7 @@ func (a *anyNotNullInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -826,7 +826,7 @@ func (a *anyNotNullInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
 					sel = sel[:inputLen]
@@ -838,7 +838,7 @@ func (a *anyNotNullInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -856,7 +856,7 @@ func (a *anyNotNullInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -877,7 +877,7 @@ func (a *anyNotNullInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -895,7 +895,7 @@ func (a *anyNotNullInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -998,7 +998,7 @@ func (a *anyNotNullInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
 					sel = sel[:inputLen]
@@ -1010,7 +1010,7 @@ func (a *anyNotNullInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1028,7 +1028,7 @@ func (a *anyNotNullInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1049,7 +1049,7 @@ func (a *anyNotNullInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1067,7 +1067,7 @@ func (a *anyNotNullInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1170,7 +1170,7 @@ func (a *anyNotNullFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
 					sel = sel[:inputLen]
@@ -1182,7 +1182,7 @@ func (a *anyNotNullFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1200,7 +1200,7 @@ func (a *anyNotNullFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1221,7 +1221,7 @@ func (a *anyNotNullFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1239,7 +1239,7 @@ func (a *anyNotNullFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1342,7 +1342,7 @@ func (a *anyNotNullTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
 					sel = sel[:inputLen]
@@ -1354,7 +1354,7 @@ func (a *anyNotNullTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1372,7 +1372,7 @@ func (a *anyNotNullTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1393,7 +1393,7 @@ func (a *anyNotNullTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1411,7 +1411,7 @@ func (a *anyNotNullTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1514,7 +1514,7 @@ func (a *anyNotNullIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
 					sel = sel[:inputLen]
@@ -1526,7 +1526,7 @@ func (a *anyNotNullIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1544,7 +1544,7 @@ func (a *anyNotNullIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1565,7 +1565,7 @@ func (a *anyNotNullIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there
@@ -1583,7 +1583,7 @@ func (a *anyNotNullIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 							// We have already seen non-null for the current group, and since there

--- a/pkg/sql/colexec/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/hash_min_max_agg.eg.go
@@ -150,12 +150,12 @@ func (a *minBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -185,12 +185,12 @@ func (a *minBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -222,12 +222,12 @@ func (a *minBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -257,12 +257,12 @@ func (a *minBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -383,12 +383,12 @@ func (a *minBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -412,12 +412,12 @@ func (a *minBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -441,12 +441,12 @@ func (a *minBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -470,12 +470,12 @@ func (a *minBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -588,12 +588,12 @@ func (a *minDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -615,12 +615,12 @@ func (a *minDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -644,12 +644,12 @@ func (a *minDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -671,12 +671,12 @@ func (a *minDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -789,12 +789,12 @@ func (a *minInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -827,12 +827,12 @@ func (a *minInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -867,12 +867,12 @@ func (a *minInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -905,12 +905,12 @@ func (a *minInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1034,12 +1034,12 @@ func (a *minInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1072,12 +1072,12 @@ func (a *minInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1112,12 +1112,12 @@ func (a *minInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1150,12 +1150,12 @@ func (a *minInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1279,12 +1279,12 @@ func (a *minInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1317,12 +1317,12 @@ func (a *minInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1357,12 +1357,12 @@ func (a *minInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1395,12 +1395,12 @@ func (a *minInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1524,12 +1524,12 @@ func (a *minFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1570,12 +1570,12 @@ func (a *minFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1618,12 +1618,12 @@ func (a *minFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1664,12 +1664,12 @@ func (a *minFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1801,12 +1801,12 @@ func (a *minTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1835,12 +1835,12 @@ func (a *minTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1871,12 +1871,12 @@ func (a *minTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1905,12 +1905,12 @@ func (a *minTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2030,12 +2030,12 @@ func (a *minIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2057,12 +2057,12 @@ func (a *minIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2086,12 +2086,12 @@ func (a *minIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2113,12 +2113,12 @@ func (a *minIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2440,12 +2440,12 @@ func (a *maxBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2475,12 +2475,12 @@ func (a *maxBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2512,12 +2512,12 @@ func (a *maxBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2547,12 +2547,12 @@ func (a *maxBoolHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2673,12 +2673,12 @@ func (a *maxBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2702,12 +2702,12 @@ func (a *maxBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2731,12 +2731,12 @@ func (a *maxBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2760,12 +2760,12 @@ func (a *maxBytesHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2878,12 +2878,12 @@ func (a *maxDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2905,12 +2905,12 @@ func (a *maxDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2934,12 +2934,12 @@ func (a *maxDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2961,12 +2961,12 @@ func (a *maxDecimalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3079,12 +3079,12 @@ func (a *maxInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3117,12 +3117,12 @@ func (a *maxInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3157,12 +3157,12 @@ func (a *maxInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3195,12 +3195,12 @@ func (a *maxInt16HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3324,12 +3324,12 @@ func (a *maxInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3362,12 +3362,12 @@ func (a *maxInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3402,12 +3402,12 @@ func (a *maxInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3440,12 +3440,12 @@ func (a *maxInt32HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3569,12 +3569,12 @@ func (a *maxInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3607,12 +3607,12 @@ func (a *maxInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3647,12 +3647,12 @@ func (a *maxInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3685,12 +3685,12 @@ func (a *maxInt64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3814,12 +3814,12 @@ func (a *maxFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3860,12 +3860,12 @@ func (a *maxFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3908,12 +3908,12 @@ func (a *maxFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3954,12 +3954,12 @@ func (a *maxFloat64HashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4091,12 +4091,12 @@ func (a *maxTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4125,12 +4125,12 @@ func (a *maxTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4161,12 +4161,12 @@ func (a *maxTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4195,12 +4195,12 @@ func (a *maxTimestampHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4320,12 +4320,12 @@ func (a *maxIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4347,12 +4347,12 @@ func (a *maxIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4376,12 +4376,12 @@ func (a *maxIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4403,12 +4403,12 @@ func (a *maxIntervalHashAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int

--- a/pkg/sql/colexec/hash_utils.eg.go
+++ b/pkg/sql/colexec/hash_utils.eg.go
@@ -58,7 +58,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						x := 0
@@ -72,7 +72,7 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
@@ -80,7 +80,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						x := 0
@@ -101,7 +101,7 @@ func rehash(
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = sel[i]
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						x := 0
@@ -115,12 +115,12 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = i
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						x := 0
@@ -151,7 +151,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
@@ -162,7 +162,7 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
@@ -170,7 +170,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
@@ -188,7 +188,7 @@ func rehash(
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = sel[i]
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
@@ -199,12 +199,12 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = i
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
@@ -232,7 +232,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for equal decimals to hash to the same value we need to
@@ -248,7 +248,7 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
@@ -256,7 +256,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for equal decimals to hash to the same value we need to
@@ -279,7 +279,7 @@ func rehash(
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = sel[i]
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for equal decimals to hash to the same value we need to
@@ -295,12 +295,12 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = i
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for equal decimals to hash to the same value we need to
@@ -332,7 +332,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -344,7 +344,7 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
@@ -352,7 +352,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -371,7 +371,7 @@ func rehash(
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = sel[i]
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -383,12 +383,12 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = i
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -413,7 +413,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -425,7 +425,7 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
@@ -433,7 +433,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -452,7 +452,7 @@ func rehash(
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = sel[i]
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -464,12 +464,12 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = i
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -495,7 +495,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -507,7 +507,7 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
@@ -515,7 +515,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -534,7 +534,7 @@ func rehash(
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = sel[i]
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -546,12 +546,12 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = i
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						// In order for integers with different widths but of the same value to
@@ -580,7 +580,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						f := v
@@ -594,7 +594,7 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
@@ -602,7 +602,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						f := v
@@ -623,7 +623,7 @@ func rehash(
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = sel[i]
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						f := v
@@ -637,12 +637,12 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = i
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						f := v
@@ -673,7 +673,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						s := v.UnixNano()
@@ -684,7 +684,7 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
@@ -692,7 +692,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						s := v.UnixNano()
@@ -710,7 +710,7 @@ func rehash(
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = sel[i]
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						s := v.UnixNano()
@@ -721,12 +721,12 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = i
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						s := v.UnixNano()
@@ -754,7 +754,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						months, days, nanos := v.Months, v.Days, v.Nanos()
@@ -767,7 +767,7 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
@@ -775,7 +775,7 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						months, days, nanos := v.Months, v.Days, v.Nanos()
@@ -795,7 +795,7 @@ func rehash(
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = sel[i]
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						months, days, nanos := v.Months, v.Days, v.Nanos()
@@ -808,12 +808,12 @@ func rehash(
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
-					_ = keys.Get(nKeys - 1) //gcassert:inline
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						cancelChecker.check(ctx)
 						selIdx = i
-						v := keys.Get(selIdx) //gcassert:inline
+						v := keys.Get(selIdx)
 						p := uintptr(buckets[i])
 
 						months, days, nanos := v.Months, v.Days, v.Nanos()

--- a/pkg/sql/colexec/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/hash_utils_tmpl.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -66,7 +65,7 @@ func _REHASH_BODY(
 	// {{if .HasSel}}
 	_ = sel[nKeys-1]
 	// {{else}}
-	_ = execgen.UNSAFEGET(keys, nKeys-1)
+	_ = keys.Get(nKeys - 1)
 	// {{end}}
 	var selIdx int
 	for i := 0; i < nKeys; i++ {
@@ -81,7 +80,7 @@ func _REHASH_BODY(
 			continue
 		}
 		// {{end}}
-		v := execgen.UNSAFEGET(keys, selIdx)
+		v := keys.Get(selIdx)
 		p := uintptr(buckets[i])
 		_ASSIGN_HASH(p, v, _, keys)
 		buckets[i] = uint64(p)

--- a/pkg/sql/colexec/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/hashtable_distinct.eg.go
@@ -83,8 +83,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -132,8 +132,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -181,8 +181,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -231,8 +231,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -278,8 +278,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -343,8 +343,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -390,8 +390,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -437,8 +437,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -485,8 +485,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -530,8 +530,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -612,8 +612,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -653,8 +653,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -694,8 +694,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -736,8 +736,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -775,8 +775,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -832,8 +832,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -871,8 +871,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -910,8 +910,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -950,8 +950,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -987,8 +987,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1060,8 +1060,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1107,8 +1107,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1154,8 +1154,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1202,8 +1202,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1247,8 +1247,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1310,8 +1310,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1355,8 +1355,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1400,8 +1400,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1446,8 +1446,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1489,8 +1489,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1558,8 +1558,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1605,8 +1605,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1652,8 +1652,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1700,8 +1700,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1745,8 +1745,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1808,8 +1808,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1853,8 +1853,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1898,8 +1898,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1944,8 +1944,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1987,8 +1987,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2057,8 +2057,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2104,8 +2104,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2151,8 +2151,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2199,8 +2199,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2244,8 +2244,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2307,8 +2307,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2352,8 +2352,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2397,8 +2397,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2443,8 +2443,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2486,8 +2486,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2559,8 +2559,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2608,8 +2608,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2657,8 +2657,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2707,8 +2707,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2754,8 +2754,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2819,8 +2819,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2866,8 +2866,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2913,8 +2913,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2961,8 +2961,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3006,8 +3006,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3081,8 +3081,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3122,8 +3122,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3163,8 +3163,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3205,8 +3205,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3244,8 +3244,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3301,8 +3301,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3340,8 +3340,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3379,8 +3379,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3419,8 +3419,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3456,8 +3456,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3528,8 +3528,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3580,8 +3580,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3632,8 +3632,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3685,8 +3685,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3735,8 +3735,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3803,8 +3803,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3853,8 +3853,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3903,8 +3903,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3954,8 +3954,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4002,8 +4002,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4076,8 +4076,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4128,8 +4128,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4180,8 +4180,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4233,8 +4233,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4283,8 +4283,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4351,8 +4351,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4401,8 +4401,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4451,8 +4451,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4502,8 +4502,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4550,8 +4550,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4625,8 +4625,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4677,8 +4677,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4729,8 +4729,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4782,8 +4782,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4832,8 +4832,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4900,8 +4900,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4950,8 +4950,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5000,8 +5000,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5051,8 +5051,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5099,8 +5099,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5177,8 +5177,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5237,8 +5237,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5297,8 +5297,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5358,8 +5358,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5416,8 +5416,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5492,8 +5492,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5550,8 +5550,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5608,8 +5608,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5667,8 +5667,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5723,8 +5723,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5809,8 +5809,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5856,8 +5856,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5903,8 +5903,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5951,8 +5951,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5996,8 +5996,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6059,8 +6059,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6104,8 +6104,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6149,8 +6149,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6195,8 +6195,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6238,8 +6238,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6313,8 +6313,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6365,8 +6365,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6417,8 +6417,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6470,8 +6470,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6520,8 +6520,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6588,8 +6588,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6638,8 +6638,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6688,8 +6688,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6739,8 +6739,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6787,8 +6787,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6861,8 +6861,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6913,8 +6913,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6965,8 +6965,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7018,8 +7018,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7068,8 +7068,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7136,8 +7136,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7186,8 +7186,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7236,8 +7236,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7287,8 +7287,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7335,8 +7335,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7410,8 +7410,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7462,8 +7462,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7514,8 +7514,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7567,8 +7567,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7617,8 +7617,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7685,8 +7685,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7735,8 +7735,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7785,8 +7785,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7836,8 +7836,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7884,8 +7884,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7962,8 +7962,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8022,8 +8022,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8082,8 +8082,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8143,8 +8143,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8201,8 +8201,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8277,8 +8277,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8335,8 +8335,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8393,8 +8393,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8452,8 +8452,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8508,8 +8508,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8594,8 +8594,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8641,8 +8641,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8688,8 +8688,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8736,8 +8736,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8781,8 +8781,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8844,8 +8844,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8889,8 +8889,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8934,8 +8934,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8980,8 +8980,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9023,8 +9023,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9099,8 +9099,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9151,8 +9151,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9203,8 +9203,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9256,8 +9256,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9306,8 +9306,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9374,8 +9374,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9424,8 +9424,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9474,8 +9474,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9525,8 +9525,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9573,8 +9573,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9647,8 +9647,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9699,8 +9699,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9751,8 +9751,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9804,8 +9804,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9854,8 +9854,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9922,8 +9922,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9972,8 +9972,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10022,8 +10022,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10073,8 +10073,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10121,8 +10121,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10196,8 +10196,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10248,8 +10248,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10300,8 +10300,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10353,8 +10353,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10403,8 +10403,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10471,8 +10471,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10521,8 +10521,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10571,8 +10571,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10622,8 +10622,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10670,8 +10670,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10748,8 +10748,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10808,8 +10808,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10868,8 +10868,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10929,8 +10929,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10987,8 +10987,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11063,8 +11063,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11121,8 +11121,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11179,8 +11179,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11238,8 +11238,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11294,8 +11294,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11380,8 +11380,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11427,8 +11427,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11474,8 +11474,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11522,8 +11522,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11567,8 +11567,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11630,8 +11630,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11675,8 +11675,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11720,8 +11720,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11766,8 +11766,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11809,8 +11809,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11888,8 +11888,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11948,8 +11948,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12008,8 +12008,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12069,8 +12069,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12127,8 +12127,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12203,8 +12203,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12261,8 +12261,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12319,8 +12319,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12378,8 +12378,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12434,8 +12434,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12516,8 +12516,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12576,8 +12576,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12636,8 +12636,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12697,8 +12697,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12755,8 +12755,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12831,8 +12831,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12889,8 +12889,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12947,8 +12947,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13006,8 +13006,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13062,8 +13062,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13145,8 +13145,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13205,8 +13205,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13265,8 +13265,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13326,8 +13326,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13384,8 +13384,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13460,8 +13460,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13518,8 +13518,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13576,8 +13576,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13635,8 +13635,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13691,8 +13691,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13777,8 +13777,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13837,8 +13837,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13897,8 +13897,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13958,8 +13958,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14016,8 +14016,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14092,8 +14092,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14150,8 +14150,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14208,8 +14208,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14267,8 +14267,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14323,8 +14323,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14409,8 +14409,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14458,8 +14458,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14507,8 +14507,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14557,8 +14557,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14604,8 +14604,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14669,8 +14669,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14716,8 +14716,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14763,8 +14763,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14811,8 +14811,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14856,8 +14856,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14938,8 +14938,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14986,8 +14986,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15034,8 +15034,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15083,8 +15083,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15129,8 +15129,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15193,8 +15193,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15239,8 +15239,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15285,8 +15285,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15332,8 +15332,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15376,8 +15376,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15457,8 +15457,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15498,8 +15498,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15539,8 +15539,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15581,8 +15581,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15620,8 +15620,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15677,8 +15677,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15716,8 +15716,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15755,8 +15755,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15795,8 +15795,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15832,8 +15832,8 @@ func (ht *hashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16379,8 +16379,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16441,8 +16441,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16505,8 +16505,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16566,8 +16566,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16634,8 +16634,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16696,8 +16696,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16760,8 +16760,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16821,8 +16821,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16904,8 +16904,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16958,8 +16958,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17014,8 +17014,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17067,8 +17067,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17127,8 +17127,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17181,8 +17181,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17237,8 +17237,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17290,8 +17290,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17371,8 +17371,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17425,8 +17425,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17481,8 +17481,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17534,8 +17534,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17594,8 +17594,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17648,8 +17648,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17704,8 +17704,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17757,8 +17757,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17830,8 +17830,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17895,8 +17895,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17962,8 +17962,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18026,8 +18026,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18097,8 +18097,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18162,8 +18162,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18229,8 +18229,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18293,8 +18293,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18380,8 +18380,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18445,8 +18445,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18512,8 +18512,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18576,8 +18576,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18647,8 +18647,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18712,8 +18712,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18779,8 +18779,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18843,8 +18843,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18932,8 +18932,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -18997,8 +18997,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19064,8 +19064,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19128,8 +19128,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19199,8 +19199,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19264,8 +19264,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19331,8 +19331,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19395,8 +19395,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19490,8 +19490,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19563,8 +19563,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19638,8 +19638,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19710,8 +19710,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19789,8 +19789,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19862,8 +19862,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -19937,8 +19937,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20009,8 +20009,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20106,8 +20106,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20167,8 +20167,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20230,8 +20230,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20290,8 +20290,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20357,8 +20357,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20418,8 +20418,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20481,8 +20481,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20541,8 +20541,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20623,8 +20623,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20677,8 +20677,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20733,8 +20733,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20786,8 +20786,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20846,8 +20846,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20900,8 +20900,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -20956,8 +20956,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -21009,8 +21009,8 @@ func (ht *hashTable) checkColForDistinctTuples(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{

--- a/pkg/sql/colexec/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/hashtable_full_default.eg.go
@@ -85,8 +85,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -132,8 +132,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -179,8 +179,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -227,8 +227,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -272,8 +272,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -337,8 +337,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -384,8 +384,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -431,8 +431,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -479,8 +479,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -524,8 +524,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -604,8 +604,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -643,8 +643,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -682,8 +682,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -722,8 +722,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -759,8 +759,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -816,8 +816,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -855,8 +855,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -894,8 +894,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -934,8 +934,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -971,8 +971,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1042,8 +1042,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1087,8 +1087,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1132,8 +1132,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1178,8 +1178,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1221,8 +1221,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1284,8 +1284,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1329,8 +1329,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1374,8 +1374,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1420,8 +1420,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1463,8 +1463,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1530,8 +1530,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1575,8 +1575,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1620,8 +1620,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1666,8 +1666,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1709,8 +1709,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1772,8 +1772,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1817,8 +1817,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1862,8 +1862,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1908,8 +1908,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1951,8 +1951,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2019,8 +2019,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2064,8 +2064,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2109,8 +2109,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2155,8 +2155,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2198,8 +2198,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2261,8 +2261,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2306,8 +2306,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2351,8 +2351,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2397,8 +2397,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2440,8 +2440,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2511,8 +2511,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2558,8 +2558,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2605,8 +2605,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2653,8 +2653,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2698,8 +2698,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2763,8 +2763,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2810,8 +2810,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2857,8 +2857,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2905,8 +2905,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2950,8 +2950,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3023,8 +3023,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3062,8 +3062,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3101,8 +3101,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3141,8 +3141,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3178,8 +3178,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3235,8 +3235,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3274,8 +3274,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3313,8 +3313,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3353,8 +3353,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3390,8 +3390,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3460,8 +3460,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3510,8 +3510,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3560,8 +3560,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3611,8 +3611,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3659,8 +3659,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3727,8 +3727,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3777,8 +3777,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3827,8 +3827,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3878,8 +3878,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3926,8 +3926,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3998,8 +3998,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4048,8 +4048,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4098,8 +4098,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4149,8 +4149,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4197,8 +4197,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4265,8 +4265,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4315,8 +4315,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4365,8 +4365,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4416,8 +4416,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4464,8 +4464,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4537,8 +4537,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4587,8 +4587,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4637,8 +4637,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4688,8 +4688,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4736,8 +4736,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4804,8 +4804,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4854,8 +4854,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4904,8 +4904,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4955,8 +4955,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5003,8 +5003,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5079,8 +5079,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5137,8 +5137,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5195,8 +5195,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5254,8 +5254,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5310,8 +5310,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5386,8 +5386,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5444,8 +5444,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5502,8 +5502,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5561,8 +5561,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5617,8 +5617,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5701,8 +5701,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5746,8 +5746,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5791,8 +5791,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5837,8 +5837,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5880,8 +5880,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5943,8 +5943,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5988,8 +5988,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6033,8 +6033,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6079,8 +6079,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6122,8 +6122,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6195,8 +6195,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6245,8 +6245,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6295,8 +6295,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6346,8 +6346,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6394,8 +6394,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6462,8 +6462,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6512,8 +6512,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6562,8 +6562,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6613,8 +6613,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6661,8 +6661,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6733,8 +6733,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6783,8 +6783,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6833,8 +6833,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6884,8 +6884,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6932,8 +6932,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7000,8 +7000,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7050,8 +7050,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7100,8 +7100,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7151,8 +7151,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7199,8 +7199,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7272,8 +7272,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7322,8 +7322,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7372,8 +7372,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7423,8 +7423,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7471,8 +7471,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7539,8 +7539,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7589,8 +7589,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7639,8 +7639,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7690,8 +7690,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7738,8 +7738,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7814,8 +7814,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7872,8 +7872,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7930,8 +7930,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7989,8 +7989,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8045,8 +8045,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8121,8 +8121,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8179,8 +8179,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8237,8 +8237,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8296,8 +8296,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8352,8 +8352,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8436,8 +8436,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8481,8 +8481,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8526,8 +8526,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8572,8 +8572,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8615,8 +8615,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8678,8 +8678,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8723,8 +8723,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8768,8 +8768,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8814,8 +8814,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8857,8 +8857,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8931,8 +8931,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8981,8 +8981,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9031,8 +9031,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9082,8 +9082,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9130,8 +9130,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9198,8 +9198,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9248,8 +9248,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9298,8 +9298,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9349,8 +9349,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9397,8 +9397,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9469,8 +9469,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9519,8 +9519,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9569,8 +9569,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9620,8 +9620,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9668,8 +9668,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9736,8 +9736,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9786,8 +9786,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9836,8 +9836,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9887,8 +9887,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9935,8 +9935,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10008,8 +10008,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10058,8 +10058,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10108,8 +10108,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10159,8 +10159,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10207,8 +10207,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10275,8 +10275,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10325,8 +10325,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10375,8 +10375,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10426,8 +10426,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10474,8 +10474,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10550,8 +10550,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10608,8 +10608,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10666,8 +10666,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10725,8 +10725,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10781,8 +10781,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10857,8 +10857,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10915,8 +10915,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10973,8 +10973,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11032,8 +11032,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11088,8 +11088,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11172,8 +11172,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11217,8 +11217,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11262,8 +11262,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11308,8 +11308,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11351,8 +11351,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11414,8 +11414,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11459,8 +11459,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11504,8 +11504,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11550,8 +11550,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11593,8 +11593,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11670,8 +11670,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11728,8 +11728,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11786,8 +11786,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11845,8 +11845,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11901,8 +11901,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11977,8 +11977,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12035,8 +12035,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12093,8 +12093,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12152,8 +12152,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12208,8 +12208,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12288,8 +12288,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12346,8 +12346,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12404,8 +12404,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12463,8 +12463,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12519,8 +12519,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12595,8 +12595,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12653,8 +12653,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12711,8 +12711,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12770,8 +12770,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12826,8 +12826,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12907,8 +12907,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12965,8 +12965,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13023,8 +13023,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13082,8 +13082,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13138,8 +13138,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13214,8 +13214,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13272,8 +13272,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13330,8 +13330,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13389,8 +13389,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13445,8 +13445,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13529,8 +13529,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13587,8 +13587,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13645,8 +13645,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13704,8 +13704,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13760,8 +13760,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13836,8 +13836,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13894,8 +13894,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13952,8 +13952,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14011,8 +14011,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14067,8 +14067,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14151,8 +14151,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14198,8 +14198,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14245,8 +14245,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14293,8 +14293,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14338,8 +14338,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14403,8 +14403,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14450,8 +14450,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14497,8 +14497,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14545,8 +14545,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14590,8 +14590,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14670,8 +14670,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14716,8 +14716,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14762,8 +14762,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14809,8 +14809,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14853,8 +14853,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14917,8 +14917,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14963,8 +14963,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15009,8 +15009,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15056,8 +15056,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15100,8 +15100,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15179,8 +15179,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15218,8 +15218,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15257,8 +15257,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15297,8 +15297,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15334,8 +15334,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15391,8 +15391,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15430,8 +15430,8 @@ func (ht *hashTable) checkCol(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15469,8 +15469,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15509,8 +15509,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15546,8 +15546,8 @@ func (ht *hashTable) checkCol(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{

--- a/pkg/sql/colexec/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/hashtable_full_deleting.eg.go
@@ -91,8 +91,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -144,8 +144,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -197,8 +197,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -251,8 +251,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -302,8 +302,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -373,8 +373,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -426,8 +426,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -479,8 +479,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -533,8 +533,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -584,8 +584,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -670,8 +670,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -715,8 +715,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -760,8 +760,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -806,8 +806,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -849,8 +849,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -912,8 +912,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -957,8 +957,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1002,8 +1002,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1048,8 +1048,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1091,8 +1091,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1168,8 +1168,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1219,8 +1219,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1270,8 +1270,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1322,8 +1322,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1371,8 +1371,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1440,8 +1440,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1491,8 +1491,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1542,8 +1542,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1594,8 +1594,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1643,8 +1643,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1716,8 +1716,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1767,8 +1767,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -1818,8 +1818,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1870,8 +1870,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1919,8 +1919,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -1988,8 +1988,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2039,8 +2039,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2090,8 +2090,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2142,8 +2142,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2191,8 +2191,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2265,8 +2265,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2316,8 +2316,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2367,8 +2367,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2419,8 +2419,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2468,8 +2468,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2537,8 +2537,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2588,8 +2588,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2639,8 +2639,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2691,8 +2691,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2740,8 +2740,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2817,8 +2817,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2870,8 +2870,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -2923,8 +2923,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -2977,8 +2977,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3028,8 +3028,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3099,8 +3099,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3152,8 +3152,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3205,8 +3205,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3259,8 +3259,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3310,8 +3310,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3389,8 +3389,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3434,8 +3434,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3479,8 +3479,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3525,8 +3525,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3568,8 +3568,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3631,8 +3631,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3676,8 +3676,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3721,8 +3721,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3767,8 +3767,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3810,8 +3810,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -3886,8 +3886,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3942,8 +3942,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -3998,8 +3998,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4055,8 +4055,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4109,8 +4109,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4183,8 +4183,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4239,8 +4239,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4295,8 +4295,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4352,8 +4352,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4406,8 +4406,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4484,8 +4484,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4540,8 +4540,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4596,8 +4596,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4653,8 +4653,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4707,8 +4707,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4781,8 +4781,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4837,8 +4837,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -4893,8 +4893,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -4950,8 +4950,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5004,8 +5004,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5083,8 +5083,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5139,8 +5139,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5195,8 +5195,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5252,8 +5252,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5306,8 +5306,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5380,8 +5380,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5436,8 +5436,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5492,8 +5492,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5549,8 +5549,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5603,8 +5603,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5685,8 +5685,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5749,8 +5749,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -5813,8 +5813,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5878,8 +5878,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -5940,8 +5940,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6022,8 +6022,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6086,8 +6086,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6150,8 +6150,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6215,8 +6215,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6277,8 +6277,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6367,8 +6367,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6418,8 +6418,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6469,8 +6469,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6521,8 +6521,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6570,8 +6570,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6639,8 +6639,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6690,8 +6690,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6741,8 +6741,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6793,8 +6793,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6842,8 +6842,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -6921,8 +6921,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -6977,8 +6977,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7033,8 +7033,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7090,8 +7090,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7144,8 +7144,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7218,8 +7218,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7274,8 +7274,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7330,8 +7330,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7387,8 +7387,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7441,8 +7441,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7519,8 +7519,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7575,8 +7575,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7631,8 +7631,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7688,8 +7688,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7742,8 +7742,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7816,8 +7816,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7872,8 +7872,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -7928,8 +7928,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -7985,8 +7985,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8039,8 +8039,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8118,8 +8118,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8174,8 +8174,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8230,8 +8230,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8287,8 +8287,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8341,8 +8341,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8415,8 +8415,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8471,8 +8471,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8527,8 +8527,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8584,8 +8584,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8638,8 +8638,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8720,8 +8720,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8784,8 +8784,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -8848,8 +8848,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8913,8 +8913,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -8975,8 +8975,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9057,8 +9057,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9121,8 +9121,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9185,8 +9185,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9250,8 +9250,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9312,8 +9312,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9402,8 +9402,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9453,8 +9453,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9504,8 +9504,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9556,8 +9556,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9605,8 +9605,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9674,8 +9674,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9725,8 +9725,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -9776,8 +9776,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9828,8 +9828,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9877,8 +9877,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -9957,8 +9957,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10013,8 +10013,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10069,8 +10069,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10126,8 +10126,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10180,8 +10180,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10254,8 +10254,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10310,8 +10310,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10366,8 +10366,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10423,8 +10423,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10477,8 +10477,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10555,8 +10555,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10611,8 +10611,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10667,8 +10667,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10724,8 +10724,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10778,8 +10778,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -10852,8 +10852,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10908,8 +10908,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -10964,8 +10964,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11021,8 +11021,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11075,8 +11075,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11154,8 +11154,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11210,8 +11210,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11266,8 +11266,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11323,8 +11323,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11377,8 +11377,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11451,8 +11451,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11507,8 +11507,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11563,8 +11563,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11620,8 +11620,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11674,8 +11674,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11756,8 +11756,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11820,8 +11820,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -11884,8 +11884,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -11949,8 +11949,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12011,8 +12011,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12093,8 +12093,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12157,8 +12157,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12221,8 +12221,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12286,8 +12286,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12348,8 +12348,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12438,8 +12438,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12489,8 +12489,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12540,8 +12540,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12592,8 +12592,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12641,8 +12641,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12710,8 +12710,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12761,8 +12761,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -12812,8 +12812,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12864,8 +12864,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12913,8 +12913,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -12996,8 +12996,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13060,8 +13060,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13124,8 +13124,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13189,8 +13189,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13251,8 +13251,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13333,8 +13333,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13397,8 +13397,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13461,8 +13461,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13526,8 +13526,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13588,8 +13588,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13674,8 +13674,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13738,8 +13738,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -13802,8 +13802,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13867,8 +13867,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -13929,8 +13929,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14011,8 +14011,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14075,8 +14075,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14139,8 +14139,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14204,8 +14204,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14266,8 +14266,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14353,8 +14353,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14417,8 +14417,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14481,8 +14481,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14546,8 +14546,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14608,8 +14608,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14690,8 +14690,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14754,8 +14754,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -14818,8 +14818,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14883,8 +14883,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -14945,8 +14945,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15035,8 +15035,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15099,8 +15099,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15163,8 +15163,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15228,8 +15228,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15290,8 +15290,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15372,8 +15372,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15436,8 +15436,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15500,8 +15500,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15565,8 +15565,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15627,8 +15627,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15717,8 +15717,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15770,8 +15770,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -15823,8 +15823,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15877,8 +15877,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15928,8 +15928,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -15999,8 +15999,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -16052,8 +16052,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -16105,8 +16105,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16159,8 +16159,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16210,8 +16210,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16296,8 +16296,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -16348,8 +16348,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -16400,8 +16400,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16453,8 +16453,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16503,8 +16503,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16573,8 +16573,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -16625,8 +16625,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -16677,8 +16677,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16730,8 +16730,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16780,8 +16780,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -16865,8 +16865,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -16910,8 +16910,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -16955,8 +16955,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17001,8 +17001,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17044,8 +17044,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17107,8 +17107,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -17152,8 +17152,8 @@ func (ht *hashTable) checkColDeleting(
 											} else if buildIsNull {
 												ht.probeScratch.differs[toCheck] = true
 											} else {
-												probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-												buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+												probeVal := probeKeys.Get(probeIdx)
+												buildVal := buildKeys.Get(buildIdx)
 												var unique bool
 
 												{
@@ -17197,8 +17197,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17243,8 +17243,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{
@@ -17286,8 +17286,8 @@ func (ht *hashTable) checkColDeleting(
 										} else if buildIsNull {
 											ht.probeScratch.differs[toCheck] = true
 										} else {
-											probeVal := probeKeys.Get(probeIdx) //gcassert:inline
-											buildVal := buildKeys.Get(buildIdx) //gcassert:inline
+											probeVal := probeKeys.Get(probeIdx)
+											buildVal := buildKeys.Get(buildIdx)
 											var unique bool
 
 											{

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -45,18 +45,6 @@ func _ASSIGN_NE(_, _, _, _, _, _ interface{}) int {
 	colexecerror.InternalError("")
 }
 
-// _L_UNSAFEGET is the template function that will be replaced by
-// "execgen.UNSAFEGET" which uses _L_TYP.
-func _L_UNSAFEGET(_, _ interface{}) interface{} {
-	colexecerror.InternalError("")
-}
-
-// _R_UNSAFEGET is the template function that will be replaced by
-// "execgen.UNSAFEGET" which uses _R_TYP.
-func _R_UNSAFEGET(_, _ interface{}) interface{} {
-	colexecerror.InternalError("")
-}
-
 // This is a code snippet that is the main body of checkCol* functions. It
 // takes in the following template "meta" variables that enable/disable certain
 // code paths:
@@ -160,8 +148,8 @@ func _CHECK_COL_BODY(
 			} else if buildIsNull {
 				ht.probeScratch.differs[toCheck] = true
 			} else {
-				probeVal := _L_UNSAFEGET(probeKeys, probeIdx)
-				buildVal := _R_UNSAFEGET(buildKeys, buildIdx)
+				probeVal := probeKeys.Get(probeIdx)
+				buildVal := buildKeys.Get(buildIdx)
 				var unique bool
 				_ASSIGN_NE(unique, probeVal, buildVal, _, probeKeys, buildKeys)
 				ht.probeScratch.differs[toCheck] = ht.probeScratch.differs[toCheck] || unique

--- a/pkg/sql/colexec/like_ops.eg.go
+++ b/pkg/sql/colexec/like_ops.eg.go
@@ -39,7 +39,7 @@ func (p *selPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = bytes.HasPrefix(arg, p.constArg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -50,10 +50,10 @@ func (p *selPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = bytes.HasPrefix(arg, p.constArg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -67,7 +67,7 @@ func (p *selPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = bytes.HasPrefix(arg, p.constArg)
 					isNull = false
 					if cmp && !isNull {
@@ -78,10 +78,10 @@ func (p *selPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = bytes.HasPrefix(arg, p.constArg)
 					isNull = false
 					if cmp && !isNull {
@@ -136,7 +136,7 @@ func (p projPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = bytes.HasPrefix(arg, p.constArg)
 				}
 			}
@@ -144,11 +144,11 @@ func (p projPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = bytes.HasPrefix(arg, p.constArg)
 				}
 			}
@@ -159,16 +159,16 @@ func (p projPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = bytes.HasPrefix(arg, p.constArg)
 			}
 		} else {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = bytes.HasPrefix(arg, p.constArg)
 			}
 		}
@@ -212,7 +212,7 @@ func (p *selSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = bytes.HasSuffix(arg, p.constArg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -223,10 +223,10 @@ func (p *selSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = bytes.HasSuffix(arg, p.constArg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -240,7 +240,7 @@ func (p *selSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = bytes.HasSuffix(arg, p.constArg)
 					isNull = false
 					if cmp && !isNull {
@@ -251,10 +251,10 @@ func (p *selSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = bytes.HasSuffix(arg, p.constArg)
 					isNull = false
 					if cmp && !isNull {
@@ -309,7 +309,7 @@ func (p projSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = bytes.HasSuffix(arg, p.constArg)
 				}
 			}
@@ -317,11 +317,11 @@ func (p projSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = bytes.HasSuffix(arg, p.constArg)
 				}
 			}
@@ -332,16 +332,16 @@ func (p projSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = bytes.HasSuffix(arg, p.constArg)
 			}
 		} else {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = bytes.HasSuffix(arg, p.constArg)
 			}
 		}
@@ -385,7 +385,7 @@ func (p *selRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = p.constArg.Match(arg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -396,10 +396,10 @@ func (p *selRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = p.constArg.Match(arg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -413,7 +413,7 @@ func (p *selRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = p.constArg.Match(arg)
 					isNull = false
 					if cmp && !isNull {
@@ -424,10 +424,10 @@ func (p *selRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = p.constArg.Match(arg)
 					isNull = false
 					if cmp && !isNull {
@@ -482,7 +482,7 @@ func (p projRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Match(arg)
 				}
 			}
@@ -490,11 +490,11 @@ func (p projRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Match(arg)
 				}
 			}
@@ -505,16 +505,16 @@ func (p projRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Match(arg)
 			}
 		} else {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Match(arg)
 			}
 		}
@@ -558,7 +558,7 @@ func (p *selNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !bytes.HasPrefix(arg, p.constArg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -569,10 +569,10 @@ func (p *selNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !bytes.HasPrefix(arg, p.constArg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -586,7 +586,7 @@ func (p *selNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !bytes.HasPrefix(arg, p.constArg)
 					isNull = false
 					if cmp && !isNull {
@@ -597,10 +597,10 @@ func (p *selNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !bytes.HasPrefix(arg, p.constArg)
 					isNull = false
 					if cmp && !isNull {
@@ -655,7 +655,7 @@ func (p projNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = !bytes.HasPrefix(arg, p.constArg)
 				}
 			}
@@ -663,11 +663,11 @@ func (p projNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = !bytes.HasPrefix(arg, p.constArg)
 				}
 			}
@@ -678,16 +678,16 @@ func (p projNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = !bytes.HasPrefix(arg, p.constArg)
 			}
 		} else {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = !bytes.HasPrefix(arg, p.constArg)
 			}
 		}
@@ -731,7 +731,7 @@ func (p *selNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !bytes.HasSuffix(arg, p.constArg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -742,10 +742,10 @@ func (p *selNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !bytes.HasSuffix(arg, p.constArg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -759,7 +759,7 @@ func (p *selNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !bytes.HasSuffix(arg, p.constArg)
 					isNull = false
 					if cmp && !isNull {
@@ -770,10 +770,10 @@ func (p *selNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !bytes.HasSuffix(arg, p.constArg)
 					isNull = false
 					if cmp && !isNull {
@@ -828,7 +828,7 @@ func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = !bytes.HasSuffix(arg, p.constArg)
 				}
 			}
@@ -836,11 +836,11 @@ func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = !bytes.HasSuffix(arg, p.constArg)
 				}
 			}
@@ -851,16 +851,16 @@ func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = !bytes.HasSuffix(arg, p.constArg)
 			}
 		} else {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = !bytes.HasSuffix(arg, p.constArg)
 			}
 		}
@@ -904,7 +904,7 @@ func (p *selNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !p.constArg.Match(arg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -915,10 +915,10 @@ func (p *selNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !p.constArg.Match(arg)
 					isNull = nulls.NullAt(i)
 					if cmp && !isNull {
@@ -932,7 +932,7 @@ func (p *selNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !p.constArg.Match(arg)
 					isNull = false
 					if cmp && !isNull {
@@ -943,10 +943,10 @@ func (p *selNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					cmp = !p.constArg.Match(arg)
 					isNull = false
 					if cmp && !isNull {
@@ -1001,7 +1001,7 @@ func (p projNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = !p.constArg.Match(arg)
 				}
 			}
@@ -1009,11 +1009,11 @@ func (p projNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = !p.constArg.Match(arg)
 				}
 			}
@@ -1024,16 +1024,16 @@ func (p projNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = !p.constArg.Match(arg)
 			}
 		} else {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = !p.constArg.Match(arg)
 			}
 		}

--- a/pkg/sql/colexec/mergejoinbase.eg.go
+++ b/pkg/sql/colexec/mergejoinbase.eg.go
@@ -66,9 +66,9 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 					return true
 				}
 				bufferedCol := bufferedGroup.firstTuple[colIdx].Bool()
-				prevVal := bufferedCol.Get(0) //gcassert:inline
+				prevVal := bufferedCol.Get(0)
 				col := batch.ColVec(int(colIdx)).Bool()
-				curVal := col.Get(tupleToLookAtIdx) //gcassert:inline
+				curVal := col.Get(tupleToLookAtIdx)
 				var match bool
 
 				{
@@ -111,9 +111,9 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 					return true
 				}
 				bufferedCol := bufferedGroup.firstTuple[colIdx].Bytes()
-				prevVal := bufferedCol.Get(0) //gcassert:inline
+				prevVal := bufferedCol.Get(0)
 				col := batch.ColVec(int(colIdx)).Bytes()
-				curVal := col.Get(tupleToLookAtIdx) //gcassert:inline
+				curVal := col.Get(tupleToLookAtIdx)
 				var match bool
 
 				{
@@ -148,9 +148,9 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 					return true
 				}
 				bufferedCol := bufferedGroup.firstTuple[colIdx].Decimal()
-				prevVal := bufferedCol.Get(0) //gcassert:inline
+				prevVal := bufferedCol.Get(0)
 				col := batch.ColVec(int(colIdx)).Decimal()
-				curVal := col.Get(tupleToLookAtIdx) //gcassert:inline
+				curVal := col.Get(tupleToLookAtIdx)
 				var match bool
 
 				{
@@ -184,9 +184,9 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 					return true
 				}
 				bufferedCol := bufferedGroup.firstTuple[colIdx].Int16()
-				prevVal := bufferedCol.Get(0) //gcassert:inline
+				prevVal := bufferedCol.Get(0)
 				col := batch.ColVec(int(colIdx)).Int16()
-				curVal := col.Get(tupleToLookAtIdx) //gcassert:inline
+				curVal := col.Get(tupleToLookAtIdx)
 				var match bool
 
 				{
@@ -228,9 +228,9 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 					return true
 				}
 				bufferedCol := bufferedGroup.firstTuple[colIdx].Int32()
-				prevVal := bufferedCol.Get(0) //gcassert:inline
+				prevVal := bufferedCol.Get(0)
 				col := batch.ColVec(int(colIdx)).Int32()
-				curVal := col.Get(tupleToLookAtIdx) //gcassert:inline
+				curVal := col.Get(tupleToLookAtIdx)
 				var match bool
 
 				{
@@ -273,9 +273,9 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 					return true
 				}
 				bufferedCol := bufferedGroup.firstTuple[colIdx].Int64()
-				prevVal := bufferedCol.Get(0) //gcassert:inline
+				prevVal := bufferedCol.Get(0)
 				col := batch.ColVec(int(colIdx)).Int64()
-				curVal := col.Get(tupleToLookAtIdx) //gcassert:inline
+				curVal := col.Get(tupleToLookAtIdx)
 				var match bool
 
 				{
@@ -321,9 +321,9 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 					return true
 				}
 				bufferedCol := bufferedGroup.firstTuple[colIdx].Float64()
-				prevVal := bufferedCol.Get(0) //gcassert:inline
+				prevVal := bufferedCol.Get(0)
 				col := batch.ColVec(int(colIdx)).Float64()
-				curVal := col.Get(tupleToLookAtIdx) //gcassert:inline
+				curVal := col.Get(tupleToLookAtIdx)
 				var match bool
 
 				{
@@ -377,9 +377,9 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 					return true
 				}
 				bufferedCol := bufferedGroup.firstTuple[colIdx].Timestamp()
-				prevVal := bufferedCol.Get(0) //gcassert:inline
+				prevVal := bufferedCol.Get(0)
 				col := batch.ColVec(int(colIdx)).Timestamp()
-				curVal := col.Get(tupleToLookAtIdx) //gcassert:inline
+				curVal := col.Get(tupleToLookAtIdx)
 				var match bool
 
 				{
@@ -421,9 +421,9 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 					return true
 				}
 				bufferedCol := bufferedGroup.firstTuple[colIdx].Interval()
-				prevVal := bufferedCol.Get(0) //gcassert:inline
+				prevVal := bufferedCol.Get(0)
 				col := batch.ColVec(int(colIdx)).Interval()
-				curVal := col.Get(tupleToLookAtIdx) //gcassert:inline
+				curVal := col.Get(tupleToLookAtIdx)
 				var match bool
 
 				{

--- a/pkg/sql/colexec/mergejoinbase_tmpl.go
+++ b/pkg/sql/colexec/mergejoinbase_tmpl.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -90,9 +89,9 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 					return true
 				}
 				bufferedCol := bufferedGroup.firstTuple[colIdx].TemplateType()
-				prevVal := execgen.UNSAFEGET(bufferedCol, 0)
+				prevVal := bufferedCol.Get(0)
 				col := batch.ColVec(int(colIdx)).TemplateType()
-				curVal := execgen.UNSAFEGET(col, tupleToLookAtIdx)
+				curVal := col.Get(tupleToLookAtIdx)
 				var match bool
 				_ASSIGN_EQ(match, prevVal, curVal, _, bufferedCol, col)
 				if !match {

--- a/pkg/sql/colexec/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_exceptall.eg.go
@@ -164,9 +164,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -203,7 +203,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -241,7 +241,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -314,7 +314,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -417,9 +417,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -449,7 +449,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -479,7 +479,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -544,7 +544,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -639,9 +639,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -671,7 +671,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -701,7 +701,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -766,7 +766,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -860,9 +860,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -902,7 +902,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -943,7 +943,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1019,7 +1019,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -1121,9 +1121,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -1163,7 +1163,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1204,7 +1204,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1280,7 +1280,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -1383,9 +1383,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -1425,7 +1425,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1466,7 +1466,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1542,7 +1542,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -1648,9 +1648,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -1698,7 +1698,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1747,7 +1747,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1831,7 +1831,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -1945,9 +1945,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -1984,7 +1984,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2021,7 +2021,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2093,7 +2093,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -2195,9 +2195,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -2227,7 +2227,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2257,7 +2257,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2322,7 +2322,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -2642,9 +2642,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -2676,7 +2676,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2705,7 +2705,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2778,7 +2778,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -2871,9 +2871,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -2898,7 +2898,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2919,7 +2919,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2984,7 +2984,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -3069,9 +3069,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -3096,7 +3096,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3117,7 +3117,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3182,7 +3182,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -3266,9 +3266,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -3303,7 +3303,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3335,7 +3335,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3411,7 +3411,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -3503,9 +3503,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -3540,7 +3540,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3572,7 +3572,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3648,7 +3648,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -3741,9 +3741,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -3778,7 +3778,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3810,7 +3810,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3886,7 +3886,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -3982,9 +3982,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -4027,7 +4027,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4067,7 +4067,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4151,7 +4151,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -4255,9 +4255,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -4289,7 +4289,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4317,7 +4317,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4389,7 +4389,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -4481,9 +4481,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -4508,7 +4508,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4529,7 +4529,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4594,7 +4594,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -4890,9 +4890,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -4920,7 +4920,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4953,7 +4953,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5015,7 +5015,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5105,9 +5105,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -5128,7 +5128,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5153,7 +5153,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5207,7 +5207,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5289,9 +5289,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -5312,7 +5312,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5337,7 +5337,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5391,7 +5391,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5472,9 +5472,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -5505,7 +5505,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5541,7 +5541,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5606,7 +5606,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5695,9 +5695,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -5728,7 +5728,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5764,7 +5764,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5829,7 +5829,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5919,9 +5919,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -5952,7 +5952,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5988,7 +5988,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6053,7 +6053,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6146,9 +6146,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -6187,7 +6187,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6231,7 +6231,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6304,7 +6304,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6405,9 +6405,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -6435,7 +6435,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6467,7 +6467,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6528,7 +6528,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6617,9 +6617,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -6640,7 +6640,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6665,7 +6665,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6719,7 +6719,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6992,9 +6992,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -7021,7 +7021,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7050,7 +7050,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7112,7 +7112,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7196,9 +7196,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -7218,7 +7218,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7239,7 +7239,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7293,7 +7293,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7369,9 +7369,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -7391,7 +7391,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7412,7 +7412,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7466,7 +7466,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7541,9 +7541,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7573,7 +7573,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7605,7 +7605,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7670,7 +7670,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7753,9 +7753,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7785,7 +7785,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7817,7 +7817,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7882,7 +7882,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7966,9 +7966,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7998,7 +7998,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8030,7 +8030,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8095,7 +8095,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8182,9 +8182,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -8222,7 +8222,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8262,7 +8262,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8335,7 +8335,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8430,9 +8430,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -8459,7 +8459,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8487,7 +8487,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8548,7 +8548,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8631,9 +8631,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -8653,7 +8653,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8674,7 +8674,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8728,7 +8728,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9087,9 +9087,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -9126,7 +9126,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9164,7 +9164,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9237,7 +9237,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -9340,9 +9340,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -9372,7 +9372,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9402,7 +9402,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9467,7 +9467,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -9562,9 +9562,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -9594,7 +9594,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9624,7 +9624,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9689,7 +9689,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -9783,9 +9783,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -9825,7 +9825,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9866,7 +9866,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9942,7 +9942,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -10044,9 +10044,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -10086,7 +10086,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10127,7 +10127,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10203,7 +10203,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -10306,9 +10306,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -10348,7 +10348,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10389,7 +10389,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10465,7 +10465,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -10571,9 +10571,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -10621,7 +10621,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10670,7 +10670,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10754,7 +10754,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -10868,9 +10868,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -10907,7 +10907,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10944,7 +10944,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11016,7 +11016,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -11118,9 +11118,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -11150,7 +11150,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11180,7 +11180,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11245,7 +11245,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -11565,9 +11565,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -11599,7 +11599,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11628,7 +11628,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11701,7 +11701,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -11794,9 +11794,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -11821,7 +11821,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11842,7 +11842,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11907,7 +11907,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -11992,9 +11992,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -12019,7 +12019,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12040,7 +12040,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12105,7 +12105,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -12189,9 +12189,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -12226,7 +12226,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12258,7 +12258,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12334,7 +12334,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -12426,9 +12426,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -12463,7 +12463,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12495,7 +12495,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12571,7 +12571,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -12664,9 +12664,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -12701,7 +12701,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12733,7 +12733,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12809,7 +12809,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -12905,9 +12905,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -12950,7 +12950,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12990,7 +12990,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13074,7 +13074,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -13178,9 +13178,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -13212,7 +13212,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13240,7 +13240,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13312,7 +13312,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -13404,9 +13404,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -13431,7 +13431,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13452,7 +13452,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13517,7 +13517,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = lSel[curLIdx]
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -13813,9 +13813,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -13843,7 +13843,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13876,7 +13876,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13938,7 +13938,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14028,9 +14028,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -14051,7 +14051,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14076,7 +14076,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14130,7 +14130,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14212,9 +14212,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -14235,7 +14235,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14260,7 +14260,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14314,7 +14314,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14395,9 +14395,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -14428,7 +14428,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14464,7 +14464,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14529,7 +14529,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14618,9 +14618,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -14651,7 +14651,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14687,7 +14687,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14752,7 +14752,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14842,9 +14842,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -14875,7 +14875,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14911,7 +14911,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14976,7 +14976,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15069,9 +15069,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -15110,7 +15110,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15154,7 +15154,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15227,7 +15227,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15328,9 +15328,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -15358,7 +15358,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15390,7 +15390,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15451,7 +15451,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15540,9 +15540,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -15563,7 +15563,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15588,7 +15588,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15642,7 +15642,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15915,9 +15915,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -15944,7 +15944,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15973,7 +15973,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16035,7 +16035,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16119,9 +16119,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -16141,7 +16141,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16162,7 +16162,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16216,7 +16216,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16292,9 +16292,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -16314,7 +16314,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16335,7 +16335,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16389,7 +16389,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16464,9 +16464,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -16496,7 +16496,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16528,7 +16528,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16593,7 +16593,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16676,9 +16676,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -16708,7 +16708,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16740,7 +16740,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16805,7 +16805,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16889,9 +16889,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -16921,7 +16921,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16953,7 +16953,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17018,7 +17018,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17105,9 +17105,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -17145,7 +17145,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17185,7 +17185,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17258,7 +17258,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17353,9 +17353,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -17382,7 +17382,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17410,7 +17410,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17471,7 +17471,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17554,9 +17554,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -17576,7 +17576,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17597,7 +17597,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17651,7 +17651,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18010,9 +18010,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -18049,7 +18049,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18087,7 +18087,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18160,7 +18160,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -18263,9 +18263,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -18295,7 +18295,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18325,7 +18325,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18390,7 +18390,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -18485,9 +18485,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -18517,7 +18517,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18547,7 +18547,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18612,7 +18612,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -18706,9 +18706,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -18748,7 +18748,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18789,7 +18789,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18865,7 +18865,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -18967,9 +18967,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -19009,7 +19009,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19050,7 +19050,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19126,7 +19126,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -19229,9 +19229,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -19271,7 +19271,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19312,7 +19312,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19388,7 +19388,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -19494,9 +19494,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -19544,7 +19544,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19593,7 +19593,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19677,7 +19677,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -19791,9 +19791,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -19830,7 +19830,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19867,7 +19867,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19939,7 +19939,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -20041,9 +20041,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -20073,7 +20073,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20103,7 +20103,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20168,7 +20168,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -20488,9 +20488,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -20522,7 +20522,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20551,7 +20551,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20624,7 +20624,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -20717,9 +20717,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -20744,7 +20744,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20765,7 +20765,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20830,7 +20830,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -20915,9 +20915,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -20942,7 +20942,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20963,7 +20963,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21028,7 +21028,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -21112,9 +21112,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -21149,7 +21149,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21181,7 +21181,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21257,7 +21257,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -21349,9 +21349,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -21386,7 +21386,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21418,7 +21418,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21494,7 +21494,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -21587,9 +21587,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -21624,7 +21624,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21656,7 +21656,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21732,7 +21732,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -21828,9 +21828,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -21873,7 +21873,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21913,7 +21913,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21997,7 +21997,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -22101,9 +22101,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -22135,7 +22135,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22163,7 +22163,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22235,7 +22235,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -22327,9 +22327,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -22354,7 +22354,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22375,7 +22375,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22440,7 +22440,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -22736,9 +22736,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -22766,7 +22766,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22799,7 +22799,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22861,7 +22861,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22951,9 +22951,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -22974,7 +22974,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22999,7 +22999,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23053,7 +23053,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23135,9 +23135,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -23158,7 +23158,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23183,7 +23183,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23237,7 +23237,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23318,9 +23318,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -23351,7 +23351,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23387,7 +23387,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23452,7 +23452,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23541,9 +23541,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -23574,7 +23574,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23610,7 +23610,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23675,7 +23675,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23765,9 +23765,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -23798,7 +23798,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23834,7 +23834,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23899,7 +23899,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23992,9 +23992,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -24033,7 +24033,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24077,7 +24077,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24150,7 +24150,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24251,9 +24251,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -24281,7 +24281,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24313,7 +24313,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24374,7 +24374,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24463,9 +24463,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -24486,7 +24486,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24511,7 +24511,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24565,7 +24565,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24838,9 +24838,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -24867,7 +24867,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24896,7 +24896,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24958,7 +24958,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25042,9 +25042,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -25064,7 +25064,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25085,7 +25085,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25139,7 +25139,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25215,9 +25215,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -25237,7 +25237,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25258,7 +25258,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25312,7 +25312,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25387,9 +25387,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -25419,7 +25419,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25451,7 +25451,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25516,7 +25516,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25599,9 +25599,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -25631,7 +25631,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25663,7 +25663,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25728,7 +25728,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25812,9 +25812,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -25844,7 +25844,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25876,7 +25876,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25941,7 +25941,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26028,9 +26028,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -26068,7 +26068,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26108,7 +26108,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26181,7 +26181,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26276,9 +26276,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -26305,7 +26305,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26333,7 +26333,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26394,7 +26394,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26477,9 +26477,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -26499,7 +26499,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26520,7 +26520,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26574,7 +26574,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26933,9 +26933,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -26972,7 +26972,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27010,7 +27010,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27083,7 +27083,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -27186,9 +27186,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -27218,7 +27218,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27248,7 +27248,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27313,7 +27313,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -27408,9 +27408,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -27440,7 +27440,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27470,7 +27470,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27535,7 +27535,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -27629,9 +27629,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -27671,7 +27671,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27712,7 +27712,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27788,7 +27788,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -27890,9 +27890,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -27932,7 +27932,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27973,7 +27973,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28049,7 +28049,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -28152,9 +28152,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -28194,7 +28194,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28235,7 +28235,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28311,7 +28311,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -28417,9 +28417,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -28467,7 +28467,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28516,7 +28516,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28600,7 +28600,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -28714,9 +28714,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -28753,7 +28753,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28790,7 +28790,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28862,7 +28862,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -28964,9 +28964,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -28996,7 +28996,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29026,7 +29026,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29091,7 +29091,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -29411,9 +29411,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -29445,7 +29445,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29474,7 +29474,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29547,7 +29547,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -29640,9 +29640,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -29667,7 +29667,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29688,7 +29688,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29753,7 +29753,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -29838,9 +29838,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -29865,7 +29865,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29886,7 +29886,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29951,7 +29951,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -30035,9 +30035,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -30072,7 +30072,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30104,7 +30104,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30180,7 +30180,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -30272,9 +30272,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -30309,7 +30309,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30341,7 +30341,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30417,7 +30417,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -30510,9 +30510,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -30547,7 +30547,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30579,7 +30579,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30655,7 +30655,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -30751,9 +30751,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -30796,7 +30796,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30836,7 +30836,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30920,7 +30920,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -31024,9 +31024,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -31058,7 +31058,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31086,7 +31086,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31158,7 +31158,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -31250,9 +31250,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -31277,7 +31277,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31298,7 +31298,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31363,7 +31363,7 @@ EqLoop:
 
 											if !nullMatch {
 												lSelIdx = curLIdx
-												newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+												newLVal := lKeys.Get(lSelIdx)
 
 												{
 													var cmpResult int
@@ -31659,9 +31659,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -31689,7 +31689,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31722,7 +31722,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31784,7 +31784,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31874,9 +31874,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -31897,7 +31897,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31922,7 +31922,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31976,7 +31976,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32058,9 +32058,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -32081,7 +32081,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32106,7 +32106,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32160,7 +32160,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32241,9 +32241,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -32274,7 +32274,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32310,7 +32310,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32375,7 +32375,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32464,9 +32464,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -32497,7 +32497,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32533,7 +32533,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32598,7 +32598,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32688,9 +32688,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -32721,7 +32721,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32757,7 +32757,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32822,7 +32822,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32915,9 +32915,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -32956,7 +32956,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33000,7 +33000,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33073,7 +33073,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33174,9 +33174,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -33204,7 +33204,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33236,7 +33236,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33297,7 +33297,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33386,9 +33386,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -33409,7 +33409,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33434,7 +33434,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33488,7 +33488,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33761,9 +33761,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -33790,7 +33790,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33819,7 +33819,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33881,7 +33881,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33965,9 +33965,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -33987,7 +33987,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34008,7 +34008,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34062,7 +34062,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34138,9 +34138,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -34160,7 +34160,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34181,7 +34181,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34235,7 +34235,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34310,9 +34310,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -34342,7 +34342,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34374,7 +34374,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34439,7 +34439,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34522,9 +34522,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -34554,7 +34554,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34586,7 +34586,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34651,7 +34651,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34735,9 +34735,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -34767,7 +34767,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34799,7 +34799,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34864,7 +34864,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34951,9 +34951,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -34991,7 +34991,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35031,7 +35031,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -35104,7 +35104,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35199,9 +35199,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -35228,7 +35228,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35256,7 +35256,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -35317,7 +35317,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35400,9 +35400,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -35422,7 +35422,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35443,7 +35443,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -35497,7 +35497,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35809,7 +35809,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35874,7 +35874,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -35939,7 +35939,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -36003,7 +36003,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36064,7 +36064,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36126,7 +36126,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36191,7 +36191,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36256,7 +36256,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36321,7 +36321,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36454,7 +36454,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36516,7 +36516,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -36578,7 +36578,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -36639,7 +36639,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36697,7 +36697,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36756,7 +36756,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36818,7 +36818,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36880,7 +36880,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36942,7 +36942,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -37076,7 +37076,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -37140,7 +37140,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -37204,7 +37204,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -37267,7 +37267,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -37327,7 +37327,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -37388,7 +37388,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -37452,7 +37452,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -37516,7 +37516,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -37580,7 +37580,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -37711,7 +37711,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -37772,7 +37772,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -37833,7 +37833,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -37893,7 +37893,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -37950,7 +37950,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -38008,7 +38008,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -38069,7 +38069,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -38130,7 +38130,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -38191,7 +38191,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -38366,7 +38366,7 @@ func (o *mergeJoinExceptAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -38430,7 +38430,7 @@ func (o *mergeJoinExceptAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol.Set(outStartIdx, val)
 										outStartIdx++
@@ -38494,7 +38494,7 @@ func (o *mergeJoinExceptAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx].Set(&val)
 										outStartIdx++
@@ -38557,7 +38557,7 @@ func (o *mergeJoinExceptAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -38617,7 +38617,7 @@ func (o *mergeJoinExceptAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -38678,7 +38678,7 @@ func (o *mergeJoinExceptAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -38742,7 +38742,7 @@ func (o *mergeJoinExceptAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -38806,7 +38806,7 @@ func (o *mergeJoinExceptAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -38870,7 +38870,7 @@ func (o *mergeJoinExceptAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -39076,7 +39076,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39144,7 +39144,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -39212,7 +39212,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -39279,7 +39279,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39343,7 +39343,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39408,7 +39408,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39476,7 +39476,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39544,7 +39544,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39612,7 +39612,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39752,7 +39752,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39818,7 +39818,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -39884,7 +39884,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -39949,7 +39949,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40011,7 +40011,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40074,7 +40074,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40140,7 +40140,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40206,7 +40206,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40272,7 +40272,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40414,7 +40414,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40482,7 +40482,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -40550,7 +40550,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -40617,7 +40617,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40681,7 +40681,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40746,7 +40746,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40814,7 +40814,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40882,7 +40882,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40950,7 +40950,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -41090,7 +41090,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -41156,7 +41156,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -41222,7 +41222,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -41287,7 +41287,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -41349,7 +41349,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -41412,7 +41412,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -41478,7 +41478,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -41544,7 +41544,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -41610,7 +41610,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -41783,7 +41783,7 @@ func (o *mergeJoinExceptAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -41812,7 +41812,7 @@ func (o *mergeJoinExceptAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol.Set(outStartIdx, v)
 									}
 								} else {
@@ -41841,7 +41841,7 @@ func (o *mergeJoinExceptAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx].Set(&v)
 									}
 								} else {
@@ -41869,7 +41869,7 @@ func (o *mergeJoinExceptAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -41894,7 +41894,7 @@ func (o *mergeJoinExceptAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -41920,7 +41920,7 @@ func (o *mergeJoinExceptAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -41949,7 +41949,7 @@ func (o *mergeJoinExceptAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -41978,7 +41978,7 @@ func (o *mergeJoinExceptAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -42007,7 +42007,7 @@ func (o *mergeJoinExceptAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {

--- a/pkg/sql/colexec/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_fullouter.eg.go
@@ -173,9 +173,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -206,7 +206,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -239,7 +239,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -301,7 +301,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -334,7 +334,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -452,9 +452,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -478,7 +478,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -503,7 +503,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -557,7 +557,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -582,7 +582,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -692,9 +692,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -718,7 +718,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -743,7 +743,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -797,7 +797,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -822,7 +822,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -931,9 +931,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -967,7 +967,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1003,7 +1003,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1068,7 +1068,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1104,7 +1104,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1221,9 +1221,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -1257,7 +1257,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1293,7 +1293,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1358,7 +1358,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1394,7 +1394,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1512,9 +1512,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -1548,7 +1548,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1584,7 +1584,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1649,7 +1649,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1685,7 +1685,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1806,9 +1806,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -1850,7 +1850,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1894,7 +1894,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1967,7 +1967,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2011,7 +2011,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2140,9 +2140,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -2173,7 +2173,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2205,7 +2205,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2266,7 +2266,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2298,7 +2298,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2415,9 +2415,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -2441,7 +2441,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2466,7 +2466,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2520,7 +2520,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2545,7 +2545,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2903,9 +2903,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -2936,7 +2936,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2965,7 +2965,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3027,7 +3027,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3057,7 +3057,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3168,9 +3168,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -3194,7 +3194,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3215,7 +3215,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3269,7 +3269,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3291,7 +3291,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3394,9 +3394,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -3420,7 +3420,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3441,7 +3441,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3495,7 +3495,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3517,7 +3517,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3619,9 +3619,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3655,7 +3655,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3687,7 +3687,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3752,7 +3752,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3785,7 +3785,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3895,9 +3895,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3931,7 +3931,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3963,7 +3963,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4028,7 +4028,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4061,7 +4061,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4172,9 +4172,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -4208,7 +4208,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4240,7 +4240,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4305,7 +4305,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4338,7 +4338,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4452,9 +4452,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -4496,7 +4496,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4536,7 +4536,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4609,7 +4609,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4650,7 +4650,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4772,9 +4772,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -4805,7 +4805,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4833,7 +4833,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4894,7 +4894,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4923,7 +4923,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5033,9 +5033,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -5059,7 +5059,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5080,7 +5080,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5134,7 +5134,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5156,7 +5156,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5502,9 +5502,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -5531,7 +5531,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5564,7 +5564,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5623,7 +5623,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5656,7 +5656,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5767,9 +5767,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -5789,7 +5789,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5814,7 +5814,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5865,7 +5865,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5890,7 +5890,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5993,9 +5993,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -6015,7 +6015,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6040,7 +6040,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6091,7 +6091,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6116,7 +6116,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6218,9 +6218,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -6250,7 +6250,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6286,7 +6286,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6348,7 +6348,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6384,7 +6384,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6494,9 +6494,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -6526,7 +6526,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6562,7 +6562,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6624,7 +6624,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6660,7 +6660,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6771,9 +6771,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -6803,7 +6803,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6839,7 +6839,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6901,7 +6901,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6937,7 +6937,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7051,9 +7051,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -7091,7 +7091,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7135,7 +7135,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7205,7 +7205,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7249,7 +7249,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7371,9 +7371,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -7400,7 +7400,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7432,7 +7432,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7490,7 +7490,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7522,7 +7522,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7632,9 +7632,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -7654,7 +7654,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7679,7 +7679,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7730,7 +7730,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7755,7 +7755,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8092,9 +8092,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -8121,7 +8121,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8150,7 +8150,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8209,7 +8209,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8239,7 +8239,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8343,9 +8343,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -8365,7 +8365,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8386,7 +8386,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8437,7 +8437,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8459,7 +8459,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8555,9 +8555,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -8577,7 +8577,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8598,7 +8598,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8649,7 +8649,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8671,7 +8671,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8766,9 +8766,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -8798,7 +8798,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8830,7 +8830,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8892,7 +8892,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8925,7 +8925,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9028,9 +9028,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9060,7 +9060,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9092,7 +9092,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9154,7 +9154,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9187,7 +9187,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9291,9 +9291,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9323,7 +9323,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9355,7 +9355,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9417,7 +9417,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9450,7 +9450,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9557,9 +9557,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -9597,7 +9597,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9637,7 +9637,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9707,7 +9707,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9748,7 +9748,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9863,9 +9863,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -9892,7 +9892,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9920,7 +9920,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9978,7 +9978,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10007,7 +10007,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10110,9 +10110,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -10132,7 +10132,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10153,7 +10153,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10204,7 +10204,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10226,7 +10226,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10642,9 +10642,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -10675,7 +10675,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10708,7 +10708,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10770,7 +10770,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10803,7 +10803,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10921,9 +10921,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -10947,7 +10947,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10972,7 +10972,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11026,7 +11026,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11051,7 +11051,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11161,9 +11161,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -11187,7 +11187,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11212,7 +11212,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11266,7 +11266,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11291,7 +11291,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11400,9 +11400,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -11436,7 +11436,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11472,7 +11472,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11537,7 +11537,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11573,7 +11573,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11690,9 +11690,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -11726,7 +11726,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11762,7 +11762,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11827,7 +11827,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11863,7 +11863,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11981,9 +11981,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -12017,7 +12017,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12053,7 +12053,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12118,7 +12118,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12154,7 +12154,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12275,9 +12275,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -12319,7 +12319,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12363,7 +12363,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12436,7 +12436,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12480,7 +12480,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12609,9 +12609,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -12642,7 +12642,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12674,7 +12674,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12735,7 +12735,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12767,7 +12767,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12884,9 +12884,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -12910,7 +12910,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12935,7 +12935,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12989,7 +12989,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13014,7 +13014,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13372,9 +13372,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -13405,7 +13405,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13434,7 +13434,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13496,7 +13496,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13526,7 +13526,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13637,9 +13637,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -13663,7 +13663,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13684,7 +13684,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13738,7 +13738,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13760,7 +13760,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13863,9 +13863,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -13889,7 +13889,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13910,7 +13910,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13964,7 +13964,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13986,7 +13986,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14088,9 +14088,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -14124,7 +14124,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14156,7 +14156,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14221,7 +14221,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14254,7 +14254,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14364,9 +14364,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -14400,7 +14400,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14432,7 +14432,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14497,7 +14497,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14530,7 +14530,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14641,9 +14641,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -14677,7 +14677,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14709,7 +14709,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14774,7 +14774,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14807,7 +14807,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14921,9 +14921,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -14965,7 +14965,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15005,7 +15005,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15078,7 +15078,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15119,7 +15119,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15241,9 +15241,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -15274,7 +15274,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15302,7 +15302,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15363,7 +15363,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15392,7 +15392,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15502,9 +15502,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -15528,7 +15528,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15549,7 +15549,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15603,7 +15603,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15625,7 +15625,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15971,9 +15971,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -16000,7 +16000,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16033,7 +16033,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16092,7 +16092,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16125,7 +16125,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16236,9 +16236,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -16258,7 +16258,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16283,7 +16283,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16334,7 +16334,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16359,7 +16359,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16462,9 +16462,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -16484,7 +16484,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16509,7 +16509,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16560,7 +16560,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16585,7 +16585,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16687,9 +16687,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -16719,7 +16719,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16755,7 +16755,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16817,7 +16817,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16853,7 +16853,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16963,9 +16963,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -16995,7 +16995,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17031,7 +17031,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17093,7 +17093,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17129,7 +17129,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17240,9 +17240,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -17272,7 +17272,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17308,7 +17308,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17370,7 +17370,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17406,7 +17406,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17520,9 +17520,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -17560,7 +17560,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17604,7 +17604,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17674,7 +17674,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17718,7 +17718,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17840,9 +17840,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -17869,7 +17869,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17901,7 +17901,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17959,7 +17959,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17991,7 +17991,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18101,9 +18101,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -18123,7 +18123,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18148,7 +18148,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18199,7 +18199,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18224,7 +18224,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18561,9 +18561,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -18590,7 +18590,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18619,7 +18619,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18678,7 +18678,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18708,7 +18708,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18812,9 +18812,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -18834,7 +18834,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18855,7 +18855,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18906,7 +18906,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18928,7 +18928,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19024,9 +19024,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -19046,7 +19046,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19067,7 +19067,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19118,7 +19118,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19140,7 +19140,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19235,9 +19235,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -19267,7 +19267,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19299,7 +19299,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19361,7 +19361,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19394,7 +19394,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19497,9 +19497,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -19529,7 +19529,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19561,7 +19561,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19623,7 +19623,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19656,7 +19656,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19760,9 +19760,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -19792,7 +19792,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19824,7 +19824,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19886,7 +19886,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19919,7 +19919,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20026,9 +20026,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -20066,7 +20066,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20106,7 +20106,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20176,7 +20176,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20217,7 +20217,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20332,9 +20332,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -20361,7 +20361,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20389,7 +20389,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20447,7 +20447,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20476,7 +20476,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20579,9 +20579,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -20601,7 +20601,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20622,7 +20622,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20673,7 +20673,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20695,7 +20695,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21111,9 +21111,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -21144,7 +21144,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21177,7 +21177,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21239,7 +21239,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21272,7 +21272,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21390,9 +21390,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -21416,7 +21416,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21441,7 +21441,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21495,7 +21495,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21520,7 +21520,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21630,9 +21630,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -21656,7 +21656,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21681,7 +21681,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21735,7 +21735,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21760,7 +21760,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21869,9 +21869,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -21905,7 +21905,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21941,7 +21941,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22006,7 +22006,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22042,7 +22042,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22159,9 +22159,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22195,7 +22195,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22231,7 +22231,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22296,7 +22296,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22332,7 +22332,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22450,9 +22450,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22486,7 +22486,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22522,7 +22522,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22587,7 +22587,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22623,7 +22623,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22744,9 +22744,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -22788,7 +22788,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22832,7 +22832,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22905,7 +22905,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22949,7 +22949,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23078,9 +23078,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -23111,7 +23111,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23143,7 +23143,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23204,7 +23204,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23236,7 +23236,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23353,9 +23353,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -23379,7 +23379,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23404,7 +23404,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23458,7 +23458,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23483,7 +23483,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23841,9 +23841,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -23874,7 +23874,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23903,7 +23903,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23965,7 +23965,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23995,7 +23995,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24106,9 +24106,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -24132,7 +24132,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24153,7 +24153,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24207,7 +24207,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24229,7 +24229,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24332,9 +24332,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -24358,7 +24358,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24379,7 +24379,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24433,7 +24433,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24455,7 +24455,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24557,9 +24557,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -24593,7 +24593,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24625,7 +24625,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24690,7 +24690,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24723,7 +24723,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24833,9 +24833,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -24869,7 +24869,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24901,7 +24901,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24966,7 +24966,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24999,7 +24999,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25110,9 +25110,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -25146,7 +25146,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25178,7 +25178,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25243,7 +25243,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25276,7 +25276,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25390,9 +25390,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -25434,7 +25434,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25474,7 +25474,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25547,7 +25547,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25588,7 +25588,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25710,9 +25710,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -25743,7 +25743,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25771,7 +25771,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25832,7 +25832,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25861,7 +25861,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25971,9 +25971,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -25997,7 +25997,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26018,7 +26018,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26072,7 +26072,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26094,7 +26094,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26440,9 +26440,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -26469,7 +26469,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26502,7 +26502,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26561,7 +26561,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26594,7 +26594,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26705,9 +26705,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -26727,7 +26727,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26752,7 +26752,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26803,7 +26803,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26828,7 +26828,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26931,9 +26931,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -26953,7 +26953,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26978,7 +26978,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27029,7 +27029,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27054,7 +27054,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27156,9 +27156,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -27188,7 +27188,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27224,7 +27224,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27286,7 +27286,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27322,7 +27322,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27432,9 +27432,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -27464,7 +27464,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27500,7 +27500,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27562,7 +27562,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27598,7 +27598,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27709,9 +27709,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -27741,7 +27741,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27777,7 +27777,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27839,7 +27839,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27875,7 +27875,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27989,9 +27989,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -28029,7 +28029,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28073,7 +28073,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28143,7 +28143,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28187,7 +28187,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28309,9 +28309,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -28338,7 +28338,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28370,7 +28370,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28428,7 +28428,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28460,7 +28460,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28570,9 +28570,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -28592,7 +28592,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28617,7 +28617,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28668,7 +28668,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28693,7 +28693,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29030,9 +29030,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -29059,7 +29059,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29088,7 +29088,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29147,7 +29147,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29177,7 +29177,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29281,9 +29281,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -29303,7 +29303,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29324,7 +29324,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29375,7 +29375,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29397,7 +29397,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29493,9 +29493,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -29515,7 +29515,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29536,7 +29536,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29587,7 +29587,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29609,7 +29609,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29704,9 +29704,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -29736,7 +29736,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29768,7 +29768,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29830,7 +29830,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29863,7 +29863,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29966,9 +29966,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -29998,7 +29998,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30030,7 +30030,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30092,7 +30092,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30125,7 +30125,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30229,9 +30229,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -30261,7 +30261,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30293,7 +30293,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30355,7 +30355,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30388,7 +30388,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30495,9 +30495,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -30535,7 +30535,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30575,7 +30575,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30645,7 +30645,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30686,7 +30686,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30801,9 +30801,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -30830,7 +30830,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30858,7 +30858,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30916,7 +30916,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30945,7 +30945,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31048,9 +31048,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -31070,7 +31070,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31091,7 +31091,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31142,7 +31142,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31164,7 +31164,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31580,9 +31580,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -31613,7 +31613,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31646,7 +31646,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31708,7 +31708,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31741,7 +31741,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31859,9 +31859,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -31885,7 +31885,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31910,7 +31910,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31964,7 +31964,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31989,7 +31989,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32099,9 +32099,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -32125,7 +32125,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32150,7 +32150,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32204,7 +32204,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32229,7 +32229,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32338,9 +32338,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -32374,7 +32374,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32410,7 +32410,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32475,7 +32475,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32511,7 +32511,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32628,9 +32628,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -32664,7 +32664,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32700,7 +32700,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32765,7 +32765,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32801,7 +32801,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32919,9 +32919,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -32955,7 +32955,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32991,7 +32991,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33056,7 +33056,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33092,7 +33092,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33213,9 +33213,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -33257,7 +33257,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33301,7 +33301,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33374,7 +33374,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33418,7 +33418,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33547,9 +33547,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -33580,7 +33580,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33612,7 +33612,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33673,7 +33673,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33705,7 +33705,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33822,9 +33822,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -33848,7 +33848,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33873,7 +33873,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33927,7 +33927,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33952,7 +33952,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34310,9 +34310,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -34343,7 +34343,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34372,7 +34372,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34434,7 +34434,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34464,7 +34464,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34575,9 +34575,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -34601,7 +34601,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34622,7 +34622,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34676,7 +34676,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34698,7 +34698,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34801,9 +34801,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -34827,7 +34827,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34848,7 +34848,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34902,7 +34902,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34924,7 +34924,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -35026,9 +35026,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -35062,7 +35062,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35094,7 +35094,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -35159,7 +35159,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35192,7 +35192,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -35302,9 +35302,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -35338,7 +35338,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35370,7 +35370,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -35435,7 +35435,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35468,7 +35468,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -35579,9 +35579,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -35615,7 +35615,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35647,7 +35647,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -35712,7 +35712,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35745,7 +35745,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -35859,9 +35859,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -35903,7 +35903,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -35943,7 +35943,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -36016,7 +36016,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -36057,7 +36057,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -36179,9 +36179,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -36212,7 +36212,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -36240,7 +36240,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -36301,7 +36301,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -36330,7 +36330,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -36440,9 +36440,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -36466,7 +36466,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -36487,7 +36487,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -36541,7 +36541,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -36563,7 +36563,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -36909,9 +36909,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -36938,7 +36938,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -36971,7 +36971,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -37030,7 +37030,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -37063,7 +37063,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -37174,9 +37174,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -37196,7 +37196,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -37221,7 +37221,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -37272,7 +37272,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -37297,7 +37297,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -37400,9 +37400,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -37422,7 +37422,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -37447,7 +37447,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -37498,7 +37498,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -37523,7 +37523,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -37625,9 +37625,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -37657,7 +37657,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -37693,7 +37693,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -37755,7 +37755,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -37791,7 +37791,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -37901,9 +37901,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -37933,7 +37933,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -37969,7 +37969,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -38031,7 +38031,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -38067,7 +38067,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -38178,9 +38178,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -38210,7 +38210,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -38246,7 +38246,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -38308,7 +38308,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -38344,7 +38344,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -38458,9 +38458,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -38498,7 +38498,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -38542,7 +38542,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -38612,7 +38612,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -38656,7 +38656,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -38778,9 +38778,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -38807,7 +38807,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -38839,7 +38839,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -38897,7 +38897,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -38929,7 +38929,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -39039,9 +39039,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -39061,7 +39061,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -39086,7 +39086,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -39137,7 +39137,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -39162,7 +39162,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -39499,9 +39499,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -39528,7 +39528,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -39557,7 +39557,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -39616,7 +39616,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -39646,7 +39646,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -39750,9 +39750,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -39772,7 +39772,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -39793,7 +39793,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -39844,7 +39844,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -39866,7 +39866,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -39962,9 +39962,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -39984,7 +39984,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -40005,7 +40005,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -40056,7 +40056,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -40078,7 +40078,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -40173,9 +40173,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -40205,7 +40205,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -40237,7 +40237,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -40299,7 +40299,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -40332,7 +40332,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -40435,9 +40435,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -40467,7 +40467,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -40499,7 +40499,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -40561,7 +40561,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -40594,7 +40594,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -40698,9 +40698,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -40730,7 +40730,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -40762,7 +40762,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -40824,7 +40824,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -40857,7 +40857,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -40964,9 +40964,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -41004,7 +41004,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -41044,7 +41044,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -41114,7 +41114,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -41155,7 +41155,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -41270,9 +41270,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -41299,7 +41299,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -41327,7 +41327,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -41385,7 +41385,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -41414,7 +41414,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -41517,9 +41517,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -41539,7 +41539,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -41560,7 +41560,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -41611,7 +41611,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -41633,7 +41633,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -41993,7 +41993,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -42058,7 +42058,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -42123,7 +42123,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -42187,7 +42187,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -42248,7 +42248,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -42310,7 +42310,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -42375,7 +42375,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -42440,7 +42440,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -42505,7 +42505,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -42638,7 +42638,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -42700,7 +42700,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -42762,7 +42762,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -42823,7 +42823,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -42881,7 +42881,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -42940,7 +42940,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43002,7 +43002,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43064,7 +43064,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43126,7 +43126,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43260,7 +43260,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43324,7 +43324,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -43388,7 +43388,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -43451,7 +43451,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43511,7 +43511,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43572,7 +43572,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43636,7 +43636,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43700,7 +43700,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43764,7 +43764,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43895,7 +43895,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -43956,7 +43956,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -44017,7 +44017,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -44077,7 +44077,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -44134,7 +44134,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -44192,7 +44192,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -44253,7 +44253,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -44314,7 +44314,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -44375,7 +44375,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -44539,7 +44539,7 @@ func (o *mergeJoinFullOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -44588,7 +44588,7 @@ func (o *mergeJoinFullOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol.Set(outStartIdx, val)
 										outStartIdx++
@@ -44637,7 +44637,7 @@ func (o *mergeJoinFullOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx].Set(&val)
 										outStartIdx++
@@ -44685,7 +44685,7 @@ func (o *mergeJoinFullOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -44730,7 +44730,7 @@ func (o *mergeJoinFullOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -44776,7 +44776,7 @@ func (o *mergeJoinFullOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -44825,7 +44825,7 @@ func (o *mergeJoinFullOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -44874,7 +44874,7 @@ func (o *mergeJoinFullOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -44923,7 +44923,7 @@ func (o *mergeJoinFullOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -45112,7 +45112,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -45182,7 +45182,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -45252,7 +45252,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -45321,7 +45321,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -45387,7 +45387,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -45454,7 +45454,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -45524,7 +45524,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -45594,7 +45594,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -45664,7 +45664,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -45808,7 +45808,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -45876,7 +45876,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -45944,7 +45944,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -46011,7 +46011,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -46075,7 +46075,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -46140,7 +46140,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -46208,7 +46208,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -46276,7 +46276,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -46344,7 +46344,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -46490,7 +46490,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -46560,7 +46560,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -46630,7 +46630,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -46699,7 +46699,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -46765,7 +46765,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -46832,7 +46832,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -46902,7 +46902,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -46972,7 +46972,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -47042,7 +47042,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -47186,7 +47186,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -47254,7 +47254,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -47322,7 +47322,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -47389,7 +47389,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -47453,7 +47453,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -47518,7 +47518,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -47586,7 +47586,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -47654,7 +47654,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -47722,7 +47722,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -47897,7 +47897,7 @@ func (o *mergeJoinFullOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -47926,7 +47926,7 @@ func (o *mergeJoinFullOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol.Set(outStartIdx, v)
 									}
 								} else {
@@ -47955,7 +47955,7 @@ func (o *mergeJoinFullOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx].Set(&v)
 									}
 								} else {
@@ -47983,7 +47983,7 @@ func (o *mergeJoinFullOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -48008,7 +48008,7 @@ func (o *mergeJoinFullOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -48034,7 +48034,7 @@ func (o *mergeJoinFullOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -48063,7 +48063,7 @@ func (o *mergeJoinFullOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -48092,7 +48092,7 @@ func (o *mergeJoinFullOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -48121,7 +48121,7 @@ func (o *mergeJoinFullOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {

--- a/pkg/sql/colexec/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/mergejoiner_inner.eg.go
@@ -150,9 +150,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -183,7 +183,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -216,7 +216,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -325,9 +325,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -351,7 +351,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -376,7 +376,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -477,9 +477,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -503,7 +503,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -528,7 +528,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -628,9 +628,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -664,7 +664,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -700,7 +700,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -808,9 +808,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -844,7 +844,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -880,7 +880,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -989,9 +989,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -1025,7 +1025,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1061,7 +1061,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1173,9 +1173,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -1217,7 +1217,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1261,7 +1261,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1381,9 +1381,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -1414,7 +1414,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1446,7 +1446,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1554,9 +1554,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -1580,7 +1580,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1605,7 +1605,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1863,9 +1863,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -1896,7 +1896,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1925,7 +1925,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2028,9 +2028,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -2054,7 +2054,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2075,7 +2075,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2170,9 +2170,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -2196,7 +2196,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2217,7 +2217,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2311,9 +2311,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -2347,7 +2347,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2379,7 +2379,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2481,9 +2481,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -2517,7 +2517,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2549,7 +2549,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2652,9 +2652,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -2688,7 +2688,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2720,7 +2720,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2826,9 +2826,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -2870,7 +2870,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2910,7 +2910,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3024,9 +3024,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -3057,7 +3057,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3085,7 +3085,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3187,9 +3187,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -3213,7 +3213,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3234,7 +3234,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3484,9 +3484,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -3513,7 +3513,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3546,7 +3546,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3649,9 +3649,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -3671,7 +3671,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3696,7 +3696,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3791,9 +3791,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -3813,7 +3813,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3838,7 +3838,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3932,9 +3932,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3964,7 +3964,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4000,7 +4000,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4102,9 +4102,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -4134,7 +4134,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4170,7 +4170,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4273,9 +4273,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -4305,7 +4305,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4341,7 +4341,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4447,9 +4447,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -4487,7 +4487,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4531,7 +4531,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4645,9 +4645,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -4674,7 +4674,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4706,7 +4706,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4808,9 +4808,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -4830,7 +4830,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4855,7 +4855,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5097,9 +5097,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -5126,7 +5126,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5155,7 +5155,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5252,9 +5252,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -5274,7 +5274,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5295,7 +5295,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5384,9 +5384,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -5406,7 +5406,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5427,7 +5427,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5515,9 +5515,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5547,7 +5547,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5579,7 +5579,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5675,9 +5675,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5707,7 +5707,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5739,7 +5739,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5836,9 +5836,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5868,7 +5868,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5900,7 +5900,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6000,9 +6000,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -6040,7 +6040,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6080,7 +6080,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6188,9 +6188,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -6217,7 +6217,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6245,7 +6245,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6341,9 +6341,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -6363,7 +6363,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6384,7 +6384,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6707,9 +6707,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -6740,7 +6740,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6773,7 +6773,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6882,9 +6882,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -6908,7 +6908,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6933,7 +6933,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7034,9 +7034,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -7060,7 +7060,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7085,7 +7085,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7185,9 +7185,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7221,7 +7221,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7257,7 +7257,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7365,9 +7365,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7401,7 +7401,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7437,7 +7437,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7546,9 +7546,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7582,7 +7582,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7618,7 +7618,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7730,9 +7730,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -7774,7 +7774,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7818,7 +7818,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7938,9 +7938,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -7971,7 +7971,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8003,7 +8003,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8111,9 +8111,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -8137,7 +8137,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8162,7 +8162,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8420,9 +8420,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -8453,7 +8453,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8482,7 +8482,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8585,9 +8585,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -8611,7 +8611,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8632,7 +8632,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8727,9 +8727,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -8753,7 +8753,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8774,7 +8774,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8868,9 +8868,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -8904,7 +8904,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8936,7 +8936,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9038,9 +9038,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9074,7 +9074,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9106,7 +9106,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9209,9 +9209,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9245,7 +9245,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9277,7 +9277,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9383,9 +9383,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -9427,7 +9427,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9467,7 +9467,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9581,9 +9581,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -9614,7 +9614,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9642,7 +9642,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9744,9 +9744,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -9770,7 +9770,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9791,7 +9791,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10041,9 +10041,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -10070,7 +10070,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10103,7 +10103,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10206,9 +10206,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -10228,7 +10228,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10253,7 +10253,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10348,9 +10348,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -10370,7 +10370,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10395,7 +10395,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10489,9 +10489,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -10521,7 +10521,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10557,7 +10557,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10659,9 +10659,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -10691,7 +10691,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10727,7 +10727,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10830,9 +10830,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -10862,7 +10862,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10898,7 +10898,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11004,9 +11004,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -11044,7 +11044,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11088,7 +11088,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11202,9 +11202,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -11231,7 +11231,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11263,7 +11263,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11365,9 +11365,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -11387,7 +11387,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11412,7 +11412,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11654,9 +11654,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -11683,7 +11683,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11712,7 +11712,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11809,9 +11809,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -11831,7 +11831,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11852,7 +11852,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11941,9 +11941,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -11963,7 +11963,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11984,7 +11984,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12072,9 +12072,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -12104,7 +12104,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12136,7 +12136,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12232,9 +12232,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -12264,7 +12264,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12296,7 +12296,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12393,9 +12393,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -12425,7 +12425,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12457,7 +12457,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12557,9 +12557,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -12597,7 +12597,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12637,7 +12637,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12745,9 +12745,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -12774,7 +12774,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12802,7 +12802,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12898,9 +12898,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -12920,7 +12920,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12941,7 +12941,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13264,9 +13264,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -13297,7 +13297,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13330,7 +13330,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13439,9 +13439,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -13465,7 +13465,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13490,7 +13490,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13591,9 +13591,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -13617,7 +13617,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13642,7 +13642,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13742,9 +13742,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -13778,7 +13778,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13814,7 +13814,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13922,9 +13922,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -13958,7 +13958,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13994,7 +13994,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14103,9 +14103,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -14139,7 +14139,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14175,7 +14175,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14287,9 +14287,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -14331,7 +14331,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14375,7 +14375,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14495,9 +14495,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -14528,7 +14528,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14560,7 +14560,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14668,9 +14668,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -14694,7 +14694,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14719,7 +14719,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14977,9 +14977,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -15010,7 +15010,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15039,7 +15039,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15142,9 +15142,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -15168,7 +15168,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15189,7 +15189,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15284,9 +15284,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -15310,7 +15310,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15331,7 +15331,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15425,9 +15425,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15461,7 +15461,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15493,7 +15493,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15595,9 +15595,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15631,7 +15631,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15663,7 +15663,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15766,9 +15766,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15802,7 +15802,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15834,7 +15834,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15940,9 +15940,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -15984,7 +15984,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16024,7 +16024,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16138,9 +16138,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -16171,7 +16171,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16199,7 +16199,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16301,9 +16301,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -16327,7 +16327,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16348,7 +16348,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16598,9 +16598,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -16627,7 +16627,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16660,7 +16660,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16763,9 +16763,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -16785,7 +16785,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16810,7 +16810,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16905,9 +16905,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -16927,7 +16927,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16952,7 +16952,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17046,9 +17046,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -17078,7 +17078,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17114,7 +17114,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17216,9 +17216,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -17248,7 +17248,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17284,7 +17284,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17387,9 +17387,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -17419,7 +17419,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17455,7 +17455,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17561,9 +17561,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -17601,7 +17601,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17645,7 +17645,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17759,9 +17759,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -17788,7 +17788,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17820,7 +17820,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17922,9 +17922,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -17944,7 +17944,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17969,7 +17969,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18211,9 +18211,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -18240,7 +18240,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18269,7 +18269,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18366,9 +18366,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -18388,7 +18388,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18409,7 +18409,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18498,9 +18498,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -18520,7 +18520,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18541,7 +18541,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18629,9 +18629,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -18661,7 +18661,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18693,7 +18693,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18789,9 +18789,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -18821,7 +18821,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18853,7 +18853,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18950,9 +18950,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -18982,7 +18982,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19014,7 +19014,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19114,9 +19114,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -19154,7 +19154,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19194,7 +19194,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19302,9 +19302,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -19331,7 +19331,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19359,7 +19359,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19455,9 +19455,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -19477,7 +19477,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19498,7 +19498,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19821,9 +19821,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -19854,7 +19854,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19887,7 +19887,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19996,9 +19996,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -20022,7 +20022,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20047,7 +20047,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20148,9 +20148,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -20174,7 +20174,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20199,7 +20199,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20299,9 +20299,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20335,7 +20335,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20371,7 +20371,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20479,9 +20479,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20515,7 +20515,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20551,7 +20551,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20660,9 +20660,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20696,7 +20696,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20732,7 +20732,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20844,9 +20844,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -20888,7 +20888,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20932,7 +20932,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21052,9 +21052,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -21085,7 +21085,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21117,7 +21117,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21225,9 +21225,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -21251,7 +21251,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21276,7 +21276,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21534,9 +21534,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -21567,7 +21567,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21596,7 +21596,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21699,9 +21699,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -21725,7 +21725,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21746,7 +21746,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21841,9 +21841,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -21867,7 +21867,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21888,7 +21888,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21982,9 +21982,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22018,7 +22018,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22050,7 +22050,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22152,9 +22152,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22188,7 +22188,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22220,7 +22220,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22323,9 +22323,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22359,7 +22359,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22391,7 +22391,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22497,9 +22497,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -22541,7 +22541,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22581,7 +22581,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22695,9 +22695,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -22728,7 +22728,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22756,7 +22756,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22858,9 +22858,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -22884,7 +22884,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22905,7 +22905,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23155,9 +23155,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -23184,7 +23184,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23217,7 +23217,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23320,9 +23320,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -23342,7 +23342,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23367,7 +23367,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23462,9 +23462,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -23484,7 +23484,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23509,7 +23509,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23603,9 +23603,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -23635,7 +23635,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23671,7 +23671,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23773,9 +23773,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -23805,7 +23805,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23841,7 +23841,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23944,9 +23944,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -23976,7 +23976,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24012,7 +24012,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24118,9 +24118,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -24158,7 +24158,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24202,7 +24202,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24316,9 +24316,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -24345,7 +24345,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24377,7 +24377,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24479,9 +24479,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -24501,7 +24501,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24526,7 +24526,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24768,9 +24768,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -24797,7 +24797,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24826,7 +24826,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24923,9 +24923,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -24945,7 +24945,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24966,7 +24966,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25055,9 +25055,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -25077,7 +25077,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25098,7 +25098,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25186,9 +25186,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -25218,7 +25218,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25250,7 +25250,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25346,9 +25346,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -25378,7 +25378,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25410,7 +25410,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25507,9 +25507,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -25539,7 +25539,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25571,7 +25571,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25671,9 +25671,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -25711,7 +25711,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25751,7 +25751,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25859,9 +25859,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -25888,7 +25888,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25916,7 +25916,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26012,9 +26012,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -26034,7 +26034,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26055,7 +26055,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26342,7 +26342,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26404,7 +26404,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -26466,7 +26466,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -26527,7 +26527,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26585,7 +26585,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26644,7 +26644,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26706,7 +26706,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26768,7 +26768,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26830,7 +26830,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26957,7 +26957,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27016,7 +27016,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -27075,7 +27075,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -27133,7 +27133,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27188,7 +27188,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27244,7 +27244,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27303,7 +27303,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27362,7 +27362,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27421,7 +27421,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27549,7 +27549,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27610,7 +27610,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -27671,7 +27671,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -27731,7 +27731,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27788,7 +27788,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27846,7 +27846,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27907,7 +27907,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27968,7 +27968,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28029,7 +28029,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28154,7 +28154,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28212,7 +28212,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -28270,7 +28270,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -28327,7 +28327,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28381,7 +28381,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28436,7 +28436,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28494,7 +28494,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28552,7 +28552,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28610,7 +28610,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28771,7 +28771,7 @@ func (o *mergeJoinInnerOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -28820,7 +28820,7 @@ func (o *mergeJoinInnerOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol.Set(outStartIdx, val)
 										outStartIdx++
@@ -28869,7 +28869,7 @@ func (o *mergeJoinInnerOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx].Set(&val)
 										outStartIdx++
@@ -28917,7 +28917,7 @@ func (o *mergeJoinInnerOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -28962,7 +28962,7 @@ func (o *mergeJoinInnerOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -29008,7 +29008,7 @@ func (o *mergeJoinInnerOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -29057,7 +29057,7 @@ func (o *mergeJoinInnerOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -29106,7 +29106,7 @@ func (o *mergeJoinInnerOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -29155,7 +29155,7 @@ func (o *mergeJoinInnerOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -29342,7 +29342,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29410,7 +29410,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -29478,7 +29478,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -29545,7 +29545,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29609,7 +29609,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29674,7 +29674,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29742,7 +29742,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29810,7 +29810,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29878,7 +29878,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30018,7 +30018,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30084,7 +30084,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -30150,7 +30150,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -30215,7 +30215,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30277,7 +30277,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30340,7 +30340,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30406,7 +30406,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30472,7 +30472,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30538,7 +30538,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30680,7 +30680,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30748,7 +30748,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -30816,7 +30816,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -30883,7 +30883,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30947,7 +30947,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31012,7 +31012,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31080,7 +31080,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31148,7 +31148,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31216,7 +31216,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31356,7 +31356,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31422,7 +31422,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -31488,7 +31488,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -31553,7 +31553,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31615,7 +31615,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31678,7 +31678,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31744,7 +31744,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31810,7 +31810,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31876,7 +31876,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32049,7 +32049,7 @@ func (o *mergeJoinInnerOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -32078,7 +32078,7 @@ func (o *mergeJoinInnerOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol.Set(outStartIdx, v)
 									}
 								} else {
@@ -32107,7 +32107,7 @@ func (o *mergeJoinInnerOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx].Set(&v)
 									}
 								} else {
@@ -32135,7 +32135,7 @@ func (o *mergeJoinInnerOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -32160,7 +32160,7 @@ func (o *mergeJoinInnerOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -32186,7 +32186,7 @@ func (o *mergeJoinInnerOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -32215,7 +32215,7 @@ func (o *mergeJoinInnerOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -32244,7 +32244,7 @@ func (o *mergeJoinInnerOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -32273,7 +32273,7 @@ func (o *mergeJoinInnerOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {

--- a/pkg/sql/colexec/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_intersectall.eg.go
@@ -153,9 +153,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -192,7 +192,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -230,7 +230,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -346,9 +346,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -378,7 +378,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -408,7 +408,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -516,9 +516,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -548,7 +548,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -578,7 +578,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -685,9 +685,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -727,7 +727,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -768,7 +768,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -883,9 +883,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -925,7 +925,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -966,7 +966,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1082,9 +1082,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -1124,7 +1124,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1165,7 +1165,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1284,9 +1284,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -1334,7 +1334,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1383,7 +1383,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1510,9 +1510,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -1549,7 +1549,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1586,7 +1586,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1701,9 +1701,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -1733,7 +1733,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1763,7 +1763,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2042,9 +2042,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -2076,7 +2076,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2105,7 +2105,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2211,9 +2211,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -2238,7 +2238,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2259,7 +2259,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2357,9 +2357,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -2384,7 +2384,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2405,7 +2405,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2502,9 +2502,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -2539,7 +2539,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2571,7 +2571,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2676,9 +2676,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -2713,7 +2713,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2745,7 +2745,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2851,9 +2851,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -2888,7 +2888,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2920,7 +2920,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3029,9 +3029,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -3074,7 +3074,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3114,7 +3114,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3231,9 +3231,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -3265,7 +3265,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3293,7 +3293,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3398,9 +3398,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -3425,7 +3425,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3446,7 +3446,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3701,9 +3701,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -3731,7 +3731,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3764,7 +3764,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3868,9 +3868,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -3891,7 +3891,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3916,7 +3916,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4012,9 +4012,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -4035,7 +4035,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4060,7 +4060,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4155,9 +4155,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -4188,7 +4188,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4224,7 +4224,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4327,9 +4327,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -4360,7 +4360,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4396,7 +4396,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4500,9 +4500,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -4533,7 +4533,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4569,7 +4569,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4676,9 +4676,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -4717,7 +4717,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4761,7 +4761,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4876,9 +4876,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -4906,7 +4906,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4938,7 +4938,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5041,9 +5041,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -5064,7 +5064,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5089,7 +5089,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5334,9 +5334,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -5363,7 +5363,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5392,7 +5392,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5490,9 +5490,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -5512,7 +5512,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5533,7 +5533,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5623,9 +5623,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -5645,7 +5645,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5666,7 +5666,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5755,9 +5755,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5787,7 +5787,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5819,7 +5819,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5916,9 +5916,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5948,7 +5948,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5980,7 +5980,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6078,9 +6078,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -6110,7 +6110,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6142,7 +6142,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6243,9 +6243,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -6283,7 +6283,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6323,7 +6323,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6432,9 +6432,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -6461,7 +6461,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6489,7 +6489,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6586,9 +6586,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -6608,7 +6608,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6629,7 +6629,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6960,9 +6960,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -6999,7 +6999,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7037,7 +7037,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7153,9 +7153,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -7185,7 +7185,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7215,7 +7215,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7323,9 +7323,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -7355,7 +7355,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7385,7 +7385,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7492,9 +7492,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -7534,7 +7534,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7575,7 +7575,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7690,9 +7690,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -7732,7 +7732,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7773,7 +7773,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7889,9 +7889,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -7931,7 +7931,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7972,7 +7972,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8091,9 +8091,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -8141,7 +8141,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8190,7 +8190,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8317,9 +8317,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -8356,7 +8356,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8393,7 +8393,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8508,9 +8508,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -8540,7 +8540,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8570,7 +8570,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8849,9 +8849,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -8883,7 +8883,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8912,7 +8912,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9018,9 +9018,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -9045,7 +9045,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9066,7 +9066,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9164,9 +9164,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -9191,7 +9191,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9212,7 +9212,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9309,9 +9309,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -9346,7 +9346,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9378,7 +9378,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9483,9 +9483,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -9520,7 +9520,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9552,7 +9552,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9658,9 +9658,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -9695,7 +9695,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9727,7 +9727,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9836,9 +9836,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -9881,7 +9881,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9921,7 +9921,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10038,9 +10038,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -10072,7 +10072,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10100,7 +10100,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10205,9 +10205,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -10232,7 +10232,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10253,7 +10253,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10508,9 +10508,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -10538,7 +10538,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10571,7 +10571,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10675,9 +10675,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -10698,7 +10698,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10723,7 +10723,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10819,9 +10819,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -10842,7 +10842,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10867,7 +10867,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10962,9 +10962,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -10995,7 +10995,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11031,7 +11031,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11134,9 +11134,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -11167,7 +11167,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11203,7 +11203,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11307,9 +11307,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -11340,7 +11340,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11376,7 +11376,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11483,9 +11483,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -11524,7 +11524,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11568,7 +11568,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11683,9 +11683,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -11713,7 +11713,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11745,7 +11745,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11848,9 +11848,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = lSel[curLIdx]
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -11871,7 +11871,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11896,7 +11896,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12141,9 +12141,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -12170,7 +12170,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12199,7 +12199,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12297,9 +12297,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -12319,7 +12319,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12340,7 +12340,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12430,9 +12430,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -12452,7 +12452,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12473,7 +12473,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12562,9 +12562,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -12594,7 +12594,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12626,7 +12626,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12723,9 +12723,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -12755,7 +12755,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12787,7 +12787,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12885,9 +12885,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -12917,7 +12917,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12949,7 +12949,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13050,9 +13050,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -13090,7 +13090,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13130,7 +13130,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13239,9 +13239,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -13268,7 +13268,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13296,7 +13296,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13393,9 +13393,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -13415,7 +13415,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13436,7 +13436,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13767,9 +13767,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -13806,7 +13806,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13844,7 +13844,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13960,9 +13960,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -13992,7 +13992,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14022,7 +14022,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14130,9 +14130,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -14162,7 +14162,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14192,7 +14192,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14299,9 +14299,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -14341,7 +14341,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14382,7 +14382,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14497,9 +14497,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -14539,7 +14539,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14580,7 +14580,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14696,9 +14696,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -14738,7 +14738,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14779,7 +14779,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14898,9 +14898,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -14948,7 +14948,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14997,7 +14997,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15124,9 +15124,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -15163,7 +15163,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15200,7 +15200,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15315,9 +15315,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -15347,7 +15347,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15377,7 +15377,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15656,9 +15656,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -15690,7 +15690,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15719,7 +15719,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15825,9 +15825,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -15852,7 +15852,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15873,7 +15873,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15971,9 +15971,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -15998,7 +15998,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16019,7 +16019,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16116,9 +16116,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -16153,7 +16153,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16185,7 +16185,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16290,9 +16290,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -16327,7 +16327,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16359,7 +16359,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16465,9 +16465,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -16502,7 +16502,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16534,7 +16534,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16643,9 +16643,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -16688,7 +16688,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16728,7 +16728,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16845,9 +16845,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -16879,7 +16879,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16907,7 +16907,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17012,9 +17012,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -17039,7 +17039,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17060,7 +17060,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17315,9 +17315,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -17345,7 +17345,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17378,7 +17378,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17482,9 +17482,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -17505,7 +17505,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17530,7 +17530,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17626,9 +17626,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -17649,7 +17649,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17674,7 +17674,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17769,9 +17769,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -17802,7 +17802,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17838,7 +17838,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17941,9 +17941,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -17974,7 +17974,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18010,7 +18010,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18114,9 +18114,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -18147,7 +18147,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18183,7 +18183,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18290,9 +18290,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -18331,7 +18331,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18375,7 +18375,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18490,9 +18490,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -18520,7 +18520,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18552,7 +18552,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18655,9 +18655,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = rSel[curRIdx]
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -18678,7 +18678,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18703,7 +18703,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18948,9 +18948,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -18977,7 +18977,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19006,7 +19006,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19104,9 +19104,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -19126,7 +19126,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19147,7 +19147,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19237,9 +19237,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -19259,7 +19259,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19280,7 +19280,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19369,9 +19369,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -19401,7 +19401,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19433,7 +19433,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19530,9 +19530,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -19562,7 +19562,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19594,7 +19594,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19692,9 +19692,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -19724,7 +19724,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19756,7 +19756,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19857,9 +19857,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -19897,7 +19897,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19937,7 +19937,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20046,9 +20046,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -20075,7 +20075,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20103,7 +20103,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20200,9 +20200,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -20222,7 +20222,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20243,7 +20243,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20574,9 +20574,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -20613,7 +20613,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20651,7 +20651,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20767,9 +20767,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -20799,7 +20799,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20829,7 +20829,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20937,9 +20937,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -20969,7 +20969,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20999,7 +20999,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21106,9 +21106,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -21148,7 +21148,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21189,7 +21189,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21304,9 +21304,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -21346,7 +21346,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21387,7 +21387,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21503,9 +21503,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -21545,7 +21545,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21586,7 +21586,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21705,9 +21705,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -21755,7 +21755,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21804,7 +21804,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21931,9 +21931,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -21970,7 +21970,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22007,7 +22007,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22122,9 +22122,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -22154,7 +22154,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22184,7 +22184,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22463,9 +22463,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -22497,7 +22497,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22526,7 +22526,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22632,9 +22632,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -22659,7 +22659,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22680,7 +22680,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22778,9 +22778,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -22805,7 +22805,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22826,7 +22826,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22923,9 +22923,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -22960,7 +22960,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22992,7 +22992,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23097,9 +23097,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -23134,7 +23134,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23166,7 +23166,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23272,9 +23272,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -23309,7 +23309,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23341,7 +23341,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23450,9 +23450,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -23495,7 +23495,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23535,7 +23535,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23652,9 +23652,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -23686,7 +23686,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23714,7 +23714,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23819,9 +23819,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -23846,7 +23846,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23867,7 +23867,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24122,9 +24122,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if !lVal && rVal {
 											cmp = -1
@@ -24152,7 +24152,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24185,7 +24185,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24289,9 +24289,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = bytes.Compare(lVal, rVal)
 
 									}
@@ -24312,7 +24312,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24337,7 +24337,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24433,9 +24433,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = tree.CompareDecimals(&lVal, &rVal)
 
 									}
@@ -24456,7 +24456,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24481,7 +24481,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24576,9 +24576,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -24609,7 +24609,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24645,7 +24645,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24748,9 +24748,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -24781,7 +24781,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24817,7 +24817,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24921,9 +24921,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := int64(lVal), int64(rVal)
@@ -24954,7 +24954,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24990,7 +24990,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25097,9 +25097,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										{
 											a, b := float64(lVal), float64(rVal)
@@ -25138,7 +25138,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25182,7 +25182,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25297,9 +25297,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 
 										if lVal.Before(rVal) {
 											cmp = -1
@@ -25327,7 +25327,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25359,7 +25359,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25462,9 +25462,9 @@ EqLoop:
 									if cmp == 0 {
 
 										lSelIdx = curLIdx
-										lVal = lKeys.Get(lSelIdx) //gcassert:inline
+										lVal = lKeys.Get(lSelIdx)
 										rSelIdx = curRIdx
-										rVal = rKeys.Get(rSelIdx) //gcassert:inline
+										rVal = rKeys.Get(rSelIdx)
 										cmp = lVal.Compare(rVal)
 
 									}
@@ -25485,7 +25485,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25510,7 +25510,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25755,9 +25755,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -25784,7 +25784,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25813,7 +25813,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25911,9 +25911,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -25933,7 +25933,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25954,7 +25954,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26044,9 +26044,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -26066,7 +26066,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26087,7 +26087,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26176,9 +26176,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26208,7 +26208,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26240,7 +26240,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26337,9 +26337,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26369,7 +26369,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26401,7 +26401,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26499,9 +26499,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26531,7 +26531,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26563,7 +26563,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26664,9 +26664,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -26704,7 +26704,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26744,7 +26744,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26853,9 +26853,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -26882,7 +26882,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26910,7 +26910,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27007,9 +27007,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -27029,7 +27029,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27050,7 +27050,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27342,7 +27342,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27404,7 +27404,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -27466,7 +27466,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -27527,7 +27527,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27585,7 +27585,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27644,7 +27644,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27706,7 +27706,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27768,7 +27768,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27830,7 +27830,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27957,7 +27957,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28016,7 +28016,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -28075,7 +28075,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -28133,7 +28133,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28188,7 +28188,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28244,7 +28244,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28303,7 +28303,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28362,7 +28362,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28421,7 +28421,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28549,7 +28549,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28610,7 +28610,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -28671,7 +28671,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -28731,7 +28731,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28788,7 +28788,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28846,7 +28846,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28907,7 +28907,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28968,7 +28968,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -29029,7 +29029,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -29154,7 +29154,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -29212,7 +29212,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -29270,7 +29270,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -29327,7 +29327,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -29381,7 +29381,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -29436,7 +29436,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -29494,7 +29494,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -29552,7 +29552,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -29610,7 +29610,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -29782,7 +29782,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -29846,7 +29846,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol.Set(outStartIdx, val)
 										outStartIdx++
@@ -29910,7 +29910,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx].Set(&val)
 										outStartIdx++
@@ -29973,7 +29973,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -30033,7 +30033,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -30094,7 +30094,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -30158,7 +30158,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -30222,7 +30222,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -30286,7 +30286,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -30492,7 +30492,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30560,7 +30560,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -30628,7 +30628,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -30695,7 +30695,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30759,7 +30759,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30824,7 +30824,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30892,7 +30892,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30960,7 +30960,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31028,7 +31028,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31168,7 +31168,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31234,7 +31234,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -31300,7 +31300,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -31365,7 +31365,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31427,7 +31427,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31490,7 +31490,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31556,7 +31556,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31622,7 +31622,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31688,7 +31688,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31830,7 +31830,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31898,7 +31898,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -31966,7 +31966,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -32033,7 +32033,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32097,7 +32097,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32162,7 +32162,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32230,7 +32230,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32298,7 +32298,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32366,7 +32366,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32506,7 +32506,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32572,7 +32572,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -32638,7 +32638,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -32703,7 +32703,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32765,7 +32765,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32828,7 +32828,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32894,7 +32894,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -32960,7 +32960,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -33026,7 +33026,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -33199,7 +33199,7 @@ func (o *mergeJoinIntersectAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -33228,7 +33228,7 @@ func (o *mergeJoinIntersectAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol.Set(outStartIdx, v)
 									}
 								} else {
@@ -33257,7 +33257,7 @@ func (o *mergeJoinIntersectAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx].Set(&v)
 									}
 								} else {
@@ -33285,7 +33285,7 @@ func (o *mergeJoinIntersectAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -33310,7 +33310,7 @@ func (o *mergeJoinIntersectAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -33336,7 +33336,7 @@ func (o *mergeJoinIntersectAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -33365,7 +33365,7 @@ func (o *mergeJoinIntersectAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -33394,7 +33394,7 @@ func (o *mergeJoinIntersectAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -33423,7 +33423,7 @@ func (o *mergeJoinIntersectAllOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {

--- a/pkg/sql/colexec/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftanti.eg.go
@@ -162,9 +162,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -195,7 +195,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -228,7 +228,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -289,7 +289,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -389,9 +389,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -415,7 +415,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -440,7 +440,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -493,7 +493,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -585,9 +585,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -611,7 +611,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -636,7 +636,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -689,7 +689,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -780,9 +780,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -816,7 +816,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -852,7 +852,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -916,7 +916,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1015,9 +1015,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -1051,7 +1051,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1087,7 +1087,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1151,7 +1151,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1251,9 +1251,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -1287,7 +1287,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1323,7 +1323,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1387,7 +1387,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1490,9 +1490,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -1534,7 +1534,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1578,7 +1578,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1650,7 +1650,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1761,9 +1761,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -1794,7 +1794,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1826,7 +1826,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1886,7 +1886,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1985,9 +1985,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -2011,7 +2011,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2036,7 +2036,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2089,7 +2089,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2384,9 +2384,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -2417,7 +2417,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2446,7 +2446,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2507,7 +2507,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2601,9 +2601,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -2627,7 +2627,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2648,7 +2648,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2701,7 +2701,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2787,9 +2787,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -2813,7 +2813,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2834,7 +2834,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2887,7 +2887,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2972,9 +2972,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3008,7 +3008,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3040,7 +3040,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3104,7 +3104,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3197,9 +3197,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3233,7 +3233,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3265,7 +3265,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3329,7 +3329,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3423,9 +3423,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3459,7 +3459,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3491,7 +3491,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3555,7 +3555,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3652,9 +3652,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -3696,7 +3696,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3736,7 +3736,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3808,7 +3808,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3913,9 +3913,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -3946,7 +3946,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3974,7 +3974,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4034,7 +4034,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4127,9 +4127,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -4153,7 +4153,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4174,7 +4174,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4227,7 +4227,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4513,9 +4513,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -4542,7 +4542,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4575,7 +4575,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4633,7 +4633,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4726,9 +4726,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -4748,7 +4748,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4773,7 +4773,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4823,7 +4823,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4908,9 +4908,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -4930,7 +4930,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4955,7 +4955,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5005,7 +5005,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5089,9 +5089,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5121,7 +5121,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5157,7 +5157,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5218,7 +5218,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5310,9 +5310,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5342,7 +5342,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5378,7 +5378,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5439,7 +5439,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5532,9 +5532,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5564,7 +5564,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5600,7 +5600,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5661,7 +5661,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5757,9 +5757,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -5797,7 +5797,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5841,7 +5841,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5910,7 +5910,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6014,9 +6014,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -6043,7 +6043,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6075,7 +6075,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6132,7 +6132,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6224,9 +6224,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -6246,7 +6246,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6271,7 +6271,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6321,7 +6321,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6595,9 +6595,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -6624,7 +6624,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6653,7 +6653,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6711,7 +6711,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6798,9 +6798,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -6820,7 +6820,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6841,7 +6841,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6891,7 +6891,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6970,9 +6970,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -6992,7 +6992,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7013,7 +7013,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7063,7 +7063,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7141,9 +7141,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7173,7 +7173,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7205,7 +7205,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7266,7 +7266,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7352,9 +7352,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7384,7 +7384,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7416,7 +7416,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7477,7 +7477,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7564,9 +7564,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7596,7 +7596,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7628,7 +7628,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7689,7 +7689,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7779,9 +7779,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -7819,7 +7819,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7859,7 +7859,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7928,7 +7928,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8026,9 +8026,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -8055,7 +8055,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8083,7 +8083,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8140,7 +8140,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8226,9 +8226,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -8248,7 +8248,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8269,7 +8269,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8319,7 +8319,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8675,9 +8675,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -8708,7 +8708,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8741,7 +8741,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8802,7 +8802,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8902,9 +8902,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -8928,7 +8928,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8953,7 +8953,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9006,7 +9006,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9098,9 +9098,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -9124,7 +9124,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9149,7 +9149,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9202,7 +9202,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9293,9 +9293,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9329,7 +9329,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9365,7 +9365,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9429,7 +9429,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9528,9 +9528,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9564,7 +9564,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9600,7 +9600,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9664,7 +9664,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9764,9 +9764,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9800,7 +9800,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9836,7 +9836,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9900,7 +9900,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10003,9 +10003,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -10047,7 +10047,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10091,7 +10091,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10163,7 +10163,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10274,9 +10274,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -10307,7 +10307,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10339,7 +10339,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10399,7 +10399,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10498,9 +10498,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -10524,7 +10524,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10549,7 +10549,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10602,7 +10602,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10897,9 +10897,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -10930,7 +10930,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10959,7 +10959,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11020,7 +11020,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11114,9 +11114,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -11140,7 +11140,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11161,7 +11161,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11214,7 +11214,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11300,9 +11300,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -11326,7 +11326,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11347,7 +11347,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11400,7 +11400,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11485,9 +11485,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -11521,7 +11521,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11553,7 +11553,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11617,7 +11617,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11710,9 +11710,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -11746,7 +11746,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11778,7 +11778,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11842,7 +11842,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11936,9 +11936,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -11972,7 +11972,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12004,7 +12004,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12068,7 +12068,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12165,9 +12165,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -12209,7 +12209,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12249,7 +12249,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12321,7 +12321,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12426,9 +12426,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -12459,7 +12459,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12487,7 +12487,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12547,7 +12547,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12640,9 +12640,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -12666,7 +12666,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12687,7 +12687,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12740,7 +12740,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13026,9 +13026,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -13055,7 +13055,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13088,7 +13088,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13146,7 +13146,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13239,9 +13239,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -13261,7 +13261,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13286,7 +13286,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13336,7 +13336,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13421,9 +13421,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -13443,7 +13443,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13468,7 +13468,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13518,7 +13518,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13602,9 +13602,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -13634,7 +13634,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13670,7 +13670,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13731,7 +13731,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13823,9 +13823,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -13855,7 +13855,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13891,7 +13891,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13952,7 +13952,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14045,9 +14045,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -14077,7 +14077,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14113,7 +14113,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14174,7 +14174,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14270,9 +14270,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -14310,7 +14310,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14354,7 +14354,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14423,7 +14423,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14527,9 +14527,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -14556,7 +14556,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14588,7 +14588,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14645,7 +14645,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14737,9 +14737,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -14759,7 +14759,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14784,7 +14784,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14834,7 +14834,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15108,9 +15108,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -15137,7 +15137,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15166,7 +15166,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15224,7 +15224,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15311,9 +15311,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -15333,7 +15333,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15354,7 +15354,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15404,7 +15404,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15483,9 +15483,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -15505,7 +15505,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15526,7 +15526,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15576,7 +15576,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15654,9 +15654,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15686,7 +15686,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15718,7 +15718,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15779,7 +15779,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15865,9 +15865,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15897,7 +15897,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15929,7 +15929,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15990,7 +15990,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16077,9 +16077,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -16109,7 +16109,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16141,7 +16141,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16202,7 +16202,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16292,9 +16292,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -16332,7 +16332,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16372,7 +16372,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16441,7 +16441,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16539,9 +16539,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -16568,7 +16568,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16596,7 +16596,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16653,7 +16653,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16739,9 +16739,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -16761,7 +16761,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16782,7 +16782,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16832,7 +16832,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17188,9 +17188,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -17221,7 +17221,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17254,7 +17254,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17315,7 +17315,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17415,9 +17415,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -17441,7 +17441,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17466,7 +17466,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17519,7 +17519,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17611,9 +17611,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -17637,7 +17637,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17662,7 +17662,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17715,7 +17715,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17806,9 +17806,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -17842,7 +17842,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17878,7 +17878,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17942,7 +17942,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18041,9 +18041,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -18077,7 +18077,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18113,7 +18113,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18177,7 +18177,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18277,9 +18277,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -18313,7 +18313,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18349,7 +18349,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18413,7 +18413,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18516,9 +18516,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -18560,7 +18560,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18604,7 +18604,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18676,7 +18676,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18787,9 +18787,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -18820,7 +18820,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18852,7 +18852,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18912,7 +18912,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19011,9 +19011,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -19037,7 +19037,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19062,7 +19062,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19115,7 +19115,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19410,9 +19410,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -19443,7 +19443,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19472,7 +19472,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19533,7 +19533,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19627,9 +19627,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -19653,7 +19653,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19674,7 +19674,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19727,7 +19727,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19813,9 +19813,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -19839,7 +19839,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19860,7 +19860,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19913,7 +19913,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19998,9 +19998,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20034,7 +20034,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20066,7 +20066,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20130,7 +20130,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20223,9 +20223,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20259,7 +20259,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20291,7 +20291,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20355,7 +20355,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20449,9 +20449,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20485,7 +20485,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20517,7 +20517,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20581,7 +20581,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20678,9 +20678,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -20722,7 +20722,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20762,7 +20762,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20834,7 +20834,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20939,9 +20939,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -20972,7 +20972,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21000,7 +21000,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21060,7 +21060,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21153,9 +21153,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -21179,7 +21179,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21200,7 +21200,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21253,7 +21253,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21539,9 +21539,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -21568,7 +21568,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21601,7 +21601,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21659,7 +21659,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21752,9 +21752,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -21774,7 +21774,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21799,7 +21799,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21849,7 +21849,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21934,9 +21934,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -21956,7 +21956,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21981,7 +21981,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22031,7 +22031,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22115,9 +22115,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22147,7 +22147,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22183,7 +22183,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22244,7 +22244,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22336,9 +22336,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22368,7 +22368,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22404,7 +22404,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22465,7 +22465,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22558,9 +22558,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22590,7 +22590,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22626,7 +22626,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22687,7 +22687,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22783,9 +22783,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -22823,7 +22823,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22867,7 +22867,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22936,7 +22936,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23040,9 +23040,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -23069,7 +23069,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23101,7 +23101,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23158,7 +23158,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23250,9 +23250,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -23272,7 +23272,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23297,7 +23297,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23347,7 +23347,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23621,9 +23621,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -23650,7 +23650,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23679,7 +23679,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23737,7 +23737,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23824,9 +23824,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -23846,7 +23846,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23867,7 +23867,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23917,7 +23917,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23996,9 +23996,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -24018,7 +24018,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24039,7 +24039,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24089,7 +24089,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24167,9 +24167,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -24199,7 +24199,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24231,7 +24231,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24292,7 +24292,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24378,9 +24378,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -24410,7 +24410,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24442,7 +24442,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24503,7 +24503,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24590,9 +24590,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -24622,7 +24622,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24654,7 +24654,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24715,7 +24715,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24805,9 +24805,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -24845,7 +24845,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24885,7 +24885,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24954,7 +24954,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25052,9 +25052,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -25081,7 +25081,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25109,7 +25109,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25166,7 +25166,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25252,9 +25252,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -25274,7 +25274,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25295,7 +25295,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25345,7 +25345,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25701,9 +25701,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -25734,7 +25734,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25767,7 +25767,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25828,7 +25828,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25928,9 +25928,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -25954,7 +25954,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25979,7 +25979,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26032,7 +26032,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26124,9 +26124,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -26150,7 +26150,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26175,7 +26175,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26228,7 +26228,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26319,9 +26319,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26355,7 +26355,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26391,7 +26391,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26455,7 +26455,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26554,9 +26554,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26590,7 +26590,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26626,7 +26626,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26690,7 +26690,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26790,9 +26790,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26826,7 +26826,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26862,7 +26862,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26926,7 +26926,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27029,9 +27029,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -27073,7 +27073,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27117,7 +27117,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27189,7 +27189,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27300,9 +27300,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -27333,7 +27333,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27365,7 +27365,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27425,7 +27425,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27524,9 +27524,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -27550,7 +27550,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27575,7 +27575,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27628,7 +27628,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27923,9 +27923,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -27956,7 +27956,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27985,7 +27985,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28046,7 +28046,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28140,9 +28140,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -28166,7 +28166,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28187,7 +28187,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28240,7 +28240,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28326,9 +28326,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -28352,7 +28352,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28373,7 +28373,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28426,7 +28426,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28511,9 +28511,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -28547,7 +28547,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28579,7 +28579,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28643,7 +28643,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28736,9 +28736,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -28772,7 +28772,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28804,7 +28804,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28868,7 +28868,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28962,9 +28962,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -28998,7 +28998,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29030,7 +29030,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29094,7 +29094,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29191,9 +29191,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -29235,7 +29235,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29275,7 +29275,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29347,7 +29347,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29452,9 +29452,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -29485,7 +29485,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29513,7 +29513,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29573,7 +29573,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29666,9 +29666,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -29692,7 +29692,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29713,7 +29713,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29766,7 +29766,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30052,9 +30052,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -30081,7 +30081,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30114,7 +30114,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30172,7 +30172,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30265,9 +30265,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -30287,7 +30287,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30312,7 +30312,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30362,7 +30362,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30447,9 +30447,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -30469,7 +30469,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30494,7 +30494,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30544,7 +30544,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30628,9 +30628,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -30660,7 +30660,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30696,7 +30696,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30757,7 +30757,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30849,9 +30849,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -30881,7 +30881,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30917,7 +30917,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30978,7 +30978,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31071,9 +31071,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -31103,7 +31103,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31139,7 +31139,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31200,7 +31200,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31296,9 +31296,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -31336,7 +31336,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31380,7 +31380,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31449,7 +31449,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31553,9 +31553,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -31582,7 +31582,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31614,7 +31614,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31671,7 +31671,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31763,9 +31763,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -31785,7 +31785,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31810,7 +31810,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31860,7 +31860,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32134,9 +32134,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -32163,7 +32163,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32192,7 +32192,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32250,7 +32250,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32337,9 +32337,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -32359,7 +32359,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32380,7 +32380,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32430,7 +32430,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32509,9 +32509,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -32531,7 +32531,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32552,7 +32552,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32602,7 +32602,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32680,9 +32680,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -32712,7 +32712,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32744,7 +32744,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32805,7 +32805,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32891,9 +32891,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -32923,7 +32923,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32955,7 +32955,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33016,7 +33016,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33103,9 +33103,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -33135,7 +33135,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33167,7 +33167,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33228,7 +33228,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33318,9 +33318,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -33358,7 +33358,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33398,7 +33398,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33467,7 +33467,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33565,9 +33565,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -33594,7 +33594,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33622,7 +33622,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33679,7 +33679,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33765,9 +33765,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -33787,7 +33787,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33808,7 +33808,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33858,7 +33858,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34169,7 +34169,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34234,7 +34234,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -34299,7 +34299,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -34363,7 +34363,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34424,7 +34424,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34486,7 +34486,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34551,7 +34551,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34616,7 +34616,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34681,7 +34681,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34814,7 +34814,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34876,7 +34876,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -34938,7 +34938,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -34999,7 +34999,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35057,7 +35057,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35116,7 +35116,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35178,7 +35178,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35240,7 +35240,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35302,7 +35302,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35436,7 +35436,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35500,7 +35500,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -35564,7 +35564,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -35627,7 +35627,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35687,7 +35687,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35748,7 +35748,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35812,7 +35812,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35876,7 +35876,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35940,7 +35940,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36071,7 +36071,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36132,7 +36132,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -36193,7 +36193,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -36253,7 +36253,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36310,7 +36310,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36368,7 +36368,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36429,7 +36429,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36490,7 +36490,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36551,7 +36551,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36715,7 +36715,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36764,7 +36764,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol.Set(outStartIdx, val)
 										outStartIdx++
@@ -36813,7 +36813,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx].Set(&val)
 										outStartIdx++
@@ -36861,7 +36861,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36906,7 +36906,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36952,7 +36952,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -37001,7 +37001,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -37050,7 +37050,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -37099,7 +37099,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -37286,7 +37286,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37354,7 +37354,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -37422,7 +37422,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -37489,7 +37489,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37553,7 +37553,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37618,7 +37618,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37686,7 +37686,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37754,7 +37754,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37822,7 +37822,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37962,7 +37962,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38028,7 +38028,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -38094,7 +38094,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -38159,7 +38159,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38221,7 +38221,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38284,7 +38284,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38350,7 +38350,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38416,7 +38416,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38482,7 +38482,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38624,7 +38624,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38692,7 +38692,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -38760,7 +38760,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -38827,7 +38827,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38891,7 +38891,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38956,7 +38956,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39024,7 +39024,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39092,7 +39092,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39160,7 +39160,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39300,7 +39300,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39366,7 +39366,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -39432,7 +39432,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -39497,7 +39497,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39559,7 +39559,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39622,7 +39622,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39688,7 +39688,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39754,7 +39754,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39820,7 +39820,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39993,7 +39993,7 @@ func (o *mergeJoinLeftAntiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40022,7 +40022,7 @@ func (o *mergeJoinLeftAntiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol.Set(outStartIdx, v)
 									}
 								} else {
@@ -40051,7 +40051,7 @@ func (o *mergeJoinLeftAntiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx].Set(&v)
 									}
 								} else {
@@ -40079,7 +40079,7 @@ func (o *mergeJoinLeftAntiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40104,7 +40104,7 @@ func (o *mergeJoinLeftAntiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40130,7 +40130,7 @@ func (o *mergeJoinLeftAntiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40159,7 +40159,7 @@ func (o *mergeJoinLeftAntiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40188,7 +40188,7 @@ func (o *mergeJoinLeftAntiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40217,7 +40217,7 @@ func (o *mergeJoinLeftAntiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {

--- a/pkg/sql/colexec/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftouter.eg.go
@@ -162,9 +162,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -195,7 +195,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -228,7 +228,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -290,7 +290,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -390,9 +390,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -416,7 +416,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -441,7 +441,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -495,7 +495,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -587,9 +587,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -613,7 +613,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -638,7 +638,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -692,7 +692,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -783,9 +783,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -819,7 +819,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -855,7 +855,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -920,7 +920,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1019,9 +1019,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -1055,7 +1055,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1091,7 +1091,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1156,7 +1156,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1256,9 +1256,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -1292,7 +1292,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1328,7 +1328,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1393,7 +1393,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1496,9 +1496,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -1540,7 +1540,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1584,7 +1584,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1657,7 +1657,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1768,9 +1768,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -1801,7 +1801,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1833,7 +1833,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1894,7 +1894,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1993,9 +1993,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -2019,7 +2019,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2044,7 +2044,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2098,7 +2098,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2394,9 +2394,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -2427,7 +2427,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2456,7 +2456,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2518,7 +2518,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2612,9 +2612,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -2638,7 +2638,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2659,7 +2659,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2713,7 +2713,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2799,9 +2799,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -2825,7 +2825,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2846,7 +2846,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2900,7 +2900,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2985,9 +2985,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3021,7 +3021,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3053,7 +3053,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3118,7 +3118,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3211,9 +3211,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3247,7 +3247,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3279,7 +3279,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3344,7 +3344,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3438,9 +3438,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3474,7 +3474,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3506,7 +3506,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3571,7 +3571,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3668,9 +3668,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -3712,7 +3712,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3752,7 +3752,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3825,7 +3825,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3930,9 +3930,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -3963,7 +3963,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3991,7 +3991,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4052,7 +4052,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4145,9 +4145,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -4171,7 +4171,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4192,7 +4192,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4246,7 +4246,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4533,9 +4533,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -4562,7 +4562,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4595,7 +4595,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4654,7 +4654,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4747,9 +4747,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -4769,7 +4769,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4794,7 +4794,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4845,7 +4845,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4930,9 +4930,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -4952,7 +4952,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4977,7 +4977,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5028,7 +5028,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5112,9 +5112,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5144,7 +5144,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5180,7 +5180,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5242,7 +5242,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5334,9 +5334,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5366,7 +5366,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5402,7 +5402,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5464,7 +5464,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5557,9 +5557,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5589,7 +5589,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5625,7 +5625,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5687,7 +5687,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5783,9 +5783,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -5823,7 +5823,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5867,7 +5867,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5937,7 +5937,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6041,9 +6041,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -6070,7 +6070,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6102,7 +6102,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6160,7 +6160,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6252,9 +6252,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -6274,7 +6274,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6299,7 +6299,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6350,7 +6350,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6625,9 +6625,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -6654,7 +6654,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6683,7 +6683,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6742,7 +6742,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6829,9 +6829,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -6851,7 +6851,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6872,7 +6872,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6923,7 +6923,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7002,9 +7002,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -7024,7 +7024,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7045,7 +7045,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7096,7 +7096,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7174,9 +7174,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7206,7 +7206,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7238,7 +7238,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7300,7 +7300,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7386,9 +7386,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7418,7 +7418,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7450,7 +7450,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7512,7 +7512,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7599,9 +7599,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7631,7 +7631,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7663,7 +7663,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7725,7 +7725,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7815,9 +7815,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -7855,7 +7855,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7895,7 +7895,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7965,7 +7965,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8063,9 +8063,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -8092,7 +8092,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8120,7 +8120,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8178,7 +8178,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8264,9 +8264,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -8286,7 +8286,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8307,7 +8307,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8358,7 +8358,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8715,9 +8715,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -8748,7 +8748,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8781,7 +8781,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8843,7 +8843,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8943,9 +8943,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -8969,7 +8969,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8994,7 +8994,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9048,7 +9048,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9140,9 +9140,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -9166,7 +9166,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9191,7 +9191,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9245,7 +9245,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9336,9 +9336,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9372,7 +9372,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9408,7 +9408,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9473,7 +9473,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9572,9 +9572,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9608,7 +9608,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9644,7 +9644,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9709,7 +9709,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9809,9 +9809,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9845,7 +9845,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9881,7 +9881,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9946,7 +9946,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10049,9 +10049,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -10093,7 +10093,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10137,7 +10137,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10210,7 +10210,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10321,9 +10321,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -10354,7 +10354,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10386,7 +10386,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10447,7 +10447,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10546,9 +10546,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -10572,7 +10572,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10597,7 +10597,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10651,7 +10651,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10947,9 +10947,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -10980,7 +10980,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11009,7 +11009,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11071,7 +11071,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11165,9 +11165,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -11191,7 +11191,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11212,7 +11212,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11266,7 +11266,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11352,9 +11352,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -11378,7 +11378,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11399,7 +11399,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11453,7 +11453,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11538,9 +11538,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -11574,7 +11574,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11606,7 +11606,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11671,7 +11671,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11764,9 +11764,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -11800,7 +11800,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11832,7 +11832,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11897,7 +11897,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11991,9 +11991,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -12027,7 +12027,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12059,7 +12059,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12124,7 +12124,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12221,9 +12221,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -12265,7 +12265,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12305,7 +12305,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12378,7 +12378,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12483,9 +12483,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -12516,7 +12516,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12544,7 +12544,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12605,7 +12605,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12698,9 +12698,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -12724,7 +12724,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12745,7 +12745,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12799,7 +12799,7 @@ EqLoop:
 											}
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13086,9 +13086,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -13115,7 +13115,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13148,7 +13148,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13207,7 +13207,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13300,9 +13300,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -13322,7 +13322,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13347,7 +13347,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13398,7 +13398,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13483,9 +13483,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -13505,7 +13505,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13530,7 +13530,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13581,7 +13581,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13665,9 +13665,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -13697,7 +13697,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13733,7 +13733,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13795,7 +13795,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13887,9 +13887,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -13919,7 +13919,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13955,7 +13955,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14017,7 +14017,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14110,9 +14110,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -14142,7 +14142,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14178,7 +14178,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14240,7 +14240,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14336,9 +14336,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -14376,7 +14376,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14420,7 +14420,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14490,7 +14490,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14594,9 +14594,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -14623,7 +14623,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14655,7 +14655,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14713,7 +14713,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14805,9 +14805,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -14827,7 +14827,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14852,7 +14852,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14903,7 +14903,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15178,9 +15178,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -15207,7 +15207,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15236,7 +15236,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15295,7 +15295,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15382,9 +15382,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -15404,7 +15404,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15425,7 +15425,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15476,7 +15476,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15555,9 +15555,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -15577,7 +15577,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15598,7 +15598,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15649,7 +15649,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15727,9 +15727,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15759,7 +15759,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15791,7 +15791,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15853,7 +15853,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15939,9 +15939,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15971,7 +15971,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16003,7 +16003,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16065,7 +16065,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16152,9 +16152,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -16184,7 +16184,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16216,7 +16216,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16278,7 +16278,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16368,9 +16368,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -16408,7 +16408,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16448,7 +16448,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16518,7 +16518,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16616,9 +16616,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -16645,7 +16645,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16673,7 +16673,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16731,7 +16731,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16817,9 +16817,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -16839,7 +16839,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16860,7 +16860,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16911,7 +16911,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17268,9 +17268,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -17301,7 +17301,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17334,7 +17334,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17396,7 +17396,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17496,9 +17496,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -17522,7 +17522,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17547,7 +17547,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17601,7 +17601,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17693,9 +17693,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -17719,7 +17719,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17744,7 +17744,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17798,7 +17798,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17889,9 +17889,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -17925,7 +17925,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17961,7 +17961,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18026,7 +18026,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18125,9 +18125,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -18161,7 +18161,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18197,7 +18197,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18262,7 +18262,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18362,9 +18362,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -18398,7 +18398,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18434,7 +18434,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18499,7 +18499,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18602,9 +18602,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -18646,7 +18646,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18690,7 +18690,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18763,7 +18763,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18874,9 +18874,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -18907,7 +18907,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18939,7 +18939,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19000,7 +19000,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19099,9 +19099,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -19125,7 +19125,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19150,7 +19150,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19204,7 +19204,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19500,9 +19500,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -19533,7 +19533,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19562,7 +19562,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19624,7 +19624,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19718,9 +19718,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -19744,7 +19744,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19765,7 +19765,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19819,7 +19819,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19905,9 +19905,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -19931,7 +19931,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19952,7 +19952,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20006,7 +20006,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20091,9 +20091,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20127,7 +20127,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20159,7 +20159,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20224,7 +20224,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20317,9 +20317,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20353,7 +20353,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20385,7 +20385,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20450,7 +20450,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20544,9 +20544,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20580,7 +20580,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20612,7 +20612,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20677,7 +20677,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20774,9 +20774,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -20818,7 +20818,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20858,7 +20858,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20931,7 +20931,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21036,9 +21036,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -21069,7 +21069,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21097,7 +21097,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21158,7 +21158,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21251,9 +21251,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -21277,7 +21277,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21298,7 +21298,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21352,7 +21352,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21639,9 +21639,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -21668,7 +21668,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21701,7 +21701,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21760,7 +21760,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21853,9 +21853,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -21875,7 +21875,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21900,7 +21900,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21951,7 +21951,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22036,9 +22036,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -22058,7 +22058,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22083,7 +22083,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22134,7 +22134,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22218,9 +22218,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22250,7 +22250,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22286,7 +22286,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22348,7 +22348,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22440,9 +22440,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22472,7 +22472,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22508,7 +22508,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22570,7 +22570,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22663,9 +22663,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22695,7 +22695,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22731,7 +22731,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22793,7 +22793,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22889,9 +22889,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -22929,7 +22929,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22973,7 +22973,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23043,7 +23043,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23147,9 +23147,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -23176,7 +23176,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23208,7 +23208,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23266,7 +23266,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23358,9 +23358,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -23380,7 +23380,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23405,7 +23405,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23456,7 +23456,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23731,9 +23731,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -23760,7 +23760,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23789,7 +23789,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23848,7 +23848,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23935,9 +23935,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -23957,7 +23957,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23978,7 +23978,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24029,7 +24029,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24108,9 +24108,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -24130,7 +24130,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24151,7 +24151,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24202,7 +24202,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24280,9 +24280,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -24312,7 +24312,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24344,7 +24344,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24406,7 +24406,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24492,9 +24492,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -24524,7 +24524,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24556,7 +24556,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24618,7 +24618,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24705,9 +24705,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -24737,7 +24737,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24769,7 +24769,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24831,7 +24831,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24921,9 +24921,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -24961,7 +24961,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25001,7 +25001,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25071,7 +25071,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25169,9 +25169,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -25198,7 +25198,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25226,7 +25226,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25284,7 +25284,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25370,9 +25370,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -25392,7 +25392,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25413,7 +25413,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25464,7 +25464,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25821,9 +25821,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -25854,7 +25854,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25887,7 +25887,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25949,7 +25949,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26049,9 +26049,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -26075,7 +26075,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26100,7 +26100,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26154,7 +26154,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26246,9 +26246,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -26272,7 +26272,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26297,7 +26297,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26351,7 +26351,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26442,9 +26442,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26478,7 +26478,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26514,7 +26514,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26579,7 +26579,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26678,9 +26678,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26714,7 +26714,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26750,7 +26750,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26815,7 +26815,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26915,9 +26915,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26951,7 +26951,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26987,7 +26987,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27052,7 +27052,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27155,9 +27155,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -27199,7 +27199,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27243,7 +27243,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27316,7 +27316,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27427,9 +27427,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -27460,7 +27460,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27492,7 +27492,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27553,7 +27553,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27652,9 +27652,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -27678,7 +27678,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27703,7 +27703,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27757,7 +27757,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28053,9 +28053,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -28086,7 +28086,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28115,7 +28115,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28177,7 +28177,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28271,9 +28271,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -28297,7 +28297,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28318,7 +28318,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28372,7 +28372,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28458,9 +28458,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -28484,7 +28484,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28505,7 +28505,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28559,7 +28559,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28644,9 +28644,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -28680,7 +28680,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28712,7 +28712,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28777,7 +28777,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28870,9 +28870,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -28906,7 +28906,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28938,7 +28938,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29003,7 +29003,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29097,9 +29097,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -29133,7 +29133,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29165,7 +29165,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29230,7 +29230,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29327,9 +29327,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -29371,7 +29371,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29411,7 +29411,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29484,7 +29484,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29589,9 +29589,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -29622,7 +29622,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29650,7 +29650,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29711,7 +29711,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29804,9 +29804,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -29830,7 +29830,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29851,7 +29851,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29905,7 +29905,7 @@ EqLoop:
 											}
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30192,9 +30192,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -30221,7 +30221,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30254,7 +30254,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30313,7 +30313,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30406,9 +30406,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -30428,7 +30428,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30453,7 +30453,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30504,7 +30504,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30589,9 +30589,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -30611,7 +30611,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30636,7 +30636,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30687,7 +30687,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30771,9 +30771,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -30803,7 +30803,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30839,7 +30839,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30901,7 +30901,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30993,9 +30993,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -31025,7 +31025,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31061,7 +31061,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31123,7 +31123,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31216,9 +31216,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -31248,7 +31248,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31284,7 +31284,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31346,7 +31346,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31442,9 +31442,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -31482,7 +31482,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31526,7 +31526,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31596,7 +31596,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31700,9 +31700,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -31729,7 +31729,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31761,7 +31761,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31819,7 +31819,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31911,9 +31911,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -31933,7 +31933,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31958,7 +31958,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32009,7 +32009,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32284,9 +32284,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -32313,7 +32313,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32342,7 +32342,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32401,7 +32401,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32488,9 +32488,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -32510,7 +32510,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32531,7 +32531,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32582,7 +32582,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32661,9 +32661,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -32683,7 +32683,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32704,7 +32704,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32755,7 +32755,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32833,9 +32833,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -32865,7 +32865,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32897,7 +32897,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32959,7 +32959,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33045,9 +33045,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -33077,7 +33077,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33109,7 +33109,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33171,7 +33171,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33258,9 +33258,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -33290,7 +33290,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33322,7 +33322,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33384,7 +33384,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33474,9 +33474,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -33514,7 +33514,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33554,7 +33554,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33624,7 +33624,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33722,9 +33722,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -33751,7 +33751,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33779,7 +33779,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33837,7 +33837,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33923,9 +33923,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -33945,7 +33945,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33966,7 +33966,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34017,7 +34017,7 @@ EqLoop:
 										for curLIdx < curLEndIdx {
 
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -34326,7 +34326,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34388,7 +34388,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -34450,7 +34450,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -34511,7 +34511,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34569,7 +34569,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34628,7 +34628,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34690,7 +34690,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34752,7 +34752,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34814,7 +34814,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34941,7 +34941,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35000,7 +35000,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -35059,7 +35059,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -35117,7 +35117,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35172,7 +35172,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35228,7 +35228,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35287,7 +35287,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35346,7 +35346,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35405,7 +35405,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35533,7 +35533,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35594,7 +35594,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -35655,7 +35655,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -35715,7 +35715,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35772,7 +35772,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35830,7 +35830,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35891,7 +35891,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35952,7 +35952,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36013,7 +36013,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36138,7 +36138,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36196,7 +36196,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -36254,7 +36254,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -36311,7 +36311,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36365,7 +36365,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36420,7 +36420,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36478,7 +36478,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36536,7 +36536,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36594,7 +36594,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36755,7 +36755,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36804,7 +36804,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol.Set(outStartIdx, val)
 										outStartIdx++
@@ -36853,7 +36853,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx].Set(&val)
 										outStartIdx++
@@ -36901,7 +36901,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36946,7 +36946,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36992,7 +36992,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -37041,7 +37041,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -37090,7 +37090,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -37139,7 +37139,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -37328,7 +37328,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37398,7 +37398,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -37468,7 +37468,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -37537,7 +37537,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37603,7 +37603,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37670,7 +37670,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37740,7 +37740,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37810,7 +37810,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37880,7 +37880,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38024,7 +38024,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38092,7 +38092,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -38160,7 +38160,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -38227,7 +38227,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38291,7 +38291,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38356,7 +38356,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38424,7 +38424,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38492,7 +38492,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38560,7 +38560,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38706,7 +38706,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38776,7 +38776,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -38846,7 +38846,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -38915,7 +38915,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38981,7 +38981,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39048,7 +39048,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39118,7 +39118,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39188,7 +39188,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39258,7 +39258,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39402,7 +39402,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39470,7 +39470,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -39538,7 +39538,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -39605,7 +39605,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39669,7 +39669,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39734,7 +39734,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39802,7 +39802,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39870,7 +39870,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39938,7 +39938,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -40113,7 +40113,7 @@ func (o *mergeJoinLeftOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40142,7 +40142,7 @@ func (o *mergeJoinLeftOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol.Set(outStartIdx, v)
 									}
 								} else {
@@ -40171,7 +40171,7 @@ func (o *mergeJoinLeftOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx].Set(&v)
 									}
 								} else {
@@ -40199,7 +40199,7 @@ func (o *mergeJoinLeftOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40224,7 +40224,7 @@ func (o *mergeJoinLeftOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40250,7 +40250,7 @@ func (o *mergeJoinLeftOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40279,7 +40279,7 @@ func (o *mergeJoinLeftOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40308,7 +40308,7 @@ func (o *mergeJoinLeftOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40337,7 +40337,7 @@ func (o *mergeJoinLeftOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {

--- a/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
@@ -150,9 +150,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -183,7 +183,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -216,7 +216,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -324,9 +324,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -350,7 +350,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -375,7 +375,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -475,9 +475,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -501,7 +501,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -526,7 +526,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -625,9 +625,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -661,7 +661,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -697,7 +697,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -804,9 +804,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -840,7 +840,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -876,7 +876,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -984,9 +984,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -1020,7 +1020,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1056,7 +1056,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1167,9 +1167,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -1211,7 +1211,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1255,7 +1255,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1374,9 +1374,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -1407,7 +1407,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1439,7 +1439,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1546,9 +1546,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -1572,7 +1572,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1597,7 +1597,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1853,9 +1853,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -1886,7 +1886,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1915,7 +1915,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2017,9 +2017,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -2043,7 +2043,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2064,7 +2064,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2158,9 +2158,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -2184,7 +2184,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2205,7 +2205,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2298,9 +2298,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -2334,7 +2334,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2366,7 +2366,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2467,9 +2467,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -2503,7 +2503,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2535,7 +2535,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2637,9 +2637,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -2673,7 +2673,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2705,7 +2705,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2810,9 +2810,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -2854,7 +2854,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2894,7 +2894,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3007,9 +3007,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -3040,7 +3040,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3068,7 +3068,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3169,9 +3169,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -3195,7 +3195,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3216,7 +3216,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3464,9 +3464,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -3493,7 +3493,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3526,7 +3526,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3628,9 +3628,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -3650,7 +3650,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3675,7 +3675,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3769,9 +3769,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -3791,7 +3791,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3816,7 +3816,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3909,9 +3909,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3941,7 +3941,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3977,7 +3977,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4078,9 +4078,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -4110,7 +4110,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4146,7 +4146,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4248,9 +4248,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -4280,7 +4280,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4316,7 +4316,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4421,9 +4421,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -4461,7 +4461,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4505,7 +4505,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4618,9 +4618,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -4647,7 +4647,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4679,7 +4679,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4780,9 +4780,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -4802,7 +4802,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4827,7 +4827,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5067,9 +5067,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -5096,7 +5096,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5125,7 +5125,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5221,9 +5221,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -5243,7 +5243,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5264,7 +5264,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5352,9 +5352,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -5374,7 +5374,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5395,7 +5395,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5482,9 +5482,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5514,7 +5514,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5546,7 +5546,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5641,9 +5641,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5673,7 +5673,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5705,7 +5705,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5801,9 +5801,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5833,7 +5833,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5865,7 +5865,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5964,9 +5964,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -6004,7 +6004,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6044,7 +6044,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6151,9 +6151,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -6180,7 +6180,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6208,7 +6208,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6303,9 +6303,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -6325,7 +6325,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6346,7 +6346,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6667,9 +6667,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -6700,7 +6700,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6733,7 +6733,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6841,9 +6841,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -6867,7 +6867,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6892,7 +6892,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6992,9 +6992,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -7018,7 +7018,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7043,7 +7043,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7142,9 +7142,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7178,7 +7178,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7214,7 +7214,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7321,9 +7321,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7357,7 +7357,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7393,7 +7393,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7501,9 +7501,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7537,7 +7537,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7573,7 +7573,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7684,9 +7684,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -7728,7 +7728,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7772,7 +7772,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7891,9 +7891,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -7924,7 +7924,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7956,7 +7956,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8063,9 +8063,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -8089,7 +8089,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8114,7 +8114,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8370,9 +8370,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -8403,7 +8403,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8432,7 +8432,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8534,9 +8534,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -8560,7 +8560,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8581,7 +8581,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8675,9 +8675,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -8701,7 +8701,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8722,7 +8722,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8815,9 +8815,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -8851,7 +8851,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8883,7 +8883,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8984,9 +8984,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9020,7 +9020,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9052,7 +9052,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9154,9 +9154,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9190,7 +9190,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9222,7 +9222,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9327,9 +9327,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -9371,7 +9371,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9411,7 +9411,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9524,9 +9524,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -9557,7 +9557,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9585,7 +9585,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9686,9 +9686,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -9712,7 +9712,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9733,7 +9733,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9981,9 +9981,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -10010,7 +10010,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10043,7 +10043,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10145,9 +10145,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -10167,7 +10167,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10192,7 +10192,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10286,9 +10286,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -10308,7 +10308,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10333,7 +10333,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10426,9 +10426,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -10458,7 +10458,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10494,7 +10494,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10595,9 +10595,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -10627,7 +10627,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10663,7 +10663,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10765,9 +10765,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -10797,7 +10797,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10833,7 +10833,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10938,9 +10938,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -10978,7 +10978,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11022,7 +11022,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11135,9 +11135,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -11164,7 +11164,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11196,7 +11196,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11297,9 +11297,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -11319,7 +11319,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11344,7 +11344,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11584,9 +11584,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -11613,7 +11613,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11642,7 +11642,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11738,9 +11738,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -11760,7 +11760,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11781,7 +11781,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11869,9 +11869,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -11891,7 +11891,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11912,7 +11912,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11999,9 +11999,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -12031,7 +12031,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12063,7 +12063,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12158,9 +12158,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -12190,7 +12190,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12222,7 +12222,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12318,9 +12318,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -12350,7 +12350,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12382,7 +12382,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12481,9 +12481,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -12521,7 +12521,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12561,7 +12561,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12668,9 +12668,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -12697,7 +12697,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12725,7 +12725,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12820,9 +12820,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -12842,7 +12842,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12863,7 +12863,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13184,9 +13184,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -13217,7 +13217,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13250,7 +13250,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13358,9 +13358,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -13384,7 +13384,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13409,7 +13409,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13509,9 +13509,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -13535,7 +13535,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13560,7 +13560,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13659,9 +13659,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -13695,7 +13695,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13731,7 +13731,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13838,9 +13838,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -13874,7 +13874,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13910,7 +13910,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14018,9 +14018,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -14054,7 +14054,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14090,7 +14090,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14201,9 +14201,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -14245,7 +14245,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14289,7 +14289,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14408,9 +14408,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -14441,7 +14441,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14473,7 +14473,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14580,9 +14580,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -14606,7 +14606,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14631,7 +14631,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14887,9 +14887,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -14920,7 +14920,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14949,7 +14949,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15051,9 +15051,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -15077,7 +15077,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15098,7 +15098,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15192,9 +15192,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -15218,7 +15218,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15239,7 +15239,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15332,9 +15332,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15368,7 +15368,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15400,7 +15400,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15501,9 +15501,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15537,7 +15537,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15569,7 +15569,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15671,9 +15671,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15707,7 +15707,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15739,7 +15739,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15844,9 +15844,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -15888,7 +15888,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15928,7 +15928,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16041,9 +16041,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -16074,7 +16074,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16102,7 +16102,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16203,9 +16203,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -16229,7 +16229,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16250,7 +16250,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16498,9 +16498,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -16527,7 +16527,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16560,7 +16560,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16662,9 +16662,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -16684,7 +16684,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16709,7 +16709,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16803,9 +16803,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -16825,7 +16825,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16850,7 +16850,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16943,9 +16943,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -16975,7 +16975,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17011,7 +17011,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17112,9 +17112,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -17144,7 +17144,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17180,7 +17180,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17282,9 +17282,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -17314,7 +17314,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17350,7 +17350,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17455,9 +17455,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -17495,7 +17495,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17539,7 +17539,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17652,9 +17652,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -17681,7 +17681,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17713,7 +17713,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17814,9 +17814,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -17836,7 +17836,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17861,7 +17861,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18101,9 +18101,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -18130,7 +18130,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18159,7 +18159,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18255,9 +18255,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -18277,7 +18277,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18298,7 +18298,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18386,9 +18386,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -18408,7 +18408,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18429,7 +18429,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18516,9 +18516,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -18548,7 +18548,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18580,7 +18580,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18675,9 +18675,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -18707,7 +18707,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18739,7 +18739,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18835,9 +18835,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -18867,7 +18867,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18899,7 +18899,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18998,9 +18998,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -19038,7 +19038,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19078,7 +19078,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19185,9 +19185,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -19214,7 +19214,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19242,7 +19242,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19337,9 +19337,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -19359,7 +19359,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19380,7 +19380,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19701,9 +19701,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -19734,7 +19734,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19767,7 +19767,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19875,9 +19875,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -19901,7 +19901,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19926,7 +19926,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20026,9 +20026,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -20052,7 +20052,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20077,7 +20077,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20176,9 +20176,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20212,7 +20212,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20248,7 +20248,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20355,9 +20355,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20391,7 +20391,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20427,7 +20427,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20535,9 +20535,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20571,7 +20571,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20607,7 +20607,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20718,9 +20718,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -20762,7 +20762,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20806,7 +20806,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20925,9 +20925,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -20958,7 +20958,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20990,7 +20990,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21097,9 +21097,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -21123,7 +21123,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21148,7 +21148,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21404,9 +21404,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -21437,7 +21437,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21466,7 +21466,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21568,9 +21568,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -21594,7 +21594,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21615,7 +21615,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21709,9 +21709,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -21735,7 +21735,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21756,7 +21756,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21849,9 +21849,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -21885,7 +21885,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21917,7 +21917,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22018,9 +22018,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22054,7 +22054,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22086,7 +22086,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22188,9 +22188,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22224,7 +22224,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22256,7 +22256,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22361,9 +22361,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -22405,7 +22405,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22445,7 +22445,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22558,9 +22558,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -22591,7 +22591,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22619,7 +22619,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22720,9 +22720,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -22746,7 +22746,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22767,7 +22767,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23015,9 +23015,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -23044,7 +23044,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23077,7 +23077,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23179,9 +23179,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -23201,7 +23201,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23226,7 +23226,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23320,9 +23320,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -23342,7 +23342,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23367,7 +23367,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23460,9 +23460,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -23492,7 +23492,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23528,7 +23528,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23629,9 +23629,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -23661,7 +23661,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23697,7 +23697,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23799,9 +23799,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -23831,7 +23831,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23867,7 +23867,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23972,9 +23972,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -24012,7 +24012,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24056,7 +24056,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24169,9 +24169,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -24198,7 +24198,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24230,7 +24230,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24331,9 +24331,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -24353,7 +24353,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24378,7 +24378,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24618,9 +24618,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -24647,7 +24647,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24676,7 +24676,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24772,9 +24772,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -24794,7 +24794,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24815,7 +24815,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24903,9 +24903,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -24925,7 +24925,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24946,7 +24946,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25033,9 +25033,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -25065,7 +25065,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25097,7 +25097,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25192,9 +25192,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -25224,7 +25224,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25256,7 +25256,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25352,9 +25352,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -25384,7 +25384,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25416,7 +25416,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25515,9 +25515,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -25555,7 +25555,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25595,7 +25595,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25702,9 +25702,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -25731,7 +25731,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25759,7 +25759,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25854,9 +25854,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -25876,7 +25876,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25897,7 +25897,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26182,7 +26182,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26244,7 +26244,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -26306,7 +26306,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -26367,7 +26367,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26425,7 +26425,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26484,7 +26484,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26546,7 +26546,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26608,7 +26608,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26670,7 +26670,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26797,7 +26797,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -26856,7 +26856,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -26915,7 +26915,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -26973,7 +26973,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27028,7 +27028,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27084,7 +27084,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27143,7 +27143,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27202,7 +27202,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27261,7 +27261,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27389,7 +27389,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27450,7 +27450,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -27511,7 +27511,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -27571,7 +27571,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27628,7 +27628,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27686,7 +27686,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27747,7 +27747,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27808,7 +27808,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27869,7 +27869,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -27994,7 +27994,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28052,7 +28052,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -28110,7 +28110,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -28167,7 +28167,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28221,7 +28221,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28276,7 +28276,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28334,7 +28334,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28392,7 +28392,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28450,7 +28450,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 
 										{
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -28611,7 +28611,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -28660,7 +28660,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol.Set(outStartIdx, val)
 										outStartIdx++
@@ -28709,7 +28709,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx].Set(&val)
 										outStartIdx++
@@ -28757,7 +28757,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -28802,7 +28802,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -28848,7 +28848,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -28897,7 +28897,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -28946,7 +28946,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -28995,7 +28995,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -29182,7 +29182,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29250,7 +29250,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -29318,7 +29318,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -29385,7 +29385,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29449,7 +29449,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29514,7 +29514,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29582,7 +29582,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29650,7 +29650,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29718,7 +29718,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29858,7 +29858,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -29924,7 +29924,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -29990,7 +29990,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -30055,7 +30055,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30117,7 +30117,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30180,7 +30180,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30246,7 +30246,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30312,7 +30312,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30378,7 +30378,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30520,7 +30520,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30588,7 +30588,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -30656,7 +30656,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -30723,7 +30723,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30787,7 +30787,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30852,7 +30852,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30920,7 +30920,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -30988,7 +30988,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31056,7 +31056,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31196,7 +31196,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31262,7 +31262,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -31328,7 +31328,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -31393,7 +31393,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31455,7 +31455,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31518,7 +31518,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31584,7 +31584,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31650,7 +31650,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31716,7 +31716,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -31889,7 +31889,7 @@ func (o *mergeJoinLeftSemiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -31918,7 +31918,7 @@ func (o *mergeJoinLeftSemiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol.Set(outStartIdx, v)
 									}
 								} else {
@@ -31947,7 +31947,7 @@ func (o *mergeJoinLeftSemiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx].Set(&v)
 									}
 								} else {
@@ -31975,7 +31975,7 @@ func (o *mergeJoinLeftSemiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -32000,7 +32000,7 @@ func (o *mergeJoinLeftSemiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -32026,7 +32026,7 @@ func (o *mergeJoinLeftSemiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -32055,7 +32055,7 @@ func (o *mergeJoinLeftSemiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -32084,7 +32084,7 @@ func (o *mergeJoinLeftSemiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -32113,7 +32113,7 @@ func (o *mergeJoinLeftSemiOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {

--- a/pkg/sql/colexec/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_rightouter.eg.go
@@ -161,9 +161,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -194,7 +194,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -227,7 +227,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -291,7 +291,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -387,9 +387,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -413,7 +413,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -438,7 +438,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -494,7 +494,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -582,9 +582,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -608,7 +608,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -633,7 +633,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -689,7 +689,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -776,9 +776,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -812,7 +812,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -848,7 +848,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -915,7 +915,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1010,9 +1010,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -1046,7 +1046,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1082,7 +1082,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1149,7 +1149,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1245,9 +1245,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -1281,7 +1281,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1317,7 +1317,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1384,7 +1384,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1483,9 +1483,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -1527,7 +1527,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1571,7 +1571,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1646,7 +1646,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1753,9 +1753,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -1786,7 +1786,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -1818,7 +1818,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1881,7 +1881,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -1976,9 +1976,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -2002,7 +2002,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2027,7 +2027,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2083,7 +2083,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2372,9 +2372,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -2405,7 +2405,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2434,7 +2434,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2495,7 +2495,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2584,9 +2584,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -2610,7 +2610,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2631,7 +2631,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2684,7 +2684,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2765,9 +2765,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -2791,7 +2791,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -2812,7 +2812,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2865,7 +2865,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -2945,9 +2945,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -2981,7 +2981,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3013,7 +3013,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3077,7 +3077,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3165,9 +3165,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3201,7 +3201,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3233,7 +3233,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3297,7 +3297,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3386,9 +3386,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -3422,7 +3422,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3454,7 +3454,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3518,7 +3518,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3610,9 +3610,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -3654,7 +3654,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3694,7 +3694,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3766,7 +3766,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3866,9 +3866,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -3899,7 +3899,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -3927,7 +3927,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -3987,7 +3987,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4075,9 +4075,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -4101,7 +4101,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4122,7 +4122,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4175,7 +4175,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4453,9 +4453,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -4482,7 +4482,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4515,7 +4515,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4579,7 +4579,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4669,9 +4669,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -4691,7 +4691,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4716,7 +4716,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4772,7 +4772,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4854,9 +4854,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -4876,7 +4876,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -4901,7 +4901,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -4957,7 +4957,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5038,9 +5038,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5070,7 +5070,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5106,7 +5106,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5173,7 +5173,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5262,9 +5262,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5294,7 +5294,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5330,7 +5330,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5397,7 +5397,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5487,9 +5487,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -5519,7 +5519,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5555,7 +5555,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5622,7 +5622,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5715,9 +5715,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -5755,7 +5755,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -5799,7 +5799,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5874,7 +5874,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -5975,9 +5975,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -6004,7 +6004,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6036,7 +6036,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6099,7 +6099,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6188,9 +6188,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -6210,7 +6210,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6235,7 +6235,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6291,7 +6291,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6564,9 +6564,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -6593,7 +6593,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6622,7 +6622,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6683,7 +6683,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6766,9 +6766,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -6788,7 +6788,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6809,7 +6809,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6862,7 +6862,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -6937,9 +6937,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -6959,7 +6959,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -6980,7 +6980,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7033,7 +7033,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7107,9 +7107,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7139,7 +7139,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7171,7 +7171,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7235,7 +7235,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7317,9 +7317,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7349,7 +7349,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7381,7 +7381,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7445,7 +7445,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7528,9 +7528,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -7560,7 +7560,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7592,7 +7592,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7656,7 +7656,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7742,9 +7742,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -7782,7 +7782,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -7822,7 +7822,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7894,7 +7894,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -7988,9 +7988,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -8017,7 +8017,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8045,7 +8045,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8105,7 +8105,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8187,9 +8187,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -8209,7 +8209,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8230,7 +8230,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8283,7 +8283,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8634,9 +8634,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -8667,7 +8667,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8700,7 +8700,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8764,7 +8764,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8860,9 +8860,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -8886,7 +8886,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -8911,7 +8911,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -8967,7 +8967,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9055,9 +9055,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -9081,7 +9081,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9106,7 +9106,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9162,7 +9162,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9249,9 +9249,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9285,7 +9285,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9321,7 +9321,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9388,7 +9388,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9483,9 +9483,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9519,7 +9519,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9555,7 +9555,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9622,7 +9622,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9718,9 +9718,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -9754,7 +9754,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -9790,7 +9790,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9857,7 +9857,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -9956,9 +9956,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -10000,7 +10000,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10044,7 +10044,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10119,7 +10119,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10226,9 +10226,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -10259,7 +10259,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10291,7 +10291,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10354,7 +10354,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10449,9 +10449,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -10475,7 +10475,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10500,7 +10500,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10556,7 +10556,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10845,9 +10845,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -10878,7 +10878,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -10907,7 +10907,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -10968,7 +10968,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11057,9 +11057,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -11083,7 +11083,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11104,7 +11104,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11157,7 +11157,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11238,9 +11238,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -11264,7 +11264,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11285,7 +11285,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11338,7 +11338,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11418,9 +11418,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -11454,7 +11454,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11486,7 +11486,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11550,7 +11550,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11638,9 +11638,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -11674,7 +11674,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11706,7 +11706,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11770,7 +11770,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11859,9 +11859,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -11895,7 +11895,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -11927,7 +11927,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -11991,7 +11991,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12083,9 +12083,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -12127,7 +12127,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12167,7 +12167,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12239,7 +12239,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12339,9 +12339,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -12372,7 +12372,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12400,7 +12400,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12460,7 +12460,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12548,9 +12548,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -12574,7 +12574,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12595,7 +12595,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12648,7 +12648,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -12926,9 +12926,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -12955,7 +12955,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -12988,7 +12988,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13052,7 +13052,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13142,9 +13142,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -13164,7 +13164,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13189,7 +13189,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13245,7 +13245,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13327,9 +13327,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -13349,7 +13349,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13374,7 +13374,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13430,7 +13430,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13511,9 +13511,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -13543,7 +13543,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13579,7 +13579,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13646,7 +13646,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13735,9 +13735,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -13767,7 +13767,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -13803,7 +13803,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13870,7 +13870,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -13960,9 +13960,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -13992,7 +13992,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14028,7 +14028,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14095,7 +14095,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14188,9 +14188,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -14228,7 +14228,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14272,7 +14272,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14347,7 +14347,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14448,9 +14448,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -14477,7 +14477,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14509,7 +14509,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14572,7 +14572,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14661,9 +14661,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -14683,7 +14683,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -14708,7 +14708,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -14764,7 +14764,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15037,9 +15037,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -15066,7 +15066,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15095,7 +15095,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15156,7 +15156,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15239,9 +15239,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -15261,7 +15261,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15282,7 +15282,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15335,7 +15335,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15410,9 +15410,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -15432,7 +15432,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15453,7 +15453,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15506,7 +15506,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15580,9 +15580,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15612,7 +15612,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15644,7 +15644,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15708,7 +15708,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15790,9 +15790,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -15822,7 +15822,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -15854,7 +15854,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -15918,7 +15918,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16001,9 +16001,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -16033,7 +16033,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16065,7 +16065,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16129,7 +16129,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16215,9 +16215,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -16255,7 +16255,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16295,7 +16295,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16367,7 +16367,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16461,9 +16461,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -16490,7 +16490,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16518,7 +16518,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16578,7 +16578,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16660,9 +16660,9 @@ EqLoop:
 								{
 
 									lSelIdx = lSel[curLIdx]
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -16682,7 +16682,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = lSel[curLIdx]
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -16703,7 +16703,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -16756,7 +16756,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17107,9 +17107,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -17140,7 +17140,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17173,7 +17173,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17237,7 +17237,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17333,9 +17333,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -17359,7 +17359,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17384,7 +17384,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17440,7 +17440,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17528,9 +17528,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -17554,7 +17554,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17579,7 +17579,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17635,7 +17635,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17722,9 +17722,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -17758,7 +17758,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -17794,7 +17794,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17861,7 +17861,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -17956,9 +17956,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -17992,7 +17992,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18028,7 +18028,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18095,7 +18095,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18191,9 +18191,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -18227,7 +18227,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18263,7 +18263,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18330,7 +18330,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18429,9 +18429,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -18473,7 +18473,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18517,7 +18517,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18592,7 +18592,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18699,9 +18699,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -18732,7 +18732,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18764,7 +18764,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18827,7 +18827,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -18922,9 +18922,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -18948,7 +18948,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -18973,7 +18973,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19029,7 +19029,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19318,9 +19318,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -19351,7 +19351,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19380,7 +19380,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19441,7 +19441,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19530,9 +19530,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -19556,7 +19556,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19577,7 +19577,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19630,7 +19630,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19711,9 +19711,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -19737,7 +19737,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19758,7 +19758,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19811,7 +19811,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -19891,9 +19891,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -19927,7 +19927,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -19959,7 +19959,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20023,7 +20023,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20111,9 +20111,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20147,7 +20147,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20179,7 +20179,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20243,7 +20243,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20332,9 +20332,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -20368,7 +20368,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20400,7 +20400,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20464,7 +20464,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20556,9 +20556,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -20600,7 +20600,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20640,7 +20640,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20712,7 +20712,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20812,9 +20812,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -20845,7 +20845,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -20873,7 +20873,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -20933,7 +20933,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21021,9 +21021,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -21047,7 +21047,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21068,7 +21068,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21121,7 +21121,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21399,9 +21399,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -21428,7 +21428,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21461,7 +21461,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21525,7 +21525,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21615,9 +21615,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -21637,7 +21637,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21662,7 +21662,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21718,7 +21718,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21800,9 +21800,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -21822,7 +21822,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -21847,7 +21847,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21903,7 +21903,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -21984,9 +21984,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22016,7 +22016,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22052,7 +22052,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22119,7 +22119,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22208,9 +22208,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22240,7 +22240,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22276,7 +22276,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22343,7 +22343,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22433,9 +22433,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -22465,7 +22465,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22501,7 +22501,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22568,7 +22568,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22661,9 +22661,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -22701,7 +22701,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22745,7 +22745,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22820,7 +22820,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -22921,9 +22921,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -22950,7 +22950,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -22982,7 +22982,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23045,7 +23045,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23134,9 +23134,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -23156,7 +23156,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23181,7 +23181,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23237,7 +23237,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23510,9 +23510,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -23539,7 +23539,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23568,7 +23568,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23629,7 +23629,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23712,9 +23712,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -23734,7 +23734,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23755,7 +23755,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23808,7 +23808,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23883,9 +23883,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -23905,7 +23905,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -23926,7 +23926,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -23979,7 +23979,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24053,9 +24053,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -24085,7 +24085,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24117,7 +24117,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24181,7 +24181,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24263,9 +24263,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -24295,7 +24295,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24327,7 +24327,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24391,7 +24391,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24474,9 +24474,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -24506,7 +24506,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24538,7 +24538,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24602,7 +24602,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24688,9 +24688,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -24728,7 +24728,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24768,7 +24768,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24840,7 +24840,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -24934,9 +24934,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -24963,7 +24963,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -24991,7 +24991,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25051,7 +25051,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25133,9 +25133,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = rSel[curRIdx]
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -25155,7 +25155,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25176,7 +25176,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25229,7 +25229,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = rSel[curRIdx]
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25580,9 +25580,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -25613,7 +25613,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25646,7 +25646,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25710,7 +25710,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25806,9 +25806,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -25832,7 +25832,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -25857,7 +25857,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -25913,7 +25913,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26001,9 +26001,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -26027,7 +26027,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26052,7 +26052,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26108,7 +26108,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26195,9 +26195,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26231,7 +26231,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26267,7 +26267,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26334,7 +26334,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26429,9 +26429,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26465,7 +26465,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26501,7 +26501,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26568,7 +26568,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26664,9 +26664,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -26700,7 +26700,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26736,7 +26736,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26803,7 +26803,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -26902,9 +26902,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -26946,7 +26946,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -26990,7 +26990,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27065,7 +27065,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27172,9 +27172,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -27205,7 +27205,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27237,7 +27237,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27300,7 +27300,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27395,9 +27395,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -27421,7 +27421,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27446,7 +27446,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27502,7 +27502,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27791,9 +27791,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -27824,7 +27824,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -27853,7 +27853,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -27914,7 +27914,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28003,9 +28003,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -28029,7 +28029,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28050,7 +28050,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28103,7 +28103,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28184,9 +28184,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -28210,7 +28210,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28231,7 +28231,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28284,7 +28284,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28364,9 +28364,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -28400,7 +28400,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28432,7 +28432,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28496,7 +28496,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28584,9 +28584,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -28620,7 +28620,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28652,7 +28652,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28716,7 +28716,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28805,9 +28805,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -28841,7 +28841,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -28873,7 +28873,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -28937,7 +28937,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29029,9 +29029,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -29073,7 +29073,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29113,7 +29113,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29185,7 +29185,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29285,9 +29285,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -29318,7 +29318,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29346,7 +29346,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29406,7 +29406,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29494,9 +29494,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -29520,7 +29520,7 @@ EqLoop:
 												break
 											}
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29541,7 +29541,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29594,7 +29594,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29872,9 +29872,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -29901,7 +29901,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -29934,7 +29934,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -29998,7 +29998,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30088,9 +30088,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -30110,7 +30110,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30135,7 +30135,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30191,7 +30191,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30273,9 +30273,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -30295,7 +30295,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30320,7 +30320,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30376,7 +30376,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30457,9 +30457,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -30489,7 +30489,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30525,7 +30525,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30592,7 +30592,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30681,9 +30681,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -30713,7 +30713,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30749,7 +30749,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30816,7 +30816,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -30906,9 +30906,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -30938,7 +30938,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -30974,7 +30974,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31041,7 +31041,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31134,9 +31134,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -31174,7 +31174,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31218,7 +31218,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31293,7 +31293,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31394,9 +31394,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -31423,7 +31423,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31455,7 +31455,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31518,7 +31518,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31607,9 +31607,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -31629,7 +31629,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -31654,7 +31654,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31710,7 +31710,7 @@ EqLoop:
 												break
 											}
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -31983,9 +31983,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if !lVal && rVal {
 										cmp = -1
@@ -32012,7 +32012,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32041,7 +32041,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32102,7 +32102,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32185,9 +32185,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = bytes.Compare(lVal, rVal)
 
 								}
@@ -32207,7 +32207,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32228,7 +32228,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32281,7 +32281,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32356,9 +32356,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = tree.CompareDecimals(&lVal, &rVal)
 
 								}
@@ -32378,7 +32378,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32399,7 +32399,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32452,7 +32452,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32526,9 +32526,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -32558,7 +32558,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32590,7 +32590,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32654,7 +32654,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32736,9 +32736,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -32768,7 +32768,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -32800,7 +32800,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32864,7 +32864,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -32947,9 +32947,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := int64(lVal), int64(rVal)
@@ -32979,7 +32979,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33011,7 +33011,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33075,7 +33075,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33161,9 +33161,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									{
 										a, b := float64(lVal), float64(rVal)
@@ -33201,7 +33201,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33241,7 +33241,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33313,7 +33313,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33407,9 +33407,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 
 									if lVal.Before(rVal) {
 										cmp = -1
@@ -33436,7 +33436,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33464,7 +33464,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33524,7 +33524,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33606,9 +33606,9 @@ EqLoop:
 								{
 
 									lSelIdx = curLIdx
-									lVal = lKeys.Get(lSelIdx) //gcassert:inline
+									lVal = lKeys.Get(lSelIdx)
 									rSelIdx = curRIdx
-									rVal = rKeys.Get(rSelIdx) //gcassert:inline
+									rVal = rKeys.Get(rSelIdx)
 									cmp = lVal.Compare(rVal)
 
 								}
@@ -33628,7 +33628,7 @@ EqLoop:
 									for curLIdx < curLEndIdx {
 										{
 											lSelIdx = curLIdx
-											newLVal := lKeys.Get(lSelIdx) //gcassert:inline
+											newLVal := lKeys.Get(lSelIdx)
 
 											{
 												var cmpResult int
@@ -33649,7 +33649,7 @@ EqLoop:
 									for curRIdx < curREndIdx {
 										{
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -33702,7 +33702,7 @@ EqLoop:
 										o.groups.addRightOuterGroup(curLIdx, curRIdx-1)
 										for curRIdx < curREndIdx {
 											rSelIdx = curRIdx
-											newRVal := rKeys.Get(rSelIdx) //gcassert:inline
+											newRVal := rKeys.Get(rSelIdx)
 
 											{
 												var cmpResult int
@@ -34009,7 +34009,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34074,7 +34074,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -34139,7 +34139,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -34203,7 +34203,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34264,7 +34264,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34326,7 +34326,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34391,7 +34391,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34456,7 +34456,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34521,7 +34521,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34654,7 +34654,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34716,7 +34716,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -34778,7 +34778,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -34839,7 +34839,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34897,7 +34897,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -34956,7 +34956,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35018,7 +35018,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35080,7 +35080,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35142,7 +35142,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35276,7 +35276,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35340,7 +35340,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -35404,7 +35404,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -35467,7 +35467,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35527,7 +35527,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35588,7 +35588,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35652,7 +35652,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35716,7 +35716,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35780,7 +35780,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 												out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 												outStartIdx += toAppend
 											} else {
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35911,7 +35911,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -35972,7 +35972,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol.Set(outStartIdx, val)
 													outStartIdx++
@@ -36033,7 +36033,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx].Set(&val)
 													outStartIdx++
@@ -36093,7 +36093,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36150,7 +36150,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36208,7 +36208,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36269,7 +36269,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36330,7 +36330,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36391,7 +36391,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 											outStartIdx += toAppend
 										} else {
 											{
-												val = srcCol.Get(srcStartIdx) //gcassert:inline
+												val = srcCol.Get(srcStartIdx)
 												for i := 0; i < toAppend; i++ {
 													outCol[outStartIdx] = val
 													outStartIdx++
@@ -36555,7 +36555,7 @@ func (o *mergeJoinRightOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36604,7 +36604,7 @@ func (o *mergeJoinRightOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol.Set(outStartIdx, val)
 										outStartIdx++
@@ -36653,7 +36653,7 @@ func (o *mergeJoinRightOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx].Set(&val)
 										outStartIdx++
@@ -36701,7 +36701,7 @@ func (o *mergeJoinRightOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36746,7 +36746,7 @@ func (o *mergeJoinRightOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36792,7 +36792,7 @@ func (o *mergeJoinRightOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36841,7 +36841,7 @@ func (o *mergeJoinRightOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36890,7 +36890,7 @@ func (o *mergeJoinRightOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -36939,7 +36939,7 @@ func (o *mergeJoinRightOuterOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = srcCol.Get(srcStartIdx) //gcassert:inline
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										outCol[outStartIdx] = val
 										outStartIdx++
@@ -37126,7 +37126,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37194,7 +37194,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -37262,7 +37262,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -37329,7 +37329,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37393,7 +37393,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37458,7 +37458,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37526,7 +37526,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37594,7 +37594,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37662,7 +37662,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(sel[o.builderState.right.curSrcStartIdx]) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37802,7 +37802,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -37868,7 +37868,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -37934,7 +37934,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -37999,7 +37999,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38061,7 +38061,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38124,7 +38124,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38190,7 +38190,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38256,7 +38256,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38322,7 +38322,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx]) //gcassert:inline
+													v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38464,7 +38464,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38532,7 +38532,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -38600,7 +38600,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -38667,7 +38667,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38731,7 +38731,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38796,7 +38796,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38864,7 +38864,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -38932,7 +38932,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39000,7 +39000,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 												if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 													out.Nulls().SetNull(outStartIdx)
 												} else {
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39140,7 +39140,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39206,7 +39206,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol.Set(outStartIdx, v)
 												}
 											} else {
@@ -39272,7 +39272,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx].Set(&v)
 												}
 											} else {
@@ -39337,7 +39337,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39399,7 +39399,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39462,7 +39462,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39528,7 +39528,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39594,7 +39594,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39660,7 +39660,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 											// instead of copy.
 											if toAppend == 1 {
 												{
-													v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+													v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 													outCol[outStartIdx] = v
 												}
 											} else {
@@ -39833,7 +39833,7 @@ func (o *mergeJoinRightOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -39862,7 +39862,7 @@ func (o *mergeJoinRightOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol.Set(outStartIdx, v)
 									}
 								} else {
@@ -39891,7 +39891,7 @@ func (o *mergeJoinRightOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx].Set(&v)
 									}
 								} else {
@@ -39919,7 +39919,7 @@ func (o *mergeJoinRightOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -39944,7 +39944,7 @@ func (o *mergeJoinRightOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -39970,7 +39970,7 @@ func (o *mergeJoinRightOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -39999,7 +39999,7 @@ func (o *mergeJoinRightOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40028,7 +40028,7 @@ func (o *mergeJoinRightOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {
@@ -40057,7 +40057,7 @@ func (o *mergeJoinRightOuterOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := srcCol.Get(o.builderState.right.curSrcStartIdx) //gcassert:inline
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										outCol[outStartIdx] = v
 									}
 								} else {

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -199,9 +199,9 @@ func _PROBE_SWITCH(
 							// {{end}}
 
 							lSelIdx = _L_SEL_IND
-							lVal = execgen.UNSAFEGET(lKeys, lSelIdx)
+							lVal = lKeys.Get(lSelIdx)
 							rSelIdx = _R_SEL_IND
-							rVal = execgen.UNSAFEGET(rKeys, rSelIdx)
+							rVal = rKeys.Get(rSelIdx)
 							_ASSIGN_CMP(cmp, lVal, rVal, lKeys, rKeys)
 
 							// {{if _JOIN_TYPE.IsSetOp}}
@@ -247,7 +247,7 @@ func _PROBE_SWITCH(
 								}
 								// {{end}}
 								lSelIdx = _L_SEL_IND
-								newLVal := execgen.UNSAFEGET(lKeys, lSelIdx)
+								newLVal := lKeys.Get(lSelIdx)
 								_ASSIGN_EQ(match, newLVal, lVal, _, lKeys, lKeys)
 								if !match {
 									lComplete = true
@@ -283,7 +283,7 @@ func _PROBE_SWITCH(
 								}
 								// {{end}}
 								rSelIdx = _R_SEL_IND
-								newRVal := execgen.UNSAFEGET(rKeys, rSelIdx)
+								newRVal := rKeys.Get(rSelIdx)
 								_ASSIGN_EQ(match, newRVal, rVal, _, rKeys, rKeys)
 								if !match {
 									rComplete = true
@@ -555,7 +555,7 @@ func _INCREMENT_LEFT_SWITCH(
 			// {{end}}
 			lSelIdx = _L_SEL_IND
 			// {{with .Global}}
-			newLVal := execgen.UNSAFEGET(lKeys, lSelIdx)
+			newLVal := lKeys.Get(lSelIdx)
 			_ASSIGN_EQ(match, newLVal, lVal, _, lKeys, lKeys)
 			// {{end}}
 			if !match {
@@ -612,7 +612,7 @@ func _INCREMENT_RIGHT_SWITCH(
 		// {{end}}
 		rSelIdx = _R_SEL_IND
 		// {{with .Global}}
-		newRVal := execgen.UNSAFEGET(rKeys, rSelIdx)
+		newRVal := rKeys.Get(rSelIdx)
 		_ASSIGN_EQ(match, newRVal, rVal, _, rKeys, rKeys)
 		// {{end}}
 		if !match {
@@ -830,7 +830,7 @@ func _LEFT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool)
 						} else
 						// {{end}}
 						{
-							val = execgen.UNSAFEGET(srcCol, srcStartIdx)
+							val = srcCol.Get(srcStartIdx)
 							for i := 0; i < toAppend; i++ {
 								execgen.SET(outCol, outStartIdx, val)
 								outStartIdx++
@@ -1019,7 +1019,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildLeftBufferedGroup(
 									out.Nulls().SetNullRange(outStartIdx, outStartIdx+toAppend)
 									outStartIdx += toAppend
 								} else {
-									val = execgen.UNSAFEGET(srcCol, srcStartIdx)
+									val = srcCol.Get(srcStartIdx)
 									for i := 0; i < toAppend; i++ {
 										execgen.SET(outCol, outStartIdx, val)
 										outStartIdx++
@@ -1150,7 +1150,7 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 							} else
 							// {{end}}
 							{
-								v := execgen.UNSAFEGET(srcCol, sel[o.builderState.right.curSrcStartIdx])
+								v := srcCol.Get(sel[o.builderState.right.curSrcStartIdx])
 								execgen.SET(outCol, outStartIdx, v)
 							}
 							// {{else}}
@@ -1160,7 +1160,7 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 							} else
 							// {{end}}
 							{
-								v := execgen.UNSAFEGET(srcCol, o.builderState.right.curSrcStartIdx)
+								v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 								execgen.SET(outCol, outStartIdx, v)
 							}
 							// {{end}}
@@ -1327,7 +1327,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildRightBufferedGroup(
 									if src.Nulls().NullAt(o.builderState.right.curSrcStartIdx) {
 										out.Nulls().SetNull(outStartIdx)
 									} else {
-										v := execgen.UNSAFEGET(srcCol, o.builderState.right.curSrcStartIdx)
+										v := srcCol.Get(o.builderState.right.curSrcStartIdx)
 										execgen.SET(outCol, outStartIdx, v)
 									}
 								} else {

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -269,12 +269,12 @@ func _ACCUMULATE_MINMAX(a *_AGG_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _H
 	// {{with .Global}}
 	if !isNull {
 		if !a.foundNonNullForCurrentGroup {
-			val := execgen.UNSAFEGET(col, i)
+			val := col.Get(i)
 			_COPYVAL_MAYBE_CAST(a.curAgg, val)
 			a.foundNonNullForCurrentGroup = true
 		} else {
 			var cmp bool
-			candidate := execgen.UNSAFEGET(col, i)
+			candidate := col.Get(i)
 			_ASSIGN_CMP(cmp, candidate, a.curAgg, _, col, _)
 			if cmp {
 				_COPYVAL_MAYBE_CAST(a.curAgg, candidate)

--- a/pkg/sql/colexec/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/ordered_any_not_null_agg.eg.go
@@ -134,7 +134,7 @@ func (a *anyNotNullBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			groups := a.groups
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
@@ -158,7 +158,7 @@ func (a *anyNotNullBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -184,7 +184,7 @@ func (a *anyNotNullBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -212,7 +212,7 @@ func (a *anyNotNullBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -238,7 +238,7 @@ func (a *anyNotNullBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) 
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -333,7 +333,7 @@ func (a *anyNotNullBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			groups := a.groups
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
@@ -357,7 +357,7 @@ func (a *anyNotNullBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = append(a.curAgg[:0], val...)
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -383,7 +383,7 @@ func (a *anyNotNullBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = append(a.curAgg[:0], val...)
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -411,7 +411,7 @@ func (a *anyNotNullBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = append(a.curAgg[:0], val...)
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -437,7 +437,7 @@ func (a *anyNotNullBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = append(a.curAgg[:0], val...)
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -532,7 +532,7 @@ func (a *anyNotNullDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint3
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			groups := a.groups
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
@@ -556,7 +556,7 @@ func (a *anyNotNullDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint3
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg.Set(&val)
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -582,7 +582,7 @@ func (a *anyNotNullDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint3
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg.Set(&val)
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -610,7 +610,7 @@ func (a *anyNotNullDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint3
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg.Set(&val)
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -636,7 +636,7 @@ func (a *anyNotNullDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint3
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg.Set(&val)
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -731,7 +731,7 @@ func (a *anyNotNullInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			groups := a.groups
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
@@ -755,7 +755,7 @@ func (a *anyNotNullInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -781,7 +781,7 @@ func (a *anyNotNullInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -809,7 +809,7 @@ func (a *anyNotNullInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -835,7 +835,7 @@ func (a *anyNotNullInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -930,7 +930,7 @@ func (a *anyNotNullInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			groups := a.groups
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
@@ -954,7 +954,7 @@ func (a *anyNotNullInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -980,7 +980,7 @@ func (a *anyNotNullInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1008,7 +1008,7 @@ func (a *anyNotNullInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1034,7 +1034,7 @@ func (a *anyNotNullInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1129,7 +1129,7 @@ func (a *anyNotNullInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			groups := a.groups
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
@@ -1153,7 +1153,7 @@ func (a *anyNotNullInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1179,7 +1179,7 @@ func (a *anyNotNullInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1207,7 +1207,7 @@ func (a *anyNotNullInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1233,7 +1233,7 @@ func (a *anyNotNullInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32)
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1328,7 +1328,7 @@ func (a *anyNotNullFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint3
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			groups := a.groups
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
@@ -1352,7 +1352,7 @@ func (a *anyNotNullFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint3
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1378,7 +1378,7 @@ func (a *anyNotNullFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint3
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1406,7 +1406,7 @@ func (a *anyNotNullFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint3
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1432,7 +1432,7 @@ func (a *anyNotNullFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint3
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1527,7 +1527,7 @@ func (a *anyNotNullTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uin
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			groups := a.groups
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
@@ -1551,7 +1551,7 @@ func (a *anyNotNullTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uin
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1577,7 +1577,7 @@ func (a *anyNotNullTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uin
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1605,7 +1605,7 @@ func (a *anyNotNullTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uin
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1631,7 +1631,7 @@ func (a *anyNotNullTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uin
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1726,7 +1726,7 @@ func (a *anyNotNullIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint
 			// Capture col to force bounds check to work. See
 			// https://github.com/golang/go/issues/39756
 			col := col
-			_ = col.Get(inputLen - 1) //gcassert:inline
+			_ = col.Get(inputLen - 1)
 			groups := a.groups
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
@@ -1750,7 +1750,7 @@ func (a *anyNotNullIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1776,7 +1776,7 @@ func (a *anyNotNullIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1804,7 +1804,7 @@ func (a *anyNotNullIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}
@@ -1830,7 +1830,7 @@ func (a *anyNotNullIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint
 							// If we haven't seen any non-nulls for the current group yet, and the
 							// current value is non-null, then we can pick the current value to be
 							// the output.
-							val := col.Get(i) //gcassert:inline
+							val := col.Get(i)
 							a.curAgg = val
 							a.foundNonNullForCurrentGroup = true
 						}

--- a/pkg/sql/colexec/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/ordered_min_max_agg.eg.go
@@ -164,12 +164,12 @@ func (a *minBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -211,12 +211,12 @@ func (a *minBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -260,12 +260,12 @@ func (a *minBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -307,12 +307,12 @@ func (a *minBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -447,12 +447,12 @@ func (a *minBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -488,12 +488,12 @@ func (a *minBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -529,12 +529,12 @@ func (a *minBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -570,12 +570,12 @@ func (a *minBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -702,12 +702,12 @@ func (a *minDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -741,12 +741,12 @@ func (a *minDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -782,12 +782,12 @@ func (a *minDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -821,12 +821,12 @@ func (a *minDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -953,12 +953,12 @@ func (a *minInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1003,12 +1003,12 @@ func (a *minInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1055,12 +1055,12 @@ func (a *minInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1105,12 +1105,12 @@ func (a *minInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1248,12 +1248,12 @@ func (a *minInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1298,12 +1298,12 @@ func (a *minInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1350,12 +1350,12 @@ func (a *minInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1400,12 +1400,12 @@ func (a *minInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1543,12 +1543,12 @@ func (a *minInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1593,12 +1593,12 @@ func (a *minInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1645,12 +1645,12 @@ func (a *minInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1695,12 +1695,12 @@ func (a *minInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1838,12 +1838,12 @@ func (a *minFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1896,12 +1896,12 @@ func (a *minFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -1956,12 +1956,12 @@ func (a *minFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2014,12 +2014,12 @@ func (a *minFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2165,12 +2165,12 @@ func (a *minTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2211,12 +2211,12 @@ func (a *minTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2259,12 +2259,12 @@ func (a *minTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2305,12 +2305,12 @@ func (a *minTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2444,12 +2444,12 @@ func (a *minIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2483,12 +2483,12 @@ func (a *minIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2524,12 +2524,12 @@ func (a *minIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2563,12 +2563,12 @@ func (a *minIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -2954,12 +2954,12 @@ func (a *maxBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3001,12 +3001,12 @@ func (a *maxBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3050,12 +3050,12 @@ func (a *maxBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3097,12 +3097,12 @@ func (a *maxBoolOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3237,12 +3237,12 @@ func (a *maxBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3278,12 +3278,12 @@ func (a *maxBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3319,12 +3319,12 @@ func (a *maxBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3360,12 +3360,12 @@ func (a *maxBytesOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = append(a.curAgg[:0], val...)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3492,12 +3492,12 @@ func (a *maxDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3531,12 +3531,12 @@ func (a *maxDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3572,12 +3572,12 @@ func (a *maxDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3611,12 +3611,12 @@ func (a *maxDecimalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg.Set(&val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3743,12 +3743,12 @@ func (a *maxInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3793,12 +3793,12 @@ func (a *maxInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3845,12 +3845,12 @@ func (a *maxInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -3895,12 +3895,12 @@ func (a *maxInt16OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4038,12 +4038,12 @@ func (a *maxInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4088,12 +4088,12 @@ func (a *maxInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4140,12 +4140,12 @@ func (a *maxInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4190,12 +4190,12 @@ func (a *maxInt32OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4333,12 +4333,12 @@ func (a *maxInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4383,12 +4383,12 @@ func (a *maxInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4435,12 +4435,12 @@ func (a *maxInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4485,12 +4485,12 @@ func (a *maxInt64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = int64(val)
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4628,12 +4628,12 @@ func (a *maxFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4686,12 +4686,12 @@ func (a *maxFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4746,12 +4746,12 @@ func (a *maxFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4804,12 +4804,12 @@ func (a *maxFloat64OrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -4955,12 +4955,12 @@ func (a *maxTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -5001,12 +5001,12 @@ func (a *maxTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -5049,12 +5049,12 @@ func (a *maxTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -5095,12 +5095,12 @@ func (a *maxTimestampOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -5234,12 +5234,12 @@ func (a *maxIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -5273,12 +5273,12 @@ func (a *maxIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = nulls.NullAt(i)
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -5314,12 +5314,12 @@ func (a *maxIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int
@@ -5353,12 +5353,12 @@ func (a *maxIntervalOrderedAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 						isNull = false
 						if !isNull {
 							if !a.foundNonNullForCurrentGroup {
-								val := col.Get(i) //gcassert:inline
+								val := col.Get(i)
 								a.curAgg = val
 								a.foundNonNullForCurrentGroup = true
 							} else {
 								var cmp bool
-								candidate := col.Get(i) //gcassert:inline
+								candidate := col.Get(i)
 
 								{
 									var cmpResult int

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -146,7 +146,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 						default:
 							srcCol := vec.Bool()
 							outCol := o.outBoolCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx) //gcassert:inline
+							v := srcCol.Get(srcRowIdx)
 							outCol[outputIdx] = v
 						}
 					case types.BytesFamily:
@@ -155,7 +155,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 						default:
 							srcCol := vec.Bytes()
 							outCol := o.outBytesCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx) //gcassert:inline
+							v := srcCol.Get(srcRowIdx)
 							outCol.Set(outputIdx, v)
 						}
 					case types.DecimalFamily:
@@ -164,7 +164,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 						default:
 							srcCol := vec.Decimal()
 							outCol := o.outDecimalCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx) //gcassert:inline
+							v := srcCol.Get(srcRowIdx)
 							outCol[outputIdx].Set(&v)
 						}
 					case types.IntFamily:
@@ -172,18 +172,18 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 						case 16:
 							srcCol := vec.Int16()
 							outCol := o.outInt16Cols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx) //gcassert:inline
+							v := srcCol.Get(srcRowIdx)
 							outCol[outputIdx] = v
 						case 32:
 							srcCol := vec.Int32()
 							outCol := o.outInt32Cols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx) //gcassert:inline
+							v := srcCol.Get(srcRowIdx)
 							outCol[outputIdx] = v
 						case -1:
 						default:
 							srcCol := vec.Int64()
 							outCol := o.outInt64Cols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx) //gcassert:inline
+							v := srcCol.Get(srcRowIdx)
 							outCol[outputIdx] = v
 						}
 					case types.FloatFamily:
@@ -192,7 +192,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 						default:
 							srcCol := vec.Float64()
 							outCol := o.outFloat64Cols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx) //gcassert:inline
+							v := srcCol.Get(srcRowIdx)
 							outCol[outputIdx] = v
 						}
 					case types.TimestampTZFamily:
@@ -201,7 +201,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 						default:
 							srcCol := vec.Timestamp()
 							outCol := o.outTimestampCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx) //gcassert:inline
+							v := srcCol.Get(srcRowIdx)
 							outCol[outputIdx] = v
 						}
 					case types.IntervalFamily:
@@ -210,7 +210,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 						default:
 							srcCol := vec.Interval()
 							outCol := o.outIntervalCols[o.outColsMap[i]]
-							v := srcCol.Get(srcRowIdx) //gcassert:inline
+							v := srcCol.Get(srcRowIdx)
 							outCol[outputIdx] = v
 						}
 					case typeconv.DatumVecCanonicalTypeFamily:

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -167,7 +167,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 						case _TYPE_WIDTH:
 							srcCol := vec._TYPE()
 							outCol := o.out_TYPECols[o.outColsMap[i]]
-							v := execgen.UNSAFEGET(srcCol, srcRowIdx)
+							v := srcCol.Get(srcRowIdx)
 							execgen.SET(outCol, outputIdx, v)
 							// {{end}}
 						}

--- a/pkg/sql/colexec/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_left_ops.eg.go
@@ -63,7 +63,7 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -71,11 +71,11 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -88,16 +88,16 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -148,7 +148,7 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -156,11 +156,11 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -173,16 +173,16 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -233,7 +233,7 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -241,11 +241,11 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -258,16 +258,16 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -318,7 +318,7 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -326,11 +326,11 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -343,16 +343,16 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -403,7 +403,7 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -411,11 +411,11 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -428,16 +428,16 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -488,7 +488,7 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -496,11 +496,11 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -513,16 +513,16 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -573,7 +573,7 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -581,11 +581,11 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -598,16 +598,16 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -658,7 +658,7 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -666,11 +666,11 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -683,16 +683,16 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -743,7 +743,7 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -751,11 +751,11 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -768,16 +768,16 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) & int64(arg)
 
@@ -929,7 +929,7 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -937,11 +937,11 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -954,16 +954,16 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1014,7 +1014,7 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1022,11 +1022,11 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1039,16 +1039,16 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1099,7 +1099,7 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1107,11 +1107,11 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1124,16 +1124,16 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1184,7 +1184,7 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1192,11 +1192,11 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1209,16 +1209,16 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1269,7 +1269,7 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1277,11 +1277,11 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1294,16 +1294,16 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1354,7 +1354,7 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1362,11 +1362,11 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1379,16 +1379,16 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1439,7 +1439,7 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1447,11 +1447,11 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1464,16 +1464,16 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1524,7 +1524,7 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1532,11 +1532,11 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1549,16 +1549,16 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1609,7 +1609,7 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1617,11 +1617,11 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1634,16 +1634,16 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) | int64(arg)
 
@@ -1795,7 +1795,7 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -1803,11 +1803,11 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -1820,16 +1820,16 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -1880,7 +1880,7 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -1888,11 +1888,11 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -1905,16 +1905,16 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -1965,7 +1965,7 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -1973,11 +1973,11 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -1990,16 +1990,16 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2050,7 +2050,7 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2058,11 +2058,11 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2075,16 +2075,16 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2135,7 +2135,7 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2143,11 +2143,11 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2160,16 +2160,16 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2220,7 +2220,7 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2228,11 +2228,11 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2245,16 +2245,16 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2305,7 +2305,7 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2313,11 +2313,11 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2330,16 +2330,16 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2390,7 +2390,7 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2398,11 +2398,11 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2415,16 +2415,16 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2475,7 +2475,7 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2483,11 +2483,11 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2500,16 +2500,16 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(p.constArg) ^ int64(arg)
 
@@ -2661,7 +2661,7 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2676,11 +2676,11 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2700,7 +2700,7 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -2714,9 +2714,9 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -2774,7 +2774,7 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2789,11 +2789,11 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2813,7 +2813,7 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -2827,9 +2827,9 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -2887,7 +2887,7 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2902,11 +2902,11 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2926,7 +2926,7 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -2940,9 +2940,9 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -3000,7 +3000,7 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -3014,11 +3014,11 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -3037,7 +3037,7 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -3050,9 +3050,9 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -3109,7 +3109,7 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3123,11 +3123,11 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3146,7 +3146,7 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -3159,9 +3159,9 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -3218,7 +3218,7 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3232,11 +3232,11 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3255,7 +3255,7 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -3268,9 +3268,9 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -3327,7 +3327,7 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3341,11 +3341,11 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3364,7 +3364,7 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -3377,9 +3377,9 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -3436,7 +3436,7 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -3452,11 +3452,11 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -3477,7 +3477,7 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -3492,9 +3492,9 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -3678,7 +3678,7 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3692,11 +3692,11 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3715,7 +3715,7 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -3728,9 +3728,9 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -3787,7 +3787,7 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3801,11 +3801,11 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3824,7 +3824,7 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -3837,9 +3837,9 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -3896,7 +3896,7 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3910,11 +3910,11 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -3933,7 +3933,7 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -3946,9 +3946,9 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -4005,7 +4005,7 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4021,11 +4021,11 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4046,7 +4046,7 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4061,9 +4061,9 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4247,7 +4247,7 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -4261,11 +4261,11 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -4284,7 +4284,7 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -4297,9 +4297,9 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -4356,7 +4356,7 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -4370,11 +4370,11 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -4393,7 +4393,7 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -4406,9 +4406,9 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -4465,7 +4465,7 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -4479,11 +4479,11 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) + int64(arg)
@@ -4502,7 +4502,7 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -4515,9 +4515,9 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) + int64(arg)
@@ -4574,7 +4574,7 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4590,11 +4590,11 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4615,7 +4615,7 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4630,9 +4630,9 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4816,7 +4816,7 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4827,11 +4827,11 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4847,7 +4847,7 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4857,9 +4857,9 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4913,17 +4913,17 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg)
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg)
 				}
 			}
@@ -4934,14 +4934,14 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(p.constArg, arg)
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(p.constArg, arg)
 			}
 		}
@@ -4990,17 +4990,17 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg)
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg)
 				}
 			}
@@ -5011,14 +5011,14 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(arg, p.constArg)
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(arg, p.constArg)
 			}
 		}
@@ -5067,17 +5067,17 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Add(arg)
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Add(arg)
 				}
 			}
@@ -5088,14 +5088,14 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Add(arg)
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Add(arg)
 			}
 		}
@@ -5269,7 +5269,7 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg}
 					var _nonDatumArgAsDatum tree.Datum
@@ -5289,7 +5289,7 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg}
 					var _nonDatumArgAsDatum tree.Datum
@@ -5310,7 +5310,7 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg}
 				var _nonDatumArgAsDatum tree.Datum
@@ -5327,7 +5327,7 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg}
 				var _nonDatumArgAsDatum tree.Datum
@@ -5386,7 +5386,7 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -5406,7 +5406,7 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -5427,7 +5427,7 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -5444,7 +5444,7 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -5503,7 +5503,7 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -5523,7 +5523,7 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -5544,7 +5544,7 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -5561,7 +5561,7 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -5620,7 +5620,7 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -5640,7 +5640,7 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -5661,7 +5661,7 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -5678,7 +5678,7 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -5737,7 +5737,7 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -5752,11 +5752,11 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -5776,7 +5776,7 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -5790,9 +5790,9 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -5850,7 +5850,7 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -5865,11 +5865,11 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -5889,7 +5889,7 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -5903,9 +5903,9 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -5963,7 +5963,7 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -5978,11 +5978,11 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -6002,7 +6002,7 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6016,9 +6016,9 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6076,7 +6076,7 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -6090,11 +6090,11 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -6113,7 +6113,7 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6126,9 +6126,9 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6185,7 +6185,7 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -6199,11 +6199,11 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -6222,7 +6222,7 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -6235,9 +6235,9 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -6294,7 +6294,7 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -6308,11 +6308,11 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -6331,7 +6331,7 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -6344,9 +6344,9 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -6403,7 +6403,7 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -6417,11 +6417,11 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -6440,7 +6440,7 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -6453,9 +6453,9 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -6512,7 +6512,7 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -6528,11 +6528,11 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -6553,7 +6553,7 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6568,9 +6568,9 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6754,7 +6754,7 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -6768,11 +6768,11 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -6791,7 +6791,7 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -6804,9 +6804,9 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -6863,7 +6863,7 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -6877,11 +6877,11 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -6900,7 +6900,7 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -6913,9 +6913,9 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -6972,7 +6972,7 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -6986,11 +6986,11 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -7009,7 +7009,7 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -7022,9 +7022,9 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -7081,7 +7081,7 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7097,11 +7097,11 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7122,7 +7122,7 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7137,9 +7137,9 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7323,7 +7323,7 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -7337,11 +7337,11 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -7360,7 +7360,7 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -7373,9 +7373,9 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -7432,7 +7432,7 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -7446,11 +7446,11 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -7469,7 +7469,7 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -7482,9 +7482,9 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -7541,7 +7541,7 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -7555,11 +7555,11 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(p.constArg) - int64(arg)
@@ -7578,7 +7578,7 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -7591,9 +7591,9 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(p.constArg) - int64(arg)
@@ -7650,7 +7650,7 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7666,11 +7666,11 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7691,7 +7691,7 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7706,9 +7706,9 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7892,7 +7892,7 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7903,11 +7903,11 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7923,7 +7923,7 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7933,9 +7933,9 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7989,7 +7989,7 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					nanos := p.constArg.Sub(arg).Nanoseconds()
 					projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -7998,11 +7998,11 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					nanos := p.constArg.Sub(arg).Nanoseconds()
 					projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -8016,7 +8016,7 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				nanos := p.constArg.Sub(arg).Nanoseconds()
 				projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -8024,9 +8024,9 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				nanos := p.constArg.Sub(arg).Nanoseconds()
 				projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -8078,17 +8078,17 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg.Mul(-1))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg.Mul(-1))
 				}
 			}
@@ -8099,14 +8099,14 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(p.constArg, arg.Mul(-1))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(p.constArg, arg.Mul(-1))
 			}
 		}
@@ -8155,17 +8155,17 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Sub(arg)
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Sub(arg)
 				}
 			}
@@ -8176,14 +8176,14 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Sub(arg)
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Sub(arg)
 			}
 		}
@@ -8458,7 +8458,7 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg}
 					var _nonDatumArgAsDatum tree.Datum
@@ -8478,7 +8478,7 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg}
 					var _nonDatumArgAsDatum tree.Datum
@@ -8499,7 +8499,7 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg}
 				var _nonDatumArgAsDatum tree.Datum
@@ -8516,7 +8516,7 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg}
 				var _nonDatumArgAsDatum tree.Datum
@@ -8575,7 +8575,7 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DBytes(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -8597,7 +8597,7 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DBytes(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -8618,7 +8618,7 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DBytes(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -8637,7 +8637,7 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 			_ = n
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DBytes(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -8696,7 +8696,7 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -8716,7 +8716,7 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -8737,7 +8737,7 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -8754,7 +8754,7 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -8813,7 +8813,7 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -8833,7 +8833,7 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -8854,7 +8854,7 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -8871,7 +8871,7 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -8930,7 +8930,7 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -8950,7 +8950,7 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -8971,7 +8971,7 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -8988,7 +8988,7 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -9047,7 +9047,7 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9062,11 +9062,11 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9086,7 +9086,7 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9100,9 +9100,9 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9160,7 +9160,7 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9175,11 +9175,11 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9199,7 +9199,7 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9213,9 +9213,9 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9273,7 +9273,7 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9288,11 +9288,11 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9312,7 +9312,7 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9326,9 +9326,9 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9386,7 +9386,7 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9400,11 +9400,11 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9423,7 +9423,7 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9436,9 +9436,9 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9495,7 +9495,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					f, err := p.constArg.Float64()
 					if err != nil {
@@ -9506,11 +9506,11 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					f, err := p.constArg.Float64()
 					if err != nil {
@@ -9526,7 +9526,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				f, err := p.constArg.Float64()
 				if err != nil {
@@ -9536,9 +9536,9 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				f, err := p.constArg.Float64()
 				if err != nil {
@@ -9592,7 +9592,7 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -9614,11 +9614,11 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -9645,7 +9645,7 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -9666,9 +9666,9 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -9733,7 +9733,7 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -9755,11 +9755,11 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -9786,7 +9786,7 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -9807,9 +9807,9 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -9874,7 +9874,7 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -9896,11 +9896,11 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -9927,7 +9927,7 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -9948,9 +9948,9 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -10015,7 +10015,7 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -10031,11 +10031,11 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -10056,7 +10056,7 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -10071,9 +10071,9 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -10132,17 +10132,17 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
@@ -10153,14 +10153,14 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
@@ -10209,7 +10209,7 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -10231,11 +10231,11 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -10262,7 +10262,7 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -10283,9 +10283,9 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -10350,7 +10350,7 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -10372,11 +10372,11 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -10403,7 +10403,7 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -10424,9 +10424,9 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -10491,7 +10491,7 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -10513,11 +10513,11 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -10544,7 +10544,7 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -10565,9 +10565,9 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -10632,7 +10632,7 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -10648,11 +10648,11 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -10673,7 +10673,7 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -10688,9 +10688,9 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -10749,17 +10749,17 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
@@ -10770,14 +10770,14 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
@@ -10826,7 +10826,7 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -10848,11 +10848,11 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -10879,7 +10879,7 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -10900,9 +10900,9 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -10967,7 +10967,7 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -10989,11 +10989,11 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -11020,7 +11020,7 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -11041,9 +11041,9 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -11108,7 +11108,7 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -11130,11 +11130,11 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(p.constArg), int64(arg)
@@ -11161,7 +11161,7 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -11182,9 +11182,9 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(p.constArg), int64(arg)
@@ -11249,7 +11249,7 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -11265,11 +11265,11 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -11290,7 +11290,7 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -11305,9 +11305,9 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -11366,17 +11366,17 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
@@ -11387,14 +11387,14 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
@@ -11443,7 +11443,7 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -11454,11 +11454,11 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -11474,7 +11474,7 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -11484,9 +11484,9 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -11540,17 +11540,17 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
 			}
@@ -11561,14 +11561,14 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.MulFloat(float64(p.constArg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.MulFloat(float64(p.constArg))
 			}
 		}
@@ -11617,17 +11617,17 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
@@ -11638,14 +11638,14 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
@@ -11694,17 +11694,17 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
@@ -11715,14 +11715,14 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
@@ -11771,17 +11771,17 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
@@ -11792,14 +11792,14 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
@@ -11848,17 +11848,17 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
 			}
@@ -11869,14 +11869,14 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.MulFloat(float64(arg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.MulFloat(float64(arg))
 			}
 		}
@@ -11925,7 +11925,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					f, err := arg.Float64()
 					if err != nil {
@@ -11936,11 +11936,11 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					f, err := arg.Float64()
 					if err != nil {
@@ -11956,7 +11956,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				f, err := arg.Float64()
 				if err != nil {
@@ -11966,9 +11966,9 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				f, err := arg.Float64()
 				if err != nil {
@@ -12022,7 +12022,7 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12041,11 +12041,11 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12069,7 +12069,7 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12087,9 +12087,9 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12151,7 +12151,7 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12170,11 +12170,11 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12198,7 +12198,7 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12216,9 +12216,9 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12280,7 +12280,7 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12299,11 +12299,11 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12327,7 +12327,7 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12345,9 +12345,9 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12409,7 +12409,7 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12427,11 +12427,11 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12454,7 +12454,7 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12471,9 +12471,9 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12534,7 +12534,7 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -12552,11 +12552,11 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -12579,7 +12579,7 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -12596,9 +12596,9 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -12659,7 +12659,7 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -12677,11 +12677,11 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -12704,7 +12704,7 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -12721,9 +12721,9 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -12784,7 +12784,7 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -12802,11 +12802,11 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -12829,7 +12829,7 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -12846,9 +12846,9 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -12909,7 +12909,7 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12929,11 +12929,11 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12958,7 +12958,7 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12977,9 +12977,9 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -13042,7 +13042,7 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13060,11 +13060,11 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13087,7 +13087,7 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13104,9 +13104,9 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13167,7 +13167,7 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13185,11 +13185,11 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13212,7 +13212,7 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13229,9 +13229,9 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13292,7 +13292,7 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13310,11 +13310,11 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13337,7 +13337,7 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13354,9 +13354,9 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13417,7 +13417,7 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -13437,11 +13437,11 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -13466,7 +13466,7 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -13485,9 +13485,9 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -13550,7 +13550,7 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13568,11 +13568,11 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13595,7 +13595,7 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13612,9 +13612,9 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13675,7 +13675,7 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13693,11 +13693,11 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13720,7 +13720,7 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13737,9 +13737,9 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13800,7 +13800,7 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13818,11 +13818,11 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -13845,7 +13845,7 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13862,9 +13862,9 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -13925,7 +13925,7 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -13945,11 +13945,11 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -13974,7 +13974,7 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -13993,9 +13993,9 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14058,7 +14058,7 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14073,11 +14073,11 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14097,7 +14097,7 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14111,9 +14111,9 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14171,7 +14171,7 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					if arg == 0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14181,11 +14181,11 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					if arg == 0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14200,7 +14200,7 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				if arg == 0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14209,9 +14209,9 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				if arg == 0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14264,7 +14264,7 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					if arg == 0.0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14274,11 +14274,11 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					if arg == 0.0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14293,7 +14293,7 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				if arg == 0.0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14302,9 +14302,9 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				if arg == 0.0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14357,7 +14357,7 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14376,11 +14376,11 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14404,7 +14404,7 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14422,9 +14422,9 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14486,7 +14486,7 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14505,11 +14505,11 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14533,7 +14533,7 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14551,9 +14551,9 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14615,7 +14615,7 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14634,11 +14634,11 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14662,7 +14662,7 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14680,9 +14680,9 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14744,7 +14744,7 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14762,11 +14762,11 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14789,7 +14789,7 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14806,9 +14806,9 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14869,7 +14869,7 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -14882,11 +14882,11 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -14904,7 +14904,7 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -14916,9 +14916,9 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -14974,7 +14974,7 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -14987,11 +14987,11 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15009,7 +15009,7 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15021,9 +15021,9 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15079,7 +15079,7 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15092,11 +15092,11 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15114,7 +15114,7 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15126,9 +15126,9 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15184,7 +15184,7 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -15204,11 +15204,11 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -15233,7 +15233,7 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -15252,9 +15252,9 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -15317,7 +15317,7 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15330,11 +15330,11 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15352,7 +15352,7 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15364,9 +15364,9 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15422,7 +15422,7 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15435,11 +15435,11 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15457,7 +15457,7 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15469,9 +15469,9 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15527,7 +15527,7 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15540,11 +15540,11 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15562,7 +15562,7 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15574,9 +15574,9 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15632,7 +15632,7 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -15652,11 +15652,11 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -15681,7 +15681,7 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -15700,9 +15700,9 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -15765,7 +15765,7 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15778,11 +15778,11 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15800,7 +15800,7 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15812,9 +15812,9 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15870,7 +15870,7 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15883,11 +15883,11 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15905,7 +15905,7 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15917,9 +15917,9 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -15975,7 +15975,7 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -15988,11 +15988,11 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -16010,7 +16010,7 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -16022,9 +16022,9 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -16080,7 +16080,7 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16100,11 +16100,11 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16129,7 +16129,7 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16148,9 +16148,9 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16213,7 +16213,7 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16228,11 +16228,11 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16252,7 +16252,7 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16266,9 +16266,9 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16326,7 +16326,7 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16345,11 +16345,11 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16373,7 +16373,7 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16391,9 +16391,9 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16455,7 +16455,7 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16474,11 +16474,11 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16502,7 +16502,7 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16520,9 +16520,9 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16584,7 +16584,7 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16603,11 +16603,11 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16631,7 +16631,7 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16649,9 +16649,9 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16713,7 +16713,7 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16731,11 +16731,11 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16758,7 +16758,7 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16775,9 +16775,9 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16838,7 +16838,7 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -16851,11 +16851,11 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -16873,7 +16873,7 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -16885,9 +16885,9 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -16943,7 +16943,7 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -16956,11 +16956,11 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -16978,7 +16978,7 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -16990,9 +16990,9 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17048,7 +17048,7 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17061,11 +17061,11 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17083,7 +17083,7 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17095,9 +17095,9 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17153,7 +17153,7 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -17173,11 +17173,11 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -17202,7 +17202,7 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -17221,9 +17221,9 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -17286,7 +17286,7 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17299,11 +17299,11 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17321,7 +17321,7 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17333,9 +17333,9 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17391,7 +17391,7 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17404,11 +17404,11 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17426,7 +17426,7 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17438,9 +17438,9 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17496,7 +17496,7 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17509,11 +17509,11 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17531,7 +17531,7 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17543,9 +17543,9 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17601,7 +17601,7 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -17621,11 +17621,11 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -17650,7 +17650,7 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -17669,9 +17669,9 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -17734,7 +17734,7 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17747,11 +17747,11 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17769,7 +17769,7 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17781,9 +17781,9 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17839,7 +17839,7 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17852,11 +17852,11 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17874,7 +17874,7 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17886,9 +17886,9 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17944,7 +17944,7 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17957,11 +17957,11 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) == 0 {
@@ -17979,7 +17979,7 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -17991,9 +17991,9 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) == 0 {
@@ -18049,7 +18049,7 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18069,11 +18069,11 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18098,7 +18098,7 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18117,9 +18117,9 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18182,7 +18182,7 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18197,11 +18197,11 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18221,7 +18221,7 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18235,9 +18235,9 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18295,7 +18295,7 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18310,11 +18310,11 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18334,7 +18334,7 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18348,9 +18348,9 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18408,7 +18408,7 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18423,11 +18423,11 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18447,7 +18447,7 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18461,9 +18461,9 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18521,7 +18521,7 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18536,11 +18536,11 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18560,7 +18560,7 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18574,9 +18574,9 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18634,7 +18634,7 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18648,11 +18648,11 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18671,7 +18671,7 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18684,9 +18684,9 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18743,7 +18743,7 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18763,11 +18763,11 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18792,7 +18792,7 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18811,9 +18811,9 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18876,7 +18876,7 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18896,11 +18896,11 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18925,7 +18925,7 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18944,9 +18944,9 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19009,7 +19009,7 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19029,11 +19029,11 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19058,7 +19058,7 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19077,9 +19077,9 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19142,7 +19142,7 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -19158,11 +19158,11 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -19183,7 +19183,7 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -19198,9 +19198,9 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -19259,7 +19259,7 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19279,11 +19279,11 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19308,7 +19308,7 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19327,9 +19327,9 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19392,7 +19392,7 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19412,11 +19412,11 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19441,7 +19441,7 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19460,9 +19460,9 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19525,7 +19525,7 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19545,11 +19545,11 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19574,7 +19574,7 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19593,9 +19593,9 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19658,7 +19658,7 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -19674,11 +19674,11 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -19699,7 +19699,7 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -19714,9 +19714,9 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -19775,7 +19775,7 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19795,11 +19795,11 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19824,7 +19824,7 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19843,9 +19843,9 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19908,7 +19908,7 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19928,11 +19928,11 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19957,7 +19957,7 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19976,9 +19976,9 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20041,7 +20041,7 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20061,11 +20061,11 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20090,7 +20090,7 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20109,9 +20109,9 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20174,7 +20174,7 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -20190,11 +20190,11 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -20215,7 +20215,7 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -20230,9 +20230,9 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -20291,7 +20291,7 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -20302,11 +20302,11 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -20322,7 +20322,7 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -20332,9 +20332,9 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -20388,7 +20388,7 @@ func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var r = []byte{}
@@ -20403,11 +20403,11 @@ func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var r = []byte{}
@@ -20425,7 +20425,7 @@ func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var r = []byte{}
@@ -20439,9 +20439,9 @@ func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var r = []byte{}
@@ -20598,7 +20598,7 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20612,11 +20612,11 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20635,7 +20635,7 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20648,9 +20648,9 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20707,7 +20707,7 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20721,11 +20721,11 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20744,7 +20744,7 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20757,9 +20757,9 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20816,7 +20816,7 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20830,11 +20830,11 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20853,7 +20853,7 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20866,9 +20866,9 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20925,7 +20925,7 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20939,11 +20939,11 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20962,7 +20962,7 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -20975,9 +20975,9 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21034,7 +21034,7 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21048,11 +21048,11 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21071,7 +21071,7 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21084,9 +21084,9 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21143,7 +21143,7 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21157,11 +21157,11 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21180,7 +21180,7 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21193,9 +21193,9 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21252,7 +21252,7 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21266,11 +21266,11 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21289,7 +21289,7 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21302,9 +21302,9 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21361,7 +21361,7 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21375,11 +21375,11 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21398,7 +21398,7 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21411,9 +21411,9 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21470,7 +21470,7 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21484,11 +21484,11 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21507,7 +21507,7 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21520,9 +21520,9 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21579,7 +21579,7 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -21599,7 +21599,7 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -21620,7 +21620,7 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -21637,7 +21637,7 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -21696,7 +21696,7 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -21716,7 +21716,7 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -21737,7 +21737,7 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -21754,7 +21754,7 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -21813,7 +21813,7 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -21833,7 +21833,7 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -21854,7 +21854,7 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -21871,7 +21871,7 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -21930,7 +21930,7 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21944,11 +21944,11 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21967,7 +21967,7 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -21980,9 +21980,9 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22039,7 +22039,7 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22053,11 +22053,11 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22076,7 +22076,7 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22089,9 +22089,9 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22148,7 +22148,7 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22162,11 +22162,11 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22185,7 +22185,7 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22198,9 +22198,9 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22257,7 +22257,7 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22271,11 +22271,11 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22294,7 +22294,7 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22307,9 +22307,9 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22366,7 +22366,7 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22380,11 +22380,11 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22403,7 +22403,7 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22416,9 +22416,9 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22475,7 +22475,7 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22489,11 +22489,11 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22512,7 +22512,7 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22525,9 +22525,9 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22584,7 +22584,7 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22598,11 +22598,11 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22621,7 +22621,7 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22634,9 +22634,9 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22693,7 +22693,7 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22707,11 +22707,11 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22730,7 +22730,7 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22743,9 +22743,9 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22802,7 +22802,7 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22816,11 +22816,11 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22839,7 +22839,7 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22852,9 +22852,9 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(arg) < 0 || int64(arg) >= 64 {
@@ -22911,7 +22911,7 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -22931,7 +22931,7 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -22952,7 +22952,7 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -22969,7 +22969,7 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23028,7 +23028,7 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23048,7 +23048,7 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23069,7 +23069,7 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23086,7 +23086,7 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23145,7 +23145,7 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23165,7 +23165,7 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23186,7 +23186,7 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23203,7 +23203,7 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23262,7 +23262,7 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DString(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23284,7 +23284,7 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DString(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23305,7 +23305,7 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DString(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23324,7 +23324,7 @@ func (p projJSONFetchValDatumConstBytesOp) Next(ctx context.Context) coldata.Bat
 			_ = n
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DString(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23383,7 +23383,7 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23403,7 +23403,7 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23424,7 +23424,7 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23441,7 +23441,7 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23500,7 +23500,7 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23520,7 +23520,7 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23541,7 +23541,7 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23558,7 +23558,7 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23617,7 +23617,7 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23637,7 +23637,7 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23658,7 +23658,7 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23675,7 +23675,7 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -58,12 +58,6 @@ func _ASSIGN(_, _, _, _, _, _ interface{}) {
 	colexecerror.InternalError("")
 }
 
-// _RETURN_UNSAFEGET is the template function that will be replaced by
-// "execgen.UNSAFEGET" which uses _RET_TYP.
-func _RETURN_UNSAFEGET(_, _ interface{}) interface{} {
-	colexecerror.InternalError("")
-}
-
 // */}}
 
 // {{define "projConstOp"}}
@@ -136,7 +130,7 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 		}
 	} else {
 		col = execgen.SLICE(col, 0, n)
-		_ = _RETURN_UNSAFEGET(projCol, n-1)
+		_ = projCol.Get(n - 1)
 		for i := 0; i < n; i++ {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}
@@ -161,7 +155,7 @@ func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool) { // */}}
 	if !colNulls.NullAt(i) {
 		// We only want to perform the projection operation if the value is not null.
 		// {{end}}
-		arg := execgen.UNSAFEGET(col, i)
+		arg := col.Get(i)
 		// {{if _IS_CONST_LEFT}}
 		_ASSIGN(projCol[i], p.constArg, arg, projCol, _, col)
 		// {{else}}

--- a/pkg/sql/colexec/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_right_ops.eg.go
@@ -64,7 +64,7 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -72,11 +72,11 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -89,16 +89,16 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -149,7 +149,7 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -157,11 +157,11 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -174,16 +174,16 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -234,7 +234,7 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -242,11 +242,11 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -259,16 +259,16 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -319,7 +319,7 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -327,11 +327,11 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -344,16 +344,16 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -404,7 +404,7 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -412,11 +412,11 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -429,16 +429,16 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -489,7 +489,7 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -497,11 +497,11 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -514,16 +514,16 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -574,7 +574,7 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -582,11 +582,11 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -599,16 +599,16 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -659,7 +659,7 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -667,11 +667,11 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -684,16 +684,16 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -744,7 +744,7 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -752,11 +752,11 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -769,16 +769,16 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) & int64(p.constArg)
 
@@ -930,7 +930,7 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -938,11 +938,11 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -955,16 +955,16 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1015,7 +1015,7 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1023,11 +1023,11 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1040,16 +1040,16 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1100,7 +1100,7 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1108,11 +1108,11 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1125,16 +1125,16 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1185,7 +1185,7 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1193,11 +1193,11 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1210,16 +1210,16 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1270,7 +1270,7 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1278,11 +1278,11 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1295,16 +1295,16 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1355,7 +1355,7 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1363,11 +1363,11 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1380,16 +1380,16 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1440,7 +1440,7 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1448,11 +1448,11 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1465,16 +1465,16 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1525,7 +1525,7 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1533,11 +1533,11 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1550,16 +1550,16 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1610,7 +1610,7 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1618,11 +1618,11 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1635,16 +1635,16 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) | int64(p.constArg)
 
@@ -1796,7 +1796,7 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -1804,11 +1804,11 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -1821,16 +1821,16 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -1881,7 +1881,7 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -1889,11 +1889,11 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -1906,16 +1906,16 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -1966,7 +1966,7 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -1974,11 +1974,11 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -1991,16 +1991,16 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2051,7 +2051,7 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2059,11 +2059,11 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2076,16 +2076,16 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2136,7 +2136,7 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2144,11 +2144,11 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2161,16 +2161,16 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2221,7 +2221,7 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2229,11 +2229,11 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2246,16 +2246,16 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2306,7 +2306,7 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2314,11 +2314,11 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2331,16 +2331,16 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2391,7 +2391,7 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2399,11 +2399,11 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2416,16 +2416,16 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2476,7 +2476,7 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2484,11 +2484,11 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2501,16 +2501,16 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				projCol[i] = int64(arg) ^ int64(p.constArg)
 
@@ -2662,7 +2662,7 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2677,11 +2677,11 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2701,7 +2701,7 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -2715,9 +2715,9 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -2775,7 +2775,7 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2790,11 +2790,11 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2814,7 +2814,7 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -2828,9 +2828,9 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -2888,7 +2888,7 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2903,11 +2903,11 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -2927,7 +2927,7 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -2941,9 +2941,9 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -3001,7 +3001,7 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -3015,11 +3015,11 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -3038,7 +3038,7 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -3051,9 +3051,9 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -3110,7 +3110,7 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3124,11 +3124,11 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3147,7 +3147,7 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -3160,9 +3160,9 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -3219,7 +3219,7 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3233,11 +3233,11 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3256,7 +3256,7 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -3269,9 +3269,9 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -3328,7 +3328,7 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3342,11 +3342,11 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3365,7 +3365,7 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -3378,9 +3378,9 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -3437,7 +3437,7 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -3453,11 +3453,11 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -3478,7 +3478,7 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -3493,9 +3493,9 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -3554,7 +3554,7 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -3576,7 +3576,7 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -3599,7 +3599,7 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -3618,7 +3618,7 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -3679,7 +3679,7 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3693,11 +3693,11 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3716,7 +3716,7 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -3729,9 +3729,9 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -3788,7 +3788,7 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3802,11 +3802,11 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3825,7 +3825,7 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -3838,9 +3838,9 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -3897,7 +3897,7 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3911,11 +3911,11 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -3934,7 +3934,7 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -3947,9 +3947,9 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -4006,7 +4006,7 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4022,11 +4022,11 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4047,7 +4047,7 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4062,9 +4062,9 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4123,7 +4123,7 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -4145,7 +4145,7 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -4168,7 +4168,7 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -4187,7 +4187,7 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -4248,7 +4248,7 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -4262,11 +4262,11 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -4285,7 +4285,7 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -4298,9 +4298,9 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -4357,7 +4357,7 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -4371,11 +4371,11 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -4394,7 +4394,7 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -4407,9 +4407,9 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -4466,7 +4466,7 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -4480,11 +4480,11 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) + int64(p.constArg)
@@ -4503,7 +4503,7 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -4516,9 +4516,9 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) + int64(p.constArg)
@@ -4575,7 +4575,7 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4591,11 +4591,11 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4616,7 +4616,7 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4631,9 +4631,9 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4692,7 +4692,7 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -4714,7 +4714,7 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -4737,7 +4737,7 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -4756,7 +4756,7 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -4817,7 +4817,7 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4828,11 +4828,11 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -4848,7 +4848,7 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4858,9 +4858,9 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -4914,17 +4914,17 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg)
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg)
 				}
 			}
@@ -4935,14 +4935,14 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(arg, p.constArg)
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(arg, p.constArg)
 			}
 		}
@@ -4991,17 +4991,17 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg)
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(p.constArg, arg)
 				}
 			}
@@ -5012,14 +5012,14 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(p.constArg, arg)
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(p.constArg, arg)
 			}
 		}
@@ -5068,17 +5068,17 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Add(p.constArg)
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Add(p.constArg)
 				}
 			}
@@ -5089,14 +5089,14 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Add(p.constArg)
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Add(p.constArg)
 			}
 		}
@@ -5145,7 +5145,7 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg}
 					var _nonDatumArgAsDatum tree.Datum
@@ -5167,7 +5167,7 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg}
 					var _nonDatumArgAsDatum tree.Datum
@@ -5190,7 +5190,7 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg}
 				var _nonDatumArgAsDatum tree.Datum
@@ -5209,7 +5209,7 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg}
 				var _nonDatumArgAsDatum tree.Datum
@@ -5738,7 +5738,7 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -5753,11 +5753,11 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -5777,7 +5777,7 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -5791,9 +5791,9 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -5851,7 +5851,7 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -5866,11 +5866,11 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -5890,7 +5890,7 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -5904,9 +5904,9 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -5964,7 +5964,7 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -5979,11 +5979,11 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -6003,7 +6003,7 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6017,9 +6017,9 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6077,7 +6077,7 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -6091,11 +6091,11 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -6114,7 +6114,7 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6127,9 +6127,9 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6186,7 +6186,7 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -6200,11 +6200,11 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -6223,7 +6223,7 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -6236,9 +6236,9 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -6295,7 +6295,7 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -6309,11 +6309,11 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -6332,7 +6332,7 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -6345,9 +6345,9 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -6404,7 +6404,7 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -6418,11 +6418,11 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -6441,7 +6441,7 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -6454,9 +6454,9 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -6513,7 +6513,7 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -6529,11 +6529,11 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -6554,7 +6554,7 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6569,9 +6569,9 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -6630,7 +6630,7 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -6652,7 +6652,7 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -6675,7 +6675,7 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -6694,7 +6694,7 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -6755,7 +6755,7 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -6769,11 +6769,11 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -6792,7 +6792,7 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -6805,9 +6805,9 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -6864,7 +6864,7 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -6878,11 +6878,11 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -6901,7 +6901,7 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -6914,9 +6914,9 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -6973,7 +6973,7 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -6987,11 +6987,11 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -7010,7 +7010,7 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -7023,9 +7023,9 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -7082,7 +7082,7 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7098,11 +7098,11 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7123,7 +7123,7 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7138,9 +7138,9 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7199,7 +7199,7 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -7221,7 +7221,7 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -7244,7 +7244,7 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -7263,7 +7263,7 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -7324,7 +7324,7 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -7338,11 +7338,11 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -7361,7 +7361,7 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -7374,9 +7374,9 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -7433,7 +7433,7 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -7447,11 +7447,11 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -7470,7 +7470,7 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -7483,9 +7483,9 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -7542,7 +7542,7 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -7556,11 +7556,11 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						result := int64(arg) - int64(p.constArg)
@@ -7579,7 +7579,7 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -7592,9 +7592,9 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					result := int64(arg) - int64(p.constArg)
@@ -7651,7 +7651,7 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7667,11 +7667,11 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7692,7 +7692,7 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7707,9 +7707,9 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7768,7 +7768,7 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -7790,7 +7790,7 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg)
 					var _nonDatumArgAsDatum tree.Datum
@@ -7813,7 +7813,7 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -7832,7 +7832,7 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg)
 				var _nonDatumArgAsDatum tree.Datum
@@ -7893,7 +7893,7 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7904,11 +7904,11 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -7924,7 +7924,7 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7934,9 +7934,9 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -7990,7 +7990,7 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					nanos := arg.Sub(p.constArg).Nanoseconds()
 					projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -7999,11 +7999,11 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					nanos := arg.Sub(p.constArg).Nanoseconds()
 					projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -8017,7 +8017,7 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				nanos := arg.Sub(p.constArg).Nanoseconds()
 				projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -8025,9 +8025,9 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				nanos := arg.Sub(p.constArg).Nanoseconds()
 				projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -8079,17 +8079,17 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg.Mul(-1))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = duration.Add(arg, p.constArg.Mul(-1))
 				}
 			}
@@ -8100,14 +8100,14 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(arg, p.constArg.Mul(-1))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = duration.Add(arg, p.constArg.Mul(-1))
 			}
 		}
@@ -8156,17 +8156,17 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Sub(p.constArg)
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Sub(p.constArg)
 				}
 			}
@@ -8177,14 +8177,14 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Sub(p.constArg)
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Sub(p.constArg)
 			}
 		}
@@ -8233,7 +8233,7 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg}
 					var _nonDatumArgAsDatum tree.Datum
@@ -8255,7 +8255,7 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg}
 					var _nonDatumArgAsDatum tree.Datum
@@ -8278,7 +8278,7 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg}
 				var _nonDatumArgAsDatum tree.Datum
@@ -8297,7 +8297,7 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col[0:n]
 			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg}
 				var _nonDatumArgAsDatum tree.Datum
@@ -9044,7 +9044,7 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9059,11 +9059,11 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9083,7 +9083,7 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9097,9 +9097,9 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9157,7 +9157,7 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9172,11 +9172,11 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9196,7 +9196,7 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9210,9 +9210,9 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9270,7 +9270,7 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9285,11 +9285,11 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9309,7 +9309,7 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9323,9 +9323,9 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9383,7 +9383,7 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9397,11 +9397,11 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -9420,7 +9420,7 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9433,9 +9433,9 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -9492,7 +9492,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					f, err := arg.Float64()
 					if err != nil {
@@ -9503,11 +9503,11 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					f, err := arg.Float64()
 					if err != nil {
@@ -9523,7 +9523,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				f, err := arg.Float64()
 				if err != nil {
@@ -9533,9 +9533,9 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				f, err := arg.Float64()
 				if err != nil {
@@ -9589,7 +9589,7 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -9611,11 +9611,11 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -9642,7 +9642,7 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -9663,9 +9663,9 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -9730,7 +9730,7 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -9752,11 +9752,11 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -9783,7 +9783,7 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -9804,9 +9804,9 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -9871,7 +9871,7 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -9893,11 +9893,11 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -9924,7 +9924,7 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -9945,9 +9945,9 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -10012,7 +10012,7 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -10028,11 +10028,11 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -10053,7 +10053,7 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -10068,9 +10068,9 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -10129,17 +10129,17 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
@@ -10150,14 +10150,14 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
@@ -10206,7 +10206,7 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -10228,11 +10228,11 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -10259,7 +10259,7 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -10280,9 +10280,9 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -10347,7 +10347,7 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -10369,11 +10369,11 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -10400,7 +10400,7 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -10421,9 +10421,9 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -10488,7 +10488,7 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -10510,11 +10510,11 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -10541,7 +10541,7 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -10562,9 +10562,9 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -10629,7 +10629,7 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -10645,11 +10645,11 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -10670,7 +10670,7 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -10685,9 +10685,9 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -10746,17 +10746,17 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
@@ -10767,14 +10767,14 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
@@ -10823,7 +10823,7 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -10845,11 +10845,11 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -10876,7 +10876,7 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -10897,9 +10897,9 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -10964,7 +10964,7 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -10986,11 +10986,11 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -11017,7 +11017,7 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -11038,9 +11038,9 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -11105,7 +11105,7 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -11127,11 +11127,11 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						_left, _right := int64(arg), int64(p.constArg)
@@ -11158,7 +11158,7 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -11179,9 +11179,9 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					_left, _right := int64(arg), int64(p.constArg)
@@ -11246,7 +11246,7 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -11262,11 +11262,11 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -11287,7 +11287,7 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -11302,9 +11302,9 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -11363,17 +11363,17 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
@@ -11384,14 +11384,14 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.Mul(int64(arg))
 			}
 		}
@@ -11440,7 +11440,7 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -11451,11 +11451,11 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -11471,7 +11471,7 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -11481,9 +11481,9 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -11537,17 +11537,17 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
 			}
@@ -11558,14 +11558,14 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.MulFloat(float64(arg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = p.constArg.MulFloat(float64(arg))
 			}
 		}
@@ -11614,17 +11614,17 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
@@ -11635,14 +11635,14 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
@@ -11691,17 +11691,17 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
@@ -11712,14 +11712,14 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
@@ -11768,17 +11768,17 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
@@ -11789,14 +11789,14 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.Mul(int64(p.constArg))
 			}
 		}
@@ -11845,17 +11845,17 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
 			}
@@ -11866,14 +11866,14 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.MulFloat(float64(p.constArg))
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 				projCol[i] = arg.MulFloat(float64(p.constArg))
 			}
 		}
@@ -11922,7 +11922,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					f, err := p.constArg.Float64()
 					if err != nil {
@@ -11933,11 +11933,11 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					f, err := p.constArg.Float64()
 					if err != nil {
@@ -11953,7 +11953,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				f, err := p.constArg.Float64()
 				if err != nil {
@@ -11963,9 +11963,9 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				f, err := p.constArg.Float64()
 				if err != nil {
@@ -12019,7 +12019,7 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12038,11 +12038,11 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12066,7 +12066,7 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12084,9 +12084,9 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12148,7 +12148,7 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12167,11 +12167,11 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12195,7 +12195,7 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12213,9 +12213,9 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12277,7 +12277,7 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12296,11 +12296,11 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12324,7 +12324,7 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12342,9 +12342,9 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12406,7 +12406,7 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12424,11 +12424,11 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12451,7 +12451,7 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12468,9 +12468,9 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12531,7 +12531,7 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -12549,11 +12549,11 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -12576,7 +12576,7 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -12593,9 +12593,9 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -12656,7 +12656,7 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -12674,11 +12674,11 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -12701,7 +12701,7 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -12718,9 +12718,9 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -12781,7 +12781,7 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -12799,11 +12799,11 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -12826,7 +12826,7 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -12843,9 +12843,9 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -12906,7 +12906,7 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12926,11 +12926,11 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -12955,7 +12955,7 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -12974,9 +12974,9 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -13039,7 +13039,7 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13057,11 +13057,11 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13084,7 +13084,7 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13101,9 +13101,9 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13164,7 +13164,7 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13182,11 +13182,11 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13209,7 +13209,7 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13226,9 +13226,9 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13289,7 +13289,7 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13307,11 +13307,11 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13334,7 +13334,7 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13351,9 +13351,9 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13414,7 +13414,7 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -13434,11 +13434,11 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -13463,7 +13463,7 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -13482,9 +13482,9 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -13547,7 +13547,7 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13565,11 +13565,11 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13592,7 +13592,7 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13609,9 +13609,9 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13672,7 +13672,7 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13690,11 +13690,11 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13717,7 +13717,7 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13734,9 +13734,9 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13797,7 +13797,7 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13815,11 +13815,11 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -13842,7 +13842,7 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13859,9 +13859,9 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -13922,7 +13922,7 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -13942,11 +13942,11 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -13971,7 +13971,7 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -13990,9 +13990,9 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14055,7 +14055,7 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14070,11 +14070,11 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14094,7 +14094,7 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14108,9 +14108,9 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14168,7 +14168,7 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					if p.constArg == 0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14178,11 +14178,11 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					if p.constArg == 0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14197,7 +14197,7 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				if p.constArg == 0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14206,9 +14206,9 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				if p.constArg == 0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14261,7 +14261,7 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					if p.constArg == 0.0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14271,11 +14271,11 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					if p.constArg == 0.0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14290,7 +14290,7 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				if p.constArg == 0.0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14299,9 +14299,9 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				if p.constArg == 0.0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -14354,7 +14354,7 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14373,11 +14373,11 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14401,7 +14401,7 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14419,9 +14419,9 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14483,7 +14483,7 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14502,11 +14502,11 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14530,7 +14530,7 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14548,9 +14548,9 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14612,7 +14612,7 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14631,11 +14631,11 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14659,7 +14659,7 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14677,9 +14677,9 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14741,7 +14741,7 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14759,11 +14759,11 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -14786,7 +14786,7 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14803,9 +14803,9 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -14866,7 +14866,7 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -14879,11 +14879,11 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -14901,7 +14901,7 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -14913,9 +14913,9 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -14971,7 +14971,7 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -14984,11 +14984,11 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15006,7 +15006,7 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15018,9 +15018,9 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15076,7 +15076,7 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15089,11 +15089,11 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15111,7 +15111,7 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15123,9 +15123,9 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15181,7 +15181,7 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -15201,11 +15201,11 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -15230,7 +15230,7 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -15249,9 +15249,9 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -15314,7 +15314,7 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15327,11 +15327,11 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15349,7 +15349,7 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15361,9 +15361,9 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15419,7 +15419,7 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15432,11 +15432,11 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15454,7 +15454,7 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15466,9 +15466,9 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15524,7 +15524,7 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15537,11 +15537,11 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15559,7 +15559,7 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15571,9 +15571,9 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15629,7 +15629,7 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -15649,11 +15649,11 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -15678,7 +15678,7 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -15697,9 +15697,9 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -15762,7 +15762,7 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15775,11 +15775,11 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15797,7 +15797,7 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15809,9 +15809,9 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15867,7 +15867,7 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15880,11 +15880,11 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15902,7 +15902,7 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15914,9 +15914,9 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -15972,7 +15972,7 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -15985,11 +15985,11 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -16007,7 +16007,7 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -16019,9 +16019,9 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -16077,7 +16077,7 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16097,11 +16097,11 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16126,7 +16126,7 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16145,9 +16145,9 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16210,7 +16210,7 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16225,11 +16225,11 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16249,7 +16249,7 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16263,9 +16263,9 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16323,7 +16323,7 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16342,11 +16342,11 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16370,7 +16370,7 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16388,9 +16388,9 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16452,7 +16452,7 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16471,11 +16471,11 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16499,7 +16499,7 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16517,9 +16517,9 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16581,7 +16581,7 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16600,11 +16600,11 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16628,7 +16628,7 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16646,9 +16646,9 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16710,7 +16710,7 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16728,11 +16728,11 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -16755,7 +16755,7 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16772,9 +16772,9 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -16835,7 +16835,7 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -16848,11 +16848,11 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -16870,7 +16870,7 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -16882,9 +16882,9 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -16940,7 +16940,7 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -16953,11 +16953,11 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -16975,7 +16975,7 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -16987,9 +16987,9 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17045,7 +17045,7 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17058,11 +17058,11 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17080,7 +17080,7 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17092,9 +17092,9 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17150,7 +17150,7 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -17170,11 +17170,11 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -17199,7 +17199,7 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -17218,9 +17218,9 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -17283,7 +17283,7 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17296,11 +17296,11 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17318,7 +17318,7 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17330,9 +17330,9 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17388,7 +17388,7 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17401,11 +17401,11 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17423,7 +17423,7 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17435,9 +17435,9 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17493,7 +17493,7 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17506,11 +17506,11 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17528,7 +17528,7 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17540,9 +17540,9 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17598,7 +17598,7 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -17618,11 +17618,11 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -17647,7 +17647,7 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -17666,9 +17666,9 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -17731,7 +17731,7 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17744,11 +17744,11 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17766,7 +17766,7 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17778,9 +17778,9 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17836,7 +17836,7 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17849,11 +17849,11 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17871,7 +17871,7 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17883,9 +17883,9 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17941,7 +17941,7 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17954,11 +17954,11 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) == 0 {
@@ -17976,7 +17976,7 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -17988,9 +17988,9 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) == 0 {
@@ -18046,7 +18046,7 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18066,11 +18066,11 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18095,7 +18095,7 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18114,9 +18114,9 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18179,7 +18179,7 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18194,11 +18194,11 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18218,7 +18218,7 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18232,9 +18232,9 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18292,7 +18292,7 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18307,11 +18307,11 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18331,7 +18331,7 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18345,9 +18345,9 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18405,7 +18405,7 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18420,11 +18420,11 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18444,7 +18444,7 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18458,9 +18458,9 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18518,7 +18518,7 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18533,11 +18533,11 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18557,7 +18557,7 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18571,9 +18571,9 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18631,7 +18631,7 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18645,11 +18645,11 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -18668,7 +18668,7 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18681,9 +18681,9 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -18740,7 +18740,7 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18760,11 +18760,11 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18789,7 +18789,7 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18808,9 +18808,9 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18873,7 +18873,7 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18893,11 +18893,11 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18922,7 +18922,7 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -18941,9 +18941,9 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19006,7 +19006,7 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19026,11 +19026,11 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19055,7 +19055,7 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19074,9 +19074,9 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19139,7 +19139,7 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -19155,11 +19155,11 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -19180,7 +19180,7 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -19195,9 +19195,9 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -19256,7 +19256,7 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19276,11 +19276,11 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19305,7 +19305,7 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19324,9 +19324,9 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19389,7 +19389,7 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19409,11 +19409,11 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19438,7 +19438,7 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19457,9 +19457,9 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19522,7 +19522,7 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19542,11 +19542,11 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19571,7 +19571,7 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19590,9 +19590,9 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19655,7 +19655,7 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -19671,11 +19671,11 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -19696,7 +19696,7 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -19711,9 +19711,9 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -19772,7 +19772,7 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19792,11 +19792,11 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19821,7 +19821,7 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19840,9 +19840,9 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19905,7 +19905,7 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19925,11 +19925,11 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19954,7 +19954,7 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -19973,9 +19973,9 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20038,7 +20038,7 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20058,11 +20058,11 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20087,7 +20087,7 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20106,9 +20106,9 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20171,7 +20171,7 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -20187,11 +20187,11 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -20212,7 +20212,7 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -20227,9 +20227,9 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -20288,7 +20288,7 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -20299,11 +20299,11 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 
@@ -20319,7 +20319,7 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -20329,9 +20329,9 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 
@@ -20385,7 +20385,7 @@ func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var r = []byte{}
@@ -20400,11 +20400,11 @@ func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var r = []byte{}
@@ -20422,7 +20422,7 @@ func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var r = []byte{}
@@ -20436,9 +20436,9 @@ func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var r = []byte{}
@@ -20595,7 +20595,7 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20609,11 +20609,11 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20632,7 +20632,7 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20645,9 +20645,9 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20704,7 +20704,7 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20718,11 +20718,11 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20741,7 +20741,7 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20754,9 +20754,9 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20813,7 +20813,7 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20827,11 +20827,11 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20850,7 +20850,7 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20863,9 +20863,9 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20922,7 +20922,7 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20936,11 +20936,11 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20959,7 +20959,7 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -20972,9 +20972,9 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21031,7 +21031,7 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21045,11 +21045,11 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21068,7 +21068,7 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21081,9 +21081,9 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21140,7 +21140,7 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21154,11 +21154,11 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21177,7 +21177,7 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21190,9 +21190,9 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21249,7 +21249,7 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21263,11 +21263,11 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21286,7 +21286,7 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21299,9 +21299,9 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21358,7 +21358,7 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21372,11 +21372,11 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21395,7 +21395,7 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21408,9 +21408,9 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21467,7 +21467,7 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21481,11 +21481,11 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21504,7 +21504,7 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21517,9 +21517,9 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21927,7 +21927,7 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21941,11 +21941,11 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21964,7 +21964,7 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -21977,9 +21977,9 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22036,7 +22036,7 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22050,11 +22050,11 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22073,7 +22073,7 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22086,9 +22086,9 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22145,7 +22145,7 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22159,11 +22159,11 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22182,7 +22182,7 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22195,9 +22195,9 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22254,7 +22254,7 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22268,11 +22268,11 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22291,7 +22291,7 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22304,9 +22304,9 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22363,7 +22363,7 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22377,11 +22377,11 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22400,7 +22400,7 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22413,9 +22413,9 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22472,7 +22472,7 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22486,11 +22486,11 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22509,7 +22509,7 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22522,9 +22522,9 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22581,7 +22581,7 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22595,11 +22595,11 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22618,7 +22618,7 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22631,9 +22631,9 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22690,7 +22690,7 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22704,11 +22704,11 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22727,7 +22727,7 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22740,9 +22740,9 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22799,7 +22799,7 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22813,11 +22813,11 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22836,7 +22836,7 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -22849,9 +22849,9 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					if int64(p.constArg) < 0 || int64(p.constArg) >= 64 {
@@ -23727,7 +23727,7 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23747,11 +23747,11 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23776,7 +23776,7 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -23795,9 +23795,9 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -23860,7 +23860,7 @@ func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23874,11 +23874,11 @@ func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23895,7 +23895,7 @@ func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -23908,9 +23908,9 @@ func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -23965,7 +23965,7 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23983,11 +23983,11 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24010,7 +24010,7 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24027,9 +24027,9 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24090,7 +24090,7 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24108,11 +24108,11 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24135,7 +24135,7 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24152,9 +24152,9 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24215,7 +24215,7 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24233,11 +24233,11 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24260,7 +24260,7 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24277,9 +24277,9 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24340,7 +24340,7 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24360,11 +24360,11 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24389,7 +24389,7 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24408,9 +24408,9 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24473,7 +24473,7 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24485,11 +24485,11 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24506,7 +24506,7 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24517,9 +24517,9 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24574,7 +24574,7 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24597,11 +24597,11 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24629,7 +24629,7 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24651,9 +24651,9 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24719,7 +24719,7 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24742,11 +24742,11 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24774,7 +24774,7 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24796,9 +24796,9 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24864,7 +24864,7 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24887,11 +24887,11 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24919,7 +24919,7 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -24941,9 +24941,9 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25009,7 +25009,7 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25040,11 +25040,11 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25080,7 +25080,7 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25110,9 +25110,9 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25186,7 +25186,7 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25204,11 +25204,11 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25231,7 +25231,7 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25248,9 +25248,9 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25311,7 +25311,7 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25334,11 +25334,11 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25366,7 +25366,7 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25388,9 +25388,9 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25456,7 +25456,7 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25479,11 +25479,11 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25511,7 +25511,7 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25533,9 +25533,9 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25601,7 +25601,7 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25624,11 +25624,11 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25656,7 +25656,7 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25678,9 +25678,9 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25746,7 +25746,7 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25777,11 +25777,11 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25817,7 +25817,7 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25847,9 +25847,9 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25923,7 +25923,7 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25941,11 +25941,11 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25968,7 +25968,7 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -25985,9 +25985,9 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26048,7 +26048,7 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26071,11 +26071,11 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26103,7 +26103,7 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26125,9 +26125,9 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26193,7 +26193,7 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26216,11 +26216,11 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26248,7 +26248,7 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26270,9 +26270,9 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26338,7 +26338,7 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26361,11 +26361,11 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26393,7 +26393,7 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26415,9 +26415,9 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26483,7 +26483,7 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26514,11 +26514,11 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26554,7 +26554,7 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26584,9 +26584,9 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26660,7 +26660,7 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26678,11 +26678,11 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26705,7 +26705,7 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26722,9 +26722,9 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26785,7 +26785,7 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26816,11 +26816,11 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26856,7 +26856,7 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26886,9 +26886,9 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -26962,7 +26962,7 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26993,11 +26993,11 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27033,7 +27033,7 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27063,9 +27063,9 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27139,7 +27139,7 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27170,11 +27170,11 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27210,7 +27210,7 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27240,9 +27240,9 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27316,7 +27316,7 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27347,11 +27347,11 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27387,7 +27387,7 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27417,9 +27417,9 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27493,7 +27493,7 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27513,11 +27513,11 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27542,7 +27542,7 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27561,9 +27561,9 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27626,7 +27626,7 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27645,11 +27645,11 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27673,7 +27673,7 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27691,9 +27691,9 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27755,7 +27755,7 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27767,11 +27767,11 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27788,7 +27788,7 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27799,9 +27799,9 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -27870,7 +27870,7 @@ func (p projEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
@@ -27906,7 +27906,7 @@ func (p projEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				arg := col.Get(i)
 
@@ -27965,7 +27965,7 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27985,11 +27985,11 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28014,7 +28014,7 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28033,9 +28033,9 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28098,7 +28098,7 @@ func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28112,11 +28112,11 @@ func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28133,7 +28133,7 @@ func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28146,9 +28146,9 @@ func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28203,7 +28203,7 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28221,11 +28221,11 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28248,7 +28248,7 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28265,9 +28265,9 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28328,7 +28328,7 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28346,11 +28346,11 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28373,7 +28373,7 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28390,9 +28390,9 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28453,7 +28453,7 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28471,11 +28471,11 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28498,7 +28498,7 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28515,9 +28515,9 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28578,7 +28578,7 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28598,11 +28598,11 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28627,7 +28627,7 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28646,9 +28646,9 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28711,7 +28711,7 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28723,11 +28723,11 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28744,7 +28744,7 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28755,9 +28755,9 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28812,7 +28812,7 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28835,11 +28835,11 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28867,7 +28867,7 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28889,9 +28889,9 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -28957,7 +28957,7 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28980,11 +28980,11 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29012,7 +29012,7 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29034,9 +29034,9 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29102,7 +29102,7 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29125,11 +29125,11 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29157,7 +29157,7 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29179,9 +29179,9 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29247,7 +29247,7 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29278,11 +29278,11 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29318,7 +29318,7 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29348,9 +29348,9 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29424,7 +29424,7 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29442,11 +29442,11 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29469,7 +29469,7 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29486,9 +29486,9 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29549,7 +29549,7 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29572,11 +29572,11 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29604,7 +29604,7 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29626,9 +29626,9 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29694,7 +29694,7 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29717,11 +29717,11 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29749,7 +29749,7 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29771,9 +29771,9 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29839,7 +29839,7 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29862,11 +29862,11 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29894,7 +29894,7 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29916,9 +29916,9 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -29984,7 +29984,7 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30015,11 +30015,11 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30055,7 +30055,7 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30085,9 +30085,9 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30161,7 +30161,7 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30179,11 +30179,11 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30206,7 +30206,7 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30223,9 +30223,9 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30286,7 +30286,7 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30309,11 +30309,11 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30341,7 +30341,7 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30363,9 +30363,9 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30431,7 +30431,7 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30454,11 +30454,11 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30486,7 +30486,7 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30508,9 +30508,9 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30576,7 +30576,7 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30599,11 +30599,11 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30631,7 +30631,7 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30653,9 +30653,9 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30721,7 +30721,7 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30752,11 +30752,11 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30792,7 +30792,7 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30822,9 +30822,9 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30898,7 +30898,7 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30916,11 +30916,11 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30943,7 +30943,7 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -30960,9 +30960,9 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31023,7 +31023,7 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31054,11 +31054,11 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31094,7 +31094,7 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31124,9 +31124,9 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31200,7 +31200,7 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31231,11 +31231,11 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31271,7 +31271,7 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31301,9 +31301,9 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31377,7 +31377,7 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31408,11 +31408,11 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31448,7 +31448,7 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31478,9 +31478,9 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31554,7 +31554,7 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31585,11 +31585,11 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31625,7 +31625,7 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31655,9 +31655,9 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31731,7 +31731,7 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31751,11 +31751,11 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31780,7 +31780,7 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31799,9 +31799,9 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31864,7 +31864,7 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31883,11 +31883,11 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31911,7 +31911,7 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31929,9 +31929,9 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -31993,7 +31993,7 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32005,11 +32005,11 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32026,7 +32026,7 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32037,9 +32037,9 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32108,7 +32108,7 @@ func (p projNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
@@ -32144,7 +32144,7 @@ func (p projNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				arg := col.Get(i)
 
@@ -32203,7 +32203,7 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32223,11 +32223,11 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32252,7 +32252,7 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32271,9 +32271,9 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32336,7 +32336,7 @@ func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32350,11 +32350,11 @@ func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32371,7 +32371,7 @@ func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32384,9 +32384,9 @@ func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32441,7 +32441,7 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32459,11 +32459,11 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32486,7 +32486,7 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32503,9 +32503,9 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32566,7 +32566,7 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32584,11 +32584,11 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32611,7 +32611,7 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32628,9 +32628,9 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32691,7 +32691,7 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32709,11 +32709,11 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32736,7 +32736,7 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32753,9 +32753,9 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32816,7 +32816,7 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32836,11 +32836,11 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32865,7 +32865,7 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32884,9 +32884,9 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32949,7 +32949,7 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32961,11 +32961,11 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32982,7 +32982,7 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -32993,9 +32993,9 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33050,7 +33050,7 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33073,11 +33073,11 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33105,7 +33105,7 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33127,9 +33127,9 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33195,7 +33195,7 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33218,11 +33218,11 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33250,7 +33250,7 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33272,9 +33272,9 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33340,7 +33340,7 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33363,11 +33363,11 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33395,7 +33395,7 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33417,9 +33417,9 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33485,7 +33485,7 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33516,11 +33516,11 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33556,7 +33556,7 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33586,9 +33586,9 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33662,7 +33662,7 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33680,11 +33680,11 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33707,7 +33707,7 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33724,9 +33724,9 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33787,7 +33787,7 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33810,11 +33810,11 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33842,7 +33842,7 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33864,9 +33864,9 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -33932,7 +33932,7 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33955,11 +33955,11 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33987,7 +33987,7 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34009,9 +34009,9 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34077,7 +34077,7 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34100,11 +34100,11 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34132,7 +34132,7 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34154,9 +34154,9 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34222,7 +34222,7 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34253,11 +34253,11 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34293,7 +34293,7 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34323,9 +34323,9 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34399,7 +34399,7 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34417,11 +34417,11 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34444,7 +34444,7 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34461,9 +34461,9 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34524,7 +34524,7 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34547,11 +34547,11 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34579,7 +34579,7 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34601,9 +34601,9 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34669,7 +34669,7 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34692,11 +34692,11 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34724,7 +34724,7 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34746,9 +34746,9 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34814,7 +34814,7 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34837,11 +34837,11 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34869,7 +34869,7 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34891,9 +34891,9 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -34959,7 +34959,7 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34990,11 +34990,11 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35030,7 +35030,7 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35060,9 +35060,9 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35136,7 +35136,7 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35154,11 +35154,11 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35181,7 +35181,7 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35198,9 +35198,9 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35261,7 +35261,7 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35292,11 +35292,11 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35332,7 +35332,7 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35362,9 +35362,9 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35438,7 +35438,7 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35469,11 +35469,11 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35509,7 +35509,7 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35539,9 +35539,9 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35615,7 +35615,7 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35646,11 +35646,11 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35686,7 +35686,7 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35716,9 +35716,9 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35792,7 +35792,7 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35823,11 +35823,11 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35863,7 +35863,7 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35893,9 +35893,9 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -35969,7 +35969,7 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35989,11 +35989,11 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36018,7 +36018,7 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36037,9 +36037,9 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36102,7 +36102,7 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36121,11 +36121,11 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36149,7 +36149,7 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36167,9 +36167,9 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36231,7 +36231,7 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36243,11 +36243,11 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36264,7 +36264,7 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36275,9 +36275,9 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36346,7 +36346,7 @@ func (p projLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
@@ -36382,7 +36382,7 @@ func (p projLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				arg := col.Get(i)
 
@@ -36441,7 +36441,7 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36461,11 +36461,11 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36490,7 +36490,7 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36509,9 +36509,9 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36574,7 +36574,7 @@ func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36588,11 +36588,11 @@ func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36609,7 +36609,7 @@ func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36622,9 +36622,9 @@ func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36679,7 +36679,7 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36697,11 +36697,11 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36724,7 +36724,7 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36741,9 +36741,9 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36804,7 +36804,7 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36822,11 +36822,11 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36849,7 +36849,7 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36866,9 +36866,9 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36929,7 +36929,7 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36947,11 +36947,11 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36974,7 +36974,7 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -36991,9 +36991,9 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37054,7 +37054,7 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37074,11 +37074,11 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37103,7 +37103,7 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37122,9 +37122,9 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37187,7 +37187,7 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37199,11 +37199,11 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37220,7 +37220,7 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37231,9 +37231,9 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37288,7 +37288,7 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37311,11 +37311,11 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37343,7 +37343,7 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37365,9 +37365,9 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37433,7 +37433,7 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37456,11 +37456,11 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37488,7 +37488,7 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37510,9 +37510,9 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37578,7 +37578,7 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37601,11 +37601,11 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37633,7 +37633,7 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37655,9 +37655,9 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37723,7 +37723,7 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37754,11 +37754,11 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37794,7 +37794,7 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37824,9 +37824,9 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37900,7 +37900,7 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37918,11 +37918,11 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37945,7 +37945,7 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -37962,9 +37962,9 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38025,7 +38025,7 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38048,11 +38048,11 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38080,7 +38080,7 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38102,9 +38102,9 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38170,7 +38170,7 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38193,11 +38193,11 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38225,7 +38225,7 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38247,9 +38247,9 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38315,7 +38315,7 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38338,11 +38338,11 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38370,7 +38370,7 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38392,9 +38392,9 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38460,7 +38460,7 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38491,11 +38491,11 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38531,7 +38531,7 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38561,9 +38561,9 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38637,7 +38637,7 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38655,11 +38655,11 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38682,7 +38682,7 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38699,9 +38699,9 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38762,7 +38762,7 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38785,11 +38785,11 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38817,7 +38817,7 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38839,9 +38839,9 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38907,7 +38907,7 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38930,11 +38930,11 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38962,7 +38962,7 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -38984,9 +38984,9 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39052,7 +39052,7 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39075,11 +39075,11 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39107,7 +39107,7 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39129,9 +39129,9 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39197,7 +39197,7 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39228,11 +39228,11 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39268,7 +39268,7 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39298,9 +39298,9 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39374,7 +39374,7 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39392,11 +39392,11 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39419,7 +39419,7 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39436,9 +39436,9 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39499,7 +39499,7 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39530,11 +39530,11 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39570,7 +39570,7 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39600,9 +39600,9 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39676,7 +39676,7 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39707,11 +39707,11 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39747,7 +39747,7 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39777,9 +39777,9 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39853,7 +39853,7 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39884,11 +39884,11 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39924,7 +39924,7 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -39954,9 +39954,9 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40030,7 +40030,7 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40061,11 +40061,11 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40101,7 +40101,7 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40131,9 +40131,9 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40207,7 +40207,7 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40227,11 +40227,11 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40256,7 +40256,7 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40275,9 +40275,9 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40340,7 +40340,7 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40359,11 +40359,11 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40387,7 +40387,7 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40405,9 +40405,9 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40469,7 +40469,7 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40481,11 +40481,11 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40502,7 +40502,7 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40513,9 +40513,9 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40584,7 +40584,7 @@ func (p projLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
@@ -40620,7 +40620,7 @@ func (p projLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				arg := col.Get(i)
 
@@ -40679,7 +40679,7 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40699,11 +40699,11 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40728,7 +40728,7 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40747,9 +40747,9 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40812,7 +40812,7 @@ func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40826,11 +40826,11 @@ func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40847,7 +40847,7 @@ func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40860,9 +40860,9 @@ func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40917,7 +40917,7 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40935,11 +40935,11 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40962,7 +40962,7 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -40979,9 +40979,9 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41042,7 +41042,7 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41060,11 +41060,11 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41087,7 +41087,7 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41104,9 +41104,9 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41167,7 +41167,7 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41185,11 +41185,11 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41212,7 +41212,7 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41229,9 +41229,9 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41292,7 +41292,7 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41312,11 +41312,11 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41341,7 +41341,7 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41360,9 +41360,9 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41425,7 +41425,7 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41437,11 +41437,11 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41458,7 +41458,7 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41469,9 +41469,9 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41526,7 +41526,7 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41549,11 +41549,11 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41581,7 +41581,7 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41603,9 +41603,9 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41671,7 +41671,7 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41694,11 +41694,11 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41726,7 +41726,7 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41748,9 +41748,9 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41816,7 +41816,7 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41839,11 +41839,11 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41871,7 +41871,7 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41893,9 +41893,9 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -41961,7 +41961,7 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41992,11 +41992,11 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42032,7 +42032,7 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42062,9 +42062,9 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42138,7 +42138,7 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42156,11 +42156,11 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42183,7 +42183,7 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42200,9 +42200,9 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42263,7 +42263,7 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42286,11 +42286,11 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42318,7 +42318,7 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42340,9 +42340,9 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42408,7 +42408,7 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42431,11 +42431,11 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42463,7 +42463,7 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42485,9 +42485,9 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42553,7 +42553,7 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42576,11 +42576,11 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42608,7 +42608,7 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42630,9 +42630,9 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42698,7 +42698,7 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42729,11 +42729,11 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42769,7 +42769,7 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42799,9 +42799,9 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42875,7 +42875,7 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42893,11 +42893,11 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42920,7 +42920,7 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -42937,9 +42937,9 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43000,7 +43000,7 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43023,11 +43023,11 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43055,7 +43055,7 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43077,9 +43077,9 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43145,7 +43145,7 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43168,11 +43168,11 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43200,7 +43200,7 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43222,9 +43222,9 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43290,7 +43290,7 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43313,11 +43313,11 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43345,7 +43345,7 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43367,9 +43367,9 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43435,7 +43435,7 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43466,11 +43466,11 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43506,7 +43506,7 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43536,9 +43536,9 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43612,7 +43612,7 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43630,11 +43630,11 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43657,7 +43657,7 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43674,9 +43674,9 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43737,7 +43737,7 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43768,11 +43768,11 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43808,7 +43808,7 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43838,9 +43838,9 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -43914,7 +43914,7 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43945,11 +43945,11 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43985,7 +43985,7 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44015,9 +44015,9 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44091,7 +44091,7 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44122,11 +44122,11 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44162,7 +44162,7 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44192,9 +44192,9 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44268,7 +44268,7 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44299,11 +44299,11 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44339,7 +44339,7 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44369,9 +44369,9 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44445,7 +44445,7 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44465,11 +44465,11 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44494,7 +44494,7 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44513,9 +44513,9 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44578,7 +44578,7 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44597,11 +44597,11 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44625,7 +44625,7 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44643,9 +44643,9 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44707,7 +44707,7 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44719,11 +44719,11 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44740,7 +44740,7 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44751,9 +44751,9 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44822,7 +44822,7 @@ func (p projGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
@@ -44858,7 +44858,7 @@ func (p projGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				arg := col.Get(i)
 
@@ -44917,7 +44917,7 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44937,11 +44937,11 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44966,7 +44966,7 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -44985,9 +44985,9 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45050,7 +45050,7 @@ func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45064,11 +45064,11 @@ func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45085,7 +45085,7 @@ func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45098,9 +45098,9 @@ func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			col = col
 			_ = 0
 			_ = n
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45155,7 +45155,7 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45173,11 +45173,11 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45200,7 +45200,7 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45217,9 +45217,9 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45280,7 +45280,7 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45298,11 +45298,11 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45325,7 +45325,7 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45342,9 +45342,9 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45405,7 +45405,7 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45423,11 +45423,11 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45450,7 +45450,7 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45467,9 +45467,9 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45530,7 +45530,7 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45550,11 +45550,11 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45579,7 +45579,7 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45598,9 +45598,9 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45663,7 +45663,7 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45675,11 +45675,11 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45696,7 +45696,7 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45707,9 +45707,9 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45764,7 +45764,7 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45787,11 +45787,11 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45819,7 +45819,7 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45841,9 +45841,9 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45909,7 +45909,7 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45932,11 +45932,11 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45964,7 +45964,7 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -45986,9 +45986,9 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46054,7 +46054,7 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46077,11 +46077,11 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46109,7 +46109,7 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46131,9 +46131,9 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46199,7 +46199,7 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46230,11 +46230,11 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46270,7 +46270,7 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46300,9 +46300,9 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46376,7 +46376,7 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46394,11 +46394,11 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46421,7 +46421,7 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46438,9 +46438,9 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46501,7 +46501,7 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46524,11 +46524,11 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46556,7 +46556,7 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46578,9 +46578,9 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46646,7 +46646,7 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46669,11 +46669,11 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46701,7 +46701,7 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46723,9 +46723,9 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46791,7 +46791,7 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46814,11 +46814,11 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46846,7 +46846,7 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46868,9 +46868,9 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -46936,7 +46936,7 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46967,11 +46967,11 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47007,7 +47007,7 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47037,9 +47037,9 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47113,7 +47113,7 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47131,11 +47131,11 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47158,7 +47158,7 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47175,9 +47175,9 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47238,7 +47238,7 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47261,11 +47261,11 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47293,7 +47293,7 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47315,9 +47315,9 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47383,7 +47383,7 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47406,11 +47406,11 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47438,7 +47438,7 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47460,9 +47460,9 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47528,7 +47528,7 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47551,11 +47551,11 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47583,7 +47583,7 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47605,9 +47605,9 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47673,7 +47673,7 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47704,11 +47704,11 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47744,7 +47744,7 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47774,9 +47774,9 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47850,7 +47850,7 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47868,11 +47868,11 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47895,7 +47895,7 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47912,9 +47912,9 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -47975,7 +47975,7 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48006,11 +48006,11 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48046,7 +48046,7 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48076,9 +48076,9 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48152,7 +48152,7 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48183,11 +48183,11 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48223,7 +48223,7 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48253,9 +48253,9 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48329,7 +48329,7 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48360,11 +48360,11 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48400,7 +48400,7 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48430,9 +48430,9 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48506,7 +48506,7 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48537,11 +48537,11 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48577,7 +48577,7 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48607,9 +48607,9 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48683,7 +48683,7 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48703,11 +48703,11 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48732,7 +48732,7 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48751,9 +48751,9 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48816,7 +48816,7 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48835,11 +48835,11 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48863,7 +48863,7 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48881,9 +48881,9 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48945,7 +48945,7 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			for _, i := range sel {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48957,11 +48957,11 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48978,7 +48978,7 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -48989,9 +48989,9 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col[0:n]
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
-				arg := col.Get(i) //gcassert:inline
+				arg := col.Get(i)
 
 				{
 					var cmpResult int
@@ -49060,7 +49060,7 @@ func (p projGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				if !colNulls.NullAt(i) {
 					// We only want to perform the projection operation if the value is not null.
@@ -49096,7 +49096,7 @@ func (p projGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = col.Slice(0, n)
-			_ = projCol.Get(n - 1) //gcassert:inline
+			_ = projCol.Get(n - 1)
 			for i := 0; i < n; i++ {
 				arg := col.Get(i)
 

--- a/pkg/sql/colexec/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/proj_non_const_ops.eg.go
@@ -87,8 +87,8 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -97,14 +97,14 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -116,8 +116,8 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -125,11 +125,11 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -183,8 +183,8 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -193,14 +193,14 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -212,8 +212,8 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -221,11 +221,11 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -279,8 +279,8 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -289,14 +289,14 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -308,8 +308,8 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -317,11 +317,11 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -375,8 +375,8 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -385,14 +385,14 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -404,8 +404,8 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -413,11 +413,11 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -471,8 +471,8 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -481,14 +481,14 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -500,8 +500,8 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -509,11 +509,11 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -567,8 +567,8 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -577,14 +577,14 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -596,8 +596,8 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -605,11 +605,11 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -663,8 +663,8 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -673,14 +673,14 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -692,8 +692,8 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -701,11 +701,11 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -759,8 +759,8 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -769,14 +769,14 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -788,8 +788,8 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -797,11 +797,11 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -855,8 +855,8 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -865,14 +865,14 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) & int64(arg2)
 
@@ -884,8 +884,8 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -893,11 +893,11 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) & int64(arg2)
 
@@ -1063,8 +1063,8 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1073,14 +1073,14 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1092,8 +1092,8 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1101,11 +1101,11 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1159,8 +1159,8 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1169,14 +1169,14 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1188,8 +1188,8 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1197,11 +1197,11 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1255,8 +1255,8 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1265,14 +1265,14 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1284,8 +1284,8 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1293,11 +1293,11 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1351,8 +1351,8 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1361,14 +1361,14 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1380,8 +1380,8 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1389,11 +1389,11 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1447,8 +1447,8 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1457,14 +1457,14 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1476,8 +1476,8 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1485,11 +1485,11 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1543,8 +1543,8 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1553,14 +1553,14 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1572,8 +1572,8 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1581,11 +1581,11 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1639,8 +1639,8 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1649,14 +1649,14 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1668,8 +1668,8 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1677,11 +1677,11 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1735,8 +1735,8 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1745,14 +1745,14 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1764,8 +1764,8 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1773,11 +1773,11 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1831,8 +1831,8 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1841,14 +1841,14 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1860,8 +1860,8 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -1869,11 +1869,11 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) | int64(arg2)
 
@@ -2039,8 +2039,8 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2049,14 +2049,14 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2068,8 +2068,8 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2077,11 +2077,11 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2135,8 +2135,8 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2145,14 +2145,14 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2164,8 +2164,8 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2173,11 +2173,11 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2231,8 +2231,8 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2241,14 +2241,14 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2260,8 +2260,8 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2269,11 +2269,11 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2327,8 +2327,8 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2337,14 +2337,14 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2356,8 +2356,8 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2365,11 +2365,11 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2423,8 +2423,8 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2433,14 +2433,14 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2452,8 +2452,8 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2461,11 +2461,11 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2519,8 +2519,8 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2529,14 +2529,14 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2548,8 +2548,8 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2557,11 +2557,11 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2615,8 +2615,8 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2625,14 +2625,14 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2644,8 +2644,8 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2653,11 +2653,11 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2711,8 +2711,8 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2721,14 +2721,14 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2740,8 +2740,8 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2749,11 +2749,11 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2807,8 +2807,8 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2817,14 +2817,14 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2836,8 +2836,8 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -2845,11 +2845,11 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				projCol[i] = int64(arg1) ^ int64(arg2)
 
@@ -3015,8 +3015,8 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -3032,14 +3032,14 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -3058,8 +3058,8 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -3074,11 +3074,11 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -3139,8 +3139,8 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -3156,14 +3156,14 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -3182,8 +3182,8 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -3198,11 +3198,11 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -3263,8 +3263,8 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -3280,14 +3280,14 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -3306,8 +3306,8 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -3322,11 +3322,11 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -3387,8 +3387,8 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -3403,14 +3403,14 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -3428,8 +3428,8 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -3443,11 +3443,11 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -3507,8 +3507,8 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -3523,14 +3523,14 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -3548,8 +3548,8 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -3563,11 +3563,11 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -3627,8 +3627,8 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -3643,14 +3643,14 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -3668,8 +3668,8 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -3683,11 +3683,11 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -3747,8 +3747,8 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -3763,14 +3763,14 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -3788,8 +3788,8 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -3803,11 +3803,11 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -3867,8 +3867,8 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -3885,14 +3885,14 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -3912,8 +3912,8 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -3929,11 +3929,11 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -3995,7 +3995,7 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -4021,7 +4021,7 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -4044,7 +4044,7 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -4066,7 +4066,7 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -4131,8 +4131,8 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -4147,14 +4147,14 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -4172,8 +4172,8 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -4187,11 +4187,11 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -4251,8 +4251,8 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -4267,14 +4267,14 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -4292,8 +4292,8 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -4307,11 +4307,11 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -4371,8 +4371,8 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -4387,14 +4387,14 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -4412,8 +4412,8 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -4427,11 +4427,11 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -4491,8 +4491,8 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -4509,14 +4509,14 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -4536,8 +4536,8 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -4553,11 +4553,11 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -4619,7 +4619,7 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -4645,7 +4645,7 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -4668,7 +4668,7 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -4690,7 +4690,7 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -4755,8 +4755,8 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -4771,14 +4771,14 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -4796,8 +4796,8 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -4811,11 +4811,11 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -4875,8 +4875,8 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -4891,14 +4891,14 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -4916,8 +4916,8 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -4931,11 +4931,11 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -4995,8 +4995,8 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -5011,14 +5011,14 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) + int64(arg2)
@@ -5036,8 +5036,8 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -5051,11 +5051,11 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) + int64(arg2)
@@ -5115,8 +5115,8 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -5133,14 +5133,14 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -5160,8 +5160,8 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -5177,11 +5177,11 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -5243,7 +5243,7 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -5269,7 +5269,7 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -5292,7 +5292,7 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -5314,7 +5314,7 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -5379,8 +5379,8 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -5392,14 +5392,14 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -5414,8 +5414,8 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -5426,11 +5426,11 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -5487,22 +5487,22 @@ func (p projPlusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = duration.Add(arg1, arg2)
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = duration.Add(arg1, arg2)
 				}
 			}
@@ -5512,18 +5512,18 @@ func (p projPlusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = duration.Add(arg1, arg2)
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = duration.Add(arg1, arg2)
 			}
 		}
@@ -5575,22 +5575,22 @@ func (p projPlusIntervalTimestampOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = duration.Add(arg2, arg1)
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = duration.Add(arg2, arg1)
 				}
 			}
@@ -5600,18 +5600,18 @@ func (p projPlusIntervalTimestampOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = duration.Add(arg2, arg1)
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = duration.Add(arg2, arg1)
 			}
 		}
@@ -5663,22 +5663,22 @@ func (p projPlusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.Add(arg2)
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.Add(arg2)
 				}
 			}
@@ -5688,18 +5688,18 @@ func (p projPlusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.Add(arg2)
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.Add(arg2)
 			}
 		}
@@ -5751,7 +5751,7 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg1}
@@ -5777,7 +5777,7 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg1}
@@ -5800,7 +5800,7 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg1}
@@ -5822,7 +5822,7 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg1}
@@ -5888,7 +5888,7 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg2}
 					var _nonDatumArgAsDatum tree.Datum
@@ -5906,13 +5906,13 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg2}
 					var _nonDatumArgAsDatum tree.Datum
@@ -5933,7 +5933,7 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg2}
 				var _nonDatumArgAsDatum tree.Datum
@@ -5950,10 +5950,10 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg2}
 				var _nonDatumArgAsDatum tree.Datum
@@ -6016,7 +6016,7 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -6034,13 +6034,13 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -6061,7 +6061,7 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -6078,10 +6078,10 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -6144,7 +6144,7 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -6162,13 +6162,13 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -6189,7 +6189,7 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -6206,10 +6206,10 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -6272,7 +6272,7 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -6290,13 +6290,13 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -6317,7 +6317,7 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -6334,10 +6334,10 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -6399,8 +6399,8 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -6416,14 +6416,14 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -6442,8 +6442,8 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -6458,11 +6458,11 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -6523,8 +6523,8 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -6540,14 +6540,14 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -6566,8 +6566,8 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -6582,11 +6582,11 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -6647,8 +6647,8 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -6664,14 +6664,14 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -6690,8 +6690,8 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -6706,11 +6706,11 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -6771,8 +6771,8 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -6787,14 +6787,14 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -6812,8 +6812,8 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -6827,11 +6827,11 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -6891,8 +6891,8 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -6907,14 +6907,14 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -6932,8 +6932,8 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -6947,11 +6947,11 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -7011,8 +7011,8 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -7027,14 +7027,14 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -7052,8 +7052,8 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -7067,11 +7067,11 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -7131,8 +7131,8 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -7147,14 +7147,14 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -7172,8 +7172,8 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -7187,11 +7187,11 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -7251,8 +7251,8 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -7269,14 +7269,14 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -7296,8 +7296,8 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -7313,11 +7313,11 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -7379,7 +7379,7 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -7405,7 +7405,7 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -7428,7 +7428,7 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -7450,7 +7450,7 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -7515,8 +7515,8 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -7531,14 +7531,14 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -7556,8 +7556,8 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -7571,11 +7571,11 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -7635,8 +7635,8 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -7651,14 +7651,14 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -7676,8 +7676,8 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -7691,11 +7691,11 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -7755,8 +7755,8 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -7771,14 +7771,14 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -7796,8 +7796,8 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -7811,11 +7811,11 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -7875,8 +7875,8 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -7893,14 +7893,14 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -7920,8 +7920,8 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -7937,11 +7937,11 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -8003,7 +8003,7 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -8029,7 +8029,7 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -8052,7 +8052,7 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -8074,7 +8074,7 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -8139,8 +8139,8 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -8155,14 +8155,14 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -8180,8 +8180,8 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -8195,11 +8195,11 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -8259,8 +8259,8 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -8275,14 +8275,14 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -8300,8 +8300,8 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -8315,11 +8315,11 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -8379,8 +8379,8 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -8395,14 +8395,14 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						result := int64(arg1) - int64(arg2)
@@ -8420,8 +8420,8 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -8435,11 +8435,11 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					result := int64(arg1) - int64(arg2)
@@ -8499,8 +8499,8 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -8517,14 +8517,14 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -8544,8 +8544,8 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -8561,11 +8561,11 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -8627,7 +8627,7 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -8653,7 +8653,7 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg1)
@@ -8676,7 +8676,7 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -8698,7 +8698,7 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg1)
@@ -8763,8 +8763,8 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -8776,14 +8776,14 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -8798,8 +8798,8 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -8810,11 +8810,11 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -8871,8 +8871,8 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					nanos := arg1.Sub(arg2).Nanoseconds()
 					projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -8882,14 +8882,14 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					nanos := arg1.Sub(arg2).Nanoseconds()
 					projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -8902,8 +8902,8 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				nanos := arg1.Sub(arg2).Nanoseconds()
 				projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -8912,11 +8912,11 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				nanos := arg1.Sub(arg2).Nanoseconds()
 				projCol[i] = duration.MakeDuration(nanos, 0, 0)
@@ -8971,22 +8971,22 @@ func (p projMinusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = duration.Add(arg1, arg2.Mul(-1))
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = duration.Add(arg1, arg2.Mul(-1))
 				}
 			}
@@ -8996,18 +8996,18 @@ func (p projMinusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = duration.Add(arg1, arg2.Mul(-1))
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = duration.Add(arg1, arg2.Mul(-1))
 			}
 		}
@@ -9059,22 +9059,22 @@ func (p projMinusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.Sub(arg2)
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.Sub(arg2)
 				}
 			}
@@ -9084,18 +9084,18 @@ func (p projMinusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.Sub(arg2)
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.Sub(arg2)
 			}
 		}
@@ -9147,7 +9147,7 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg1}
@@ -9173,7 +9173,7 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg1}
@@ -9196,7 +9196,7 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg1}
@@ -9218,7 +9218,7 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
 				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg1}
@@ -9396,7 +9396,7 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg2}
 					var _nonDatumArgAsDatum tree.Datum
@@ -9414,13 +9414,13 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInterval{Duration: arg2}
 					var _nonDatumArgAsDatum tree.Datum
@@ -9441,7 +9441,7 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg2}
 				var _nonDatumArgAsDatum tree.Datum
@@ -9458,10 +9458,10 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInterval{Duration: arg2}
 				var _nonDatumArgAsDatum tree.Datum
@@ -9524,7 +9524,7 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DBytes(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -9542,13 +9542,13 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DBytes(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -9569,7 +9569,7 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DBytes(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -9586,10 +9586,10 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DBytes(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -9652,7 +9652,7 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -9670,13 +9670,13 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -9697,7 +9697,7 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -9714,10 +9714,10 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -9780,7 +9780,7 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -9798,13 +9798,13 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -9825,7 +9825,7 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -9842,10 +9842,10 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -9908,7 +9908,7 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -9926,13 +9926,13 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -9953,7 +9953,7 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -9970,10 +9970,10 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -10035,8 +10035,8 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -10052,14 +10052,14 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -10078,8 +10078,8 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -10094,11 +10094,11 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -10159,8 +10159,8 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -10176,14 +10176,14 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -10202,8 +10202,8 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -10218,11 +10218,11 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -10283,8 +10283,8 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -10300,14 +10300,14 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -10326,8 +10326,8 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -10342,11 +10342,11 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -10407,8 +10407,8 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -10423,14 +10423,14 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -10448,8 +10448,8 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -10463,11 +10463,11 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -10527,8 +10527,8 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					f, err := arg1.Float64()
 					if err != nil {
@@ -10540,14 +10540,14 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					f, err := arg1.Float64()
 					if err != nil {
@@ -10562,8 +10562,8 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				f, err := arg1.Float64()
 				if err != nil {
@@ -10574,11 +10574,11 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				f, err := arg1.Float64()
 				if err != nil {
@@ -10635,8 +10635,8 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -10659,14 +10659,14 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -10692,8 +10692,8 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -10715,11 +10715,11 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -10787,8 +10787,8 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -10811,14 +10811,14 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -10844,8 +10844,8 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -10867,11 +10867,11 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -10939,8 +10939,8 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -10963,14 +10963,14 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -10996,8 +10996,8 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -11019,11 +11019,11 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -11091,8 +11091,8 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -11109,14 +11109,14 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -11136,8 +11136,8 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -11153,11 +11153,11 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -11219,22 +11219,22 @@ func (p projMultInt16IntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
@@ -11244,18 +11244,18 @@ func (p projMultInt16IntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg2.Mul(int64(arg1))
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg2.Mul(int64(arg1))
 			}
 		}
@@ -11307,8 +11307,8 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -11331,14 +11331,14 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -11364,8 +11364,8 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -11387,11 +11387,11 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -11459,8 +11459,8 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -11483,14 +11483,14 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -11516,8 +11516,8 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -11539,11 +11539,11 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -11611,8 +11611,8 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -11635,14 +11635,14 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -11668,8 +11668,8 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -11691,11 +11691,11 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -11763,8 +11763,8 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -11781,14 +11781,14 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -11808,8 +11808,8 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -11825,11 +11825,11 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -11891,22 +11891,22 @@ func (p projMultInt32IntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
@@ -11916,18 +11916,18 @@ func (p projMultInt32IntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg2.Mul(int64(arg1))
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg2.Mul(int64(arg1))
 			}
 		}
@@ -11979,8 +11979,8 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -12003,14 +12003,14 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -12036,8 +12036,8 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -12059,11 +12059,11 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -12131,8 +12131,8 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -12155,14 +12155,14 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -12188,8 +12188,8 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -12211,11 +12211,11 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -12283,8 +12283,8 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -12307,14 +12307,14 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						_left, _right := int64(arg1), int64(arg2)
@@ -12340,8 +12340,8 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -12363,11 +12363,11 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					_left, _right := int64(arg1), int64(arg2)
@@ -12435,8 +12435,8 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -12453,14 +12453,14 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -12480,8 +12480,8 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -12497,11 +12497,11 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -12563,22 +12563,22 @@ func (p projMultInt64IntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
@@ -12588,18 +12588,18 @@ func (p projMultInt64IntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg2.Mul(int64(arg1))
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg2.Mul(int64(arg1))
 			}
 		}
@@ -12651,8 +12651,8 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -12664,14 +12664,14 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -12686,8 +12686,8 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -12698,11 +12698,11 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -12759,22 +12759,22 @@ func (p projMultFloat64IntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg2.MulFloat(float64(arg1))
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg2.MulFloat(float64(arg1))
 				}
 			}
@@ -12784,18 +12784,18 @@ func (p projMultFloat64IntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg2.MulFloat(float64(arg1))
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg2.MulFloat(float64(arg1))
 			}
 		}
@@ -12847,22 +12847,22 @@ func (p projMultIntervalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
@@ -12872,18 +12872,18 @@ func (p projMultIntervalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.Mul(int64(arg2))
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.Mul(int64(arg2))
 			}
 		}
@@ -12935,22 +12935,22 @@ func (p projMultIntervalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
@@ -12960,18 +12960,18 @@ func (p projMultIntervalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.Mul(int64(arg2))
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.Mul(int64(arg2))
 			}
 		}
@@ -13023,22 +13023,22 @@ func (p projMultIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
@@ -13048,18 +13048,18 @@ func (p projMultIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.Mul(int64(arg2))
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.Mul(int64(arg2))
 			}
 		}
@@ -13111,22 +13111,22 @@ func (p projMultIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.MulFloat(float64(arg2))
 				}
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 					projCol[i] = arg1.MulFloat(float64(arg2))
 				}
 			}
@@ -13136,18 +13136,18 @@ func (p projMultIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.MulFloat(float64(arg2))
 			}
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 				projCol[i] = arg1.MulFloat(float64(arg2))
 			}
 		}
@@ -13199,8 +13199,8 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					f, err := arg2.Float64()
 					if err != nil {
@@ -13212,14 +13212,14 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					f, err := arg2.Float64()
 					if err != nil {
@@ -13234,8 +13234,8 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				f, err := arg2.Float64()
 				if err != nil {
@@ -13246,11 +13246,11 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				f, err := arg2.Float64()
 				if err != nil {
@@ -13307,8 +13307,8 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -13328,14 +13328,14 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -13358,8 +13358,8 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -13378,11 +13378,11 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -13447,8 +13447,8 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -13468,14 +13468,14 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -13498,8 +13498,8 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -13518,11 +13518,11 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -13587,8 +13587,8 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -13608,14 +13608,14 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -13638,8 +13638,8 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -13658,11 +13658,11 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -13727,8 +13727,8 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -13747,14 +13747,14 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -13776,8 +13776,8 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -13795,11 +13795,11 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -13863,8 +13863,8 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -13883,14 +13883,14 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -13912,8 +13912,8 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -13931,11 +13931,11 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -13999,8 +13999,8 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -14019,14 +14019,14 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -14048,8 +14048,8 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -14067,11 +14067,11 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -14135,8 +14135,8 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -14155,14 +14155,14 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -14184,8 +14184,8 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -14203,11 +14203,11 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -14271,8 +14271,8 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -14293,14 +14293,14 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -14324,8 +14324,8 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -14345,11 +14345,11 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -14415,8 +14415,8 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -14435,14 +14435,14 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -14464,8 +14464,8 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -14483,11 +14483,11 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -14551,8 +14551,8 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -14571,14 +14571,14 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -14600,8 +14600,8 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -14619,11 +14619,11 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -14687,8 +14687,8 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -14707,14 +14707,14 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -14736,8 +14736,8 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -14755,11 +14755,11 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -14823,8 +14823,8 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -14845,14 +14845,14 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -14876,8 +14876,8 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -14897,11 +14897,11 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -14967,8 +14967,8 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -14987,14 +14987,14 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -15016,8 +15016,8 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -15035,11 +15035,11 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -15103,8 +15103,8 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -15123,14 +15123,14 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -15152,8 +15152,8 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -15171,11 +15171,11 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -15239,8 +15239,8 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -15259,14 +15259,14 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -15288,8 +15288,8 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -15307,11 +15307,11 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -15375,8 +15375,8 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -15397,14 +15397,14 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -15428,8 +15428,8 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -15449,11 +15449,11 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -15519,8 +15519,8 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -15536,14 +15536,14 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -15562,8 +15562,8 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -15578,11 +15578,11 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -15643,8 +15643,8 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					if arg2 == 0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -15655,14 +15655,14 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					if arg2 == 0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -15676,8 +15676,8 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				if arg2 == 0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -15687,11 +15687,11 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				if arg2 == 0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -15747,8 +15747,8 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					if arg2 == 0.0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -15759,14 +15759,14 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					if arg2 == 0.0 {
 						colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -15780,8 +15780,8 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				if arg2 == 0.0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -15791,11 +15791,11 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				if arg2 == 0.0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
@@ -15851,8 +15851,8 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -15872,14 +15872,14 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -15902,8 +15902,8 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -15922,11 +15922,11 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -15991,8 +15991,8 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -16012,14 +16012,14 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -16042,8 +16042,8 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -16062,11 +16062,11 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -16131,8 +16131,8 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -16152,14 +16152,14 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -16182,8 +16182,8 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -16202,11 +16202,11 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -16271,8 +16271,8 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -16291,14 +16291,14 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -16320,8 +16320,8 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -16339,11 +16339,11 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -16407,8 +16407,8 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -16422,14 +16422,14 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -16446,8 +16446,8 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -16460,11 +16460,11 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -16523,8 +16523,8 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -16538,14 +16538,14 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -16562,8 +16562,8 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -16576,11 +16576,11 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -16639,8 +16639,8 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -16654,14 +16654,14 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -16678,8 +16678,8 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -16692,11 +16692,11 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -16755,8 +16755,8 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -16777,14 +16777,14 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -16808,8 +16808,8 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -16829,11 +16829,11 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -16899,8 +16899,8 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -16914,14 +16914,14 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -16938,8 +16938,8 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -16952,11 +16952,11 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -17015,8 +17015,8 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -17030,14 +17030,14 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -17054,8 +17054,8 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -17068,11 +17068,11 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -17131,8 +17131,8 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -17146,14 +17146,14 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -17170,8 +17170,8 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -17184,11 +17184,11 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -17247,8 +17247,8 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -17269,14 +17269,14 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -17300,8 +17300,8 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -17321,11 +17321,11 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -17391,8 +17391,8 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -17406,14 +17406,14 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -17430,8 +17430,8 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -17444,11 +17444,11 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -17507,8 +17507,8 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -17522,14 +17522,14 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -17546,8 +17546,8 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -17560,11 +17560,11 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -17623,8 +17623,8 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -17638,14 +17638,14 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -17662,8 +17662,8 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -17676,11 +17676,11 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -17739,8 +17739,8 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -17761,14 +17761,14 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -17792,8 +17792,8 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -17813,11 +17813,11 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -17883,8 +17883,8 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -17900,14 +17900,14 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -17926,8 +17926,8 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -17942,11 +17942,11 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -18007,8 +18007,8 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -18028,14 +18028,14 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -18058,8 +18058,8 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -18078,11 +18078,11 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -18147,8 +18147,8 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -18168,14 +18168,14 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -18198,8 +18198,8 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -18218,11 +18218,11 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -18287,8 +18287,8 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -18308,14 +18308,14 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -18338,8 +18338,8 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -18358,11 +18358,11 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -18427,8 +18427,8 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -18447,14 +18447,14 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -18476,8 +18476,8 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -18495,11 +18495,11 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -18563,8 +18563,8 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -18578,14 +18578,14 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -18602,8 +18602,8 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -18616,11 +18616,11 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -18679,8 +18679,8 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -18694,14 +18694,14 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -18718,8 +18718,8 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -18732,11 +18732,11 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -18795,8 +18795,8 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -18810,14 +18810,14 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -18834,8 +18834,8 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -18848,11 +18848,11 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -18911,8 +18911,8 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -18933,14 +18933,14 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -18964,8 +18964,8 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -18985,11 +18985,11 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -19055,8 +19055,8 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19070,14 +19070,14 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19094,8 +19094,8 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19108,11 +19108,11 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19171,8 +19171,8 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19186,14 +19186,14 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19210,8 +19210,8 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19224,11 +19224,11 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19287,8 +19287,8 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19302,14 +19302,14 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19326,8 +19326,8 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19340,11 +19340,11 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19403,8 +19403,8 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -19425,14 +19425,14 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -19456,8 +19456,8 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -19477,11 +19477,11 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -19547,8 +19547,8 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19562,14 +19562,14 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19586,8 +19586,8 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19600,11 +19600,11 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19663,8 +19663,8 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19678,14 +19678,14 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19702,8 +19702,8 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19716,11 +19716,11 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19779,8 +19779,8 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19794,14 +19794,14 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) == 0 {
@@ -19818,8 +19818,8 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19832,11 +19832,11 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) == 0 {
@@ -19895,8 +19895,8 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -19917,14 +19917,14 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -19948,8 +19948,8 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -19969,11 +19969,11 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -20039,8 +20039,8 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -20056,14 +20056,14 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -20082,8 +20082,8 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -20098,11 +20098,11 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -20163,8 +20163,8 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -20180,14 +20180,14 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -20206,8 +20206,8 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -20222,11 +20222,11 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -20287,8 +20287,8 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -20304,14 +20304,14 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -20330,8 +20330,8 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -20346,11 +20346,11 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -20411,8 +20411,8 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -20428,14 +20428,14 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -20454,8 +20454,8 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -20470,11 +20470,11 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -20535,8 +20535,8 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -20551,14 +20551,14 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -20576,8 +20576,8 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -20591,11 +20591,11 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -20655,8 +20655,8 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20677,14 +20677,14 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20708,8 +20708,8 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20729,11 +20729,11 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20799,8 +20799,8 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20821,14 +20821,14 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20852,8 +20852,8 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20873,11 +20873,11 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20943,8 +20943,8 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20965,14 +20965,14 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -20996,8 +20996,8 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21017,11 +21017,11 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21087,8 +21087,8 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -21105,14 +21105,14 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -21132,8 +21132,8 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -21149,11 +21149,11 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -21215,8 +21215,8 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21237,14 +21237,14 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21268,8 +21268,8 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21289,11 +21289,11 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21359,8 +21359,8 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21381,14 +21381,14 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21412,8 +21412,8 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21433,11 +21433,11 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21503,8 +21503,8 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21525,14 +21525,14 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21556,8 +21556,8 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21577,11 +21577,11 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21647,8 +21647,8 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -21665,14 +21665,14 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -21692,8 +21692,8 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -21709,11 +21709,11 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -21775,8 +21775,8 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21797,14 +21797,14 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21828,8 +21828,8 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21849,11 +21849,11 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21919,8 +21919,8 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21941,14 +21941,14 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21972,8 +21972,8 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -21993,11 +21993,11 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -22063,8 +22063,8 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -22085,14 +22085,14 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -22116,8 +22116,8 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -22137,11 +22137,11 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
@@ -22207,8 +22207,8 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -22225,14 +22225,14 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -22252,8 +22252,8 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -22269,11 +22269,11 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -22335,8 +22335,8 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -22348,14 +22348,14 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 
@@ -22370,8 +22370,8 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -22382,11 +22382,11 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 
@@ -22443,8 +22443,8 @@ func (p projConcatBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var r = []byte{}
@@ -22460,8 +22460,8 @@ func (p projConcatBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var r = []byte{}
@@ -22478,8 +22478,8 @@ func (p projConcatBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var r = []byte{}
@@ -22491,8 +22491,8 @@ func (p projConcatBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var r = []byte{}
@@ -22663,8 +22663,8 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -22679,14 +22679,14 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -22704,8 +22704,8 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -22719,11 +22719,11 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -22783,8 +22783,8 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -22799,14 +22799,14 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -22824,8 +22824,8 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -22839,11 +22839,11 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -22903,8 +22903,8 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -22919,14 +22919,14 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -22944,8 +22944,8 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -22959,11 +22959,11 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23023,8 +23023,8 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23039,14 +23039,14 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23064,8 +23064,8 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23079,11 +23079,11 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23143,8 +23143,8 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23159,14 +23159,14 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23184,8 +23184,8 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23199,11 +23199,11 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23263,8 +23263,8 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23279,14 +23279,14 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23304,8 +23304,8 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23319,11 +23319,11 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23383,8 +23383,8 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23399,14 +23399,14 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23424,8 +23424,8 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23439,11 +23439,11 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23503,8 +23503,8 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23519,14 +23519,14 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23544,8 +23544,8 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23559,11 +23559,11 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23623,8 +23623,8 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23639,14 +23639,14 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23664,8 +23664,8 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23679,11 +23679,11 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -23744,7 +23744,7 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23762,13 +23762,13 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23789,7 +23789,7 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23806,10 +23806,10 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23872,7 +23872,7 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23890,13 +23890,13 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -23917,7 +23917,7 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -23934,10 +23934,10 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -24000,7 +24000,7 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -24018,13 +24018,13 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -24045,7 +24045,7 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -24062,10 +24062,10 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -24127,8 +24127,8 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24143,14 +24143,14 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24168,8 +24168,8 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24183,11 +24183,11 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24247,8 +24247,8 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24263,14 +24263,14 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24288,8 +24288,8 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24303,11 +24303,11 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24367,8 +24367,8 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24383,14 +24383,14 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24408,8 +24408,8 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24423,11 +24423,11 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24487,8 +24487,8 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24503,14 +24503,14 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24528,8 +24528,8 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24543,11 +24543,11 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24607,8 +24607,8 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24623,14 +24623,14 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24648,8 +24648,8 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24663,11 +24663,11 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24727,8 +24727,8 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24743,14 +24743,14 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24768,8 +24768,8 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24783,11 +24783,11 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24847,8 +24847,8 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24863,14 +24863,14 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24888,8 +24888,8 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24903,11 +24903,11 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24967,8 +24967,8 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -24983,14 +24983,14 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -25008,8 +25008,8 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -25023,11 +25023,11 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -25087,8 +25087,8 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -25103,14 +25103,14 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -25128,8 +25128,8 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -25143,11 +25143,11 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					if int64(arg2) < 0 || int64(arg2) >= 64 {
@@ -25208,7 +25208,7 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25226,13 +25226,13 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25253,7 +25253,7 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25270,10 +25270,10 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25336,7 +25336,7 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25354,13 +25354,13 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25381,7 +25381,7 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25398,10 +25398,10 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25464,7 +25464,7 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25482,13 +25482,13 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25509,7 +25509,7 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25526,10 +25526,10 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25592,7 +25592,7 @@ func (p projJSONFetchValDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DString(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25610,13 +25610,13 @@ func (p projJSONFetchValDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DString(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25637,7 +25637,7 @@ func (p projJSONFetchValDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DString(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25654,10 +25654,10 @@ func (p projJSONFetchValDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DString(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25720,7 +25720,7 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25738,13 +25738,13 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25765,7 +25765,7 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25782,10 +25782,10 @@ func (p projJSONFetchValDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25848,7 +25848,7 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25866,13 +25866,13 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25893,7 +25893,7 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25910,10 +25910,10 @@ func (p projJSONFetchValDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -25976,7 +25976,7 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -25994,13 +25994,13 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
 					arg1 := col1.Get(i)
-					arg2 := col2.Get(i) //gcassert:inline
+					arg2 := col2.Get(i)
 
 					_convertedNativeElem := tree.DInt(arg2)
 					var _nonDatumArgAsDatum tree.Datum
@@ -26021,7 +26021,7 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			sel = sel[:n]
 			for _, i := range sel {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -26038,10 +26038,10 @@ func (p projJSONFetchValDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
 			_ = projCol.Get(colLen - 1)
-			_ = col2.Get(colLen - 1) //gcassert:inline
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
-				arg2 := col2.Get(i) //gcassert:inline
+				arg2 := col2.Get(i)
 
 				_convertedNativeElem := tree.DInt(arg2)
 				var _nonDatumArgAsDatum tree.Datum
@@ -26103,8 +26103,8 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26125,14 +26125,14 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26156,8 +26156,8 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26177,11 +26177,11 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26247,8 +26247,8 @@ func (p projEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26263,8 +26263,8 @@ func (p projEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26280,8 +26280,8 @@ func (p projEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26292,8 +26292,8 @@ func (p projEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26351,8 +26351,8 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26371,14 +26371,14 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26400,8 +26400,8 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26419,11 +26419,11 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26487,8 +26487,8 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26507,14 +26507,14 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26536,8 +26536,8 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26555,11 +26555,11 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26623,8 +26623,8 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26643,14 +26643,14 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26672,8 +26672,8 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26691,11 +26691,11 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26759,8 +26759,8 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26781,14 +26781,14 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26812,8 +26812,8 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26833,11 +26833,11 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26903,8 +26903,8 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26917,14 +26917,14 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26940,8 +26940,8 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -26953,11 +26953,11 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27015,8 +27015,8 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27040,14 +27040,14 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27074,8 +27074,8 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27098,11 +27098,11 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27171,8 +27171,8 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27196,14 +27196,14 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27230,8 +27230,8 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27254,11 +27254,11 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27327,8 +27327,8 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27352,14 +27352,14 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27386,8 +27386,8 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27410,11 +27410,11 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27483,8 +27483,8 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27516,14 +27516,14 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27558,8 +27558,8 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27590,11 +27590,11 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27671,8 +27671,8 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27691,14 +27691,14 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27720,8 +27720,8 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27739,11 +27739,11 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27807,8 +27807,8 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27832,14 +27832,14 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27866,8 +27866,8 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27890,11 +27890,11 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -27963,8 +27963,8 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27988,14 +27988,14 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28022,8 +28022,8 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28046,11 +28046,11 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28119,8 +28119,8 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28144,14 +28144,14 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28178,8 +28178,8 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28202,11 +28202,11 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28275,8 +28275,8 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28308,14 +28308,14 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28350,8 +28350,8 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28382,11 +28382,11 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28463,8 +28463,8 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28483,14 +28483,14 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28512,8 +28512,8 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28531,11 +28531,11 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28599,8 +28599,8 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28624,14 +28624,14 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28658,8 +28658,8 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28682,11 +28682,11 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28755,8 +28755,8 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28780,14 +28780,14 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28814,8 +28814,8 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28838,11 +28838,11 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28911,8 +28911,8 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28936,14 +28936,14 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28970,8 +28970,8 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -28994,11 +28994,11 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -29067,8 +29067,8 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29100,14 +29100,14 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29142,8 +29142,8 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -29174,11 +29174,11 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -29255,8 +29255,8 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29275,14 +29275,14 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29304,8 +29304,8 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -29323,11 +29323,11 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -29391,8 +29391,8 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29424,14 +29424,14 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29466,8 +29466,8 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -29498,11 +29498,11 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -29579,8 +29579,8 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29612,14 +29612,14 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29654,8 +29654,8 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -29686,11 +29686,11 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -29767,8 +29767,8 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29800,14 +29800,14 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29842,8 +29842,8 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -29874,11 +29874,11 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -29955,8 +29955,8 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29988,14 +29988,14 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30030,8 +30030,8 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30062,11 +30062,11 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30143,8 +30143,8 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30165,14 +30165,14 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30196,8 +30196,8 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30217,11 +30217,11 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30287,8 +30287,8 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30308,14 +30308,14 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30338,8 +30338,8 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30358,11 +30358,11 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30427,8 +30427,8 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30441,14 +30441,14 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30464,8 +30464,8 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30477,11 +30477,11 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30555,7 +30555,7 @@ func (p projEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
@@ -30595,7 +30595,7 @@ func (p projEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
@@ -30659,8 +30659,8 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30681,14 +30681,14 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30712,8 +30712,8 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30733,11 +30733,11 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30803,8 +30803,8 @@ func (p projNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30819,8 +30819,8 @@ func (p projNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30836,8 +30836,8 @@ func (p projNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30848,8 +30848,8 @@ func (p projNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30907,8 +30907,8 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30927,14 +30927,14 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30956,8 +30956,8 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -30975,11 +30975,11 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31043,8 +31043,8 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31063,14 +31063,14 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31092,8 +31092,8 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31111,11 +31111,11 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31179,8 +31179,8 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31199,14 +31199,14 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31228,8 +31228,8 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31247,11 +31247,11 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31315,8 +31315,8 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31337,14 +31337,14 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31368,8 +31368,8 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31389,11 +31389,11 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31459,8 +31459,8 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31473,14 +31473,14 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31496,8 +31496,8 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31509,11 +31509,11 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31571,8 +31571,8 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31596,14 +31596,14 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31630,8 +31630,8 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31654,11 +31654,11 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31727,8 +31727,8 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31752,14 +31752,14 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31786,8 +31786,8 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31810,11 +31810,11 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31883,8 +31883,8 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31908,14 +31908,14 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31942,8 +31942,8 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -31966,11 +31966,11 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32039,8 +32039,8 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32072,14 +32072,14 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32114,8 +32114,8 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32146,11 +32146,11 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32227,8 +32227,8 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32247,14 +32247,14 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32276,8 +32276,8 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32295,11 +32295,11 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32363,8 +32363,8 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32388,14 +32388,14 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32422,8 +32422,8 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32446,11 +32446,11 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32519,8 +32519,8 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32544,14 +32544,14 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32578,8 +32578,8 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32602,11 +32602,11 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32675,8 +32675,8 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32700,14 +32700,14 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32734,8 +32734,8 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32758,11 +32758,11 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32831,8 +32831,8 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32864,14 +32864,14 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32906,8 +32906,8 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -32938,11 +32938,11 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33019,8 +33019,8 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33039,14 +33039,14 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33068,8 +33068,8 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33087,11 +33087,11 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33155,8 +33155,8 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33180,14 +33180,14 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33214,8 +33214,8 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33238,11 +33238,11 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33311,8 +33311,8 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33336,14 +33336,14 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33370,8 +33370,8 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33394,11 +33394,11 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33467,8 +33467,8 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33492,14 +33492,14 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33526,8 +33526,8 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33550,11 +33550,11 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33623,8 +33623,8 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33656,14 +33656,14 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33698,8 +33698,8 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33730,11 +33730,11 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33811,8 +33811,8 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33831,14 +33831,14 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33860,8 +33860,8 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33879,11 +33879,11 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -33947,8 +33947,8 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33980,14 +33980,14 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34022,8 +34022,8 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34054,11 +34054,11 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34135,8 +34135,8 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34168,14 +34168,14 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34210,8 +34210,8 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34242,11 +34242,11 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34323,8 +34323,8 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34356,14 +34356,14 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34398,8 +34398,8 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34430,11 +34430,11 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34511,8 +34511,8 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34544,14 +34544,14 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34586,8 +34586,8 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34618,11 +34618,11 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34699,8 +34699,8 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34721,14 +34721,14 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34752,8 +34752,8 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34773,11 +34773,11 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34843,8 +34843,8 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34864,14 +34864,14 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34894,8 +34894,8 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34914,11 +34914,11 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -34983,8 +34983,8 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34997,14 +34997,14 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35020,8 +35020,8 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35033,11 +35033,11 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35111,7 +35111,7 @@ func (p projNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
@@ -35151,7 +35151,7 @@ func (p projNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
@@ -35215,8 +35215,8 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35237,14 +35237,14 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35268,8 +35268,8 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35289,11 +35289,11 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35359,8 +35359,8 @@ func (p projLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35375,8 +35375,8 @@ func (p projLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35392,8 +35392,8 @@ func (p projLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35404,8 +35404,8 @@ func (p projLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35463,8 +35463,8 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35483,14 +35483,14 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35512,8 +35512,8 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35531,11 +35531,11 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35599,8 +35599,8 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35619,14 +35619,14 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35648,8 +35648,8 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35667,11 +35667,11 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35735,8 +35735,8 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35755,14 +35755,14 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35784,8 +35784,8 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35803,11 +35803,11 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35871,8 +35871,8 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35893,14 +35893,14 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35924,8 +35924,8 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -35945,11 +35945,11 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36015,8 +36015,8 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36029,14 +36029,14 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36052,8 +36052,8 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36065,11 +36065,11 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36127,8 +36127,8 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36152,14 +36152,14 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36186,8 +36186,8 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36210,11 +36210,11 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36283,8 +36283,8 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36308,14 +36308,14 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36342,8 +36342,8 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36366,11 +36366,11 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36439,8 +36439,8 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36464,14 +36464,14 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36498,8 +36498,8 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36522,11 +36522,11 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36595,8 +36595,8 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36628,14 +36628,14 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36670,8 +36670,8 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36702,11 +36702,11 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36783,8 +36783,8 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36803,14 +36803,14 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36832,8 +36832,8 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36851,11 +36851,11 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -36919,8 +36919,8 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36944,14 +36944,14 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36978,8 +36978,8 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37002,11 +37002,11 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37075,8 +37075,8 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37100,14 +37100,14 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37134,8 +37134,8 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37158,11 +37158,11 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37231,8 +37231,8 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37256,14 +37256,14 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37290,8 +37290,8 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37314,11 +37314,11 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37387,8 +37387,8 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37420,14 +37420,14 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37462,8 +37462,8 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37494,11 +37494,11 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37575,8 +37575,8 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37595,14 +37595,14 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37624,8 +37624,8 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37643,11 +37643,11 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37711,8 +37711,8 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37736,14 +37736,14 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37770,8 +37770,8 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37794,11 +37794,11 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37867,8 +37867,8 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37892,14 +37892,14 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37926,8 +37926,8 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -37950,11 +37950,11 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38023,8 +38023,8 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38048,14 +38048,14 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38082,8 +38082,8 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38106,11 +38106,11 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38179,8 +38179,8 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38212,14 +38212,14 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38254,8 +38254,8 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38286,11 +38286,11 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38367,8 +38367,8 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38387,14 +38387,14 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38416,8 +38416,8 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38435,11 +38435,11 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38503,8 +38503,8 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38536,14 +38536,14 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38578,8 +38578,8 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38610,11 +38610,11 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38691,8 +38691,8 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38724,14 +38724,14 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38766,8 +38766,8 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38798,11 +38798,11 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38879,8 +38879,8 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38912,14 +38912,14 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38954,8 +38954,8 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -38986,11 +38986,11 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39067,8 +39067,8 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39100,14 +39100,14 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39142,8 +39142,8 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39174,11 +39174,11 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39255,8 +39255,8 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39277,14 +39277,14 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39308,8 +39308,8 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39329,11 +39329,11 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39399,8 +39399,8 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39420,14 +39420,14 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39450,8 +39450,8 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39470,11 +39470,11 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39539,8 +39539,8 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39553,14 +39553,14 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39576,8 +39576,8 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39589,11 +39589,11 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39667,7 +39667,7 @@ func (p projLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
@@ -39707,7 +39707,7 @@ func (p projLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
@@ -39771,8 +39771,8 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39793,14 +39793,14 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39824,8 +39824,8 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39845,11 +39845,11 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39915,8 +39915,8 @@ func (p projLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39931,8 +39931,8 @@ func (p projLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39948,8 +39948,8 @@ func (p projLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -39960,8 +39960,8 @@ func (p projLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40019,8 +40019,8 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40039,14 +40039,14 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40068,8 +40068,8 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40087,11 +40087,11 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40155,8 +40155,8 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40175,14 +40175,14 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40204,8 +40204,8 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40223,11 +40223,11 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40291,8 +40291,8 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40311,14 +40311,14 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40340,8 +40340,8 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40359,11 +40359,11 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40427,8 +40427,8 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40449,14 +40449,14 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40480,8 +40480,8 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40501,11 +40501,11 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40571,8 +40571,8 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40585,14 +40585,14 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40608,8 +40608,8 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40621,11 +40621,11 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40683,8 +40683,8 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40708,14 +40708,14 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40742,8 +40742,8 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40766,11 +40766,11 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40839,8 +40839,8 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40864,14 +40864,14 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40898,8 +40898,8 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40922,11 +40922,11 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -40995,8 +40995,8 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41020,14 +41020,14 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41054,8 +41054,8 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41078,11 +41078,11 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41151,8 +41151,8 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41184,14 +41184,14 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41226,8 +41226,8 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41258,11 +41258,11 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41339,8 +41339,8 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41359,14 +41359,14 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41388,8 +41388,8 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41407,11 +41407,11 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41475,8 +41475,8 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41500,14 +41500,14 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41534,8 +41534,8 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41558,11 +41558,11 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41631,8 +41631,8 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41656,14 +41656,14 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41690,8 +41690,8 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41714,11 +41714,11 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41787,8 +41787,8 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41812,14 +41812,14 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41846,8 +41846,8 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41870,11 +41870,11 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -41943,8 +41943,8 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41976,14 +41976,14 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42018,8 +42018,8 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42050,11 +42050,11 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42131,8 +42131,8 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42151,14 +42151,14 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42180,8 +42180,8 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42199,11 +42199,11 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42267,8 +42267,8 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42292,14 +42292,14 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42326,8 +42326,8 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42350,11 +42350,11 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42423,8 +42423,8 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42448,14 +42448,14 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42482,8 +42482,8 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42506,11 +42506,11 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42579,8 +42579,8 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42604,14 +42604,14 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42638,8 +42638,8 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42662,11 +42662,11 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42735,8 +42735,8 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42768,14 +42768,14 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42810,8 +42810,8 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42842,11 +42842,11 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42923,8 +42923,8 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42943,14 +42943,14 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42972,8 +42972,8 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -42991,11 +42991,11 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -43059,8 +43059,8 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43092,14 +43092,14 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43134,8 +43134,8 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -43166,11 +43166,11 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -43247,8 +43247,8 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43280,14 +43280,14 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43322,8 +43322,8 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -43354,11 +43354,11 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -43435,8 +43435,8 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43468,14 +43468,14 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43510,8 +43510,8 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -43542,11 +43542,11 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -43623,8 +43623,8 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43656,14 +43656,14 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43698,8 +43698,8 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -43730,11 +43730,11 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -43811,8 +43811,8 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43833,14 +43833,14 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43864,8 +43864,8 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -43885,11 +43885,11 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -43955,8 +43955,8 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43976,14 +43976,14 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44006,8 +44006,8 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44026,11 +44026,11 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44095,8 +44095,8 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44109,14 +44109,14 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44132,8 +44132,8 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44145,11 +44145,11 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44223,7 +44223,7 @@ func (p projLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
@@ -44263,7 +44263,7 @@ func (p projLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
@@ -44327,8 +44327,8 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44349,14 +44349,14 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44380,8 +44380,8 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44401,11 +44401,11 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44471,8 +44471,8 @@ func (p projGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44487,8 +44487,8 @@ func (p projGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44504,8 +44504,8 @@ func (p projGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44516,8 +44516,8 @@ func (p projGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44575,8 +44575,8 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44595,14 +44595,14 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44624,8 +44624,8 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44643,11 +44643,11 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44711,8 +44711,8 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44731,14 +44731,14 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44760,8 +44760,8 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44779,11 +44779,11 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44847,8 +44847,8 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44867,14 +44867,14 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44896,8 +44896,8 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44915,11 +44915,11 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -44983,8 +44983,8 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45005,14 +45005,14 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45036,8 +45036,8 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45057,11 +45057,11 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45127,8 +45127,8 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45141,14 +45141,14 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45164,8 +45164,8 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45177,11 +45177,11 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45239,8 +45239,8 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45264,14 +45264,14 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45298,8 +45298,8 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45322,11 +45322,11 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45395,8 +45395,8 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45420,14 +45420,14 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45454,8 +45454,8 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45478,11 +45478,11 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45551,8 +45551,8 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45576,14 +45576,14 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45610,8 +45610,8 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45634,11 +45634,11 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45707,8 +45707,8 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45740,14 +45740,14 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45782,8 +45782,8 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45814,11 +45814,11 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45895,8 +45895,8 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45915,14 +45915,14 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45944,8 +45944,8 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -45963,11 +45963,11 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46031,8 +46031,8 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46056,14 +46056,14 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46090,8 +46090,8 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46114,11 +46114,11 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46187,8 +46187,8 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46212,14 +46212,14 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46246,8 +46246,8 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46270,11 +46270,11 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46343,8 +46343,8 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46368,14 +46368,14 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46402,8 +46402,8 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46426,11 +46426,11 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46499,8 +46499,8 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46532,14 +46532,14 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46574,8 +46574,8 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46606,11 +46606,11 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46687,8 +46687,8 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46707,14 +46707,14 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46736,8 +46736,8 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46755,11 +46755,11 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46823,8 +46823,8 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46848,14 +46848,14 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46882,8 +46882,8 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46906,11 +46906,11 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -46979,8 +46979,8 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47004,14 +47004,14 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47038,8 +47038,8 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47062,11 +47062,11 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47135,8 +47135,8 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47160,14 +47160,14 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47194,8 +47194,8 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47218,11 +47218,11 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47291,8 +47291,8 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47324,14 +47324,14 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47366,8 +47366,8 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47398,11 +47398,11 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47479,8 +47479,8 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47499,14 +47499,14 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47528,8 +47528,8 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47547,11 +47547,11 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47615,8 +47615,8 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47648,14 +47648,14 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47690,8 +47690,8 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47722,11 +47722,11 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47803,8 +47803,8 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47836,14 +47836,14 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47878,8 +47878,8 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47910,11 +47910,11 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -47991,8 +47991,8 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48024,14 +48024,14 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48066,8 +48066,8 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -48098,11 +48098,11 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -48179,8 +48179,8 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48212,14 +48212,14 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48254,8 +48254,8 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -48286,11 +48286,11 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -48367,8 +48367,8 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48389,14 +48389,14 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48420,8 +48420,8 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -48441,11 +48441,11 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -48511,8 +48511,8 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48532,14 +48532,14 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48562,8 +48562,8 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -48582,11 +48582,11 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -48651,8 +48651,8 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48665,14 +48665,14 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48688,8 +48688,8 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -48701,11 +48701,11 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -48779,7 +48779,7 @@ func (p projGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
@@ -48819,7 +48819,7 @@ func (p projGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)
@@ -48883,8 +48883,8 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48905,14 +48905,14 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48936,8 +48936,8 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -48957,11 +48957,11 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49027,8 +49027,8 @@ func (p projGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49043,8 +49043,8 @@ func (p projGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49060,8 +49060,8 @@ func (p projGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49072,8 +49072,8 @@ func (p projGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49131,8 +49131,8 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49151,14 +49151,14 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49180,8 +49180,8 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49199,11 +49199,11 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49267,8 +49267,8 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49287,14 +49287,14 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49316,8 +49316,8 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49335,11 +49335,11 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49403,8 +49403,8 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49423,14 +49423,14 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49452,8 +49452,8 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49471,11 +49471,11 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49539,8 +49539,8 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49561,14 +49561,14 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49592,8 +49592,8 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49613,11 +49613,11 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49683,8 +49683,8 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49697,14 +49697,14 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49720,8 +49720,8 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49733,11 +49733,11 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49795,8 +49795,8 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49820,14 +49820,14 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49854,8 +49854,8 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49878,11 +49878,11 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -49951,8 +49951,8 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49976,14 +49976,14 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50010,8 +50010,8 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50034,11 +50034,11 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50107,8 +50107,8 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50132,14 +50132,14 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50166,8 +50166,8 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50190,11 +50190,11 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50263,8 +50263,8 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50296,14 +50296,14 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50338,8 +50338,8 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50370,11 +50370,11 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50451,8 +50451,8 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50471,14 +50471,14 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50500,8 +50500,8 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50519,11 +50519,11 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50587,8 +50587,8 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50612,14 +50612,14 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50646,8 +50646,8 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50670,11 +50670,11 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50743,8 +50743,8 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50768,14 +50768,14 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50802,8 +50802,8 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50826,11 +50826,11 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50899,8 +50899,8 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50924,14 +50924,14 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50958,8 +50958,8 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -50982,11 +50982,11 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51055,8 +51055,8 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51088,14 +51088,14 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51130,8 +51130,8 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51162,11 +51162,11 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51243,8 +51243,8 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51263,14 +51263,14 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51292,8 +51292,8 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51311,11 +51311,11 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51379,8 +51379,8 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51404,14 +51404,14 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51438,8 +51438,8 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51462,11 +51462,11 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51535,8 +51535,8 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51560,14 +51560,14 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51594,8 +51594,8 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51618,11 +51618,11 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51691,8 +51691,8 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51716,14 +51716,14 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51750,8 +51750,8 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51774,11 +51774,11 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51847,8 +51847,8 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51880,14 +51880,14 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51922,8 +51922,8 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -51954,11 +51954,11 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52035,8 +52035,8 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52055,14 +52055,14 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52084,8 +52084,8 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52103,11 +52103,11 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52171,8 +52171,8 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52204,14 +52204,14 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52246,8 +52246,8 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52278,11 +52278,11 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52359,8 +52359,8 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52392,14 +52392,14 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52434,8 +52434,8 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52466,11 +52466,11 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52547,8 +52547,8 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52580,14 +52580,14 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52622,8 +52622,8 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52654,11 +52654,11 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52735,8 +52735,8 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52768,14 +52768,14 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52810,8 +52810,8 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52842,11 +52842,11 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52923,8 +52923,8 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52945,14 +52945,14 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52976,8 +52976,8 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -52997,11 +52997,11 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -53067,8 +53067,8 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53088,14 +53088,14 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53118,8 +53118,8 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -53138,11 +53138,11 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -53207,8 +53207,8 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53221,14 +53221,14 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
 					// We only want to perform the projection operation if both values are not
 					// null.
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53244,8 +53244,8 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -53257,11 +53257,11 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1[0:n]
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
-			_ = col2.Get(colLen - 1)    //gcassert:inline
+			_ = projCol.Get(colLen - 1)
+			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
-				arg1 := col1.Get(i) //gcassert:inline
-				arg2 := col2.Get(i) //gcassert:inline
+				arg1 := col1.Get(i)
+				arg2 := col2.Get(i)
 
 				{
 					var cmpResult int
@@ -53335,7 +53335,7 @@ func (p projGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
@@ -53375,7 +53375,7 @@ func (p projGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col1 = col1.Slice(0, n)
 			colLen := col1.Len()
-			_ = projCol.Get(colLen - 1) //gcassert:inline
+			_ = projCol.Get(colLen - 1)
 			_ = col2.Get(colLen - 1)
 			for i := 0; i < n; i++ {
 				arg1 := col1.Get(i)

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -54,24 +54,6 @@ func _ASSIGN(_, _, _, _, _, _ interface{}) {
 	colexecerror.InternalError("")
 }
 
-// _L_UNSAFEGET is the template function that will be replaced by
-// "execgen.UNSAFEGET" which uses _L_TYP.
-func _L_UNSAFEGET(_, _ interface{}) interface{} {
-	colexecerror.InternalError("")
-}
-
-// _R_UNSAFEGET is the template function that will be replaced by
-// "execgen.UNSAFEGET" which uses _R_TYP.
-func _R_UNSAFEGET(_, _ interface{}) interface{} {
-	colexecerror.InternalError("")
-}
-
-// _RETURN_UNSAFEGET is the template function that will be replaced by
-// "execgen.UNSAFEGET" which uses _RET_TYP.
-func _RETURN_UNSAFEGET(_, _ interface{}) interface{} {
-	colexecerror.InternalError("")
-}
-
 // */}}
 
 // projConstOpBase contains all of the fields for projections with a constant,
@@ -166,8 +148,8 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 		// types, we simply omit this code snippet for Bytes. */}}
 		col1 = execgen.SLICE(col1, 0, n)
 		colLen := col1.Len()
-		_ = _RETURN_UNSAFEGET(projCol, colLen-1)
-		_ = _R_UNSAFEGET(col2, colLen-1)
+		_ = projCol.Get(colLen - 1)
+		_ = col2.Get(colLen - 1)
 		// {{end}}
 		for i := 0; i < n; i++ {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
@@ -193,8 +175,8 @@ func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool) { // */}}
 		// We only want to perform the projection operation if both values are not
 		// null.
 		// {{end}}
-		arg1 := _L_UNSAFEGET(col1, i)
-		arg2 := _R_UNSAFEGET(col2, i)
+		arg1 := col1.Get(i)
+		arg2 := col2.Get(i)
 		_ASSIGN(projCol[i], arg1, arg2, projCol, col1, col2)
 		// {{if _HAS_NULLS}}
 	}

--- a/pkg/sql/colexec/select_in.eg.go
+++ b/pkg/sql/colexec/select_in.eg.go
@@ -473,7 +473,7 @@ func (si *selectInOpBool) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInBool(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -482,9 +482,9 @@ func (si *selectInOpBool) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInBool(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -495,7 +495,7 @@ func (si *selectInOpBool) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInBool(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -504,9 +504,9 @@ func (si *selectInOpBool) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInBool(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -555,7 +555,7 @@ func (pi *projectInOpBool) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInBool(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -570,7 +570,7 @@ func (pi *projectInOpBool) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInBool(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -584,7 +584,7 @@ func (pi *projectInOpBool) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInBool(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -595,7 +595,7 @@ func (pi *projectInOpBool) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col = col[0:n]
 			for i := 0; i < n; i++ {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInBool(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -702,7 +702,7 @@ func (si *selectInOpBytes) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInBytes(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -711,9 +711,9 @@ func (si *selectInOpBytes) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInBytes(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -724,7 +724,7 @@ func (si *selectInOpBytes) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInBytes(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -733,9 +733,9 @@ func (si *selectInOpBytes) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInBytes(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -784,7 +784,7 @@ func (pi *projectInOpBytes) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInBytes(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -801,7 +801,7 @@ func (pi *projectInOpBytes) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInBytes(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -815,7 +815,7 @@ func (pi *projectInOpBytes) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInBytes(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -828,7 +828,7 @@ func (pi *projectInOpBytes) Next(ctx context.Context) coldata.Batch {
 			_ = 0
 			_ = n
 			for i := 0; i < n; i++ {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInBytes(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -935,7 +935,7 @@ func (si *selectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInDecimal(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -944,9 +944,9 @@ func (si *selectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInDecimal(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -957,7 +957,7 @@ func (si *selectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInDecimal(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -966,9 +966,9 @@ func (si *selectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInDecimal(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1017,7 +1017,7 @@ func (pi *projectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInDecimal(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -1032,7 +1032,7 @@ func (pi *projectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInDecimal(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -1046,7 +1046,7 @@ func (pi *projectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInDecimal(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -1057,7 +1057,7 @@ func (pi *projectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col = col[0:n]
 			for i := 0; i < n; i++ {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInDecimal(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -1175,7 +1175,7 @@ func (si *selectInOpInt16) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInt16(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1184,9 +1184,9 @@ func (si *selectInOpInt16) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInt16(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1197,7 +1197,7 @@ func (si *selectInOpInt16) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInInt16(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1206,9 +1206,9 @@ func (si *selectInOpInt16) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInInt16(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1257,7 +1257,7 @@ func (pi *projectInOpInt16) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInInt16(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -1272,7 +1272,7 @@ func (pi *projectInOpInt16) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInInt16(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -1286,7 +1286,7 @@ func (pi *projectInOpInt16) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInInt16(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -1297,7 +1297,7 @@ func (pi *projectInOpInt16) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col = col[0:n]
 			for i := 0; i < n; i++ {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInInt16(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -1415,7 +1415,7 @@ func (si *selectInOpInt32) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInt32(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1424,9 +1424,9 @@ func (si *selectInOpInt32) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInt32(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1437,7 +1437,7 @@ func (si *selectInOpInt32) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInInt32(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1446,9 +1446,9 @@ func (si *selectInOpInt32) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInInt32(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1497,7 +1497,7 @@ func (pi *projectInOpInt32) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInInt32(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -1512,7 +1512,7 @@ func (pi *projectInOpInt32) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInInt32(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -1526,7 +1526,7 @@ func (pi *projectInOpInt32) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInInt32(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -1537,7 +1537,7 @@ func (pi *projectInOpInt32) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col = col[0:n]
 			for i := 0; i < n; i++ {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInInt32(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -1655,7 +1655,7 @@ func (si *selectInOpInt64) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInt64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1664,9 +1664,9 @@ func (si *selectInOpInt64) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInt64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1677,7 +1677,7 @@ func (si *selectInOpInt64) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInInt64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1686,9 +1686,9 @@ func (si *selectInOpInt64) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInInt64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1737,7 +1737,7 @@ func (pi *projectInOpInt64) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInInt64(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -1752,7 +1752,7 @@ func (pi *projectInOpInt64) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInInt64(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -1766,7 +1766,7 @@ func (pi *projectInOpInt64) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInInt64(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -1777,7 +1777,7 @@ func (pi *projectInOpInt64) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col = col[0:n]
 			for i := 0; i < n; i++ {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInInt64(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -1903,7 +1903,7 @@ func (si *selectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInFloat64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1912,9 +1912,9 @@ func (si *selectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInFloat64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1925,7 +1925,7 @@ func (si *selectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInFloat64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1934,9 +1934,9 @@ func (si *selectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInFloat64(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -1985,7 +1985,7 @@ func (pi *projectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInFloat64(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -2000,7 +2000,7 @@ func (pi *projectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInFloat64(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -2014,7 +2014,7 @@ func (pi *projectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInFloat64(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -2025,7 +2025,7 @@ func (pi *projectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col = col[0:n]
 			for i := 0; i < n; i++ {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInFloat64(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -2139,7 +2139,7 @@ func (si *selectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInTimestamp(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -2148,9 +2148,9 @@ func (si *selectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInTimestamp(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -2161,7 +2161,7 @@ func (si *selectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInTimestamp(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -2170,9 +2170,9 @@ func (si *selectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInTimestamp(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -2221,7 +2221,7 @@ func (pi *projectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInTimestamp(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -2236,7 +2236,7 @@ func (pi *projectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInTimestamp(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -2250,7 +2250,7 @@ func (pi *projectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInTimestamp(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -2261,7 +2261,7 @@ func (pi *projectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col = col[0:n]
 			for i := 0; i < n; i++ {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInTimestamp(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -2368,7 +2368,7 @@ func (si *selectInOpInterval) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInterval(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -2377,9 +2377,9 @@ func (si *selectInOpInterval) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpInInterval(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -2390,7 +2390,7 @@ func (si *selectInOpInterval) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInInterval(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -2399,9 +2399,9 @@ func (si *selectInOpInterval) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					if cmpInInterval(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -2450,7 +2450,7 @@ func (pi *projectInOpInterval) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInInterval(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -2465,7 +2465,7 @@ func (pi *projectInOpInterval) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := col.Get(i) //gcassert:inline
+					v := col.Get(i)
 					cmpRes := cmpInInterval(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -2479,7 +2479,7 @@ func (pi *projectInOpInterval) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInInterval(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -2490,7 +2490,7 @@ func (pi *projectInOpInterval) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col = col[0:n]
 			for i := 0; i < n; i++ {
-				v := col.Get(i) //gcassert:inline
+				v := col.Get(i)
 				cmpRes := cmpInInterval(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -219,7 +219,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := execgen.UNSAFEGET(col, i)
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpIn_TYPE(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -228,9 +228,9 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = execgen.UNSAFEGET(col, n-1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := execgen.UNSAFEGET(col, i)
+					v := col.Get(i)
 					if !nulls.NullAt(i) && cmpIn_TYPE(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -241,7 +241,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := execgen.UNSAFEGET(col, i)
+					v := col.Get(i)
 					if cmpIn_TYPE(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -250,9 +250,9 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = execgen.UNSAFEGET(col, n-1)
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					v := execgen.UNSAFEGET(col, i)
+					v := col.Get(i)
 					if cmpIn_TYPE(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
 						idx++
@@ -301,7 +301,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := execgen.UNSAFEGET(col, i)
+					v := col.Get(i)
 					cmpRes := cmpIn_TYPE(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -316,7 +316,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := execgen.UNSAFEGET(col, i)
+					v := col.Get(i)
 					cmpRes := cmpIn_TYPE(v, col, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(i)
@@ -330,7 +330,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := execgen.UNSAFEGET(col, i)
+				v := col.Get(i)
 				cmpRes := cmpIn_TYPE(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)
@@ -341,7 +341,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col = execgen.SLICE(col, 0, n)
 			for i := 0; i < n; i++ {
-				v := execgen.UNSAFEGET(col, i)
+				v := col.Get(i)
 				cmpRes := cmpIn_TYPE(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(i)

--- a/pkg/sql/colexec/selection_ops.eg.go
+++ b/pkg/sql/colexec/selection_ops.eg.go
@@ -72,7 +72,7 @@ func (p *selEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -97,10 +97,10 @@ func (p *selEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -128,7 +128,7 @@ func (p *selEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -153,10 +153,10 @@ func (p *selEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -222,8 +222,8 @@ func (p *selEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -248,12 +248,12 @@ func (p *selEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -281,8 +281,8 @@ func (p *selEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -307,12 +307,12 @@ func (p *selEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -376,7 +376,7 @@ func (p *selEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -393,10 +393,10 @@ func (p *selEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -416,7 +416,7 @@ func (p *selEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -433,10 +433,10 @@ func (p *selEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -494,8 +494,8 @@ func (p *selEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -512,12 +512,12 @@ func (p *selEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -537,8 +537,8 @@ func (p *selEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -555,12 +555,12 @@ func (p *selEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -616,7 +616,7 @@ func (p *selEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -639,10 +639,10 @@ func (p *selEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -668,7 +668,7 @@ func (p *selEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -691,10 +691,10 @@ func (p *selEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -758,8 +758,8 @@ func (p *selEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -782,12 +782,12 @@ func (p *selEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -813,8 +813,8 @@ func (p *selEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -837,12 +837,12 @@ func (p *selEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -904,7 +904,7 @@ func (p *selEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -927,10 +927,10 @@ func (p *selEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -956,7 +956,7 @@ func (p *selEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -979,10 +979,10 @@ func (p *selEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1046,8 +1046,8 @@ func (p *selEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1070,12 +1070,12 @@ func (p *selEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1101,8 +1101,8 @@ func (p *selEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1125,12 +1125,12 @@ func (p *selEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1192,7 +1192,7 @@ func (p *selEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1215,10 +1215,10 @@ func (p *selEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1244,7 +1244,7 @@ func (p *selEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1267,10 +1267,10 @@ func (p *selEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1334,8 +1334,8 @@ func (p *selEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1358,12 +1358,12 @@ func (p *selEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1389,8 +1389,8 @@ func (p *selEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1413,12 +1413,12 @@ func (p *selEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1480,7 +1480,7 @@ func (p *selEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1505,10 +1505,10 @@ func (p *selEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1536,7 +1536,7 @@ func (p *selEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1561,10 +1561,10 @@ func (p *selEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1630,8 +1630,8 @@ func (p *selEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1656,12 +1656,12 @@ func (p *selEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1689,8 +1689,8 @@ func (p *selEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1715,12 +1715,12 @@ func (p *selEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1784,7 +1784,7 @@ func (p *selEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1801,10 +1801,10 @@ func (p *selEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1824,7 +1824,7 @@ func (p *selEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1841,10 +1841,10 @@ func (p *selEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -1902,8 +1902,8 @@ func (p *selEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1920,12 +1920,12 @@ func (p *selEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1945,8 +1945,8 @@ func (p *selEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -1963,12 +1963,12 @@ func (p *selEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2024,7 +2024,7 @@ func (p *selEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2052,10 +2052,10 @@ func (p *selEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2086,7 +2086,7 @@ func (p *selEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2114,10 +2114,10 @@ func (p *selEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2186,8 +2186,8 @@ func (p *selEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2215,12 +2215,12 @@ func (p *selEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2251,8 +2251,8 @@ func (p *selEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2280,12 +2280,12 @@ func (p *selEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2352,7 +2352,7 @@ func (p *selEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2380,10 +2380,10 @@ func (p *selEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2414,7 +2414,7 @@ func (p *selEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2442,10 +2442,10 @@ func (p *selEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2514,8 +2514,8 @@ func (p *selEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2543,12 +2543,12 @@ func (p *selEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2579,8 +2579,8 @@ func (p *selEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2608,12 +2608,12 @@ func (p *selEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2680,7 +2680,7 @@ func (p *selEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2708,10 +2708,10 @@ func (p *selEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2742,7 +2742,7 @@ func (p *selEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2770,10 +2770,10 @@ func (p *selEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -2842,8 +2842,8 @@ func (p *selEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2871,12 +2871,12 @@ func (p *selEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2907,8 +2907,8 @@ func (p *selEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -2936,12 +2936,12 @@ func (p *selEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3008,7 +3008,7 @@ func (p *selEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3044,10 +3044,10 @@ func (p *selEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3086,7 +3086,7 @@ func (p *selEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3122,10 +3122,10 @@ func (p *selEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3202,8 +3202,8 @@ func (p *selEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3239,12 +3239,12 @@ func (p *selEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3283,8 +3283,8 @@ func (p *selEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3320,12 +3320,12 @@ func (p *selEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3400,7 +3400,7 @@ func (p *selEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3423,10 +3423,10 @@ func (p *selEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3452,7 +3452,7 @@ func (p *selEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3475,10 +3475,10 @@ func (p *selEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3542,8 +3542,8 @@ func (p *selEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3566,12 +3566,12 @@ func (p *selEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3597,8 +3597,8 @@ func (p *selEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3621,12 +3621,12 @@ func (p *selEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3688,7 +3688,7 @@ func (p *selEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3716,10 +3716,10 @@ func (p *selEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3750,7 +3750,7 @@ func (p *selEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3778,10 +3778,10 @@ func (p *selEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -3850,8 +3850,8 @@ func (p *selEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3879,12 +3879,12 @@ func (p *selEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3915,8 +3915,8 @@ func (p *selEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -3944,12 +3944,12 @@ func (p *selEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4016,7 +4016,7 @@ func (p *selEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4044,10 +4044,10 @@ func (p *selEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4078,7 +4078,7 @@ func (p *selEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4106,10 +4106,10 @@ func (p *selEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4178,8 +4178,8 @@ func (p *selEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4207,12 +4207,12 @@ func (p *selEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4243,8 +4243,8 @@ func (p *selEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4272,12 +4272,12 @@ func (p *selEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4344,7 +4344,7 @@ func (p *selEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4372,10 +4372,10 @@ func (p *selEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4406,7 +4406,7 @@ func (p *selEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4434,10 +4434,10 @@ func (p *selEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4506,8 +4506,8 @@ func (p *selEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4535,12 +4535,12 @@ func (p *selEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4571,8 +4571,8 @@ func (p *selEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4600,12 +4600,12 @@ func (p *selEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4672,7 +4672,7 @@ func (p *selEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4708,10 +4708,10 @@ func (p *selEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4750,7 +4750,7 @@ func (p *selEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4786,10 +4786,10 @@ func (p *selEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -4866,8 +4866,8 @@ func (p *selEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4903,12 +4903,12 @@ func (p *selEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4947,8 +4947,8 @@ func (p *selEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -4984,12 +4984,12 @@ func (p *selEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5064,7 +5064,7 @@ func (p *selEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5087,10 +5087,10 @@ func (p *selEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5116,7 +5116,7 @@ func (p *selEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5139,10 +5139,10 @@ func (p *selEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5206,8 +5206,8 @@ func (p *selEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5230,12 +5230,12 @@ func (p *selEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5261,8 +5261,8 @@ func (p *selEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5285,12 +5285,12 @@ func (p *selEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5352,7 +5352,7 @@ func (p *selEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5380,10 +5380,10 @@ func (p *selEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5414,7 +5414,7 @@ func (p *selEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5442,10 +5442,10 @@ func (p *selEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5514,8 +5514,8 @@ func (p *selEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5543,12 +5543,12 @@ func (p *selEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5579,8 +5579,8 @@ func (p *selEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5608,12 +5608,12 @@ func (p *selEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5680,7 +5680,7 @@ func (p *selEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5708,10 +5708,10 @@ func (p *selEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5742,7 +5742,7 @@ func (p *selEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5770,10 +5770,10 @@ func (p *selEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -5842,8 +5842,8 @@ func (p *selEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5871,12 +5871,12 @@ func (p *selEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5907,8 +5907,8 @@ func (p *selEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -5936,12 +5936,12 @@ func (p *selEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6008,7 +6008,7 @@ func (p *selEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6036,10 +6036,10 @@ func (p *selEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6070,7 +6070,7 @@ func (p *selEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6098,10 +6098,10 @@ func (p *selEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6170,8 +6170,8 @@ func (p *selEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6199,12 +6199,12 @@ func (p *selEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6235,8 +6235,8 @@ func (p *selEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6264,12 +6264,12 @@ func (p *selEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6336,7 +6336,7 @@ func (p *selEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6372,10 +6372,10 @@ func (p *selEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6414,7 +6414,7 @@ func (p *selEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6450,10 +6450,10 @@ func (p *selEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6530,8 +6530,8 @@ func (p *selEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6567,12 +6567,12 @@ func (p *selEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6611,8 +6611,8 @@ func (p *selEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6648,12 +6648,12 @@ func (p *selEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6728,7 +6728,7 @@ func (p *selEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6751,10 +6751,10 @@ func (p *selEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6780,7 +6780,7 @@ func (p *selEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6803,10 +6803,10 @@ func (p *selEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -6870,8 +6870,8 @@ func (p *selEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6894,12 +6894,12 @@ func (p *selEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6925,8 +6925,8 @@ func (p *selEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -6949,12 +6949,12 @@ func (p *selEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -7016,7 +7016,7 @@ func (p *selEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7052,10 +7052,10 @@ func (p *selEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7094,7 +7094,7 @@ func (p *selEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7130,10 +7130,10 @@ func (p *selEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7210,8 +7210,8 @@ func (p *selEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -7247,12 +7247,12 @@ func (p *selEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -7291,8 +7291,8 @@ func (p *selEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -7328,12 +7328,12 @@ func (p *selEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -7408,7 +7408,7 @@ func (p *selEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7444,10 +7444,10 @@ func (p *selEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7486,7 +7486,7 @@ func (p *selEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7522,10 +7522,10 @@ func (p *selEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7602,8 +7602,8 @@ func (p *selEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -7639,12 +7639,12 @@ func (p *selEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -7683,8 +7683,8 @@ func (p *selEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -7720,12 +7720,12 @@ func (p *selEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -7800,7 +7800,7 @@ func (p *selEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7836,10 +7836,10 @@ func (p *selEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7878,7 +7878,7 @@ func (p *selEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7914,10 +7914,10 @@ func (p *selEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -7994,8 +7994,8 @@ func (p *selEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8031,12 +8031,12 @@ func (p *selEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8075,8 +8075,8 @@ func (p *selEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8112,12 +8112,12 @@ func (p *selEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8192,7 +8192,7 @@ func (p *selEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -8228,10 +8228,10 @@ func (p *selEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -8270,7 +8270,7 @@ func (p *selEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -8306,10 +8306,10 @@ func (p *selEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -8386,8 +8386,8 @@ func (p *selEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8423,12 +8423,12 @@ func (p *selEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8467,8 +8467,8 @@ func (p *selEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8504,12 +8504,12 @@ func (p *selEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8584,7 +8584,7 @@ func (p *selEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -8609,10 +8609,10 @@ func (p *selEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -8640,7 +8640,7 @@ func (p *selEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -8665,10 +8665,10 @@ func (p *selEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -8734,8 +8734,8 @@ func (p *selEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8760,12 +8760,12 @@ func (p *selEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8793,8 +8793,8 @@ func (p *selEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8819,12 +8819,12 @@ func (p *selEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -8888,7 +8888,7 @@ func (p *selEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -8912,10 +8912,10 @@ func (p *selEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -8942,7 +8942,7 @@ func (p *selEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -8966,10 +8966,10 @@ func (p *selEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -9034,8 +9034,8 @@ func (p *selEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9059,12 +9059,12 @@ func (p *selEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9091,8 +9091,8 @@ func (p *selEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9116,12 +9116,12 @@ func (p *selEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9184,7 +9184,7 @@ func (p *selEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -9201,10 +9201,10 @@ func (p *selEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -9224,7 +9224,7 @@ func (p *selEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -9241,10 +9241,10 @@ func (p *selEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -9302,8 +9302,8 @@ func (p *selEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9320,12 +9320,12 @@ func (p *selEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9345,8 +9345,8 @@ func (p *selEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9363,12 +9363,12 @@ func (p *selEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9680,7 +9680,7 @@ func (p *selNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -9705,10 +9705,10 @@ func (p *selNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -9736,7 +9736,7 @@ func (p *selNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -9761,10 +9761,10 @@ func (p *selNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -9830,8 +9830,8 @@ func (p *selNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9856,12 +9856,12 @@ func (p *selNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9889,8 +9889,8 @@ func (p *selNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9915,12 +9915,12 @@ func (p *selNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -9984,7 +9984,7 @@ func (p *selNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10001,10 +10001,10 @@ func (p *selNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10024,7 +10024,7 @@ func (p *selNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10041,10 +10041,10 @@ func (p *selNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10102,8 +10102,8 @@ func (p *selNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10120,12 +10120,12 @@ func (p *selNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10145,8 +10145,8 @@ func (p *selNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10163,12 +10163,12 @@ func (p *selNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10224,7 +10224,7 @@ func (p *selNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10247,10 +10247,10 @@ func (p *selNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10276,7 +10276,7 @@ func (p *selNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10299,10 +10299,10 @@ func (p *selNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10366,8 +10366,8 @@ func (p *selNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10390,12 +10390,12 @@ func (p *selNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10421,8 +10421,8 @@ func (p *selNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10445,12 +10445,12 @@ func (p *selNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10512,7 +10512,7 @@ func (p *selNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10535,10 +10535,10 @@ func (p *selNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10564,7 +10564,7 @@ func (p *selNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10587,10 +10587,10 @@ func (p *selNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10654,8 +10654,8 @@ func (p *selNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10678,12 +10678,12 @@ func (p *selNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10709,8 +10709,8 @@ func (p *selNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10733,12 +10733,12 @@ func (p *selNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10800,7 +10800,7 @@ func (p *selNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10823,10 +10823,10 @@ func (p *selNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10852,7 +10852,7 @@ func (p *selNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10875,10 +10875,10 @@ func (p *selNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -10942,8 +10942,8 @@ func (p *selNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10966,12 +10966,12 @@ func (p *selNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -10997,8 +10997,8 @@ func (p *selNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11021,12 +11021,12 @@ func (p *selNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11088,7 +11088,7 @@ func (p *selNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11113,10 +11113,10 @@ func (p *selNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11144,7 +11144,7 @@ func (p *selNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11169,10 +11169,10 @@ func (p *selNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11238,8 +11238,8 @@ func (p *selNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11264,12 +11264,12 @@ func (p *selNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11297,8 +11297,8 @@ func (p *selNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11323,12 +11323,12 @@ func (p *selNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11392,7 +11392,7 @@ func (p *selNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11409,10 +11409,10 @@ func (p *selNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11432,7 +11432,7 @@ func (p *selNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11449,10 +11449,10 @@ func (p *selNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11510,8 +11510,8 @@ func (p *selNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11528,12 +11528,12 @@ func (p *selNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11553,8 +11553,8 @@ func (p *selNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11571,12 +11571,12 @@ func (p *selNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11632,7 +11632,7 @@ func (p *selNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11660,10 +11660,10 @@ func (p *selNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11694,7 +11694,7 @@ func (p *selNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11722,10 +11722,10 @@ func (p *selNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11794,8 +11794,8 @@ func (p *selNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11823,12 +11823,12 @@ func (p *selNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11859,8 +11859,8 @@ func (p *selNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11888,12 +11888,12 @@ func (p *selNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -11960,7 +11960,7 @@ func (p *selNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -11988,10 +11988,10 @@ func (p *selNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -12022,7 +12022,7 @@ func (p *selNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -12050,10 +12050,10 @@ func (p *selNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -12122,8 +12122,8 @@ func (p *selNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -12151,12 +12151,12 @@ func (p *selNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -12187,8 +12187,8 @@ func (p *selNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -12216,12 +12216,12 @@ func (p *selNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -12288,7 +12288,7 @@ func (p *selNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -12316,10 +12316,10 @@ func (p *selNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -12350,7 +12350,7 @@ func (p *selNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -12378,10 +12378,10 @@ func (p *selNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -12450,8 +12450,8 @@ func (p *selNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -12479,12 +12479,12 @@ func (p *selNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -12515,8 +12515,8 @@ func (p *selNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -12544,12 +12544,12 @@ func (p *selNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -12616,7 +12616,7 @@ func (p *selNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -12652,10 +12652,10 @@ func (p *selNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -12694,7 +12694,7 @@ func (p *selNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -12730,10 +12730,10 @@ func (p *selNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -12810,8 +12810,8 @@ func (p *selNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -12847,12 +12847,12 @@ func (p *selNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -12891,8 +12891,8 @@ func (p *selNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -12928,12 +12928,12 @@ func (p *selNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13008,7 +13008,7 @@ func (p *selNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13031,10 +13031,10 @@ func (p *selNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13060,7 +13060,7 @@ func (p *selNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13083,10 +13083,10 @@ func (p *selNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13150,8 +13150,8 @@ func (p *selNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13174,12 +13174,12 @@ func (p *selNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13205,8 +13205,8 @@ func (p *selNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13229,12 +13229,12 @@ func (p *selNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13296,7 +13296,7 @@ func (p *selNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13324,10 +13324,10 @@ func (p *selNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13358,7 +13358,7 @@ func (p *selNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13386,10 +13386,10 @@ func (p *selNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13458,8 +13458,8 @@ func (p *selNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13487,12 +13487,12 @@ func (p *selNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13523,8 +13523,8 @@ func (p *selNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13552,12 +13552,12 @@ func (p *selNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13624,7 +13624,7 @@ func (p *selNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13652,10 +13652,10 @@ func (p *selNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13686,7 +13686,7 @@ func (p *selNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13714,10 +13714,10 @@ func (p *selNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13786,8 +13786,8 @@ func (p *selNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13815,12 +13815,12 @@ func (p *selNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13851,8 +13851,8 @@ func (p *selNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13880,12 +13880,12 @@ func (p *selNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -13952,7 +13952,7 @@ func (p *selNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -13980,10 +13980,10 @@ func (p *selNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14014,7 +14014,7 @@ func (p *selNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14042,10 +14042,10 @@ func (p *selNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14114,8 +14114,8 @@ func (p *selNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14143,12 +14143,12 @@ func (p *selNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14179,8 +14179,8 @@ func (p *selNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14208,12 +14208,12 @@ func (p *selNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14280,7 +14280,7 @@ func (p *selNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14316,10 +14316,10 @@ func (p *selNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14358,7 +14358,7 @@ func (p *selNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14394,10 +14394,10 @@ func (p *selNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14474,8 +14474,8 @@ func (p *selNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14511,12 +14511,12 @@ func (p *selNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14555,8 +14555,8 @@ func (p *selNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14592,12 +14592,12 @@ func (p *selNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14672,7 +14672,7 @@ func (p *selNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14695,10 +14695,10 @@ func (p *selNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14724,7 +14724,7 @@ func (p *selNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14747,10 +14747,10 @@ func (p *selNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14814,8 +14814,8 @@ func (p *selNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14838,12 +14838,12 @@ func (p *selNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14869,8 +14869,8 @@ func (p *selNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14893,12 +14893,12 @@ func (p *selNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -14960,7 +14960,7 @@ func (p *selNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -14988,10 +14988,10 @@ func (p *selNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15022,7 +15022,7 @@ func (p *selNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15050,10 +15050,10 @@ func (p *selNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15122,8 +15122,8 @@ func (p *selNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15151,12 +15151,12 @@ func (p *selNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15187,8 +15187,8 @@ func (p *selNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15216,12 +15216,12 @@ func (p *selNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15288,7 +15288,7 @@ func (p *selNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15316,10 +15316,10 @@ func (p *selNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15350,7 +15350,7 @@ func (p *selNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15378,10 +15378,10 @@ func (p *selNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15450,8 +15450,8 @@ func (p *selNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15479,12 +15479,12 @@ func (p *selNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15515,8 +15515,8 @@ func (p *selNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15544,12 +15544,12 @@ func (p *selNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15616,7 +15616,7 @@ func (p *selNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15644,10 +15644,10 @@ func (p *selNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15678,7 +15678,7 @@ func (p *selNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15706,10 +15706,10 @@ func (p *selNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15778,8 +15778,8 @@ func (p *selNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15807,12 +15807,12 @@ func (p *selNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15843,8 +15843,8 @@ func (p *selNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15872,12 +15872,12 @@ func (p *selNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -15944,7 +15944,7 @@ func (p *selNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -15980,10 +15980,10 @@ func (p *selNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -16022,7 +16022,7 @@ func (p *selNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -16058,10 +16058,10 @@ func (p *selNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -16138,8 +16138,8 @@ func (p *selNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -16175,12 +16175,12 @@ func (p *selNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -16219,8 +16219,8 @@ func (p *selNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -16256,12 +16256,12 @@ func (p *selNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -16336,7 +16336,7 @@ func (p *selNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -16359,10 +16359,10 @@ func (p *selNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -16388,7 +16388,7 @@ func (p *selNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -16411,10 +16411,10 @@ func (p *selNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -16478,8 +16478,8 @@ func (p *selNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -16502,12 +16502,12 @@ func (p *selNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -16533,8 +16533,8 @@ func (p *selNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -16557,12 +16557,12 @@ func (p *selNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -16624,7 +16624,7 @@ func (p *selNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -16660,10 +16660,10 @@ func (p *selNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -16702,7 +16702,7 @@ func (p *selNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -16738,10 +16738,10 @@ func (p *selNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -16818,8 +16818,8 @@ func (p *selNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -16855,12 +16855,12 @@ func (p *selNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -16899,8 +16899,8 @@ func (p *selNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -16936,12 +16936,12 @@ func (p *selNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -17016,7 +17016,7 @@ func (p *selNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17052,10 +17052,10 @@ func (p *selNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17094,7 +17094,7 @@ func (p *selNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17130,10 +17130,10 @@ func (p *selNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17210,8 +17210,8 @@ func (p *selNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -17247,12 +17247,12 @@ func (p *selNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -17291,8 +17291,8 @@ func (p *selNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -17328,12 +17328,12 @@ func (p *selNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -17408,7 +17408,7 @@ func (p *selNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17444,10 +17444,10 @@ func (p *selNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17486,7 +17486,7 @@ func (p *selNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17522,10 +17522,10 @@ func (p *selNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17602,8 +17602,8 @@ func (p *selNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -17639,12 +17639,12 @@ func (p *selNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -17683,8 +17683,8 @@ func (p *selNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -17720,12 +17720,12 @@ func (p *selNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -17800,7 +17800,7 @@ func (p *selNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17836,10 +17836,10 @@ func (p *selNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17878,7 +17878,7 @@ func (p *selNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17914,10 +17914,10 @@ func (p *selNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -17994,8 +17994,8 @@ func (p *selNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18031,12 +18031,12 @@ func (p *selNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18075,8 +18075,8 @@ func (p *selNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18112,12 +18112,12 @@ func (p *selNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18192,7 +18192,7 @@ func (p *selNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18217,10 +18217,10 @@ func (p *selNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18248,7 +18248,7 @@ func (p *selNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18273,10 +18273,10 @@ func (p *selNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18342,8 +18342,8 @@ func (p *selNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18368,12 +18368,12 @@ func (p *selNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18401,8 +18401,8 @@ func (p *selNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18427,12 +18427,12 @@ func (p *selNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18496,7 +18496,7 @@ func (p *selNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18520,10 +18520,10 @@ func (p *selNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18550,7 +18550,7 @@ func (p *selNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18574,10 +18574,10 @@ func (p *selNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18642,8 +18642,8 @@ func (p *selNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18667,12 +18667,12 @@ func (p *selNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18699,8 +18699,8 @@ func (p *selNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18724,12 +18724,12 @@ func (p *selNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18792,7 +18792,7 @@ func (p *selNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18809,10 +18809,10 @@ func (p *selNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18832,7 +18832,7 @@ func (p *selNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18849,10 +18849,10 @@ func (p *selNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -18910,8 +18910,8 @@ func (p *selNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18928,12 +18928,12 @@ func (p *selNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18953,8 +18953,8 @@ func (p *selNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -18971,12 +18971,12 @@ func (p *selNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -19288,7 +19288,7 @@ func (p *selLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19313,10 +19313,10 @@ func (p *selLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19344,7 +19344,7 @@ func (p *selLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19369,10 +19369,10 @@ func (p *selLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19438,8 +19438,8 @@ func (p *selLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -19464,12 +19464,12 @@ func (p *selLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -19497,8 +19497,8 @@ func (p *selLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -19523,12 +19523,12 @@ func (p *selLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -19592,7 +19592,7 @@ func (p *selLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19609,10 +19609,10 @@ func (p *selLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19632,7 +19632,7 @@ func (p *selLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19649,10 +19649,10 @@ func (p *selLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19710,8 +19710,8 @@ func (p *selLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -19728,12 +19728,12 @@ func (p *selLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -19753,8 +19753,8 @@ func (p *selLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -19771,12 +19771,12 @@ func (p *selLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -19832,7 +19832,7 @@ func (p *selLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19855,10 +19855,10 @@ func (p *selLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19884,7 +19884,7 @@ func (p *selLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19907,10 +19907,10 @@ func (p *selLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -19974,8 +19974,8 @@ func (p *selLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -19998,12 +19998,12 @@ func (p *selLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20029,8 +20029,8 @@ func (p *selLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20053,12 +20053,12 @@ func (p *selLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20120,7 +20120,7 @@ func (p *selLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20143,10 +20143,10 @@ func (p *selLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20172,7 +20172,7 @@ func (p *selLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20195,10 +20195,10 @@ func (p *selLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20262,8 +20262,8 @@ func (p *selLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20286,12 +20286,12 @@ func (p *selLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20317,8 +20317,8 @@ func (p *selLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20341,12 +20341,12 @@ func (p *selLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20408,7 +20408,7 @@ func (p *selLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20431,10 +20431,10 @@ func (p *selLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20460,7 +20460,7 @@ func (p *selLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20483,10 +20483,10 @@ func (p *selLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20550,8 +20550,8 @@ func (p *selLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20574,12 +20574,12 @@ func (p *selLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20605,8 +20605,8 @@ func (p *selLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20629,12 +20629,12 @@ func (p *selLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20696,7 +20696,7 @@ func (p *selLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20721,10 +20721,10 @@ func (p *selLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20752,7 +20752,7 @@ func (p *selLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20777,10 +20777,10 @@ func (p *selLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -20846,8 +20846,8 @@ func (p *selLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20872,12 +20872,12 @@ func (p *selLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20905,8 +20905,8 @@ func (p *selLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -20931,12 +20931,12 @@ func (p *selLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21000,7 +21000,7 @@ func (p *selLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21017,10 +21017,10 @@ func (p *selLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21040,7 +21040,7 @@ func (p *selLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21057,10 +21057,10 @@ func (p *selLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21118,8 +21118,8 @@ func (p *selLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21136,12 +21136,12 @@ func (p *selLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21161,8 +21161,8 @@ func (p *selLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21179,12 +21179,12 @@ func (p *selLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21240,7 +21240,7 @@ func (p *selLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21268,10 +21268,10 @@ func (p *selLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21302,7 +21302,7 @@ func (p *selLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21330,10 +21330,10 @@ func (p *selLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21402,8 +21402,8 @@ func (p *selLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21431,12 +21431,12 @@ func (p *selLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21467,8 +21467,8 @@ func (p *selLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21496,12 +21496,12 @@ func (p *selLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21568,7 +21568,7 @@ func (p *selLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21596,10 +21596,10 @@ func (p *selLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21630,7 +21630,7 @@ func (p *selLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21658,10 +21658,10 @@ func (p *selLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21730,8 +21730,8 @@ func (p *selLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21759,12 +21759,12 @@ func (p *selLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21795,8 +21795,8 @@ func (p *selLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21824,12 +21824,12 @@ func (p *selLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -21896,7 +21896,7 @@ func (p *selLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21924,10 +21924,10 @@ func (p *selLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21958,7 +21958,7 @@ func (p *selLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -21986,10 +21986,10 @@ func (p *selLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22058,8 +22058,8 @@ func (p *selLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22087,12 +22087,12 @@ func (p *selLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22123,8 +22123,8 @@ func (p *selLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22152,12 +22152,12 @@ func (p *selLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22224,7 +22224,7 @@ func (p *selLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22260,10 +22260,10 @@ func (p *selLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22302,7 +22302,7 @@ func (p *selLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22338,10 +22338,10 @@ func (p *selLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22418,8 +22418,8 @@ func (p *selLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22455,12 +22455,12 @@ func (p *selLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22499,8 +22499,8 @@ func (p *selLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22536,12 +22536,12 @@ func (p *selLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22616,7 +22616,7 @@ func (p *selLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22639,10 +22639,10 @@ func (p *selLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22668,7 +22668,7 @@ func (p *selLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22691,10 +22691,10 @@ func (p *selLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22758,8 +22758,8 @@ func (p *selLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22782,12 +22782,12 @@ func (p *selLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22813,8 +22813,8 @@ func (p *selLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22837,12 +22837,12 @@ func (p *selLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -22904,7 +22904,7 @@ func (p *selLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22932,10 +22932,10 @@ func (p *selLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22966,7 +22966,7 @@ func (p *selLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -22994,10 +22994,10 @@ func (p *selLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23066,8 +23066,8 @@ func (p *selLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23095,12 +23095,12 @@ func (p *selLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23131,8 +23131,8 @@ func (p *selLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23160,12 +23160,12 @@ func (p *selLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23232,7 +23232,7 @@ func (p *selLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23260,10 +23260,10 @@ func (p *selLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23294,7 +23294,7 @@ func (p *selLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23322,10 +23322,10 @@ func (p *selLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23394,8 +23394,8 @@ func (p *selLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23423,12 +23423,12 @@ func (p *selLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23459,8 +23459,8 @@ func (p *selLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23488,12 +23488,12 @@ func (p *selLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23560,7 +23560,7 @@ func (p *selLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23588,10 +23588,10 @@ func (p *selLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23622,7 +23622,7 @@ func (p *selLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23650,10 +23650,10 @@ func (p *selLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23722,8 +23722,8 @@ func (p *selLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23751,12 +23751,12 @@ func (p *selLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23787,8 +23787,8 @@ func (p *selLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23816,12 +23816,12 @@ func (p *selLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -23888,7 +23888,7 @@ func (p *selLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23924,10 +23924,10 @@ func (p *selLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -23966,7 +23966,7 @@ func (p *selLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24002,10 +24002,10 @@ func (p *selLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24082,8 +24082,8 @@ func (p *selLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24119,12 +24119,12 @@ func (p *selLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24163,8 +24163,8 @@ func (p *selLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24200,12 +24200,12 @@ func (p *selLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24280,7 +24280,7 @@ func (p *selLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24303,10 +24303,10 @@ func (p *selLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24332,7 +24332,7 @@ func (p *selLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24355,10 +24355,10 @@ func (p *selLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24422,8 +24422,8 @@ func (p *selLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24446,12 +24446,12 @@ func (p *selLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24477,8 +24477,8 @@ func (p *selLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24501,12 +24501,12 @@ func (p *selLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24568,7 +24568,7 @@ func (p *selLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24596,10 +24596,10 @@ func (p *selLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24630,7 +24630,7 @@ func (p *selLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24658,10 +24658,10 @@ func (p *selLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24730,8 +24730,8 @@ func (p *selLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24759,12 +24759,12 @@ func (p *selLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24795,8 +24795,8 @@ func (p *selLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24824,12 +24824,12 @@ func (p *selLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -24896,7 +24896,7 @@ func (p *selLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24924,10 +24924,10 @@ func (p *selLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24958,7 +24958,7 @@ func (p *selLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -24986,10 +24986,10 @@ func (p *selLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25058,8 +25058,8 @@ func (p *selLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25087,12 +25087,12 @@ func (p *selLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25123,8 +25123,8 @@ func (p *selLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25152,12 +25152,12 @@ func (p *selLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25224,7 +25224,7 @@ func (p *selLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25252,10 +25252,10 @@ func (p *selLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25286,7 +25286,7 @@ func (p *selLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25314,10 +25314,10 @@ func (p *selLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25386,8 +25386,8 @@ func (p *selLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25415,12 +25415,12 @@ func (p *selLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25451,8 +25451,8 @@ func (p *selLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25480,12 +25480,12 @@ func (p *selLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25552,7 +25552,7 @@ func (p *selLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25588,10 +25588,10 @@ func (p *selLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25630,7 +25630,7 @@ func (p *selLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25666,10 +25666,10 @@ func (p *selLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25746,8 +25746,8 @@ func (p *selLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25783,12 +25783,12 @@ func (p *selLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25827,8 +25827,8 @@ func (p *selLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25864,12 +25864,12 @@ func (p *selLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -25944,7 +25944,7 @@ func (p *selLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25967,10 +25967,10 @@ func (p *selLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -25996,7 +25996,7 @@ func (p *selLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26019,10 +26019,10 @@ func (p *selLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26086,8 +26086,8 @@ func (p *selLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26110,12 +26110,12 @@ func (p *selLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26141,8 +26141,8 @@ func (p *selLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26165,12 +26165,12 @@ func (p *selLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26232,7 +26232,7 @@ func (p *selLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26268,10 +26268,10 @@ func (p *selLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26310,7 +26310,7 @@ func (p *selLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26346,10 +26346,10 @@ func (p *selLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26426,8 +26426,8 @@ func (p *selLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26463,12 +26463,12 @@ func (p *selLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26507,8 +26507,8 @@ func (p *selLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26544,12 +26544,12 @@ func (p *selLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26624,7 +26624,7 @@ func (p *selLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26660,10 +26660,10 @@ func (p *selLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26702,7 +26702,7 @@ func (p *selLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26738,10 +26738,10 @@ func (p *selLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -26818,8 +26818,8 @@ func (p *selLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26855,12 +26855,12 @@ func (p *selLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26899,8 +26899,8 @@ func (p *selLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -26936,12 +26936,12 @@ func (p *selLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27016,7 +27016,7 @@ func (p *selLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27052,10 +27052,10 @@ func (p *selLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27094,7 +27094,7 @@ func (p *selLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27130,10 +27130,10 @@ func (p *selLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27210,8 +27210,8 @@ func (p *selLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27247,12 +27247,12 @@ func (p *selLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27291,8 +27291,8 @@ func (p *selLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27328,12 +27328,12 @@ func (p *selLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27408,7 +27408,7 @@ func (p *selLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27444,10 +27444,10 @@ func (p *selLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27486,7 +27486,7 @@ func (p *selLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27522,10 +27522,10 @@ func (p *selLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27602,8 +27602,8 @@ func (p *selLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27639,12 +27639,12 @@ func (p *selLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27683,8 +27683,8 @@ func (p *selLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27720,12 +27720,12 @@ func (p *selLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27800,7 +27800,7 @@ func (p *selLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27825,10 +27825,10 @@ func (p *selLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27856,7 +27856,7 @@ func (p *selLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27881,10 +27881,10 @@ func (p *selLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -27950,8 +27950,8 @@ func (p *selLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -27976,12 +27976,12 @@ func (p *selLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28009,8 +28009,8 @@ func (p *selLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28035,12 +28035,12 @@ func (p *selLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28104,7 +28104,7 @@ func (p *selLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28128,10 +28128,10 @@ func (p *selLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28158,7 +28158,7 @@ func (p *selLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28182,10 +28182,10 @@ func (p *selLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28250,8 +28250,8 @@ func (p *selLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28275,12 +28275,12 @@ func (p *selLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28307,8 +28307,8 @@ func (p *selLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28332,12 +28332,12 @@ func (p *selLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28400,7 +28400,7 @@ func (p *selLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28417,10 +28417,10 @@ func (p *selLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28440,7 +28440,7 @@ func (p *selLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28457,10 +28457,10 @@ func (p *selLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28518,8 +28518,8 @@ func (p *selLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28536,12 +28536,12 @@ func (p *selLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28561,8 +28561,8 @@ func (p *selLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28579,12 +28579,12 @@ func (p *selLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -28896,7 +28896,7 @@ func (p *selLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28921,10 +28921,10 @@ func (p *selLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28952,7 +28952,7 @@ func (p *selLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -28977,10 +28977,10 @@ func (p *selLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29046,8 +29046,8 @@ func (p *selLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29072,12 +29072,12 @@ func (p *selLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29105,8 +29105,8 @@ func (p *selLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29131,12 +29131,12 @@ func (p *selLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29200,7 +29200,7 @@ func (p *selLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29217,10 +29217,10 @@ func (p *selLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29240,7 +29240,7 @@ func (p *selLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29257,10 +29257,10 @@ func (p *selLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29318,8 +29318,8 @@ func (p *selLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29336,12 +29336,12 @@ func (p *selLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29361,8 +29361,8 @@ func (p *selLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29379,12 +29379,12 @@ func (p *selLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29440,7 +29440,7 @@ func (p *selLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29463,10 +29463,10 @@ func (p *selLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29492,7 +29492,7 @@ func (p *selLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29515,10 +29515,10 @@ func (p *selLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29582,8 +29582,8 @@ func (p *selLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29606,12 +29606,12 @@ func (p *selLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29637,8 +29637,8 @@ func (p *selLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29661,12 +29661,12 @@ func (p *selLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29728,7 +29728,7 @@ func (p *selLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29751,10 +29751,10 @@ func (p *selLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29780,7 +29780,7 @@ func (p *selLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29803,10 +29803,10 @@ func (p *selLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -29870,8 +29870,8 @@ func (p *selLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29894,12 +29894,12 @@ func (p *selLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29925,8 +29925,8 @@ func (p *selLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -29949,12 +29949,12 @@ func (p *selLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30016,7 +30016,7 @@ func (p *selLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30039,10 +30039,10 @@ func (p *selLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30068,7 +30068,7 @@ func (p *selLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30091,10 +30091,10 @@ func (p *selLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30158,8 +30158,8 @@ func (p *selLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30182,12 +30182,12 @@ func (p *selLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30213,8 +30213,8 @@ func (p *selLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30237,12 +30237,12 @@ func (p *selLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30304,7 +30304,7 @@ func (p *selLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30329,10 +30329,10 @@ func (p *selLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30360,7 +30360,7 @@ func (p *selLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30385,10 +30385,10 @@ func (p *selLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30454,8 +30454,8 @@ func (p *selLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30480,12 +30480,12 @@ func (p *selLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30513,8 +30513,8 @@ func (p *selLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30539,12 +30539,12 @@ func (p *selLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30608,7 +30608,7 @@ func (p *selLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30625,10 +30625,10 @@ func (p *selLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30648,7 +30648,7 @@ func (p *selLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30665,10 +30665,10 @@ func (p *selLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30726,8 +30726,8 @@ func (p *selLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30744,12 +30744,12 @@ func (p *selLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30769,8 +30769,8 @@ func (p *selLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30787,12 +30787,12 @@ func (p *selLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -30848,7 +30848,7 @@ func (p *selLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30876,10 +30876,10 @@ func (p *selLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30910,7 +30910,7 @@ func (p *selLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -30938,10 +30938,10 @@ func (p *selLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31010,8 +31010,8 @@ func (p *selLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31039,12 +31039,12 @@ func (p *selLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31075,8 +31075,8 @@ func (p *selLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31104,12 +31104,12 @@ func (p *selLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31176,7 +31176,7 @@ func (p *selLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31204,10 +31204,10 @@ func (p *selLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31238,7 +31238,7 @@ func (p *selLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31266,10 +31266,10 @@ func (p *selLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31338,8 +31338,8 @@ func (p *selLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31367,12 +31367,12 @@ func (p *selLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31403,8 +31403,8 @@ func (p *selLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31432,12 +31432,12 @@ func (p *selLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31504,7 +31504,7 @@ func (p *selLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31532,10 +31532,10 @@ func (p *selLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31566,7 +31566,7 @@ func (p *selLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31594,10 +31594,10 @@ func (p *selLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31666,8 +31666,8 @@ func (p *selLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31695,12 +31695,12 @@ func (p *selLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31731,8 +31731,8 @@ func (p *selLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31760,12 +31760,12 @@ func (p *selLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -31832,7 +31832,7 @@ func (p *selLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31868,10 +31868,10 @@ func (p *selLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31910,7 +31910,7 @@ func (p *selLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -31946,10 +31946,10 @@ func (p *selLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32026,8 +32026,8 @@ func (p *selLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32063,12 +32063,12 @@ func (p *selLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32107,8 +32107,8 @@ func (p *selLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32144,12 +32144,12 @@ func (p *selLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32224,7 +32224,7 @@ func (p *selLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32247,10 +32247,10 @@ func (p *selLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32276,7 +32276,7 @@ func (p *selLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32299,10 +32299,10 @@ func (p *selLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32366,8 +32366,8 @@ func (p *selLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32390,12 +32390,12 @@ func (p *selLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32421,8 +32421,8 @@ func (p *selLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32445,12 +32445,12 @@ func (p *selLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32512,7 +32512,7 @@ func (p *selLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32540,10 +32540,10 @@ func (p *selLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32574,7 +32574,7 @@ func (p *selLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32602,10 +32602,10 @@ func (p *selLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32674,8 +32674,8 @@ func (p *selLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32703,12 +32703,12 @@ func (p *selLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32739,8 +32739,8 @@ func (p *selLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32768,12 +32768,12 @@ func (p *selLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -32840,7 +32840,7 @@ func (p *selLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32868,10 +32868,10 @@ func (p *selLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32902,7 +32902,7 @@ func (p *selLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -32930,10 +32930,10 @@ func (p *selLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33002,8 +33002,8 @@ func (p *selLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33031,12 +33031,12 @@ func (p *selLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33067,8 +33067,8 @@ func (p *selLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33096,12 +33096,12 @@ func (p *selLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33168,7 +33168,7 @@ func (p *selLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33196,10 +33196,10 @@ func (p *selLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33230,7 +33230,7 @@ func (p *selLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33258,10 +33258,10 @@ func (p *selLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33330,8 +33330,8 @@ func (p *selLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33359,12 +33359,12 @@ func (p *selLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33395,8 +33395,8 @@ func (p *selLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33424,12 +33424,12 @@ func (p *selLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33496,7 +33496,7 @@ func (p *selLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33532,10 +33532,10 @@ func (p *selLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33574,7 +33574,7 @@ func (p *selLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33610,10 +33610,10 @@ func (p *selLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33690,8 +33690,8 @@ func (p *selLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33727,12 +33727,12 @@ func (p *selLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33771,8 +33771,8 @@ func (p *selLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33808,12 +33808,12 @@ func (p *selLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -33888,7 +33888,7 @@ func (p *selLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33911,10 +33911,10 @@ func (p *selLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33940,7 +33940,7 @@ func (p *selLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -33963,10 +33963,10 @@ func (p *selLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34030,8 +34030,8 @@ func (p *selLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34054,12 +34054,12 @@ func (p *selLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34085,8 +34085,8 @@ func (p *selLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34109,12 +34109,12 @@ func (p *selLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34176,7 +34176,7 @@ func (p *selLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34204,10 +34204,10 @@ func (p *selLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34238,7 +34238,7 @@ func (p *selLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34266,10 +34266,10 @@ func (p *selLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34338,8 +34338,8 @@ func (p *selLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34367,12 +34367,12 @@ func (p *selLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34403,8 +34403,8 @@ func (p *selLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34432,12 +34432,12 @@ func (p *selLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34504,7 +34504,7 @@ func (p *selLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34532,10 +34532,10 @@ func (p *selLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34566,7 +34566,7 @@ func (p *selLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34594,10 +34594,10 @@ func (p *selLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34666,8 +34666,8 @@ func (p *selLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34695,12 +34695,12 @@ func (p *selLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34731,8 +34731,8 @@ func (p *selLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34760,12 +34760,12 @@ func (p *selLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -34832,7 +34832,7 @@ func (p *selLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34860,10 +34860,10 @@ func (p *selLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34894,7 +34894,7 @@ func (p *selLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34922,10 +34922,10 @@ func (p *selLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -34994,8 +34994,8 @@ func (p *selLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35023,12 +35023,12 @@ func (p *selLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35059,8 +35059,8 @@ func (p *selLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35088,12 +35088,12 @@ func (p *selLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35160,7 +35160,7 @@ func (p *selLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35196,10 +35196,10 @@ func (p *selLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35238,7 +35238,7 @@ func (p *selLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35274,10 +35274,10 @@ func (p *selLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35354,8 +35354,8 @@ func (p *selLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35391,12 +35391,12 @@ func (p *selLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35435,8 +35435,8 @@ func (p *selLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35472,12 +35472,12 @@ func (p *selLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35552,7 +35552,7 @@ func (p *selLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35575,10 +35575,10 @@ func (p *selLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35604,7 +35604,7 @@ func (p *selLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35627,10 +35627,10 @@ func (p *selLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35694,8 +35694,8 @@ func (p *selLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35718,12 +35718,12 @@ func (p *selLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35749,8 +35749,8 @@ func (p *selLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35773,12 +35773,12 @@ func (p *selLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -35840,7 +35840,7 @@ func (p *selLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35876,10 +35876,10 @@ func (p *selLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35918,7 +35918,7 @@ func (p *selLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -35954,10 +35954,10 @@ func (p *selLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36034,8 +36034,8 @@ func (p *selLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36071,12 +36071,12 @@ func (p *selLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36115,8 +36115,8 @@ func (p *selLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36152,12 +36152,12 @@ func (p *selLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36232,7 +36232,7 @@ func (p *selLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36268,10 +36268,10 @@ func (p *selLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36310,7 +36310,7 @@ func (p *selLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36346,10 +36346,10 @@ func (p *selLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36426,8 +36426,8 @@ func (p *selLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36463,12 +36463,12 @@ func (p *selLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36507,8 +36507,8 @@ func (p *selLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36544,12 +36544,12 @@ func (p *selLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36624,7 +36624,7 @@ func (p *selLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36660,10 +36660,10 @@ func (p *selLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36702,7 +36702,7 @@ func (p *selLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36738,10 +36738,10 @@ func (p *selLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -36818,8 +36818,8 @@ func (p *selLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36855,12 +36855,12 @@ func (p *selLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36899,8 +36899,8 @@ func (p *selLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -36936,12 +36936,12 @@ func (p *selLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37016,7 +37016,7 @@ func (p *selLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37052,10 +37052,10 @@ func (p *selLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37094,7 +37094,7 @@ func (p *selLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37130,10 +37130,10 @@ func (p *selLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37210,8 +37210,8 @@ func (p *selLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37247,12 +37247,12 @@ func (p *selLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37291,8 +37291,8 @@ func (p *selLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37328,12 +37328,12 @@ func (p *selLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37408,7 +37408,7 @@ func (p *selLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37433,10 +37433,10 @@ func (p *selLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37464,7 +37464,7 @@ func (p *selLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37489,10 +37489,10 @@ func (p *selLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37558,8 +37558,8 @@ func (p *selLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37584,12 +37584,12 @@ func (p *selLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37617,8 +37617,8 @@ func (p *selLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37643,12 +37643,12 @@ func (p *selLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37712,7 +37712,7 @@ func (p *selLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37736,10 +37736,10 @@ func (p *selLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37766,7 +37766,7 @@ func (p *selLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37790,10 +37790,10 @@ func (p *selLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -37858,8 +37858,8 @@ func (p *selLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37883,12 +37883,12 @@ func (p *selLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37915,8 +37915,8 @@ func (p *selLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -37940,12 +37940,12 @@ func (p *selLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38008,7 +38008,7 @@ func (p *selLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38025,10 +38025,10 @@ func (p *selLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38048,7 +38048,7 @@ func (p *selLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38065,10 +38065,10 @@ func (p *selLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38126,8 +38126,8 @@ func (p *selLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38144,12 +38144,12 @@ func (p *selLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38169,8 +38169,8 @@ func (p *selLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38187,12 +38187,12 @@ func (p *selLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38504,7 +38504,7 @@ func (p *selGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38529,10 +38529,10 @@ func (p *selGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38560,7 +38560,7 @@ func (p *selGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38585,10 +38585,10 @@ func (p *selGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38654,8 +38654,8 @@ func (p *selGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38680,12 +38680,12 @@ func (p *selGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38713,8 +38713,8 @@ func (p *selGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38739,12 +38739,12 @@ func (p *selGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38808,7 +38808,7 @@ func (p *selGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38825,10 +38825,10 @@ func (p *selGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38848,7 +38848,7 @@ func (p *selGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38865,10 +38865,10 @@ func (p *selGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -38926,8 +38926,8 @@ func (p *selGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38944,12 +38944,12 @@ func (p *selGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38969,8 +38969,8 @@ func (p *selGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -38987,12 +38987,12 @@ func (p *selGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39048,7 +39048,7 @@ func (p *selGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39071,10 +39071,10 @@ func (p *selGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39100,7 +39100,7 @@ func (p *selGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39123,10 +39123,10 @@ func (p *selGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39190,8 +39190,8 @@ func (p *selGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39214,12 +39214,12 @@ func (p *selGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39245,8 +39245,8 @@ func (p *selGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39269,12 +39269,12 @@ func (p *selGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39336,7 +39336,7 @@ func (p *selGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39359,10 +39359,10 @@ func (p *selGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39388,7 +39388,7 @@ func (p *selGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39411,10 +39411,10 @@ func (p *selGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39478,8 +39478,8 @@ func (p *selGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39502,12 +39502,12 @@ func (p *selGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39533,8 +39533,8 @@ func (p *selGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39557,12 +39557,12 @@ func (p *selGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39624,7 +39624,7 @@ func (p *selGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39647,10 +39647,10 @@ func (p *selGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39676,7 +39676,7 @@ func (p *selGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39699,10 +39699,10 @@ func (p *selGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39766,8 +39766,8 @@ func (p *selGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39790,12 +39790,12 @@ func (p *selGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39821,8 +39821,8 @@ func (p *selGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39845,12 +39845,12 @@ func (p *selGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -39912,7 +39912,7 @@ func (p *selGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39937,10 +39937,10 @@ func (p *selGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39968,7 +39968,7 @@ func (p *selGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -39993,10 +39993,10 @@ func (p *selGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40062,8 +40062,8 @@ func (p *selGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40088,12 +40088,12 @@ func (p *selGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40121,8 +40121,8 @@ func (p *selGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40147,12 +40147,12 @@ func (p *selGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40216,7 +40216,7 @@ func (p *selGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40233,10 +40233,10 @@ func (p *selGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40256,7 +40256,7 @@ func (p *selGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40273,10 +40273,10 @@ func (p *selGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40334,8 +40334,8 @@ func (p *selGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40352,12 +40352,12 @@ func (p *selGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40377,8 +40377,8 @@ func (p *selGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40395,12 +40395,12 @@ func (p *selGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40456,7 +40456,7 @@ func (p *selGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40484,10 +40484,10 @@ func (p *selGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40518,7 +40518,7 @@ func (p *selGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40546,10 +40546,10 @@ func (p *selGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40618,8 +40618,8 @@ func (p *selGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40647,12 +40647,12 @@ func (p *selGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40683,8 +40683,8 @@ func (p *selGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40712,12 +40712,12 @@ func (p *selGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40784,7 +40784,7 @@ func (p *selGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40812,10 +40812,10 @@ func (p *selGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40846,7 +40846,7 @@ func (p *selGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40874,10 +40874,10 @@ func (p *selGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -40946,8 +40946,8 @@ func (p *selGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -40975,12 +40975,12 @@ func (p *selGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41011,8 +41011,8 @@ func (p *selGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41040,12 +41040,12 @@ func (p *selGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41112,7 +41112,7 @@ func (p *selGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41140,10 +41140,10 @@ func (p *selGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41174,7 +41174,7 @@ func (p *selGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41202,10 +41202,10 @@ func (p *selGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41274,8 +41274,8 @@ func (p *selGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41303,12 +41303,12 @@ func (p *selGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41339,8 +41339,8 @@ func (p *selGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41368,12 +41368,12 @@ func (p *selGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41440,7 +41440,7 @@ func (p *selGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41476,10 +41476,10 @@ func (p *selGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41518,7 +41518,7 @@ func (p *selGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41554,10 +41554,10 @@ func (p *selGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41634,8 +41634,8 @@ func (p *selGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41671,12 +41671,12 @@ func (p *selGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41715,8 +41715,8 @@ func (p *selGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41752,12 +41752,12 @@ func (p *selGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41832,7 +41832,7 @@ func (p *selGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41855,10 +41855,10 @@ func (p *selGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41884,7 +41884,7 @@ func (p *selGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41907,10 +41907,10 @@ func (p *selGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -41974,8 +41974,8 @@ func (p *selGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -41998,12 +41998,12 @@ func (p *selGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42029,8 +42029,8 @@ func (p *selGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42053,12 +42053,12 @@ func (p *selGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42120,7 +42120,7 @@ func (p *selGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42148,10 +42148,10 @@ func (p *selGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42182,7 +42182,7 @@ func (p *selGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42210,10 +42210,10 @@ func (p *selGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42282,8 +42282,8 @@ func (p *selGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42311,12 +42311,12 @@ func (p *selGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42347,8 +42347,8 @@ func (p *selGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42376,12 +42376,12 @@ func (p *selGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42448,7 +42448,7 @@ func (p *selGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42476,10 +42476,10 @@ func (p *selGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42510,7 +42510,7 @@ func (p *selGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42538,10 +42538,10 @@ func (p *selGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42610,8 +42610,8 @@ func (p *selGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42639,12 +42639,12 @@ func (p *selGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42675,8 +42675,8 @@ func (p *selGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42704,12 +42704,12 @@ func (p *selGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42776,7 +42776,7 @@ func (p *selGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42804,10 +42804,10 @@ func (p *selGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42838,7 +42838,7 @@ func (p *selGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42866,10 +42866,10 @@ func (p *selGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -42938,8 +42938,8 @@ func (p *selGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -42967,12 +42967,12 @@ func (p *selGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43003,8 +43003,8 @@ func (p *selGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43032,12 +43032,12 @@ func (p *selGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43104,7 +43104,7 @@ func (p *selGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43140,10 +43140,10 @@ func (p *selGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43182,7 +43182,7 @@ func (p *selGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43218,10 +43218,10 @@ func (p *selGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43298,8 +43298,8 @@ func (p *selGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43335,12 +43335,12 @@ func (p *selGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43379,8 +43379,8 @@ func (p *selGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43416,12 +43416,12 @@ func (p *selGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43496,7 +43496,7 @@ func (p *selGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43519,10 +43519,10 @@ func (p *selGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43548,7 +43548,7 @@ func (p *selGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43571,10 +43571,10 @@ func (p *selGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43638,8 +43638,8 @@ func (p *selGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43662,12 +43662,12 @@ func (p *selGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43693,8 +43693,8 @@ func (p *selGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43717,12 +43717,12 @@ func (p *selGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43784,7 +43784,7 @@ func (p *selGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43812,10 +43812,10 @@ func (p *selGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43846,7 +43846,7 @@ func (p *selGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43874,10 +43874,10 @@ func (p *selGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -43946,8 +43946,8 @@ func (p *selGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -43975,12 +43975,12 @@ func (p *selGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44011,8 +44011,8 @@ func (p *selGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44040,12 +44040,12 @@ func (p *selGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44112,7 +44112,7 @@ func (p *selGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44140,10 +44140,10 @@ func (p *selGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44174,7 +44174,7 @@ func (p *selGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44202,10 +44202,10 @@ func (p *selGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44274,8 +44274,8 @@ func (p *selGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44303,12 +44303,12 @@ func (p *selGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44339,8 +44339,8 @@ func (p *selGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44368,12 +44368,12 @@ func (p *selGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44440,7 +44440,7 @@ func (p *selGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44468,10 +44468,10 @@ func (p *selGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44502,7 +44502,7 @@ func (p *selGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44530,10 +44530,10 @@ func (p *selGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44602,8 +44602,8 @@ func (p *selGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44631,12 +44631,12 @@ func (p *selGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44667,8 +44667,8 @@ func (p *selGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44696,12 +44696,12 @@ func (p *selGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44768,7 +44768,7 @@ func (p *selGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44804,10 +44804,10 @@ func (p *selGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44846,7 +44846,7 @@ func (p *selGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44882,10 +44882,10 @@ func (p *selGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -44962,8 +44962,8 @@ func (p *selGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -44999,12 +44999,12 @@ func (p *selGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45043,8 +45043,8 @@ func (p *selGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45080,12 +45080,12 @@ func (p *selGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45160,7 +45160,7 @@ func (p *selGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45183,10 +45183,10 @@ func (p *selGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45212,7 +45212,7 @@ func (p *selGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45235,10 +45235,10 @@ func (p *selGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45302,8 +45302,8 @@ func (p *selGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45326,12 +45326,12 @@ func (p *selGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45357,8 +45357,8 @@ func (p *selGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45381,12 +45381,12 @@ func (p *selGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45448,7 +45448,7 @@ func (p *selGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45484,10 +45484,10 @@ func (p *selGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45526,7 +45526,7 @@ func (p *selGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45562,10 +45562,10 @@ func (p *selGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45642,8 +45642,8 @@ func (p *selGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45679,12 +45679,12 @@ func (p *selGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45723,8 +45723,8 @@ func (p *selGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45760,12 +45760,12 @@ func (p *selGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -45840,7 +45840,7 @@ func (p *selGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45876,10 +45876,10 @@ func (p *selGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45918,7 +45918,7 @@ func (p *selGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -45954,10 +45954,10 @@ func (p *selGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46034,8 +46034,8 @@ func (p *selGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46071,12 +46071,12 @@ func (p *selGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46115,8 +46115,8 @@ func (p *selGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46152,12 +46152,12 @@ func (p *selGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46232,7 +46232,7 @@ func (p *selGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46268,10 +46268,10 @@ func (p *selGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46310,7 +46310,7 @@ func (p *selGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46346,10 +46346,10 @@ func (p *selGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46426,8 +46426,8 @@ func (p *selGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46463,12 +46463,12 @@ func (p *selGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46507,8 +46507,8 @@ func (p *selGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46544,12 +46544,12 @@ func (p *selGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46624,7 +46624,7 @@ func (p *selGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46660,10 +46660,10 @@ func (p *selGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46702,7 +46702,7 @@ func (p *selGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46738,10 +46738,10 @@ func (p *selGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -46818,8 +46818,8 @@ func (p *selGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46855,12 +46855,12 @@ func (p *selGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46899,8 +46899,8 @@ func (p *selGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -46936,12 +46936,12 @@ func (p *selGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47016,7 +47016,7 @@ func (p *selGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47041,10 +47041,10 @@ func (p *selGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47072,7 +47072,7 @@ func (p *selGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47097,10 +47097,10 @@ func (p *selGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47166,8 +47166,8 @@ func (p *selGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47192,12 +47192,12 @@ func (p *selGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47225,8 +47225,8 @@ func (p *selGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47251,12 +47251,12 @@ func (p *selGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47320,7 +47320,7 @@ func (p *selGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47344,10 +47344,10 @@ func (p *selGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47374,7 +47374,7 @@ func (p *selGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47398,10 +47398,10 @@ func (p *selGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47466,8 +47466,8 @@ func (p *selGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47491,12 +47491,12 @@ func (p *selGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47523,8 +47523,8 @@ func (p *selGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47548,12 +47548,12 @@ func (p *selGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47616,7 +47616,7 @@ func (p *selGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47633,10 +47633,10 @@ func (p *selGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47656,7 +47656,7 @@ func (p *selGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47673,10 +47673,10 @@ func (p *selGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -47734,8 +47734,8 @@ func (p *selGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47752,12 +47752,12 @@ func (p *selGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47777,8 +47777,8 @@ func (p *selGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -47795,12 +47795,12 @@ func (p *selGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48112,7 +48112,7 @@ func (p *selGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48137,10 +48137,10 @@ func (p *selGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48168,7 +48168,7 @@ func (p *selGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48193,10 +48193,10 @@ func (p *selGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48262,8 +48262,8 @@ func (p *selGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48288,12 +48288,12 @@ func (p *selGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48321,8 +48321,8 @@ func (p *selGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48347,12 +48347,12 @@ func (p *selGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48416,7 +48416,7 @@ func (p *selGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48433,10 +48433,10 @@ func (p *selGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48456,7 +48456,7 @@ func (p *selGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48473,10 +48473,10 @@ func (p *selGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48534,8 +48534,8 @@ func (p *selGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48552,12 +48552,12 @@ func (p *selGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48577,8 +48577,8 @@ func (p *selGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48595,12 +48595,12 @@ func (p *selGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48656,7 +48656,7 @@ func (p *selGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48679,10 +48679,10 @@ func (p *selGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48708,7 +48708,7 @@ func (p *selGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48731,10 +48731,10 @@ func (p *selGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48798,8 +48798,8 @@ func (p *selGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48822,12 +48822,12 @@ func (p *selGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48853,8 +48853,8 @@ func (p *selGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48877,12 +48877,12 @@ func (p *selGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -48944,7 +48944,7 @@ func (p *selGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48967,10 +48967,10 @@ func (p *selGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -48996,7 +48996,7 @@ func (p *selGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49019,10 +49019,10 @@ func (p *selGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49086,8 +49086,8 @@ func (p *selGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49110,12 +49110,12 @@ func (p *selGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49141,8 +49141,8 @@ func (p *selGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49165,12 +49165,12 @@ func (p *selGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49232,7 +49232,7 @@ func (p *selGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49255,10 +49255,10 @@ func (p *selGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49284,7 +49284,7 @@ func (p *selGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49307,10 +49307,10 @@ func (p *selGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49374,8 +49374,8 @@ func (p *selGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49398,12 +49398,12 @@ func (p *selGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49429,8 +49429,8 @@ func (p *selGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49453,12 +49453,12 @@ func (p *selGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49520,7 +49520,7 @@ func (p *selGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49545,10 +49545,10 @@ func (p *selGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49576,7 +49576,7 @@ func (p *selGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49601,10 +49601,10 @@ func (p *selGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49670,8 +49670,8 @@ func (p *selGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49696,12 +49696,12 @@ func (p *selGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49729,8 +49729,8 @@ func (p *selGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49755,12 +49755,12 @@ func (p *selGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49824,7 +49824,7 @@ func (p *selGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49841,10 +49841,10 @@ func (p *selGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49864,7 +49864,7 @@ func (p *selGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49881,10 +49881,10 @@ func (p *selGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -49942,8 +49942,8 @@ func (p *selGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49960,12 +49960,12 @@ func (p *selGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -49985,8 +49985,8 @@ func (p *selGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50003,12 +50003,12 @@ func (p *selGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50064,7 +50064,7 @@ func (p *selGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50092,10 +50092,10 @@ func (p *selGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50126,7 +50126,7 @@ func (p *selGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50154,10 +50154,10 @@ func (p *selGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50226,8 +50226,8 @@ func (p *selGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50255,12 +50255,12 @@ func (p *selGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50291,8 +50291,8 @@ func (p *selGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50320,12 +50320,12 @@ func (p *selGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50392,7 +50392,7 @@ func (p *selGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50420,10 +50420,10 @@ func (p *selGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50454,7 +50454,7 @@ func (p *selGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50482,10 +50482,10 @@ func (p *selGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50554,8 +50554,8 @@ func (p *selGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50583,12 +50583,12 @@ func (p *selGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50619,8 +50619,8 @@ func (p *selGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50648,12 +50648,12 @@ func (p *selGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50720,7 +50720,7 @@ func (p *selGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50748,10 +50748,10 @@ func (p *selGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50782,7 +50782,7 @@ func (p *selGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50810,10 +50810,10 @@ func (p *selGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -50882,8 +50882,8 @@ func (p *selGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50911,12 +50911,12 @@ func (p *selGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50947,8 +50947,8 @@ func (p *selGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -50976,12 +50976,12 @@ func (p *selGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51048,7 +51048,7 @@ func (p *selGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51084,10 +51084,10 @@ func (p *selGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51126,7 +51126,7 @@ func (p *selGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51162,10 +51162,10 @@ func (p *selGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51242,8 +51242,8 @@ func (p *selGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51279,12 +51279,12 @@ func (p *selGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51323,8 +51323,8 @@ func (p *selGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51360,12 +51360,12 @@ func (p *selGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51440,7 +51440,7 @@ func (p *selGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51463,10 +51463,10 @@ func (p *selGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51492,7 +51492,7 @@ func (p *selGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51515,10 +51515,10 @@ func (p *selGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51582,8 +51582,8 @@ func (p *selGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51606,12 +51606,12 @@ func (p *selGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51637,8 +51637,8 @@ func (p *selGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51661,12 +51661,12 @@ func (p *selGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51728,7 +51728,7 @@ func (p *selGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51756,10 +51756,10 @@ func (p *selGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51790,7 +51790,7 @@ func (p *selGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51818,10 +51818,10 @@ func (p *selGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -51890,8 +51890,8 @@ func (p *selGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51919,12 +51919,12 @@ func (p *selGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51955,8 +51955,8 @@ func (p *selGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -51984,12 +51984,12 @@ func (p *selGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52056,7 +52056,7 @@ func (p *selGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52084,10 +52084,10 @@ func (p *selGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52118,7 +52118,7 @@ func (p *selGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52146,10 +52146,10 @@ func (p *selGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52218,8 +52218,8 @@ func (p *selGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52247,12 +52247,12 @@ func (p *selGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52283,8 +52283,8 @@ func (p *selGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52312,12 +52312,12 @@ func (p *selGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52384,7 +52384,7 @@ func (p *selGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52412,10 +52412,10 @@ func (p *selGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52446,7 +52446,7 @@ func (p *selGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52474,10 +52474,10 @@ func (p *selGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52546,8 +52546,8 @@ func (p *selGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52575,12 +52575,12 @@ func (p *selGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52611,8 +52611,8 @@ func (p *selGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52640,12 +52640,12 @@ func (p *selGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52712,7 +52712,7 @@ func (p *selGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52748,10 +52748,10 @@ func (p *selGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52790,7 +52790,7 @@ func (p *selGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52826,10 +52826,10 @@ func (p *selGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -52906,8 +52906,8 @@ func (p *selGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52943,12 +52943,12 @@ func (p *selGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -52987,8 +52987,8 @@ func (p *selGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53024,12 +53024,12 @@ func (p *selGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53104,7 +53104,7 @@ func (p *selGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53127,10 +53127,10 @@ func (p *selGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53156,7 +53156,7 @@ func (p *selGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53179,10 +53179,10 @@ func (p *selGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53246,8 +53246,8 @@ func (p *selGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53270,12 +53270,12 @@ func (p *selGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53301,8 +53301,8 @@ func (p *selGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53325,12 +53325,12 @@ func (p *selGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53392,7 +53392,7 @@ func (p *selGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53420,10 +53420,10 @@ func (p *selGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53454,7 +53454,7 @@ func (p *selGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53482,10 +53482,10 @@ func (p *selGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53554,8 +53554,8 @@ func (p *selGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53583,12 +53583,12 @@ func (p *selGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53619,8 +53619,8 @@ func (p *selGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53648,12 +53648,12 @@ func (p *selGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53720,7 +53720,7 @@ func (p *selGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53748,10 +53748,10 @@ func (p *selGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53782,7 +53782,7 @@ func (p *selGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53810,10 +53810,10 @@ func (p *selGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -53882,8 +53882,8 @@ func (p *selGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53911,12 +53911,12 @@ func (p *selGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53947,8 +53947,8 @@ func (p *selGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -53976,12 +53976,12 @@ func (p *selGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54048,7 +54048,7 @@ func (p *selGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54076,10 +54076,10 @@ func (p *selGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54110,7 +54110,7 @@ func (p *selGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54138,10 +54138,10 @@ func (p *selGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54210,8 +54210,8 @@ func (p *selGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54239,12 +54239,12 @@ func (p *selGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54275,8 +54275,8 @@ func (p *selGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54304,12 +54304,12 @@ func (p *selGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54376,7 +54376,7 @@ func (p *selGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54412,10 +54412,10 @@ func (p *selGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54454,7 +54454,7 @@ func (p *selGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54490,10 +54490,10 @@ func (p *selGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54570,8 +54570,8 @@ func (p *selGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54607,12 +54607,12 @@ func (p *selGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54651,8 +54651,8 @@ func (p *selGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54688,12 +54688,12 @@ func (p *selGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54768,7 +54768,7 @@ func (p *selGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54791,10 +54791,10 @@ func (p *selGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54820,7 +54820,7 @@ func (p *selGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54843,10 +54843,10 @@ func (p *selGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -54910,8 +54910,8 @@ func (p *selGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54934,12 +54934,12 @@ func (p *selGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54965,8 +54965,8 @@ func (p *selGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -54989,12 +54989,12 @@ func (p *selGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -55056,7 +55056,7 @@ func (p *selGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -55092,10 +55092,10 @@ func (p *selGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -55134,7 +55134,7 @@ func (p *selGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -55170,10 +55170,10 @@ func (p *selGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -55250,8 +55250,8 @@ func (p *selGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -55287,12 +55287,12 @@ func (p *selGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -55331,8 +55331,8 @@ func (p *selGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -55368,12 +55368,12 @@ func (p *selGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -55448,7 +55448,7 @@ func (p *selGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -55484,10 +55484,10 @@ func (p *selGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -55526,7 +55526,7 @@ func (p *selGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -55562,10 +55562,10 @@ func (p *selGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -55642,8 +55642,8 @@ func (p *selGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -55679,12 +55679,12 @@ func (p *selGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -55723,8 +55723,8 @@ func (p *selGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -55760,12 +55760,12 @@ func (p *selGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -55840,7 +55840,7 @@ func (p *selGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -55876,10 +55876,10 @@ func (p *selGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -55918,7 +55918,7 @@ func (p *selGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -55954,10 +55954,10 @@ func (p *selGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -56034,8 +56034,8 @@ func (p *selGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56071,12 +56071,12 @@ func (p *selGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56115,8 +56115,8 @@ func (p *selGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56152,12 +56152,12 @@ func (p *selGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56232,7 +56232,7 @@ func (p *selGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -56268,10 +56268,10 @@ func (p *selGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -56310,7 +56310,7 @@ func (p *selGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -56346,10 +56346,10 @@ func (p *selGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -56426,8 +56426,8 @@ func (p *selGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56463,12 +56463,12 @@ func (p *selGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56507,8 +56507,8 @@ func (p *selGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56544,12 +56544,12 @@ func (p *selGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56624,7 +56624,7 @@ func (p *selGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -56649,10 +56649,10 @@ func (p *selGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -56680,7 +56680,7 @@ func (p *selGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -56705,10 +56705,10 @@ func (p *selGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -56774,8 +56774,8 @@ func (p *selGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56800,12 +56800,12 @@ func (p *selGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56833,8 +56833,8 @@ func (p *selGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56859,12 +56859,12 @@ func (p *selGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -56928,7 +56928,7 @@ func (p *selGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -56952,10 +56952,10 @@ func (p *selGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -56982,7 +56982,7 @@ func (p *selGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -57006,10 +57006,10 @@ func (p *selGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -57074,8 +57074,8 @@ func (p *selGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -57099,12 +57099,12 @@ func (p *selGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -57131,8 +57131,8 @@ func (p *selGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -57156,12 +57156,12 @@ func (p *selGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -57224,7 +57224,7 @@ func (p *selGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -57241,10 +57241,10 @@ func (p *selGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -57264,7 +57264,7 @@ func (p *selGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -57281,10 +57281,10 @@ func (p *selGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col.Get(n - 1) //gcassert:inline
+				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg := col.Get(i) //gcassert:inline
+					arg := col.Get(i)
 
 					{
 						var cmpResult int
@@ -57342,8 +57342,8 @@ func (p *selGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -57360,12 +57360,12 @@ func (p *selGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -57385,8 +57385,8 @@ func (p *selGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int
@@ -57403,12 +57403,12 @@ func (p *selGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				_ = col1.Get(n - 1) //gcassert:inline
-				_ = col2.Get(n - 1) //gcassert:inline
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
 					var cmp bool
-					arg1 := col1.Get(i) //gcassert:inline
-					arg2 := col2.Get(i) //gcassert:inline
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
 
 					{
 						var cmpResult int

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -64,7 +63,7 @@ func _SEL_CONST_LOOP(_HAS_NULLS bool) { // */}}
 		sel = sel[:n]
 		for _, i := range sel {
 			var cmp bool
-			arg := execgen.UNSAFEGET(col, i)
+			arg := col.Get(i)
 			_ASSIGN_CMP(cmp, arg, p.constArg, _, col, _)
 			// {{if _HAS_NULLS}}
 			isNull = nulls.NullAt(i)
@@ -79,10 +78,10 @@ func _SEL_CONST_LOOP(_HAS_NULLS bool) { // */}}
 	} else {
 		batch.SetSelection(true)
 		sel := batch.Selection()
-		_ = execgen.UNSAFEGET(col, n-1)
+		_ = col.Get(n - 1)
 		for i := 0; i < n; i++ {
 			var cmp bool
-			arg := execgen.UNSAFEGET(col, i)
+			arg := col.Get(i)
 			_ASSIGN_CMP(cmp, arg, p.constArg, _, col, _)
 			// {{if _HAS_NULLS}}
 			isNull = nulls.NullAt(i)
@@ -109,8 +108,8 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 		sel = sel[:n]
 		for _, i := range sel {
 			var cmp bool
-			arg1 := _L_UNSAFEGET(col1, i)
-			arg2 := _R_UNSAFEGET(col2, i)
+			arg1 := col1.Get(i)
+			arg2 := col2.Get(i)
 			_ASSIGN_CMP(cmp, arg1, arg2, _, col1, col2)
 			// {{if _HAS_NULLS}}
 			isNull = nulls.NullAt(i)
@@ -125,12 +124,12 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 	} else {
 		batch.SetSelection(true)
 		sel := batch.Selection()
-		_ = _L_UNSAFEGET(col1, n-1)
-		_ = _R_UNSAFEGET(col2, n-1)
+		_ = col1.Get(n - 1)
+		_ = col2.Get(n - 1)
 		for i := 0; i < n; i++ {
 			var cmp bool
-			arg1 := _L_UNSAFEGET(col1, i)
-			arg2 := _R_UNSAFEGET(col2, i)
+			arg1 := col1.Get(i)
+			arg2 := col2.Get(i)
 			_ASSIGN_CMP(cmp, arg1, arg2, _, col1, col2)
 			// {{if _HAS_NULLS}}
 			isNull = nulls.NullAt(i)

--- a/pkg/sql/colexec/sort.eg.go
+++ b/pkg/sql/colexec/sort.eg.go
@@ -425,8 +425,8 @@ func (s *sortBoolAscWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -503,8 +503,8 @@ func (s *sortBytesAscWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -573,8 +573,8 @@ func (s *sortDecimalAscWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -643,8 +643,8 @@ func (s *sortInt16AscWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -724,8 +724,8 @@ func (s *sortInt32AscWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -805,8 +805,8 @@ func (s *sortInt64AscWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -886,8 +886,8 @@ func (s *sortFloat64AscWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -975,8 +975,8 @@ func (s *sortTimestampAscWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1052,8 +1052,8 @@ func (s *sortIntervalAscWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1194,8 +1194,8 @@ func (s *sortBoolDescWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1272,8 +1272,8 @@ func (s *sortBytesDescWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1342,8 +1342,8 @@ func (s *sortDecimalDescWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1412,8 +1412,8 @@ func (s *sortInt16DescWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1493,8 +1493,8 @@ func (s *sortInt32DescWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1574,8 +1574,8 @@ func (s *sortInt64DescWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1655,8 +1655,8 @@ func (s *sortFloat64DescWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1744,8 +1744,8 @@ func (s *sortTimestampDescWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1821,8 +1821,8 @@ func (s *sortIntervalDescWithNullsOp) Less(i, j int) bool {
 	}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1953,8 +1953,8 @@ func (s *sortBoolAscOp) sortPartitions(ctx context.Context, partitions []int) {
 func (s *sortBoolAscOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2021,8 +2021,8 @@ func (s *sortBytesAscOp) sortPartitions(ctx context.Context, partitions []int) {
 func (s *sortBytesAscOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2081,8 +2081,8 @@ func (s *sortDecimalAscOp) sortPartitions(ctx context.Context, partitions []int)
 func (s *sortDecimalAscOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2141,8 +2141,8 @@ func (s *sortInt16AscOp) sortPartitions(ctx context.Context, partitions []int) {
 func (s *sortInt16AscOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2212,8 +2212,8 @@ func (s *sortInt32AscOp) sortPartitions(ctx context.Context, partitions []int) {
 func (s *sortInt32AscOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2283,8 +2283,8 @@ func (s *sortInt64AscOp) sortPartitions(ctx context.Context, partitions []int) {
 func (s *sortInt64AscOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2354,8 +2354,8 @@ func (s *sortFloat64AscOp) sortPartitions(ctx context.Context, partitions []int)
 func (s *sortFloat64AscOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2433,8 +2433,8 @@ func (s *sortTimestampAscOp) sortPartitions(ctx context.Context, partitions []in
 func (s *sortTimestampAscOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2500,8 +2500,8 @@ func (s *sortIntervalAscOp) sortPartitions(ctx context.Context, partitions []int
 func (s *sortIntervalAscOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2622,8 +2622,8 @@ func (s *sortBoolDescOp) sortPartitions(ctx context.Context, partitions []int) {
 func (s *sortBoolDescOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2690,8 +2690,8 @@ func (s *sortBytesDescOp) sortPartitions(ctx context.Context, partitions []int) 
 func (s *sortBytesDescOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2750,8 +2750,8 @@ func (s *sortDecimalDescOp) sortPartitions(ctx context.Context, partitions []int
 func (s *sortDecimalDescOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2810,8 +2810,8 @@ func (s *sortInt16DescOp) sortPartitions(ctx context.Context, partitions []int) 
 func (s *sortInt16DescOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2881,8 +2881,8 @@ func (s *sortInt32DescOp) sortPartitions(ctx context.Context, partitions []int) 
 func (s *sortInt32DescOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2952,8 +2952,8 @@ func (s *sortInt64DescOp) sortPartitions(ctx context.Context, partitions []int) 
 func (s *sortInt64DescOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3023,8 +3023,8 @@ func (s *sortFloat64DescOp) sortPartitions(ctx context.Context, partitions []int
 func (s *sortFloat64DescOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3102,8 +3102,8 @@ func (s *sortTimestampDescOp) sortPartitions(ctx context.Context, partitions []i
 func (s *sortTimestampDescOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3169,8 +3169,8 @@ func (s *sortIntervalDescOp) sortPartitions(ctx context.Context, partitions []in
 func (s *sortIntervalDescOp) Less(i, j int) bool {
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(s.order[i]) //gcassert:inline
-	arg2 := s.sortCol.Get(s.order[j]) //gcassert:inline
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -183,8 +182,8 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) Less(i, j int) bool {
 	// {{end}}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := execgen.UNSAFEGET(s.sortCol, s.order[i])
-	arg2 := execgen.UNSAFEGET(s.sortCol, s.order[j])
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 	_ASSIGN_LT(lt, arg1, arg2, _, s.sortCol, s.sortCol)
 	return lt
 }

--- a/pkg/sql/colexec/values_differ.eg.go
+++ b/pkg/sql/colexec/values_differ.eg.go
@@ -42,8 +42,8 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			} else if aNull || bNull {
 				return true
 			}
-			arg1 := aCol.Get(aValueIdx) //gcassert:inline
-			arg2 := bCol.Get(bValueIdx) //gcassert:inline
+			arg1 := aCol.Get(aValueIdx)
+			arg2 := bCol.Get(bValueIdx)
 			var unique bool
 
 			{
@@ -77,8 +77,8 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			} else if aNull || bNull {
 				return true
 			}
-			arg1 := aCol.Get(aValueIdx) //gcassert:inline
-			arg2 := bCol.Get(bValueIdx) //gcassert:inline
+			arg1 := aCol.Get(aValueIdx)
+			arg2 := bCol.Get(bValueIdx)
 			var unique bool
 
 			{
@@ -104,8 +104,8 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			} else if aNull || bNull {
 				return true
 			}
-			arg1 := aCol.Get(aValueIdx) //gcassert:inline
-			arg2 := bCol.Get(bValueIdx) //gcassert:inline
+			arg1 := aCol.Get(aValueIdx)
+			arg2 := bCol.Get(bValueIdx)
 			var unique bool
 
 			{
@@ -130,8 +130,8 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			} else if aNull || bNull {
 				return true
 			}
-			arg1 := aCol.Get(aValueIdx) //gcassert:inline
-			arg2 := bCol.Get(bValueIdx) //gcassert:inline
+			arg1 := aCol.Get(aValueIdx)
+			arg2 := bCol.Get(bValueIdx)
 			var unique bool
 
 			{
@@ -164,8 +164,8 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			} else if aNull || bNull {
 				return true
 			}
-			arg1 := aCol.Get(aValueIdx) //gcassert:inline
-			arg2 := bCol.Get(bValueIdx) //gcassert:inline
+			arg1 := aCol.Get(aValueIdx)
+			arg2 := bCol.Get(bValueIdx)
 			var unique bool
 
 			{
@@ -199,8 +199,8 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			} else if aNull || bNull {
 				return true
 			}
-			arg1 := aCol.Get(aValueIdx) //gcassert:inline
-			arg2 := bCol.Get(bValueIdx) //gcassert:inline
+			arg1 := aCol.Get(aValueIdx)
+			arg2 := bCol.Get(bValueIdx)
 			var unique bool
 
 			{
@@ -237,8 +237,8 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			} else if aNull || bNull {
 				return true
 			}
-			arg1 := aCol.Get(aValueIdx) //gcassert:inline
-			arg2 := bCol.Get(bValueIdx) //gcassert:inline
+			arg1 := aCol.Get(aValueIdx)
+			arg2 := bCol.Get(bValueIdx)
 			var unique bool
 
 			{
@@ -283,8 +283,8 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			} else if aNull || bNull {
 				return true
 			}
-			arg1 := aCol.Get(aValueIdx) //gcassert:inline
-			arg2 := bCol.Get(bValueIdx) //gcassert:inline
+			arg1 := aCol.Get(aValueIdx)
+			arg2 := bCol.Get(bValueIdx)
 			var unique bool
 
 			{
@@ -317,8 +317,8 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			} else if aNull || bNull {
 				return true
 			}
-			arg1 := aCol.Get(aValueIdx) //gcassert:inline
-			arg2 := bCol.Get(bValueIdx) //gcassert:inline
+			arg1 := aCol.Get(aValueIdx)
+			arg2 := bCol.Get(bValueIdx)
 			var unique bool
 
 			{

--- a/pkg/sql/colexec/values_differ_tmpl.go
+++ b/pkg/sql/colexec/values_differ_tmpl.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -70,8 +69,8 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			} else if aNull || bNull {
 				return true
 			}
-			arg1 := execgen.UNSAFEGET(aCol, aValueIdx)
-			arg2 := execgen.UNSAFEGET(bCol, bValueIdx)
+			arg1 := aCol.Get(aValueIdx)
+			arg2 := bCol.Get(bValueIdx)
 			var unique bool
 			_ASSIGN_NE(unique, arg1, arg2, _, aCol, bCol)
 			return unique

--- a/pkg/sql/colexec/vec_comparators.eg.go
+++ b/pkg/sql/colexec/vec_comparators.eg.go
@@ -56,8 +56,8 @@ func (c *BoolVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int) 
 	} else if n2 {
 		return 1
 	}
-	left := c.vecs[vecIdx1].Get(valIdx1)  //gcassert:inline
-	right := c.vecs[vecIdx2].Get(valIdx2) //gcassert:inline
+	left := c.vecs[vecIdx1].Get(valIdx1)
+	right := c.vecs[vecIdx2].Get(valIdx2)
 	var cmp int
 
 	if !left && right {
@@ -81,7 +81,7 @@ func (c *BoolVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		v := c.vecs[srcVecIdx].Get(srcIdx) //gcassert:inline
+		v := c.vecs[srcVecIdx].Get(srcIdx)
 		c.vecs[dstVecIdx][dstIdx] = v
 	}
 }
@@ -101,8 +101,8 @@ func (c *BytesVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	} else if n2 {
 		return 1
 	}
-	left := c.vecs[vecIdx1].Get(valIdx1)  //gcassert:inline
-	right := c.vecs[vecIdx2].Get(valIdx2) //gcassert:inline
+	left := c.vecs[vecIdx1].Get(valIdx1)
+	right := c.vecs[vecIdx2].Get(valIdx2)
 	var cmp int
 	cmp = bytes.Compare(left, right)
 	return cmp
@@ -143,8 +143,8 @@ func (c *DecimalVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 in
 	} else if n2 {
 		return 1
 	}
-	left := c.vecs[vecIdx1].Get(valIdx1)  //gcassert:inline
-	right := c.vecs[vecIdx2].Get(valIdx2) //gcassert:inline
+	left := c.vecs[vecIdx1].Get(valIdx1)
+	right := c.vecs[vecIdx2].Get(valIdx2)
 	var cmp int
 	cmp = tree.CompareDecimals(&left, &right)
 	return cmp
@@ -160,7 +160,7 @@ func (c *DecimalVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int)
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		v := c.vecs[srcVecIdx].Get(srcIdx) //gcassert:inline
+		v := c.vecs[srcVecIdx].Get(srcIdx)
 		c.vecs[dstVecIdx][dstIdx].Set(&v)
 	}
 }
@@ -180,8 +180,8 @@ func (c *Int16VecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	} else if n2 {
 		return 1
 	}
-	left := c.vecs[vecIdx1].Get(valIdx1)  //gcassert:inline
-	right := c.vecs[vecIdx2].Get(valIdx2) //gcassert:inline
+	left := c.vecs[vecIdx1].Get(valIdx1)
+	right := c.vecs[vecIdx2].Get(valIdx2)
 	var cmp int
 
 	{
@@ -208,7 +208,7 @@ func (c *Int16VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		v := c.vecs[srcVecIdx].Get(srcIdx) //gcassert:inline
+		v := c.vecs[srcVecIdx].Get(srcIdx)
 		c.vecs[dstVecIdx][dstIdx] = v
 	}
 }
@@ -228,8 +228,8 @@ func (c *Int32VecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	} else if n2 {
 		return 1
 	}
-	left := c.vecs[vecIdx1].Get(valIdx1)  //gcassert:inline
-	right := c.vecs[vecIdx2].Get(valIdx2) //gcassert:inline
+	left := c.vecs[vecIdx1].Get(valIdx1)
+	right := c.vecs[vecIdx2].Get(valIdx2)
 	var cmp int
 
 	{
@@ -256,7 +256,7 @@ func (c *Int32VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		v := c.vecs[srcVecIdx].Get(srcIdx) //gcassert:inline
+		v := c.vecs[srcVecIdx].Get(srcIdx)
 		c.vecs[dstVecIdx][dstIdx] = v
 	}
 }
@@ -276,8 +276,8 @@ func (c *Int64VecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	} else if n2 {
 		return 1
 	}
-	left := c.vecs[vecIdx1].Get(valIdx1)  //gcassert:inline
-	right := c.vecs[vecIdx2].Get(valIdx2) //gcassert:inline
+	left := c.vecs[vecIdx1].Get(valIdx1)
+	right := c.vecs[vecIdx2].Get(valIdx2)
 	var cmp int
 
 	{
@@ -304,7 +304,7 @@ func (c *Int64VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		v := c.vecs[srcVecIdx].Get(srcIdx) //gcassert:inline
+		v := c.vecs[srcVecIdx].Get(srcIdx)
 		c.vecs[dstVecIdx][dstIdx] = v
 	}
 }
@@ -324,8 +324,8 @@ func (c *Float64VecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 in
 	} else if n2 {
 		return 1
 	}
-	left := c.vecs[vecIdx1].Get(valIdx1)  //gcassert:inline
-	right := c.vecs[vecIdx2].Get(valIdx2) //gcassert:inline
+	left := c.vecs[vecIdx1].Get(valIdx1)
+	right := c.vecs[vecIdx2].Get(valIdx2)
 	var cmp int
 
 	{
@@ -360,7 +360,7 @@ func (c *Float64VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int)
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		v := c.vecs[srcVecIdx].Get(srcIdx) //gcassert:inline
+		v := c.vecs[srcVecIdx].Get(srcIdx)
 		c.vecs[dstVecIdx][dstIdx] = v
 	}
 }
@@ -380,8 +380,8 @@ func (c *TimestampVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 
 	} else if n2 {
 		return 1
 	}
-	left := c.vecs[vecIdx1].Get(valIdx1)  //gcassert:inline
-	right := c.vecs[vecIdx2].Get(valIdx2) //gcassert:inline
+	left := c.vecs[vecIdx1].Get(valIdx1)
+	right := c.vecs[vecIdx2].Get(valIdx2)
 	var cmp int
 
 	if left.Before(right) {
@@ -404,7 +404,7 @@ func (c *TimestampVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx in
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		v := c.vecs[srcVecIdx].Get(srcIdx) //gcassert:inline
+		v := c.vecs[srcVecIdx].Get(srcIdx)
 		c.vecs[dstVecIdx][dstIdx] = v
 	}
 }
@@ -424,8 +424,8 @@ func (c *IntervalVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 i
 	} else if n2 {
 		return 1
 	}
-	left := c.vecs[vecIdx1].Get(valIdx1)  //gcassert:inline
-	right := c.vecs[vecIdx2].Get(valIdx2) //gcassert:inline
+	left := c.vecs[vecIdx1].Get(valIdx1)
+	right := c.vecs[vecIdx2].Get(valIdx2)
 	var cmp int
 	cmp = left.Compare(right)
 	return cmp
@@ -441,7 +441,7 @@ func (c *IntervalVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		v := c.vecs[srcVecIdx].Get(srcIdx) //gcassert:inline
+		v := c.vecs[srcVecIdx].Get(srcIdx)
 		c.vecs[dstVecIdx][dstIdx] = v
 	}
 }

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -86,8 +86,8 @@ func (c *_TYPEVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	} else if n2 {
 		return 1
 	}
-	left := execgen.UNSAFEGET(c.vecs[vecIdx1], valIdx1)
-	right := execgen.UNSAFEGET(c.vecs[vecIdx2], valIdx2)
+	left := c.vecs[vecIdx1].Get(valIdx1)
+	right := c.vecs[vecIdx2].Get(valIdx2)
 	var cmp int
 	_COMPARE(cmp, left, right, c.vecs[vecIdx1], c.vecs[vecIdx2])
 	return cmp
@@ -112,7 +112,7 @@ func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		// source bytes slice is. Refer to the CopySlice comment for an example.
 		execgen.COPYSLICE(c.vecs[dstVecIdx], c.vecs[srcVecIdx], dstIdx, srcIdx, srcIdx+1)
 		// {{else}}
-		v := execgen.UNSAFEGET(c.vecs[srcVecIdx], srcIdx)
+		v := c.vecs[srcVecIdx].Get(srcIdx)
 		execgen.SET(c.vecs[dstVecIdx], dstIdx, v)
 		// {{end}}
 	}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1626,7 +1626,7 @@ func TestLint(t *testing.T) {
 	t.Run("TestGCAssert", func(t *testing.T) {
 		t.Parallel()
 		var buf strings.Builder
-		if err := gcassert.GCAssert("../../sql/colexec", &buf); err != nil {
+		if err := gcassert.GCAssert(&buf, "../../col/coldata", "../../sql/colexec"); err != nil {
 			t.Fatal(err)
 		}
 		output := buf.String()


### PR DESCRIPTION
gcassert now supports marking methods as inlined, so we can guarantee
that methods are inlined without having to insert a comment on each
callsite.