### PR TITLE
opt: improve re-typing to equivalent but non-identical types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -179,11 +179,15 @@ EXPLAIN (VEC) SELECT _int2 * _int2 FROM ints WHERE _int4 + _int4 = _int8 + 2
 ----
 │
 └ Node 1
-  └ *colexec.projMultInt16Int16Op
-    └ *colexec.selEQInt64Int64Op
-      └ *colexec.projPlusInt64Int64ConstOp
-        └ *colexec.projPlusInt32Int32Op
-          └ *colfetcher.colBatchScan
+  └ *colexec.projMultInt64Int64Op
+    └ *colexec.castOp
+      └ *colexec.castOp
+        └ *colexec.selEQInt64Int64Op
+          └ *colexec.projPlusInt64Int64ConstOp
+            └ *colexec.projPlusInt64Int64Op
+              └ *colexec.castOp
+                └ *colexec.castOp
+                  └ *colfetcher.colBatchScan
 
 query I
 SELECT _int2 * _int2 FROM ints WHERE _int4 + _int4 = _int8 + 2

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -106,24 +106,28 @@ EXPLAIN (VEC) SELECT _inet - _int2 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexec.projMinusDatumInt16Op
-    └ *colfetcher.colBatchScan
+  └ *colexec.projMinusDatumInt64Op
+    └ *colexec.castOp
+      └ *colfetcher.colBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _int2^_int4 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexec.projPowInt16Int32Op
-    └ *colfetcher.colBatchScan
+  └ *colexec.projPowInt64Int64Op
+    └ *colexec.castOp
+      └ *colexec.castOp
+        └ *colfetcher.colBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _int2^_int FROM many_types
 ----
 │
 └ Node 1
-  └ *colexec.projPowInt16Int64Op
-    └ *colfetcher.colBatchScan
+  └ *colexec.projPowInt64Int64Op
+    └ *colexec.castOp
+      └ *colfetcher.colBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _float^_float FROM many_types
@@ -138,8 +142,9 @@ EXPLAIN (VEC) SELECT _decimal^_int4 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexec.projPowDecimalInt32Op
-    └ *colfetcher.colBatchScan
+  └ *colexec.projPowDecimalInt64Op
+    └ *colexec.castOp
+      └ *colfetcher.colBatchScan
 
 query R rowsort
 SELECT _float^_float FROM many_types
@@ -182,8 +187,9 @@ EXPLAIN (VEC) SELECT _int4 + _inet FROM many_types
 ----
 │
 └ Node 1
-  └ *colexec.projPlusInt32DatumOp
-    └ *colfetcher.colBatchScan
+  └ *colexec.projPlusDatumInt64Op
+    └ *colexec.castOp
+      └ *colfetcher.colBatchScan
 
 query T rowsort
 SELECT _int4 + _inet FROM many_types
@@ -377,16 +383,18 @@ EXPLAIN (VEC) SELECT _varbit << _int2 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexec.projLShiftDatumInt16Op
-    └ *colfetcher.colBatchScan
+  └ *colexec.projLShiftDatumInt64Op
+    └ *colexec.castOp
+      └ *colfetcher.colBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _varbit << _int4 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexec.projLShiftDatumInt32Op
-    └ *colfetcher.colBatchScan
+  └ *colexec.projLShiftDatumInt64Op
+    └ *colexec.castOp
+      └ *colfetcher.colBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _varbit << _int FROM many_types
@@ -410,16 +418,18 @@ EXPLAIN (VEC) SELECT _varbit >> _int2 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexec.projRShiftDatumInt16Op
-    └ *colfetcher.colBatchScan
+  └ *colexec.projRShiftDatumInt64Op
+    └ *colexec.castOp
+      └ *colfetcher.colBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _varbit >> _int4 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexec.projRShiftDatumInt32Op
-    └ *colfetcher.colBatchScan
+  └ *colexec.projRShiftDatumInt64Op
+    └ *colexec.castOp
+      └ *colfetcher.colBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _varbit >> _int FROM many_types
@@ -458,8 +468,9 @@ EXPLAIN (VEC) SELECT _json -> _int2 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexec.projJSONFetchValDatumInt16Op
-    └ *colfetcher.colBatchScan
+  └ *colexec.projJSONFetchValDatumInt64Op
+    └ *colexec.castOp
+      └ *colfetcher.colBatchScan
 
 query I rowsort
 SELECT _int2^_int FROM many_types WHERE _int2 < 10 AND _int < 10
