### PR TITLE
release: ship libgeos.* and libgeos_c.* files

### DIFF
--- a/pkg/cmd/publish-artifacts/main_test.go
+++ b/pkg/cmd/publish-artifacts/main_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
 )
 
 // Whether to run slow tests.
@@ -79,6 +79,29 @@ func TestMain(t *testing.T) {
 		},
 		{
 			Bucket:             "cockroach",
+			ContentDisposition: "attachment; filename=libgeos.darwin-amd64." + shaStub + ".dylib",
+			Key:                "/cockroach/lib/libgeos.darwin-amd64." + shaStub + ".dylib",
+		},
+		{
+			Bucket:                  "cockroach",
+			CacheControl:            "no-cache",
+			Key:                     "cockroach/lib/libgeos.darwin-amd64.dylib.LATEST",
+			WebsiteRedirectLocation: "/cockroach/lib/libgeos.darwin-amd64." + shaStub + ".dylib",
+		},
+		{
+			Bucket:             "cockroach",
+			ContentDisposition: "attachment; filename=libgeos_c.darwin-amd64." + shaStub + ".dylib",
+			Key:                "/cockroach/lib/libgeos_c.darwin-amd64." + shaStub + ".dylib",
+		},
+		{
+			Bucket:                  "cockroach",
+			CacheControl:            "no-cache",
+			Key:                     "cockroach/lib/libgeos_c.darwin-amd64.dylib.LATEST",
+			WebsiteRedirectLocation: "/cockroach/lib/libgeos_c.darwin-amd64." + shaStub + ".dylib",
+		},
+
+		{
+			Bucket:             "cockroach",
 			ContentDisposition: "attachment; filename=cockroach.linux-gnu-amd64." + shaStub,
 			Key:                "/cockroach/cockroach.linux-gnu-amd64." + shaStub,
 		},
@@ -88,6 +111,29 @@ func TestMain(t *testing.T) {
 			Key:                     "cockroach/cockroach.linux-gnu-amd64.LATEST",
 			WebsiteRedirectLocation: "/cockroach/cockroach.linux-gnu-amd64." + shaStub,
 		},
