### PR TITLE
roachtest: bump PredecessorVersion(20.1) to 19.2.9

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1147,7 +1147,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	// map.
 	verMap := map[string]string{
 		"20.2": "20.1.3",
-		"20.1": "19.2.8",
+		"20.1": "19.2.9",
 		"19.2": "19.1.10",
 		"19.1": "2.1.9",
 		"2.2":  "2.1.9",


### PR DESCRIPTION
Increase predecessor version after 19.2 release

Release note: None