### PR TITLE
builder: upgrade to autouseradd 1.2.0

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20200804-160354
+version=20200818-182851
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"
@@ -180,25 +180,19 @@ set +e
 # is only used if the env var is not set already.
 DATADRIVEN_QUIET_LOG=${DATADRIVEN_QUIET_LOG-true}
 
-# NB: for some mysterious reason, TMPDIR gets lost if passed via --env into
-# docker run below, hence the workaround to invoke `env` inside of the
-# container. See:
-#
-# https://github.com/cockroachdb/cockroach/issues/50507
-# https://github.com/benesch/autouseradd/issues/2
-#
 # shellcheck disable=SC2086
 docker run --init --privileged -i ${tty-} --rm \
   -u "$uid:$gid" \
   ${vols} \
   --workdir="/go/src/github.com/cockroachdb/cockroach" \
+  --env="TMPDIR=/go/src/github.com/cockroachdb/cockroach/artifacts" \
   --env="PAGER=cat" \
   --env="GOTRACEBACK=${GOTRACEBACK-all}" \
   --env="TZ=America/New_York" \
   --env="DATADRIVEN_QUIET_LOG=${DATADRIVEN_QUIET_LOG}" \
   --env=COCKROACH_BUILDER_CCACHE \
   --env=COCKROACH_BUILDER_CCACHE_MAXSIZE \
-  "${image}:${version}" env TMPDIR=/go/src/github.com/cockroachdb/cockroach/artifacts "$@"
+  "${image}:${version}" "$@"
 
 # Build container needs to have at least 4GB of RAM available to compile the project
 # successfully, which is not true in some cases (i.e. Docker for MacOS by default).

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -284,8 +284,8 @@ RUN rm -rf /tmp/* /var/lib/apt/lists/*
 
 RUN ln -s /go/src/github.com/cockroachdb/cockroach/build/builder/mkrelease.sh /usr/local/bin/mkrelease
 
-RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.1.0/autouseradd-1.1.0-amd64.tar.gz \
-    | tar xz -C /usr --strip-components 1
+RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.2.0/autouseradd-1.2.0-amd64.tar.gz \
+    | tar xz -C / --strip-components 1
 
 COPY entrypoint.sh /usr/local/bin
 


### PR DESCRIPTION
The new version of autouseradd has a fix for the TMPDIR propagation
issue. (It is also a bit more careful to propagate other variables that
are normally dropped in "secure-execution mode", on the off chance that
a later version of the builder wants to propagate those.)

@tbg up to you whether you want this. You'll have to rebuild the builder since I no longer have Docker Hub permissions (and also don't feel like sitting through the 1hr long build process :D). But should be quick if you've got a warm Docker cache already.