### PR TITLE
ui: Correct tooltip auto position

### DIFF
--- a/pkg/ui/src/views/shared/components/toolTip/index.tsx
+++ b/pkg/ui/src/views/shared/components/toolTip/index.tsx
@@ -35,12 +35,12 @@ const cx = classNames.bind(styles);
 
 // tslint:disable-next-line: variable-name
 export const ToolTipWrapper = (props: ToolTipWrapperProps) => {
-  const { text, children, placement } = props;
-  const overlayClassName = cx("tooltip__preset--white", `tooltip__preset--placement-${placement}`);
+  const { text, children, placement = "bottom" } = props;
+  const overlayClassName = cx("tooltip-wrapper", "tooltip__preset--white");
   return (
     <Tooltip
       title={ text }
-      placement="bottom"
+      placement={placement}
       overlayClassName={overlayClassName}
       {...props}
     >

--- a/pkg/ui/src/views/shared/components/toolTip/tooltip.module.styl
+++ b/pkg/ui/src/views/shared/components/toolTip/tooltip.module.styl
@@ -10,24 +10,19 @@
 
 @require '~src/components/core/index.styl'
 
+.tooltip-wrapper
+  :global(.ant-tooltip-arrow)
+    width 20px
+    height 20px
+    &::before
+      background-color: $colors--neutral-0
+      width 20px
+      height 20px
+      border: solid 1px #e7ecf3;
+      box-shadow: none;
+
 :global(.ant-tooltip).tooltip__preset--white
   max-width 500px
-  :global(.ant-tooltip-content)
-    position relative
-    &:after, &:before
-      content ''
-      display block;
-      position absolute;
-      width 0
-      height 0
-      border-style solid
-    &:after
-      border-width 10px
-    &:before
-      border-width 10px
-  :global(.ant-tooltip-arrow)
-    &:before
-      background-color transparent
   :global(.ant-tooltip-inner)
     padding 10px
     border-radius 3px
@@ -37,27 +32,3 @@
     font-family $font-family--base
     text-align left
     color $colors--neutral-6
-
-.tooltip__preset--placement-bottom
-  :global(.ant-tooltip-content)
-    &:after, &:before
-      transform translate(-50%, 0)
-      left 50%
-    &:after
-      top -19px
-      border-color transparent transparent $colors--neutral-0 transparent
-    &:before
-      top -21px
-      border-color transparent transparent $colors--neutral-2 transparent
-
-.tooltip__preset--placement-left
-  :global(.ant-tooltip-content)
-    &:after, &:before
-      top 50%
-      transform translate(0, -50%)
-    &:after
-      right -16px
-      border-color transparent transparent transparent $colors--neutral-0
-    &:before
-      right -18px
-      border-color transparent transparent transparent $colors--neutral-2


### PR DESCRIPTION
Resolves #49863

Due to some custom styles which redefined the position of tooltip arrow, it
broke the behavior of tooltip when the position has to be flipped in
opposite direction.

Current fix restyles original tooltip arrow styles instead of defining
new one arrow and hiding the original one.

Release note: none

<img width="1424" alt="Screenshot 2020-07-07 at 5 33 32 PM" src="https://user-images.githubusercontent.com/3106437/86797335-38d03880-c078-11ea-9639-715f03e4ad76.png">