+		{
+			Bucket:             "cockroach",
+			ContentDisposition: "attachment; filename=libgeos.linux-gnu-amd64." + shaStub + ".so",
+			Key:                "/cockroach/lib/libgeos.linux-gnu-amd64." + shaStub + ".so",
+		},
+		{
+			Bucket:                  "cockroach",
+			CacheControl:            "no-cache",
+			Key:                     "cockroach/lib/libgeos.linux-gnu-amd64.so.LATEST",
+			WebsiteRedirectLocation: "/cockroach/lib/libgeos.linux-gnu-amd64." + shaStub + ".so",
+		},
+		{
+			Bucket:             "cockroach",
+			ContentDisposition: "attachment; filename=libgeos_c.linux-gnu-amd64." + shaStub + ".so",
+			Key:                "/cockroach/lib/libgeos_c.linux-gnu-amd64." + shaStub + ".so",
+		},
+		{
+			Bucket:                  "cockroach",
+			CacheControl:            "no-cache",
+			Key:                     "cockroach/lib/libgeos_c.linux-gnu-amd64.so.LATEST",
+			WebsiteRedirectLocation: "/cockroach/lib/libgeos_c.linux-gnu-amd64." + shaStub + ".so",
+		},
+
 		{
 			Bucket:             "cockroach",
 			ContentDisposition: "attachment; filename=cockroach.race.linux-gnu-amd64." + shaStub,
@@ -101,6 +147,29 @@ func TestMain(t *testing.T) {
 		},
 		{
 			Bucket:             "cockroach",
+			ContentDisposition: "attachment; filename=libgeos.race.linux-gnu-amd64." + shaStub + ".so",
+			Key:                "/cockroach/lib/libgeos.race.linux-gnu-amd64." + shaStub + ".so",
+		},
+		{
+			Bucket:                  "cockroach",
+			CacheControl:            "no-cache",
+			Key:                     "cockroach/lib/libgeos.race.linux-gnu-amd64.so.LATEST",
+			WebsiteRedirectLocation: "/cockroach/lib/libgeos.race.linux-gnu-amd64." + shaStub + ".so",
+		},
+		{
+			Bucket:             "cockroach",
+			ContentDisposition: "attachment; filename=libgeos_c.race.linux-gnu-amd64." + shaStub + ".so",
+			Key:                "/cockroach/lib/libgeos_c.race.linux-gnu-amd64." + shaStub + ".so",
+		},
+		{
+			Bucket:                  "cockroach",
+			CacheControl:            "no-cache",
+			Key:                     "cockroach/lib/libgeos_c.race.linux-gnu-amd64.so.LATEST",
+			WebsiteRedirectLocation: "/cockroach/lib/libgeos_c.race.linux-gnu-amd64." + shaStub + ".so",
+		},
+
+		{
+			Bucket:             "cockroach",
 			ContentDisposition: "attachment; filename=cockroach.windows-amd64." + shaStub + ".exe",
 			Key:                "/cockroach/cockroach.windows-amd64." + shaStub + ".exe",
 		},
@@ -110,6 +179,29 @@ func TestMain(t *testing.T) {
 			Key:                     "cockroach/cockroach.windows-amd64.LATEST",
 			WebsiteRedirectLocation: "/cockroach/cockroach.windows-amd64." + shaStub + ".exe",
 		},
+		{
+			Bucket:             "cockroach",
+			ContentDisposition: "attachment; filename=libgeos.windows-amd64." + shaStub + ".dll",
+			Key:                "/cockroach/lib/libgeos.windows-amd64." + shaStub + ".dll",
+		},
+		{
+			Bucket:                  "cockroach",
+			CacheControl:            "no-cache",
+			Key:                     "cockroach/lib/libgeos.windows-amd64.dll.LATEST",
+			WebsiteRedirectLocation: "/cockroach/lib/libgeos.windows-amd64." + shaStub + ".dll",
+		},
+		{
+			Bucket:             "cockroach",
+			ContentDisposition: "attachment; filename=libgeos_c.windows-amd64." + shaStub + ".dll",
+			Key:                "/cockroach/lib/libgeos_c.windows-amd64." + shaStub + ".dll",
+		},
+		{
+			Bucket:                  "cockroach",
+			CacheControl:            "no-cache",
+			Key:                     "cockroach/lib/libgeos_c.windows-amd64.dll.LATEST",
+			WebsiteRedirectLocation: "/cockroach/lib/libgeos_c.windows-amd64." + shaStub + ".dll",
+		},
+
 		{
 			Bucket:             "cockroach",
 			ContentDisposition: "attachment; filename=workload." + shaStub,
@@ -191,15 +283,5 @@ func TestMain(t *testing.T) {
 		acts = append(acts, act)
 	}
 
-	for i := len(exp); i < len(acts); i++ {
-		exp = append(exp, testCase{})
-	}
-	for i := len(acts); i < len(exp); i++ {
-		acts = append(acts, testCase{})
-	}
-
-	if len(pretty.Diff(acts, exp)) > 0 {
-		t.Error("diff(act, exp) is nontrivial")
-		pretty.Ldiff(t, acts, exp)
-	}
+	require.Equal(t, exp, acts)
 }

--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -316,16 +316,15 @@ type opts struct {
 }
 
 func putNonRelease(svc s3I, o opts) {
-	crdbPath := filepath.Join(o.PkgDir, o.Base)
-	files := []release.NonReleaseFile{
-		release.MakeCRDBBinaryNonReleaseFile(o.Base, crdbPath, o.VersionStr),
-	}
 	release.PutNonRelease(
 		svc,
 		release.PutNonReleaseOptions{
 			Branch:     o.Branch,
 			BucketName: o.BucketName,
-			Files:      files,
+			Files: append(
+				[]release.NonReleaseFile{release.MakeCRDBBinaryNonReleaseFile(o.Base, filepath.Join(o.PkgDir, o.Base), o.VersionStr)},
+				release.MakeCRDBLibraryNonReleaseFiles(o.PkgDir, o.BuildType, o.VersionStr, o.Suffix)...,
+			),
 		},
 	)
 }
@@ -341,17 +340,16 @@ func s3KeyArchive(o opts) (string, string) {
 }
 
 func putRelease(svc s3I, o opts) {
-	crdbPath := filepath.Join(o.PkgDir, o.Base)
-	files := []release.ArchiveFile{
-		release.MakeCRDBBinaryArchiveFile(o.Base, crdbPath),
-	}
 	release.PutRelease(svc, release.PutReleaseOptions{
 		BucketName: o.BucketName,
 		NoCache:    false,
 		Suffix:     o.Suffix,
 		BuildType:  o.BuildType,
 		VersionStr: o.VersionStr,
-		Files:      files,
+		Files: append(
+			[]release.ArchiveFile{release.MakeCRDBBinaryArchiveFile(o.Base, filepath.Join(o.PkgDir, o.Base))},
+			release.MakeCRDBLibraryArchiveFiles(o.PkgDir, o.BuildType)...,
+		),
 	})
 }
 


### PR DESCRIPTION
This commit adds libgeos.* and libgeos_c.* files to be uploaded to S3 at
`s3://cockroach/cockroach/lib/` as well as adding the files into the
.tar.gz and .zip archives.

Release note (general change): The CockroachDB tarballs now include
libgeos and libgeos_c static libraries, which are required to be copied
to /usr/local/lib/cockroach for UNIX/MacOS systems to perform certain
geospatial operations. The Windows location will be finalized at a later
date. This location is configurable with the `--geo-libs` flag.