### PR TITLE
server: disable DistSQL in server's InternalExecutor until migrations complete

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -610,6 +610,18 @@ func (s *sqlServer) start(
 			// present situation).
 			DistSQLMode: sessiondata.DistSQLOff,
 		})
+	{
+		// The server's internalExecutor might be used as a side effect of
+		// migrations, so disable distribution for the same reason as above until
+		// all migrations have been run.
+		s.internalExecutor.SetSessionData(
+			&sessiondata.SessionData{
+				DistSQLMode: sessiondata.DistSQLOff,
+			})
+		defer func() {
+			s.internalExecutor.SetSessionData(&sessiondata.SessionData{})
+		}()
+	}
 	migMgr := sqlmigrations.NewManager(
 		stopper,
 		s.execCfg.DB,


### PR DESCRIPTION
DistSQL is fragile on node startup (see #44101) and is therefore disabled in
the migration manager's internal executor. However, migrations sometimes have
side effects and sometimes end up using the SQL server's internal executor
which had DistSQL enabled.

This commit disabled DistSQL for this internal executor until the migrations
complete to avoid flakiness.

Release note: None (testing flake fix)

Fixes #50000 