@@ -492,8 +503,9 @@ EXPLAIN (VEC) SELECT _json -> _int4 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexec.projJSONFetchValDatumInt32Op
-    └ *colfetcher.colBatchScan
+  └ *colexec.projJSONFetchValDatumInt64Op
+    └ *colexec.castOp
+      └ *colfetcher.colBatchScan
 
 query T
 SELECT _json -> _int4 FROM many_types

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -424,29 +424,29 @@ query TTTTT
 EXPLAIN (VERBOSE)
 INSERT INTO insert_t (SELECT length(k), 2 FROM kv ORDER BY k || v LIMIT 10) RETURNING x+v
 ----
-·                                        distribution  local                  ·                              ·
-·                                        vectorized    false                  ·                              ·
-render                                   ·             ·                      ("?column?")                   ·
- │                                       render 0      x + v                  ·                              ·
- └── run                                 ·             ·                      (x, v, rowid[hidden])          ·
-      └── insert                         ·             ·                      (x, v, rowid[hidden])          ·
-           │                             into          insert_t(x, v, rowid)  ·                              ·
-           │                             strategy      inserter               ·                              ·
-           └── render                    ·             ·                      (length, "?column?", column9)  ·
-                │                        render 0      length                 ·                              ·
-                │                        render 1      "?column?"             ·                              ·
-                │                        render 2      unique_rowid()         ·                              ·
-                └── limit                ·             ·                      (length, "?column?", column8)  +column8
-                     │                   count         10                     ·                              ·
-                     └── sort            ·             ·                      (length, "?column?", column8)  +column8
-                          │              order         +column8               ·                              ·
-                          └── render     ·             ·                      (length, "?column?", column8)  ·
-                               │         render 0      length(k)              ·                              ·
-                               │         render 1      2                      ·                              ·
-                               │         render 2      k || v                 ·                              ·
-                               └── scan  ·             ·                      (k, v)                         ·
-·                                        table         kv@primary             ·                              ·
-·                                        spans         FULL SCAN              ·                              ·
+·                                        distribution  local                   ·                              ·
+·                                        vectorized    false                   ·                              ·
+render                                   ·             ·                       ("?column?")                   ·
+ │                                       render 0      x + v                   ·                              ·
+ └── run                                 ·             ·                       (x, v, rowid[hidden])          ·
+      └── insert                         ·             ·                       (x, v, rowid[hidden])          ·
+           │                             into          insert_t(x, v, rowid)   ·                              ·
+           │                             strategy      inserter                ·                              ·
+           └── render                    ·             ·                       (length, "?column?", column9)  ·
+                │                        render 0      length                  ·                              ·
+                │                        render 1      "?column?"              ·                              ·
+                │                        render 2      unique_rowid()          ·                              ·
+                └── limit                ·             ·                       (length, "?column?", column8)  +column8
+                     │                   count         10                      ·                              ·
+                     └── sort            ·             ·                       (length, "?column?", column8)  +column8
+                          │              order         +column8                ·                              ·
+                          └── render     ·             ·                       (length, "?column?", column8)  ·
+                               │         render 0      length(k)               ·                              ·
+                               │         render 1      2                       ·                              ·
+                               │         render 2      k::STRING || v::STRING  ·                              ·
+                               └── scan  ·             ·                       (k, v)                         ·
+·                                        table         kv@primary              ·                              ·
+·                                        spans         FULL SCAN               ·                              ·
 
 # ------------------------------------------------------------------------------
 # Insert rows into table during schema changes.

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -842,8 +842,9 @@ concat [type=int[]]
  ├── array: [type=int[]]
  │    ├── const: 1 [type=int]
  │    └── const: 2 [type=int]
