### PR TITLE
flowinfra: avoid locking mutex in ScheduleFlow happy case

### DIFF
--- a/pkg/sql/flowinfra/flow_scheduler.go
+++ b/pkg/sql/flowinfra/flow_scheduler.go
@@ -13,6 +13,7 @@ package flowinfra
 import (
 	"container/list"
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -43,9 +44,12 @@ type FlowScheduler struct {
 
 	mu struct {
 		syncutil.Mutex
-		numRunning      int
-		maxRunningFlows int
-		queue           *list.List
+		queue *list.List
+	}
+
+	atomics struct {
+		numRunning      int32
+		maxRunningFlows int32
 	}
 }
 
@@ -72,27 +76,35 @@ func NewFlowScheduler(
 		metrics:        metrics,
 	}
 	fs.mu.queue = list.New()
-	fs.mu.maxRunningFlows = int(settingMaxRunningFlows.Get(&settings.SV))
+	fs.atomics.maxRunningFlows = int32(settingMaxRunningFlows.Get(&settings.SV))
 	settingMaxRunningFlows.SetOnChange(&settings.SV, func() {
-		fs.mu.Lock()
-		fs.mu.maxRunningFlows = int(settingMaxRunningFlows.Get(&settings.SV))
-		fs.mu.Unlock()
+		atomic.StoreInt32(&fs.atomics.maxRunningFlows, int32(settingMaxRunningFlows.Get(&settings.SV)))
 	})
 	return fs
 }
 
+// canRunFlow returns whether the FlowScheduler can run the flow. If true is
+// returned, numRunning is also incremented.
+// TODO(radu): we will have more complex resource accounting (like memory).
+//  For now we just limit the number of concurrent flows.
 func (fs *FlowScheduler) canRunFlow(_ Flow) bool {
-	// TODO(radu): we will have more complex resource accounting (like memory).
-	// For now we just limit the number of concurrent flows.
-	return fs.mu.numRunning < fs.mu.maxRunningFlows
+	// Optimistically increase numRunning to account for this new flow.
+	newNumRunning := atomic.AddInt32(&fs.atomics.numRunning, 1)
+	if newNumRunning <= atomic.LoadInt32(&fs.atomics.maxRunningFlows) {
+		// Happy case. This flow did not bring us over the limit, so return that the
+		// flow can be run and is accounted for in numRunning.
+		return true
+	}
+	atomic.AddInt32(&fs.atomics.numRunning, -1)
+	return false
 }
 
