### PR TITLE
lease: skip TestDescriptorRefreshOnRetry

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -818,6 +818,9 @@ CREATE TABLE t.foo (v INT);
 // a query are properly released before the query is retried.
 func TestDescriptorRefreshOnRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/50037")
+
 	params, _ := tests.CreateTestServerParams()
 
 	fooAcquiredCount := int32(0)


### PR DESCRIPTION
Failed on master. Tracked in #50037.

Release note: None