### PR TITLE
opt: fix typing of Coalesce

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -237,3 +237,9 @@ SELECT 1::pg_catalog.special_int
 # don't have types.
 query error pq: type "crdb_internal.mytype" does not exist
 SELECT 1::crdb_internal.mytype
+
+# Regression test for #50978.
+query T
+SELECT CASE WHEN true THEN 1234:::OID ELSE COALESCE(NULL, NULL) END
+----
+1234

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -136,7 +136,7 @@ project
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── COALESCE(i:2, NULL, NULL) [as=coalesce:7, outer=(2)]
+      └── COALESCE(i:2, CAST(NULL AS INT8), CAST(NULL AS INT8)) [as=coalesce:7, outer=(2)]
 
 norm expect=SimplifyCoalesce
 SELECT COALESCE((1, 2, 3), (2, 3, 4)) FROM a

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -253,8 +253,13 @@ func (b *Builder) buildScalar(
 
 	case *tree.CoalesceExpr:
 		args := make(memo.ScalarListExpr, len(t.Exprs))
+		typ := t.ResolvedType()
 		for i := range args {
-			args[i] = b.buildScalar(t.TypedExprAt(i), inScope, nil, nil, colRefs)
+			// The type of the CoalesceExpr might be different than the inputs (e.g.
+			// when they are NULL). Force all inputs to be the same type, so that we
+			// build coalesce operator with the correct type.
+			expr := tree.ReType(t.TypedExprAt(i), typ)
+			args[i] = b.buildScalar(expr, inScope, nil, nil, colRefs)
 		}
 		out = b.factory.ConstructCoalesce(args)
 

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -1243,3 +1243,19 @@ if-err [type=decimal]
  │    └── variable: "@1":1 [type=decimal]
  └── err-code
       └── const: '10000' [type=string]
+
+# Verify that we build a Coalesce of the correct type when the inputs
+# are NULL (#50978).
+build-scalar
+CASE WHEN true THEN 1234:::OID ELSE COALESCE(NULL, NULL) END
+----
+case [type=oid]
+ ├── true [type=bool]
+ ├── when [type=oid]
+ │    ├── true [type=bool]
+ │    └── const: 1234 [type=oid]
+ └── coalesce [type=oid]
+      ├── cast: OID [type=oid]
+      │    └── null [type=unknown]
+      └── cast: OID [type=oid]
+           └── null [type=unknown]

--- a/pkg/sql/physicalplan/expression.go
+++ b/pkg/sql/physicalplan/expression.go
@@ -120,9 +120,10 @@ func (e *evalAndReplaceSubqueryVisitor) VisitPre(expr tree.Expr) (bool, tree.Exp
 			e.err = err
 			return false, expr
 		}
-		var newExpr tree.Expr = val
-		if _, isTuple := val.(*tree.DTuple); !isTuple && expr.ResolvedType().Family() != types.UnknownFamily {
-			newExpr = tree.NewTypedCastExpr(val, expr.ResolvedType())
+		newExpr := tree.Expr(val)
+		typ := expr.ResolvedType()
+		if _, isTuple := val.(*tree.DTuple); !isTuple && typ.Family() != types.UnknownFamily && typ.Family() != types.TupleFamily {
+			newExpr = tree.NewTypedCastExpr(val, typ)
 		}
 		return false, newExpr
 	default:


### PR DESCRIPTION
The Coalesce TypedExpr can have a resolved type that is not identical to the
inputs. This change retypes the inputs to the proper type so that the optimizer
operator has the correct type.

Fixes #50978.

Release note (bug fix): fixed an internal error in some cases involving COALESCE
with NULL inputs.