### PR TITLE
sql: stop modifying table descriptors during type hydration

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -492,10 +492,11 @@ func (p *planner) LookupTableByID(
 	}
 	// TODO (rohany): This shouldn't be needed once the descs.Collection always
 	//  returns descriptors with hydrated types.
-	if err := p.maybeHydrateTypesInDescriptor(ctx, table); err != nil {
+	hydratedDesc, err := p.maybeHydrateTypesInDescriptor(ctx, table)
+	if err != nil {
 		return catalog.TableEntry{}, err
 	}
-	return catalog.TableEntry{Desc: table}, nil
+	return catalog.TableEntry{Desc: hydratedDesc.(*sqlbase.ImmutableTableDescriptor)}, nil
 }
 
 // TypeAsString enforces (not hints) that the given expression typechecks as a


### PR DESCRIPTION
We were incorrectly modifying `ImmutableTableDescriptors` when hydrating
the type metadata within them. This PR changes the behavior to make a
copy of the `ImmutableTableDescriptor` before performing the hydration
logic. Note that this is not the end goal of this process -- we are
working towards maintaining caches of table descriptors with hydrated
type metadata.

Release note: None