- └── cast: INT2 [type=int2]
-      └── null [type=unknown]
+ └── cast: INT8 [type=int]
+      └── cast: INT2 [type=int2]
+           └── null [type=unknown]
 
 build-scalar
 NULL::oid || ARRAY[1, 2]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -175,7 +175,7 @@ project
  ├── scan kv
  │    └── columns: k:1!null v:2
  └── projections
-      └── v:2 || 'foo' [as=r:3]
+      └── v:2::STRING || 'foo' [as=r:3]
 
 build
 SELECT lower(v) FROM kv

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1646,7 +1646,7 @@ update decimals
       │    │    │    │    │    ├── columns: decimals.a:5!null decimals.b:6 c:7 decimals.d:8
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── decimals.d:8
-      │    │    │    │    │              └── decimals.a:5 + c:7
+      │    │    │    │    │              └── decimals.a:5::DECIMAL + c:7::DECIMAL
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:9]
       │    │    │    │         └── ARRAY[0.95,NULL,15] [as=b_new:10]
@@ -1654,7 +1654,7 @@ update decimals
       │    │    │         ├── crdb_internal.round_decimal_values(a_new:9, 0) [as=a:11]
       │    │    │         └── crdb_internal.round_decimal_values(b_new:10, 1) [as=b:12]
       │    │    └── projections
-      │    │         └── a:11 + c:7 [as=column13:13]
+      │    │         └── a:11 + c:7::DECIMAL [as=column13:13]
       │    └── projections
       │         └── crdb_internal.round_decimal_values(column13:13, 1) [as=d:14]
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1689,13 +1689,13 @@ upsert decimals
       │    │    │    │    │    │    ├── columns: decimals.a:13!null decimals.b:14 decimals.c:15 decimals.d:16
       │    │    │    │    │    │    └── computed column expressions
       │    │    │    │    │    │         └── decimals.d:16
-      │    │    │    │    │    │              └── decimals.a:13 + decimals.c:15
+      │    │    │    │    │    │              └── decimals.a:13::DECIMAL + decimals.c:15::DECIMAL
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a:8 = decimals.a:13
       │    │    │    │    └── projections
       │    │    │    │         └── crdb_internal.round_decimal_values(b:9, 1) [as=b:17]
       │    │    │    └── projections
-      │    │    │         └── decimals.a:13 + decimals.c:15 [as=column18:18]
+      │    │    │         └── decimals.a:13::DECIMAL + decimals.c:15::DECIMAL [as=column18:18]
       │    │    └── projections
       │    │         └── crdb_internal.round_decimal_values(column18:18, 1) [as=d:19]
       │    └── projections
@@ -1768,11 +1768,11 @@ upsert decimals
       │    │    │    │    │    ├── columns: decimals.a:13!null decimals.b:14 decimals.c:15 decimals.d:16
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── decimals.d:16
-      │    │    │    │    │              └── decimals.a:13 + decimals.c:15
+      │    │    │    │    │              └── decimals.a:13::DECIMAL + decimals.c:15::DECIMAL
       │    │    │    │    └── filters
       │    │    │    │         └── a:8 = decimals.a:13
       │    │    │    └── projections
-      │    │    │         └── decimals.a:13 + decimals.c:15 [as=column17:17]
+      │    │    │         └── decimals.a:13::DECIMAL + decimals.c:15::DECIMAL [as=column17:17]
       │    │    └── projections
       │    │         └── crdb_internal.round_decimal_values(column17:17, 1) [as=d:18]
       │    └── projections
@@ -1852,7 +1852,7 @@ upsert decimals
       │    │    │    │    │    │    │    ├── columns: decimals.a:13!null decimals.b:14 decimals.c:15 decimals.d:16
       │    │    │    │    │    │    │    └── computed column expressions
       │    │    │    │    │    │    │         └── decimals.d:16
