### PR TITLE
kv/gc: don't continue iterating and spamming logs when deadline exceeded

### DIFF
--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -222,7 +222,9 @@ func runGCOld(
 
 	// Clean up the AbortSpan.
 	log.Event(ctx, "processing AbortSpan")
-	processAbortSpan(ctx, snap, desc.RangeID, txnExp, &info, gcer)
+	if err := processAbortSpan(ctx, snap, desc.RangeID, txnExp, &info, gcer); err != nil {
+		log.Warningf(ctx, "while gc'ing abort span: %s", err)
+	}
 
 	log.Eventf(ctx, "GC'ed keys; stats %+v", info)
 


### PR DESCRIPTION
Before this change, we'd see logs like:
```
W200706 11:23:10.682177 15143568003 kv/kvserver/gc/gc.go:337  [n118,gc,s118,r6153/1:/Table/57/1/"user1216{19…-44…}] failed to GC a batch of keys: result is ambiguous (context deadline exceeded)
W200706 11:23:10.685251 15143568003 kv/kvserver/gc/gc.go:337  [n118,gc,s118,r6153/1:/Table/57/1/"user1216{19…-44…}] failed to GC a batch of keys: aborted during Replica.Send: context deadline exceeded
W200706 11:23:10.688667 15143568003 kv/kvserver/gc/gc.go:337  [n118,gc,s118,r6153/1:/Table/57/1/"user1216{19…-44…}] failed to GC a batch of keys: aborted during Replica.Send: context deadline exceeded
W200706 11:23:10.691760 15143568003 kv/kvserver/gc/gc.go:337  [n118,gc,s118,r6153/1:/Table/57/1/"user1216{19…-44…}] failed to GC a batch of keys: aborted during Replica.Send: context deadline exceeded
...
```

if a GC attempt hit its deadline. Now, we terminate iteration early and do our best to stop running GC once the context is canceled / exceeding its deadline.