### PR TITLE
sql: add a `TypeDescriptor.Validate` function

### DIFF
--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -141,6 +141,12 @@ func (p *planner) createDescriptorWithID(
 		return err
 	}
 
+	if mutType, ok := descriptor.(*sqlbase.MutableTypeDescriptor); ok {
+		if err := mutType.Validate(ctx, p.txn, p.ExecCfg().Codec); err != nil {
+			return err
+		}
+	}
+
 	mutDesc, isTable := descriptor.(*sqlbase.MutableTableDescriptor)
 	if isTable {
 		if err := mutDesc.ValidateTable(); err != nil {

--- a/pkg/sql/sqlbase/validate_test.go
+++ b/pkg/sql/sqlbase/validate_test.go
@@ -196,6 +196,22 @@ var validationMap = []struct {
 			"Match":             {status: thisFieldReferencesNoObjects},
 		},
 	},
+	{
+		obj: TypeDescriptor{},
+		fieldMap: map[string]validationStatusInfo{
+			"Name":             {status: iSolemnlySwearThisFieldIsValidated},
+			"ID":               {status: iSolemnlySwearThisFieldIsValidated},
+			"Version":          {status: thisFieldReferencesNoObjects},
+			"ModificationTime": {status: thisFieldReferencesNoObjects},
+			"DrainingNames":    {status: thisFieldReferencesNoObjects},
+			"ParentID":         {status: iSolemnlySwearThisFieldIsValidated},
+			"ParentSchemaID":   {status: iSolemnlySwearThisFieldIsValidated},
+			"Kind":             {status: thisFieldReferencesNoObjects},
+			"ArrayTypeID":      {status: iSolemnlySwearThisFieldIsValidated},
+			"EnumMembers":      {status: iSolemnlySwearThisFieldIsValidated},
+			"Alias":            {status: iSolemnlySwearThisFieldIsValidated},
+		},
+	},
 }
 
 type validationStatusInfo struct {


### PR DESCRIPTION
This PR adds a validation function for `TypeDescriptor` and calls it
before `TypeDescriptor`s are written to disk.

Release note: None