-      │    │    │    │    │    │    │              └── decimals.a:13 + decimals.c:15
+      │    │    │    │    │    │    │              └── decimals.a:13::DECIMAL + decimals.c:15::DECIMAL
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         └── a:8 = decimals.a:13
       │    │    │    │    │    └── projections
@@ -1860,7 +1860,7 @@ upsert decimals
       │    │    │    │    └── projections
       │    │    │    │         └── crdb_internal.round_decimal_values(b_new:17, 1) [as=b:18]
       │    │    │    └── projections
-      │    │    │         └── decimals.a:13 + decimals.c:15 [as=column19:19]
+      │    │    │         └── decimals.a:13::DECIMAL + decimals.c:15::DECIMAL [as=column19:19]
       │    │    └── projections
       │    │         └── crdb_internal.round_decimal_values(column19:19, 1) [as=d:20]
       │    └── projections

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -2020,7 +2020,7 @@ project
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:10 = p.productid:12 [outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10)]
  │    │    │    └── projections
- │    │    │         └── li.quantity:11 * cost:14 [as=column16:16, outer=(11,14), immutable]
+ │    │    │         └── li.quantity:11::INT8 * cost:14::DECIMAL [as=column16:16, outer=(11,14), immutable]
  │    │    ├── left-join (merge)
  │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:4 lineitems1_.ordernumber:5 lineitems1_.productid:6 lineitems1_.quantity:7
  │    │    │    ├── left ordering: +1,+2
@@ -2198,7 +2198,7 @@ project
  │    │    │    │    │    │    └── filters
  │    │    │    │    │    │         └── li.productid:17 = p.productid:19 [outer=(17,19), constraints=(/17: (/NULL - ]; /19: (/NULL - ]), fd=(17)==(19), (19)==(17)]
  │    │    │    │    │    └── projections
- │    │    │    │    │         └── li.quantity:18 * p.cost:21 [as=column23:23, outer=(18,21), immutable]
+ │    │    │    │    │         └── li.quantity:18::INT8 * p.cost:21::DECIMAL [as=column23:23, outer=(18,21), immutable]
  │    │    │    │    └── filters
  │    │    │    │         ├── li.customerid:15 = orders1_.customerid:4 [outer=(4,15), constraints=(/4: (/NULL - ]; /15: (/NULL - ]), fd=(4)==(15), (15)==(4)]
  │    │    │    │         └── li.ordernumber:16 = orders1_.ordernumber:5 [outer=(5,16), constraints=(/5: (/NULL - ]; /16: (/NULL - ]), fd=(5)==(16), (16)==(5)]
@@ -2316,7 +2316,7 @@ project
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:10 = p.productid:12 [outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10)]
  │    │    │    └── projections
- │    │    │         └── li.quantity:11 * cost:14 [as=column16:16, outer=(11,14), immutable]
+ │    │    │         └── li.quantity:11::INT8 * cost:14::DECIMAL [as=column16:16, outer=(11,14), immutable]
  │    │    ├── left-join (merge)
  │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:4 lineitems1_.ordernumber:5 lineitems1_.productid:6 lineitems1_.quantity:7
  │    │    │    ├── left ordering: +1,+2
@@ -2414,7 +2414,7 @@ project
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:6 = p.productid:8 [outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
  │    │    │    └── projections
- │    │    │         └── quantity:7 * cost:10 [as=column12:12, outer=(7,10), immutable]
+ │    │    │         └── quantity:7::INT8 * cost:10::DECIMAL [as=column12:12, outer=(7,10), immutable]
  │    │    └── filters
  │    │         ├── li.customerid:4 = order0_.customerid:1 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
  │    │         └── li.ordernumber:5 = order0_.ordernumber:2 [outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -458,7 +458,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(10-18)
            └── projections
-                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18 + 3860.61, 2) [as=w_ytd:20, outer=(18), immutable]
+                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18::DECIMAL + 3860.61, 2) [as=w_ytd:20, outer=(18), immutable]
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -492,7 +492,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── crdb_internal.round_decimal_values(district.d_ytd:21 + 3860.61, 2) [as=d_ytd:24, outer=(21), immutable]
+                └── crdb_internal.round_decimal_values(district.d_ytd:21::DECIMAL + 3860.61, 2) [as=d_ytd:24, outer=(21), immutable]
 
 opt format=hide-qual
 SELECT c_id
