### PR TITLE
storage: fix leaktest calls in tests

### DIFF
--- a/pkg/storage/metamorphic/main_test.go
+++ b/pkg/storage/metamorphic/main_test.go
@@ -1,0 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package metamorphic
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -154,7 +154,7 @@ func runMetaTest(run testRun) {
 // TestRocksPebbleEquivalence runs the MVCC Metamorphic test suite, and checks
 // for matching outputs by the test suite between RocksDB and Pebble.
 func TestRocksPebbleEquivalence(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	if util.RaceEnabled {
 		// This test times out with the race detector enabled.
@@ -187,7 +187,7 @@ func TestRocksPebbleEquivalence(t *testing.T) {
 // enabled, and ensures that the output remains the same across different
 // engine sequences with restarts in between.
 func TestRocksPebbleRestarts(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	if util.RaceEnabled {
 		// This test times out with the race detector enabled.
@@ -219,7 +219,7 @@ func TestRocksPebbleRestarts(t *testing.T) {
 // TestRocksPebbleCheck checks whether the output file specified with --check has
 // matching behavior across rocks/pebble.
 func TestRocksPebbleCheck(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
 	if *check != "" {


### PR DESCRIPTION
This commit fixes the deferred calls to leaktest.AfterTest to actually
execute the closure it returns. This commit also marks the tests in this
package to be included in the set of test files that will be checked for
proper leaktest.AfterTest invocations by the linter.

Release note: None