### PR TITLE
ui: Hide Now option from Custom time range

### DIFF
--- a/pkg/ui/src/views/cluster/components/range/index.tsx
+++ b/pkg/ui/src/views/cluster/components/range/index.tsx
@@ -290,7 +290,6 @@ class RangeSelect extends React.Component<RangeSelectProps, RangeSelectState> {
             allowClear={false}
             format={`${timePickerFormat} ${moment(start).isSame(moment.utc(), "minute") && "[- Now]" || ""}`}
             use12Hours
-            addon={this.renderTimePickerAddon(DateTypes.DATE_FROM)}
             onChange={this.onChangeDate(DateTypes.DATE_FROM)}
             disabledHours={isSameDate && this.getDisabledHours(true) || undefined}
             disabledMinutes={isSameDate && this.getDisabledMinutes(true) || undefined}


### PR DESCRIPTION
Resolves #45939

It doesn't make any sense for Now button in "From" timepicker for custom
time range, because at least 10 minutes range has to be selected.

Release note (admin ui change): Remove Now button for "From" timepicker
in custom time range (Metrics page)

<img width="661" alt="Screenshot 2020-07-07 at 10 57 26 AM" src="https://user-images.githubusercontent.com/3106437/86742326-b5472500-c040-11ea-8f84-020066625830.png">