@@ -584,10 +584,10 @@ project
  │         │    ├── key: ()
  │         │    └── fd: ()-->(22-42)
  │         └── projections
- │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
- │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
+ │              ├── crdb_internal.round_decimal_values(customer.c_balance:38::DECIMAL - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
+ │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39::DECIMAL + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
  │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40), immutable]
- │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42), immutable]
+ │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42::STRING, 500) ELSE c_data:42::STRING END [as=c_data_new:46, outer=(22-24,35,42), immutable]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21), immutable]
 
@@ -906,7 +906,7 @@ update customer
       │    ├── key: (22,23)
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
-           ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:45, outer=(23,38), immutable]
+           ├── crdb_internal.round_decimal_values(customer.c_balance:38::DECIMAL + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:45, outer=(23,38), immutable]
            └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41), immutable]
 
 opt format=hide-qual

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -461,7 +461,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(10-18)
            └── projections
-                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18 + 3860.61, 2) [as=w_ytd:20, outer=(18), immutable]
+                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18::DECIMAL + 3860.61, 2) [as=w_ytd:20, outer=(18), immutable]
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -495,7 +495,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── crdb_internal.round_decimal_values(district.d_ytd:21 + 3860.61, 2) [as=d_ytd:24, outer=(21), immutable]
+                └── crdb_internal.round_decimal_values(district.d_ytd:21::DECIMAL + 3860.61, 2) [as=d_ytd:24, outer=(21), immutable]
 
 opt format=hide-qual
 SELECT c_id
@@ -587,10 +587,10 @@ project
  │         │    ├── key: ()
  │         │    └── fd: ()-->(22-42)
  │         └── projections
- │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
- │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
+ │              ├── crdb_internal.round_decimal_values(customer.c_balance:38::DECIMAL - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
+ │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39::DECIMAL + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
  │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40), immutable]
- │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42), immutable]
+ │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42::STRING, 500) ELSE c_data:42::STRING END [as=c_data_new:46, outer=(22-24,35,42), immutable]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21), immutable]
 
@@ -909,7 +909,7 @@ update customer
       │    ├── key: (22,23)
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
-           ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:45, outer=(23,38), immutable]
+           ├── crdb_internal.round_decimal_values(customer.c_balance:38::DECIMAL + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:45, outer=(23,38), immutable]
            └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41), immutable]
 
 opt format=hide-qual

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -455,7 +455,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(10-18)
            └── projections
-                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18 + 3860.61, 2) [as=w_ytd:20, outer=(18), immutable]
+                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18::DECIMAL + 3860.61, 2) [as=w_ytd:20, outer=(18), immutable]
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -489,7 +489,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── crdb_internal.round_decimal_values(district.d_ytd:21 + 3860.61, 2) [as=d_ytd:24, outer=(21), immutable]
+                └── crdb_internal.round_decimal_values(district.d_ytd:21::DECIMAL + 3860.61, 2) [as=d_ytd:24, outer=(21), immutable]
 
 opt format=hide-qual
 SELECT c_id
@@ -581,10 +581,10 @@ project
  │         │    ├── key: ()
  │         │    └── fd: ()-->(22-42)
  │         └── projections
- │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
- │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
+ │              ├── crdb_internal.round_decimal_values(customer.c_balance:38::DECIMAL - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
+ │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39::DECIMAL + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
  │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40), immutable]
