### PR TITLE
roachtest: fix acceptance/decommission

### DIFF
--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -444,7 +444,7 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 		// Until 20.2, --self is not supported.
 		// TODO(knz): Remove this alternative when roachtest does not
 		// test any version lower than 20.2.
-		if strings.Contains(cmdOutput, "ERROR: unknown flag: --self") {
+		if strings.Contains(cmdOutput, ": unknown flag: --self") {
 			t.l.Printf("--self not supported; skipping recommission with --self")
 			selfFlagSupported = false
 		} else {
@@ -708,6 +708,12 @@ WHERE "eventType" IN ($1, $2) ORDER BY timestamp`,
 			{"node_decommissioned", "3"},
 			{"node_recommissioned", "3"},
 			{"node_decommissioned", "1"},
+		}
+
+		if !selfFlagSupported {
+			// If `--self` is not supported then we don't expect to see
+			// node 1 self decommission and recommission (step 3 and 4).
+			expMatrix = append(expMatrix[:2], expMatrix[4:]...)
 		}
 
 		if !reflect.DeepEqual(matrix, expMatrix) {


### PR DESCRIPTION
The added --self flag makes the test fail with 20.1 and 19.2

With 20.1 the flag is not supported and so the expected
result should reflect that the step where a node decommissions self
will not happen.
With 19.2 the match that --self is not supported doesn't work
as the error message capitalization differs.

The fix changes the expected result and corrects the match of --self not
supported to work with 19.2 as well

Release note: None