### PR TITLE
kvcoord: don't deal with NLHE in grpcTransport

### DIFF
--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -198,24 +198,23 @@ func TestComplexScenarios(t *testing.T) {
 func TestSplitHealthy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	type batchClient struct {
+		replica roachpb.ReplicaDescriptor
+		healthy bool
+	}
+
 	testData := []struct {
-		in       []batchClient
-		out      []batchClient
-		nHealthy int
+		in  []batchClient
+		out []roachpb.ReplicaDescriptor
 	}{
-		{nil, nil, 0},
+		{nil, []roachpb.ReplicaDescriptor{}},
 		{
 			[]batchClient{
 				{replica: roachpb.ReplicaDescriptor{NodeID: 1}, healthy: false},
 				{replica: roachpb.ReplicaDescriptor{NodeID: 2}, healthy: false},
 				{replica: roachpb.ReplicaDescriptor{NodeID: 3}, healthy: true},
 			},
-			[]batchClient{
-				{replica: roachpb.ReplicaDescriptor{NodeID: 3}, healthy: true},
-				{replica: roachpb.ReplicaDescriptor{NodeID: 1}, healthy: false},
-				{replica: roachpb.ReplicaDescriptor{NodeID: 2}, healthy: false},
-			},
-			1,
+			[]roachpb.ReplicaDescriptor{{NodeID: 3}, {NodeID: 1}, {NodeID: 2}},
 		},
 		{
 			[]batchClient{
@@ -223,12 +222,7 @@ func TestSplitHealthy(t *testing.T) {
 				{replica: roachpb.ReplicaDescriptor{NodeID: 2}, healthy: false},
 				{replica: roachpb.ReplicaDescriptor{NodeID: 3}, healthy: true},
 			},
-			[]batchClient{
-				{replica: roachpb.ReplicaDescriptor{NodeID: 1}, healthy: true},
-				{replica: roachpb.ReplicaDescriptor{NodeID: 3}, healthy: true},
-				{replica: roachpb.ReplicaDescriptor{NodeID: 2}, healthy: false},
-			},
-			2,
+			[]roachpb.ReplicaDescriptor{{NodeID: 1}, {NodeID: 3}, {NodeID: 2}},
 		},
 		{
 			[]batchClient{
@@ -236,23 +230,23 @@ func TestSplitHealthy(t *testing.T) {
 				{replica: roachpb.ReplicaDescriptor{NodeID: 2}, healthy: true},
 				{replica: roachpb.ReplicaDescriptor{NodeID: 3}, healthy: true},
 			},
-			[]batchClient{
-				{replica: roachpb.ReplicaDescriptor{NodeID: 1}, healthy: true},
-				{replica: roachpb.ReplicaDescriptor{NodeID: 2}, healthy: true},
-				{replica: roachpb.ReplicaDescriptor{NodeID: 3}, healthy: true},
-			},
-			3,
+			[]roachpb.ReplicaDescriptor{{NodeID: 1}, {NodeID: 2}, {NodeID: 3}},
 		},
 	}
 
-	for i, td := range testData {
-		nHealthy := splitHealthy(td.in)
-		if nHealthy != td.nHealthy {
-			t.Errorf("%d. splitHealthy(%+v) = %d; not %d", i, td.in, nHealthy, td.nHealthy)
-		}
-		if !reflect.DeepEqual(td.in, td.out) {
-			t.Errorf("%d. splitHealthy(...)\n  = %+v;\nnot %+v", i, td.in, td.out)
-		}
+	for _, td := range testData {
+		t.Run("", func(t *testing.T) {
+			replicas := make([]roachpb.ReplicaDescriptor, len(td.in))
+			health := make(map[roachpb.ReplicaDescriptor]bool)
+			for i, r := range td.in {
+				replicas[i] = r.replica
+				health[replicas[i]] = r.healthy
+			}
+			splitHealthy(replicas, health)
+			if !reflect.DeepEqual(replicas, td.out) {
+				t.Errorf("splitHealthy(...) = %+v not %+v", replicas, td.out)
+			}
+		})
 	}
 }
 

--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -132,14 +132,14 @@ func (gt *grpcTransport) IsExhausted() bool {
 	if gt.clientIndex < len(gt.orderedClients) {
 		return false
 	}
-	return !gt.maybeResurrectRetryablesLocked()
+	return !gt.maybeResurrectRetryables()
 }
 
-// maybeResurrectRetryablesLocked moves already-tried replicas which
+// maybeResurrectRetryables moves already-tried replicas which
 // experienced a retryable error (currently this means a
 // NotLeaseHolderError) into a newly-active state so that they can be
 // retried. Returns true if any replicas were moved to active.
-func (gt *grpcTransport) maybeResurrectRetryablesLocked() bool {
+func (gt *grpcTransport) maybeResurrectRetryables() bool {
 	var resurrect []batchClient
 	for i := 0; i < gt.clientIndex; i++ {
 		if c := gt.orderedClients[i]; c.retryable && timeutil.Since(c.deadline) >= 0 {
@@ -147,7 +147,7 @@ func (gt *grpcTransport) maybeResurrectRetryablesLocked() bool {
 		}
 	}
 	for _, c := range resurrect {
-		gt.moveToFrontLocked(c.replica)
+		gt.moveToFront(c.replica)
 	}
 	return len(resurrect) > 0
 }
@@ -238,10 +238,10 @@ func (gt *grpcTransport) NextReplica() roachpb.ReplicaDescriptor {
 }
 
 func (gt *grpcTransport) MoveToFront(replica roachpb.ReplicaDescriptor) {
-	gt.moveToFrontLocked(replica)
+	gt.moveToFront(replica)
 }
 
-func (gt *grpcTransport) moveToFrontLocked(replica roachpb.ReplicaDescriptor) {
+func (gt *grpcTransport) moveToFront(replica roachpb.ReplicaDescriptor) {
 	for i := range gt.orderedClients {
 		if gt.orderedClients[i].replica == replica {
 			// Clear the retryable bit as this replica is being made

--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -12,6 +12,7 @@ package kvcoord
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -32,11 +33,6 @@ type SendOptions struct {
 	metrics *DistSenderMetrics
 }
 
-type batchClient struct {
-	replica roachpb.ReplicaDescriptor
-	healthy bool
-}
-
 // TransportFactory encapsulates all interaction with the RPC
 // subsystem, allowing it to be mocked out for testing. The factory
 // function returns a Transport object which is used to send requests
@@ -48,6 +44,8 @@ type batchClient struct {
 //
 // TODO(bdarnell): clean up this crufty interface; it was extracted
 // verbatim from the non-abstracted code.
+// TODO(andrei): This should take just []roachpb.ReplicaDescriptor; ReplicaSlice
+// has unneeded data in it.
 type TransportFactory func(
 	SendOptions, *nodedialer.Dialer, ReplicaSlice,
 ) (Transport, error)
@@ -90,39 +88,39 @@ type Transport interface {
 // During race builds, we wrap this to hold on to and read all obtained
 // requests in a tight loop, exposing data races; see transport_race.go.
 func grpcTransportFactoryImpl(
-	opts SendOptions, nodeDialer *nodedialer.Dialer, replicas ReplicaSlice,
+	opts SendOptions, nodeDialer *nodedialer.Dialer, rs ReplicaSlice,
 ) (Transport, error) {
-	clients := make([]batchClient, 0, len(replicas))
-	for _, replica := range replicas {
-		healthy := nodeDialer.ConnHealth(replica.NodeID, opts.class) == nil
-		clients = append(clients, batchClient{
-			replica: replica.ReplicaDescriptor,
-			healthy: healthy,
-		})
+	health := make(map[roachpb.ReplicaDescriptor]bool)
+	replicas := make([]roachpb.ReplicaDescriptor, len(rs))
+	for i, rinfo := range rs {
+		r := rinfo.ReplicaDescriptor
+		replicas[i] = r
+		health[r] = nodeDialer.ConnHealth(r.NodeID, opts.class) == nil
 	}
 
-	// Put known-healthy clients first.
-	splitHealthy(clients)
+	// Put known-healthy clients first, while otherwise respecting the existing
+	// ordering of the replicas.
+	splitHealthy(replicas, health)
 
 	return &grpcTransport{
-		opts:           opts,
-		nodeDialer:     nodeDialer,
-		class:          opts.class,
-		orderedClients: clients,
+		opts:       opts,
+		nodeDialer: nodeDialer,
+		class:      opts.class,
+		replicas:   replicas,
 	}, nil
 }
 
 type grpcTransport struct {
-	opts           SendOptions
-	nodeDialer     *nodedialer.Dialer
-	class          rpc.ConnectionClass
-	clientIndex    int
-	orderedClients []batchClient
+	opts        SendOptions
+	nodeDialer  *nodedialer.Dialer
+	class       rpc.ConnectionClass
+	clientIndex int
+	replicas    []roachpb.ReplicaDescriptor
 }
 
 // IsExhausted returns false if there are any untried replicas remaining.
 func (gt *grpcTransport) IsExhausted() bool {
-	return gt.clientIndex >= len(gt.orderedClients)
+	return gt.clientIndex >= len(gt.replicas)
 }
 
 // SendNext invokes the specified RPC on the supplied client when the
@@ -131,14 +129,14 @@ func (gt *grpcTransport) IsExhausted() bool {
 func (gt *grpcTransport) SendNext(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error) {
-	client := gt.orderedClients[gt.clientIndex]
+	r := gt.replicas[gt.clientIndex]
 	ctx, iface, err := gt.NextInternalClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	ba.Replica = client.replica
-	return gt.sendBatch(ctx, client.replica.NodeID, iface, ba)
+	ba.Replica = r
+	return gt.sendBatch(ctx, r.NodeID, iface, ba)
 }
 
 // NB: nodeID is unused, but accessible in stack traces.
@@ -185,16 +183,16 @@ func (gt *grpcTransport) sendBatch(
 func (gt *grpcTransport) NextInternalClient(
 	ctx context.Context,
 ) (context.Context, roachpb.InternalClient, error) {
-	client := gt.orderedClients[gt.clientIndex]
+	r := gt.replicas[gt.clientIndex]
 	gt.clientIndex++
-	return gt.nodeDialer.DialInternalClient(ctx, client.replica.NodeID, gt.class)
+	return gt.nodeDialer.DialInternalClient(ctx, r.NodeID, gt.class)
 }
 
 func (gt *grpcTransport) NextReplica() roachpb.ReplicaDescriptor {
 	if gt.IsExhausted() {
 		return roachpb.ReplicaDescriptor{}
 	}
-	return gt.orderedClients[gt.clientIndex].replica
+	return gt.replicas[gt.clientIndex]
 }
 
 func (gt *grpcTransport) MoveToFront(replica roachpb.ReplicaDescriptor) {
@@ -202,16 +200,15 @@ func (gt *grpcTransport) MoveToFront(replica roachpb.ReplicaDescriptor) {
 }
 
 func (gt *grpcTransport) moveToFront(replica roachpb.ReplicaDescriptor) {
-	for i := range gt.orderedClients {
-		if gt.orderedClients[i].replica == replica {
+	for i := range gt.replicas {
+		if gt.replicas[i] == replica {
 			// If we've already processed the replica, decrement the current
 			// index before we swap.
 			if i < gt.clientIndex {
 				gt.clientIndex--
 			}
 			// Swap the client representing this replica to the front.
-			gt.orderedClients[i], gt.orderedClients[gt.clientIndex] =
-				gt.orderedClients[gt.clientIndex], gt.orderedClients[i]
+			gt.replicas[i], gt.replicas[gt.clientIndex] = gt.replicas[gt.clientIndex], gt.replicas[i]
 			return
 		}
 	}
@@ -222,23 +219,31 @@ func (gt *grpcTransport) moveToFront(replica roachpb.ReplicaDescriptor) {
 // be rearranged first in the slice, and unhealthy clients will be rearranged
 // last. Within these two groups, the rearrangement will be stable. The function
 // will then return the number of healthy clients.
-func splitHealthy(clients []batchClient) int {
-	var nHealthy int
-	sort.Stable(byHealth(clients))
-	for _, client := range clients {
-		if client.healthy {
-			nHealthy++
-		}
-	}
-	return nHealthy
+func splitHealthy(replicas []roachpb.ReplicaDescriptor, health map[roachpb.ReplicaDescriptor]bool) {
+	sort.Stable(byHealth{replicas: replicas, health: health})
 }
 
 // byHealth sorts a slice of batchClients by their health with healthy first.
-type byHealth []batchClient
+type byHealth struct {
+	replicas []roachpb.ReplicaDescriptor
+	health   map[roachpb.ReplicaDescriptor]bool
+}
 
-func (h byHealth) Len() int           { return len(h) }
-func (h byHealth) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
-func (h byHealth) Less(i, j int) bool { return h[i].healthy && !h[j].healthy }
+func (h byHealth) Len() int { return len(h.replicas) }
+func (h byHealth) Swap(i, j int) {
+	h.replicas[i], h.replicas[j] = h.replicas[j], h.replicas[i]
+}
+func (h byHealth) Less(i, j int) bool {
+	ih, ok := h.health[h.replicas[i]]
+	if !ok {
+		panic(fmt.Sprintf("missing health info for %s", h.replicas[i]))
+	}
+	jh, ok := h.health[h.replicas[j]]
+	if !ok {
+		panic(fmt.Sprintf("missing health info for %s", h.replicas[j]))
+	}
+	return ih && !jh
+}
 
 // SenderTransportFactory wraps a client.Sender for use as a KV
 // Transport. This is useful for tests that want to use DistSender

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -30,19 +30,14 @@ func TestTransportMoveToFront(t *testing.T) {
 	rd1 := roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 1, ReplicaID: 1}
 	rd2 := roachpb.ReplicaDescriptor{NodeID: 2, StoreID: 2, ReplicaID: 2}
 	rd3 := roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3, ReplicaID: 3}
-	clients := []batchClient{
-		{replica: rd1},
-		{replica: rd2},
-		{replica: rd3},
-	}
-	gt := grpcTransport{orderedClients: clients}
+	gt := grpcTransport{replicas: []roachpb.ReplicaDescriptor{rd1, rd2, rd3}}
 
 	verifyOrder := func(replicas []roachpb.ReplicaDescriptor) {
 		file, line, _ := caller.Lookup(1)
-		for i, bc := range gt.orderedClients {
-			if bc.replica != replicas[i] {
+		for i, r := range gt.replicas {
+			if r != replicas[i] {
 				t.Fatalf("%s:%d: expected order %+v; got mismatch at index %d: %+v",
-					file, line, replicas, i, bc.replica)
+					file, line, replicas, i, r)
 			}
 		}
 	}


### PR DESCRIPTION
Before this patch, the grpcTransport was keeping track of which replicas
had returned NotLeaseholderErrors, and it would retry these replicas
when the transport was otherwise exhausted. The logic didn't make a
whole lot of sense - we were only retrying those replicas if more than
1s had passed since the error.
Doing this sort of thing is not the transport's responsibility since the
DistSender also has logic for dealing with NLHEs. The logic is geared
towards figuring out who the leaseholder is rather than retrying
replicas for no particular reason.

Release note: None