- │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42), immutable]
+ │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42::STRING, 500) ELSE c_data:42::STRING END [as=c_data_new:46, outer=(22-24,35,42), immutable]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21), immutable]
 
@@ -907,7 +907,7 @@ update customer
       │    ├── key: (22,23)
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
-           ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:45, outer=(23,38), immutable]
+           ├── crdb_internal.round_decimal_values(customer.c_balance:38::DECIMAL + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:45, outer=(23,38), immutable]
            └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41), immutable]
 
 opt format=hide-qual

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -146,7 +146,7 @@ sort
       │    │    │    └── filters
       │    │    │         └── sc_id:1 = in_sc_id:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       │    │    └── projections
-      │    │         └── tr_qty:34 * tr_bid_price:35 [as=column42:42, outer=(34,35), immutable]
+      │    │         └── tr_qty:34::INT8 * tr_bid_price:35::DECIMAL [as=column42:42, outer=(34,35), immutable]
       │    └── aggregations
       │         └── sum [as=sum:43, outer=(42)]
       │              └── column42:42
@@ -287,7 +287,7 @@ limit
  │         │    │    │    │    └── filters (true)
  │         │    │    │    └── filters (true)
  │         │    │    └── projections
- │         │    │         └── hs_qty:9 * lt_price:12 [as=column15:15, outer=(9,12), immutable]
+ │         │    │         └── hs_qty:9::INT8 * lt_price:12::DECIMAL [as=column15:15, outer=(9,12), immutable]
  │         │    └── aggregations
  │         │         ├── sum [as=sum:16, outer=(15)]
  │         │         │    └── column15:15
@@ -1826,7 +1826,7 @@ project
  │    │    │    │    └── fd: ()-->(1), (2)-->(3)
  │    │    │    └── filters (true)
  │    │    └── projections
- │    │         └── hs_qty:3 * lt_price:6 [as=column9:9, outer=(3,6), immutable]
+ │    │         └── hs_qty:3::INT8 * lt_price:6::DECIMAL [as=column9:9, outer=(3,6), immutable]
  │    └── aggregations
  │         └── sum [as=sum:10, outer=(9)]
  │              └── column9:9
@@ -2273,7 +2273,7 @@ update holding_summary
       │    ├── key: ()
       │    └── fd: ()-->(4-6)
       └── projections
-           └── hs_qty:6 + 10 [as=hs_qty_new:7, outer=(6), immutable]
+           └── hs_qty:6::INT8 + 10 [as=hs_qty_new:7, outer=(6), immutable]
 
 # Q7
 opt
@@ -2400,7 +2400,7 @@ update holding
       │    └── fd: ()-->(7-12)
       └── projections
            ├── h_price:11 > 0 [as=check1:14, outer=(11), immutable]
-           └── h_qty:12 + 10 [as=h_qty_new:13, outer=(12), immutable]
+           └── h_qty:12::INT8 + 10 [as=h_qty_new:13, outer=(12), immutable]
 
 # Q11
 opt
@@ -2598,7 +2598,7 @@ update holding_summary
       │    ├── key: ()
       │    └── fd: ()-->(4-6)
       └── projections
-           └── hs_qty:6 + 10 [as=hs_qty_new:7, outer=(6), immutable]
+           └── hs_qty:6::INT8 + 10 [as=hs_qty_new:7, outer=(6), immutable]
 
 # Q16
 opt
@@ -3028,7 +3028,7 @@ project
  │         │    └── fd: ()-->(7-12)
  │         └── projections
  │              ├── ca_tax_st:11 IN (0, 1, 2) [as=check1:15, outer=(11)]
- │              └── crdb_internal.round_decimal_values(customer_account.ca_bal:12 + 1E+2, 2) [as=ca_bal:14, outer=(12), immutable]
+ │              └── crdb_internal.round_decimal_values(customer_account.ca_bal:12::DECIMAL + 1E+2, 2) [as=ca_bal:14, outer=(12), immutable]
  └── projections
       └── customer_account.ca_bal:6::FLOAT8 [as=ca_bal:16, outer=(6), immutable]
 

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1014,9 +1014,9 @@ sort
       │    │    └── filters
       │    │         └── id:16 = transactiondetails.cardid:4 [outer=(4,16), constraints=(/4: (/NULL - ]; /16: (/NULL - ]), fd=(4)==(16), (16)==(4)]
       │    └── projections
