### PR TITLE
TeamCity agent image: add awscli

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -31,6 +31,7 @@ apt-get update --yes
 
 # Install the necessary dependencies. Keep this list small!
 apt-get install --yes \
+  awscli \
   docker-ce \
   docker-compose \
   gnome-keyring \
@@ -81,6 +82,11 @@ cd "$repo"
 git submodule update --init --recursive
 for branch in $(git branch --all --list --sort=-committerdate 'origin/release-*' | head -n1) master
 do
+  # Clean out all non-checked-in files. This is because of the check-in of
+  # the generated execgen files. Once we are no longer building 20.1 builds,
+  # the `git clean -dxf` line can be removed.
+  git clean -dxf
+
   git checkout "$branch"
   COCKROACH_BUILDER_CCACHE=1 build/builder.sh make test testrace TESTS=-
   # TODO(benesch): store the acceptanceversion somewhere more accessible.


### PR DESCRIPTION
Before: There was no awscli in the TeamCity agent images.

Why: To allow uploading to S3 from the CLI without needing a docker image.

Now: The awscli package is installed on the TeamCity agent.

Fixes: #51029

Release note: None