### PR TITLE
backupccl: protect StartTime on incremental backups

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -713,6 +713,9 @@ func backupPlanHook(
 			}
 			if len(spans) > 0 {
 				tsToProtect := endTime
+				if !startTime.IsEmpty() {
+					tsToProtect = startTime
+				}
 				rec := jobsprotectedts.MakeRecord(*backupDetails.ProtectedTimestampRecord, *sj.ID(), tsToProtect, spans)
 				return p.ExecCfg().ProtectedTimestampProvider.Protect(ctx, txn, rec)
 			}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3777,9 +3777,10 @@ func TestProtectedTimestampsDuringBackup(t *testing.T) {
 	// A sketch of the test is as follows:
 	//
 	//  * Create a table foo to backup.
+	//  * Create an initial BACKUP of foo.
 	//  * Set a 1 second gcttl for foo.
-	//  * Start a BACKUP which blocks after setup (after time of backup is
-	//    decided), until it is signaled.
+	//  * Start a BACKUP incremental from that base backup which blocks after
+	//	  setup (after time of backup is decided), until it is signaled.
 	//  * Manually enqueue the ranges for GC and ensure that at least one
 	//    range ran the GC.
 	//  * Unblock the backup.
@@ -3815,6 +3816,9 @@ func TestProtectedTimestampsDuringBackup(t *testing.T) {
 	conn := tc.ServerConn(0)
 	runner := sqlutils.MakeSQLRunner(conn)
 	runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES)")
+	close(allowResponse)
+	runner.Exec(t, `BACKUP TABLE FOO TO 'nodelocal://0/foo'`) // create a base backup.
+	allowResponse = make(chan struct{})
 	runner.Exec(t, "SET CLUSTER SETTING kv.protectedts.poll_interval = '100ms';")
 	runner.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING gc.ttlseconds = 1;")
 	rRand, _ := randutil.NewPseudoRand()
@@ -3834,7 +3838,7 @@ func TestProtectedTimestampsDuringBackup(t *testing.T) {
 		// backup fails. This test does not particularly care if the BACKUP
 		// completes with a success or failure, as long as the timestamp is released
 		// shortly after the BACKUP is unblocked.
-		_, _ = conn.Exec(`BACKUP TABLE FOO TO 'nodelocal://1/foo'`) // ignore error.
+		_, _ = conn.Exec(`BACKUP TABLE FOO TO 'nodelocal://0/foo-inc' INCREMENTAL FROM 'nodelocal://0/foo'`) // ignore error.
 	}()
 
 	var jobID string


### PR DESCRIPTION
Previously we only protected endTime, but this could mean a GC
during the backup execution could start deleting revisions
within the backup's interval.

Fixes #51066.

Release note (bug fix): Fix a bug where very long running incremental backups could fail if the data they were backing up was garbage collected.