### PR TITLE
sql: change volatility of timezone with TIME and TIMETZ to stable

### DIFF
--- a/pkg/sql/sem/builtins/all_builtins_test.go
+++ b/pkg/sql/sem/builtins/all_builtins_test.go
@@ -140,10 +140,10 @@ func TestOverloadsVolatilityMatchesPostgres(t *testing.T) {
 
 	// Check each builtin against Postgres.
 	for name, builtin := range builtins {
-		if builtin.props.IgnoreVolatilityCheck {
-			continue
-		}
 		for idx, overload := range builtin.overloads {
+			if overload.IgnoreVolatilityCheck {
+				continue
+			}
 			postgresVolatility, found := findOverloadVolatility(name, overload)
 			if !found {
 				continue

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -138,9 +138,6 @@ func makeTypeIOBuiltin(argTypes tree.TypeList, returnType *types.T) builtinDefin
 	return builtinDefinition{
 		props: tree.FunctionProperties{
 			Category: categoryCompatibility,
-			// Ignore validity checks for typeio builtins.
-			// We don't implement these anyway, and they are very hard to special case.
-			IgnoreVolatilityCheck: true,
 		},
 		overloads: []tree.Overload{
 			{
@@ -151,6 +148,10 @@ func makeTypeIOBuiltin(argTypes tree.TypeList, returnType *types.T) builtinDefin
 				},
 				Info:       notUsableInfo,
 				Volatility: tree.VolatilityVolatile,
+				// Ignore validity checks for typeio builtins. We don't
+				// implement these anyway, and they are very hard to special
+				// case.
+				IgnoreVolatilityCheck: true,
 			},
 		},
 	}

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -84,11 +84,6 @@ type FunctionProperties struct {
 	// with the FmtParsable directive.
 	AmbiguousReturnType bool
 
-	// IgnoreVolatilityCheck ignores checking the functions overloads against
-	// the Postgres ones at test time.
-	// This should be used with caution.
-	IgnoreVolatilityCheck bool
-
 	// HasSequenceArguments is true if the builtin function takes in a sequence
 	// name (string) and can be used in a scalar expression.
 	// TODO(richardjcai): When implicit casting is supported, these builtins

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -80,6 +80,11 @@ type Overload struct {
 	// SpecializedVecBuiltin is used to let the vectorized engine
 	// know when an Overload has a specialized vectorized operator.
 	SpecializedVecBuiltin SpecializedVectorizedBuiltin
+
+	// IgnoreVolatilityCheck ignores checking the functions overload's
+	// volatility against Postgres's volatility at test time.
+	// This should be used with caution.
+	IgnoreVolatilityCheck bool
 }
 
 // params implements the overloadImpl interface.


### PR DESCRIPTION
sql: change volatility of timezone with TIME and TIMETZ to stable

The `timezone(STRING, TIME)` and `timezone(STRING, TIMETZ)` function
overloads were originally marked as volatile to copy Postgres's
volatility for the `timezone(STRING, TIMETZ)` overload (Postgres does
not implement `timezone (STRING, TIME)`.

Postgres's volatility settings for all overloads of `timezone` are
below.

       Name   |          Argument data types          | Volatility
    ----------+---------------------------------------+------------------
     timezone | interval, time with time zone         | immutable   zone
     timezone | interval, timestamp with time zone    | immutable
     timezone | interval, timestamp without time zone | immutable
     timezone | text, time with time zone             | volatile    zone
     timezone | text, timestamp with time zone        | immutable
     timezone | text, timestamp without time zone     | immutable

This single overload is singled out as volatile by Postgres because it
is dependent on C's `time(NULL)`. See the Postgres commit originally
marking this overload volatility, and the lines of code showing the
dependence:

https://github.com/postgres/postgres/commit/35979e6c35b75b0f6ed68b60f120459380ead3c4
https://github.com/postgres/postgres/blob/ac3a4866c0bf1d7a14009f18d3b42ffcb063a7e9/src/backend/utils/adt/date.c#L2816

CRDB does not have the same issue. All `timezone` overloads have the
same volatility, stable. This commit marks them as such.

Additional context: https://github.com/cockroachdb/cockroach/pull/48756#issuecomment-627672686

This commit also moves the `IgnoreVolatilityCheck` field from function
definitions to overloads. This allows overloads of the same function to
be ignored when asserting that the volalitity of an overload matches
Postgres's assigned volatility.

Release note: None
