### PR TITLE
sql: update logictest blocklist issue number

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(50840)
+# LogicTest: !3node-tenant(50048)
 # see also files `drop_sequence`, `alter_sequence`, `rename_sequence`
 
 # USING THE `lastval` FUNCTION


### PR DESCRIPTION
Logictests for sequences were earlier blocked on issue #50840. From the
discussion on the issue, the root cause is #50048. This PR updates
the logictest blocklist to reflect that.

Release note: none