-      │         ├── transactiondetails.sellprice:6 * quantity:5 [as=column31:31, outer=(5,6), immutable]
-      │         ├── transactiondetails.buyprice:7 * quantity:5 [as=column33:33, outer=(5,7), immutable]
-      │         ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column35:35, outer=(5-7), immutable]
+      │         ├── quantity:5 * transactiondetails.sellprice:6::DECIMAL [as=column31:31, outer=(5,6), immutable]
+      │         ├── quantity:5 * transactiondetails.buyprice:7::DECIMAL [as=column33:33, outer=(5,7), immutable]
+      │         ├── quantity:5 * (transactiondetails.sellprice:6::DECIMAL - transactiondetails.buyprice:7::DECIMAL) [as=column35:35, outer=(5-7), immutable]
       │         └── extract('day', transactiondate:3) [as=column37:37, outer=(3), stable]
       └── aggregations
            ├── sum [as=sum:32, outer=(31)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1018,9 +1018,9 @@ sort
       │    │    └── filters
       │    │         └── id:20 = transactiondetails.cardid:4 [outer=(4,20), constraints=(/4: (/NULL - ]; /20: (/NULL - ]), fd=(4)==(20), (20)==(4)]
       │    └── projections
-      │         ├── transactiondetails.sellprice:6 * quantity:5 [as=column39:39, outer=(5,6), immutable]
-      │         ├── transactiondetails.buyprice:7 * quantity:5 [as=column41:41, outer=(5,7), immutable]
-      │         ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column43:43, outer=(5-7), immutable]
+      │         ├── quantity:5 * transactiondetails.sellprice:6::DECIMAL [as=column39:39, outer=(5,6), immutable]
+      │         ├── quantity:5 * transactiondetails.buyprice:7::DECIMAL [as=column41:41, outer=(5,7), immutable]
+      │         ├── quantity:5 * (transactiondetails.sellprice:6::DECIMAL - transactiondetails.buyprice:7::DECIMAL) [as=column43:43, outer=(5-7), immutable]
       │         └── extract('day', transactiondate:3) [as=column45:45, outer=(3), stable]
       └── aggregations
            ├── sum [as=sum:40, outer=(39)]
@@ -1578,7 +1578,7 @@ update ci
       │         └── const-agg [as=q:33, outer=(33)]
       │              └── q:33
       └── projections
-           ├── crdb_internal.round_decimal_values(buyprice:21 - discount:23, 4) [as=discountbuyprice:47, outer=(21,23), immutable]
+           ├── crdb_internal.round_decimal_values(buyprice:21::DECIMAL - discount:23::DECIMAL, 4) [as=discountbuyprice:47, outer=(21,23), immutable]
            ├── CAST(NULL AS STRING) [as=column44:44]
            ├── 0 [as=column45:45]
            └── COALESCE(sum_int:41, 0) [as=actualinventory_new:43, outer=(41)]

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -981,7 +981,7 @@ func init() {
 // ReType ensures that the given numeric expression evaluates
 // to the requested type, inserting a cast if necessary.
 func ReType(expr TypedExpr, wantedType *types.T) TypedExpr {
-	if expr.ResolvedType().Equivalent(wantedType) {
+	if wantedType.Family() == types.AnyFamily || expr.ResolvedType().Identical(wantedType) {
 		return expr
 	}
 	res := &CastExpr{Expr: expr, Type: wantedType}


### PR DESCRIPTION
I noticed that the `ReType` function uses `Equivalent`. This is not strict
enough if our expectation is that the re-typed expression will have the wanted
`ResolvedType()`. This commit changes this to use `Identical`.

Release note: None