### PR TITLE
roachtest: bump PredecessorVersion(19.2) to 19.1.11

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1148,7 +1148,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	verMap := map[string]string{
 		"20.2": "20.1.3",
 		"20.1": "19.2.9",
-		"19.2": "19.1.10",
+		"19.2": "19.1.11",
 		"19.1": "2.1.9",
 		"2.2":  "2.1.9",
 		"2.1":  "2.0.7",


### PR DESCRIPTION
Increase predecessor version after 19.1 release
Release note: None