-// runFlowNow starts the given flow; does not wait for the flow to complete.
+// runFlowNow starts the given flow; does not wait for the flow to complete. The
+// caller is responsible for incrementing numRunning.
 func (fs *FlowScheduler) runFlowNow(ctx context.Context, f Flow) error {
 	log.VEventf(
-		ctx, 1, "flow scheduler running flow %s, currently running %d", f.GetID(), fs.mu.numRunning,
+		ctx, 1, "flow scheduler running flow %s, currently running %d", f.GetID(), atomic.LoadInt32(&fs.atomics.numRunning)-1,
 	)
-	fs.mu.numRunning++
 	fs.metrics.FlowStart()
 	if err := f.Start(ctx, func() { fs.flowDoneCh <- f }); err != nil {
 		return err
@@ -114,12 +126,11 @@ func (fs *FlowScheduler) runFlowNow(ctx context.Context, f Flow) error {
 func (fs *FlowScheduler) ScheduleFlow(ctx context.Context, f Flow) error {
 	return fs.stopper.RunTaskWithErr(
 		ctx, "flowinfra.FlowScheduler: scheduling flow", func(ctx context.Context) error {
-			fs.mu.Lock()
-			defer fs.mu.Unlock()
-
 			if fs.canRunFlow(f) {
 				return fs.runFlowNow(ctx, f)
 			}
+			fs.mu.Lock()
+			defer fs.mu.Unlock()
 			log.VEventf(ctx, 1, "flow scheduler enqueuing flow %s to be run later", f.GetID())
 			fs.metrics.FlowsQueued.Inc(1)
 			fs.mu.queue.PushBack(&flowWithCtx{
@@ -141,7 +152,7 @@ func (fs *FlowScheduler) Start() {
 		defer fs.mu.Unlock()
 
 		for {
-			if stopped && fs.mu.numRunning == 0 {
+			if stopped && atomic.LoadInt32(&fs.atomics.numRunning) == 0 {
 				// TODO(radu): somehow error out the flows that are still in the queue.
 				return
 			}
@@ -149,7 +160,9 @@ func (fs *FlowScheduler) Start() {
 			select {
 			case <-fs.flowDoneCh:
 				fs.mu.Lock()
-				fs.mu.numRunning--
+				// Decrement numRunning lazily (i.e. only if there is no new flow to
+				// run).
+				decrementNumRunning := stopped
 				fs.metrics.FlowStop()
 				if !stopped {
 					if frElem := fs.mu.queue.Front(); frElem != nil {
@@ -167,7 +180,12 @@ func (fs *FlowScheduler) Start() {
 						if err := fs.runFlowNow(n.ctx, n.flow); err != nil {
 							log.Errorf(n.ctx, "error starting queued flow: %s", err)
 						}
+					} else {
+						decrementNumRunning = true
 					}
+				}
+				if decrementNumRunning {
+					atomic.AddInt32(&fs.atomics.numRunning, -1)
 				}
 
 			case <-fs.stopper.ShouldStop():

--- a/pkg/sql/flowinfra/flow_scheduler_test.go
+++ b/pkg/sql/flowinfra/flow_scheduler_test.go
@@ -1,0 +1,142 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package flowinfra
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type mockFlow struct {
+	// runCh is a chan that is closed when either Run or Start is called.
+	runCh chan struct{}
+	// doneCh is a chan that the flow blocks on when run through Start and Wait
+	// or Run. Close this channel to unblock the flow.
+	doneCh chan struct{}
+	// doneCb is set when a caller calls Start and is executed at the end of the
+	// Wait method.
+	doneCb func()
+}
+
+var _ Flow = &mockFlow{}
+
+func newMockFlow() *mockFlow {
+	return &mockFlow{runCh: make(chan struct{}), doneCh: make(chan struct{})}
+}
+
+func (m *mockFlow) Setup(
+	_ context.Context, _ *execinfrapb.FlowSpec, _ FuseOpt,
+) (context.Context, error) {
+	panic("not implemented")
+}
+
+func (m *mockFlow) SetTxn(_ *kv.Txn) {
+	panic("not implemented")
+}
+
+func (m *mockFlow) Start(_ context.Context, doneCb func()) error {
+	close(m.runCh)
+	m.doneCb = doneCb
+	return nil
+}
+
+func (m *mockFlow) Run(_ context.Context, doneCb func()) error {
+	close(m.runCh)
+	<-m.doneCh
+	doneCb()
+	return nil
+}
+
+func (m *mockFlow) Wait() {
+	<-m.doneCh
+	m.doneCb()
+}
+
+func (m *mockFlow) IsLocal() bool {
+	panic("not implemented")
+}
+
+func (m *mockFlow) IsVectorized() bool {
+	panic("not implemented")
+}
+
+func (m *mockFlow) GetFlowCtx() *execinfra.FlowCtx {
+	panic("not implemented")
+}
+
+func (m *mockFlow) AddStartable(_ Startable) {
+	panic("not implemented")
+}
+
+func (m *mockFlow) GetID() execinfrapb.FlowID {
+	return execinfrapb.FlowID{UUID: uuid.Nil}
+}
+
+func (m *mockFlow) Cleanup(_ context.Context) {}
+
+func (m *mockFlow) ConcurrentExecution() bool {
+	panic("not implemented")
+}
+
+func TestFlowScheduler(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var (
+		ctx      = context.Background()
+		stopper  = stop.NewStopper()
+		settings = cluster.MakeTestingClusterSettings()
+		metrics  = execinfra.MakeDistSQLMetrics(base.DefaultHistogramWindowInterval())
+	)
+	defer stopper.Stop(ctx)
+
+	scheduler := NewFlowScheduler(log.AmbientContext{}, stopper, settings, &metrics)
+	scheduler.Start()
+	scheduler.atomics.maxRunningFlows = 1
+	getNumRunning := func() int {
+		return int(atomic.LoadInt32(&scheduler.atomics.numRunning))
+	}
+
+	flow1 := newMockFlow()
+	require.NoError(t, scheduler.ScheduleFlow(ctx, flow1))
+	require.Equal(t, 1, getNumRunning())
+
+	flow2 := newMockFlow()
+	require.NoError(t, scheduler.ScheduleFlow(ctx, flow2))
+	// numRunning should still be 1 because a maximum of 1 flow can run at a time
+	// and flow1 has not finished yet.
+	require.Equal(t, 1, getNumRunning())
+
+	close(flow1.doneCh)
+	// Now that flow1 has finished, flow2 should be run.
+	<-flow2.runCh
+	require.Equal(t, 1, getNumRunning())
+	close(flow2.doneCh)
+	testutils.SucceedsSoon(t, func() error {
+		if getNumRunning() != 0 {
+			return errors.New("expected numRunning to fall back to 0")
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
The point of locking the mutex is to check whether a flow the scheduler is
about to run would push the number of running flows over the limit. This has
shown to be a source of significant mutex contention in TPC-E (see #50022).

This commit implements that check using atomics, which is cheaper than locking
the mutex.

Release note (performance improvement): unnecessary mutex contention observed
in heavy read workloads has been removed.

Closes #50022