### PR TITLE
colexec: use execgen directives for and_or op

### DIFF
--- a/pkg/sql/colexec/and_or_projection.eg.go
+++ b/pkg/sql/colexec/and_or_projection.eg.go
@@ -119,34 +119,49 @@ func (o *andProjOp) Next(ctx context.Context) coldata.Batch {
 	// knownResult indicates the boolean value which if present on the left side
 	// fully determines the result of the logical operation.
 	var (
-		knownResult             bool
-		isLeftNull, isRightNull bool
+		knownResult bool
 	)
 	leftCol := batch.ColVec(o.leftIdx)
 	leftColVals := leftCol.Bool()
+	leftNulls := leftCol.Nulls()
 	var curIdx int
 	if usesSel {
 		sel := batch.Selection()
 		origSel := o.origSel[:origLen]
 		if leftCol.MaybeHasNulls() {
-			leftNulls := leftCol.Nulls()
 			for _, i := range origSel {
-				isLeftNull = leftNulls.NullAt(i)
-				if isLeftNull || leftColVals[i] != knownResult {
-					// We add the tuple into the selection vector if the left value is NULL or
-					// it is different from knownResult.
-					sel[curIdx] = i
-					curIdx++
+				{
+					var __retval_0 int
+					{
+						if (true && leftNulls.NullAt(i)) || leftColVals[i] != knownResult {
+							// We add the tuple into the selection vector if the left value is NULL or
+							// it is different from knownResult.
+							sel[curIdx] = i
+							curIdx++
+						}
+						{
+							__retval_0 = curIdx
+						}
+					}
+					curIdx = __retval_0
 				}
 			}
 		} else {
 			for _, i := range origSel {
-				isLeftNull = false
-				if isLeftNull || leftColVals[i] != knownResult {
-					// We add the tuple into the selection vector if the left value is NULL or
-					// it is different from knownResult.
-					sel[curIdx] = i
-					curIdx++
+				{
+					var __retval_0 int
+					{
+						if (false && leftNulls.NullAt(i)) || leftColVals[i] != knownResult {
+							// We add the tuple into the selection vector if the left value is NULL or
+							// it is different from knownResult.
+							sel[curIdx] = i
+							curIdx++
+						}
+						{
+							__retval_0 = curIdx
+						}
+					}
+					curIdx = __retval_0
 				}
 			}
 		}
@@ -154,24 +169,39 @@ func (o *andProjOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetSelection(true)
 		sel := batch.Selection()
 		if leftCol.MaybeHasNulls() {
-			leftNulls := leftCol.Nulls()
 			for i := 0; i < origLen; i++ {
-				isLeftNull = leftNulls.NullAt(i)
-				if isLeftNull || leftColVals[i] != knownResult {
-					// We add the tuple into the selection vector if the left value is NULL or
-					// it is different from knownResult.
-					sel[curIdx] = i
-					curIdx++
+				{
+					var __retval_0 int
+					{
+						if (true && leftNulls.NullAt(i)) || leftColVals[i] != knownResult {
+							// We add the tuple into the selection vector if the left value is NULL or
+							// it is different from knownResult.
+							sel[curIdx] = i
+							curIdx++
+						}
+						{
+							__retval_0 = curIdx
+						}
+					}
+					curIdx = __retval_0
 				}
 			}
 		} else {
 			for i := 0; i < origLen; i++ {
-				isLeftNull = false
-				if isLeftNull || leftColVals[i] != knownResult {
-					// We add the tuple into the selection vector if the left value is NULL or
-					// it is different from knownResult.
-					sel[curIdx] = i
-					curIdx++
+				{
+					var __retval_0 int
+					{
+						if (false && leftNulls.NullAt(i)) || leftColVals[i] != knownResult {
+							// We add the tuple into the selection vector if the left value is NULL or
+							// it is different from knownResult.
+							sel[curIdx] = i
+							curIdx++
+						}
+						{
+							__retval_0 = curIdx
+						}
+					}
+					curIdx = __retval_0
 				}
 			}
 		}
@@ -199,10 +229,12 @@ func (o *andProjOp) Next(ctx context.Context) coldata.Batch {
 	var (
 		rightCol     coldata.Vec
 		rightColVals []bool
+		rightNulls   *coldata.Nulls
 	)
 	if ranRightSide {
 		rightCol = batch.ColVec(o.rightIdx)
 		rightColVals = rightCol.Bool()
+		rightNulls = rightCol.Nulls()
 	}
 	outputCol := batch.ColVec(o.outputIdx)
 	outputColVals := outputCol.Bool()
@@ -215,243 +247,24 @@ func (o *andProjOp) Next(ctx context.Context) coldata.Batch {
 	// This is where we populate the output - do the actual evaluation of the
 	// logical operation.
 	if leftCol.MaybeHasNulls() {
-		leftNulls := leftCol.Nulls()
 		if rightCol != nil && rightCol.MaybeHasNulls() {
-			rightNulls := rightCol.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				for _, idx := range sel[:origLen] {
-					isLeftNull = leftNulls.NullAt(idx)
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = rightNulls.NullAt(idx)
-						rightVal := rightColVals[idx]
-						// The rules for AND'ing two booleans are:
-						// 1. if at least one of the values is FALSE, then the result is also FALSE
-						// 2. if both values are TRUE, then the result is also TRUE
-						// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is FALSE.
-							outputColVals[idx] = false
-						} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
-							// Rule 2: both booleans are TRUE.
-							outputColVals[idx] = true
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			} else {
-				if ranRightSide {
-					_ = rightColVals[origLen-1]
-				}
-				_ = outputColVals[origLen-1]
-				for idx := range leftColVals[:origLen] {
-					isLeftNull = leftNulls.NullAt(idx)
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = rightNulls.NullAt(idx)
-						rightVal := rightColVals[idx]
-						// The rules for AND'ing two booleans are:
-						// 1. if at least one of the values is FALSE, then the result is also FALSE
-						// 2. if both values are TRUE, then the result is also TRUE
-						// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is FALSE.
-							outputColVals[idx] = false
-						} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
-							// Rule 2: both booleans are TRUE.
-							outputColVals[idx] = true
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			}
+			setValues_false_true_true(batch, knownResult, leftNulls, rightNulls, outputNulls,
+				leftColVals, rightColVals, outputColVals, ranRightSide, origLen,
+			)
 		} else {
-			if sel := batch.Selection(); sel != nil {
-				for _, idx := range sel[:origLen] {
-					isLeftNull = leftNulls.NullAt(idx)
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = false
-						rightVal := rightColVals[idx]
-						// The rules for AND'ing two booleans are:
-						// 1. if at least one of the values is FALSE, then the result is also FALSE
-						// 2. if both values are TRUE, then the result is also TRUE
-						// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is FALSE.
-							outputColVals[idx] = false
-						} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
-							// Rule 2: both booleans are TRUE.
-							outputColVals[idx] = true
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			} else {
-				if ranRightSide {
-					_ = rightColVals[origLen-1]
-				}
-				_ = outputColVals[origLen-1]
-				for idx := range leftColVals[:origLen] {
-					isLeftNull = leftNulls.NullAt(idx)
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = false
-						rightVal := rightColVals[idx]
-						// The rules for AND'ing two booleans are:
-						// 1. if at least one of the values is FALSE, then the result is also FALSE
-						// 2. if both values are TRUE, then the result is also TRUE
-						// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is FALSE.
-							outputColVals[idx] = false
-						} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
-							// Rule 2: both booleans are TRUE.
-							outputColVals[idx] = true
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			}
+			setValues_false_true_false(batch, knownResult, leftNulls, rightNulls, outputNulls,
+				leftColVals, rightColVals, outputColVals, ranRightSide, origLen,
+			)
 		}
 	} else {
 		if rightCol != nil && rightCol.MaybeHasNulls() {
-			rightNulls := rightCol.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				for _, idx := range sel[:origLen] {
-					isLeftNull = false
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = rightNulls.NullAt(idx)
-						rightVal := rightColVals[idx]
-						// The rules for AND'ing two booleans are:
-						// 1. if at least one of the values is FALSE, then the result is also FALSE
-						// 2. if both values are TRUE, then the result is also TRUE
-						// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is FALSE.
-							outputColVals[idx] = false
-						} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
-							// Rule 2: both booleans are TRUE.
-							outputColVals[idx] = true
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			} else {
-				if ranRightSide {
-					_ = rightColVals[origLen-1]
-				}
-				_ = outputColVals[origLen-1]
-				for idx := range leftColVals[:origLen] {
-					isLeftNull = false
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = rightNulls.NullAt(idx)
-						rightVal := rightColVals[idx]
-						// The rules for AND'ing two booleans are:
-						// 1. if at least one of the values is FALSE, then the result is also FALSE
-						// 2. if both values are TRUE, then the result is also TRUE
-						// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is FALSE.
-							outputColVals[idx] = false
-						} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
-							// Rule 2: both booleans are TRUE.
-							outputColVals[idx] = true
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			}
+			setValues_false_false_true(batch, knownResult, leftNulls, rightNulls, outputNulls,
+				leftColVals, rightColVals, outputColVals, ranRightSide, origLen,
+			)
 		} else {
-			if sel := batch.Selection(); sel != nil {
-				for _, idx := range sel[:origLen] {
-					isLeftNull = false
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = false
-						rightVal := rightColVals[idx]
-						// The rules for AND'ing two booleans are:
-						// 1. if at least one of the values is FALSE, then the result is also FALSE
-						// 2. if both values are TRUE, then the result is also TRUE
-						// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is FALSE.
-							outputColVals[idx] = false
-						} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
-							// Rule 2: both booleans are TRUE.
-							outputColVals[idx] = true
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			} else {
-				if ranRightSide {
-					_ = rightColVals[origLen-1]
-				}
-				_ = outputColVals[origLen-1]
-				for idx := range leftColVals[:origLen] {
-					isLeftNull = false
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = false
-						rightVal := rightColVals[idx]
-						// The rules for AND'ing two booleans are:
-						// 1. if at least one of the values is FALSE, then the result is also FALSE
-						// 2. if both values are TRUE, then the result is also TRUE
-						// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is FALSE.
-							outputColVals[idx] = false
-						} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
-							// Rule 2: both booleans are TRUE.
-							outputColVals[idx] = true
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			}
+			setValues_false_false_false(batch, knownResult, leftNulls, rightNulls, outputNulls,
+				leftColVals, rightColVals, outputColVals, ranRightSide, origLen,
+			)
 		}
 	}
 
@@ -557,35 +370,50 @@ func (o *orProjOp) Next(ctx context.Context) coldata.Batch {
 	// knownResult indicates the boolean value which if present on the left side
 	// fully determines the result of the logical operation.
 	var (
-		knownResult             bool
-		isLeftNull, isRightNull bool
+		knownResult bool
 	)
 	knownResult = true
 	leftCol := batch.ColVec(o.leftIdx)
 	leftColVals := leftCol.Bool()
+	leftNulls := leftCol.Nulls()
 	var curIdx int
 	if usesSel {
 		sel := batch.Selection()
 		origSel := o.origSel[:origLen]
 		if leftCol.MaybeHasNulls() {
-			leftNulls := leftCol.Nulls()
 			for _, i := range origSel {
-				isLeftNull = leftNulls.NullAt(i)
-				if isLeftNull || leftColVals[i] != knownResult {
-					// We add the tuple into the selection vector if the left value is NULL or
-					// it is different from knownResult.
-					sel[curIdx] = i
-					curIdx++
+				{
+					var __retval_0 int
+					{
+						if (true && leftNulls.NullAt(i)) || leftColVals[i] != knownResult {
+							// We add the tuple into the selection vector if the left value is NULL or
+							// it is different from knownResult.
+							sel[curIdx] = i
+							curIdx++
+						}
+						{
+							__retval_0 = curIdx
+						}
+					}
+					curIdx = __retval_0
 				}
 			}
 		} else {
 			for _, i := range origSel {
-				isLeftNull = false
-				if isLeftNull || leftColVals[i] != knownResult {
-					// We add the tuple into the selection vector if the left value is NULL or
-					// it is different from knownResult.
-					sel[curIdx] = i
-					curIdx++
+				{
+					var __retval_0 int
+					{
+						if (false && leftNulls.NullAt(i)) || leftColVals[i] != knownResult {
+							// We add the tuple into the selection vector if the left value is NULL or
+							// it is different from knownResult.
+							sel[curIdx] = i
+							curIdx++
+						}
+						{
+							__retval_0 = curIdx
+						}
+					}
+					curIdx = __retval_0
 				}
 			}
 		}
@@ -593,24 +421,39 @@ func (o *orProjOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetSelection(true)
 		sel := batch.Selection()
 		if leftCol.MaybeHasNulls() {
-			leftNulls := leftCol.Nulls()
 			for i := 0; i < origLen; i++ {
-				isLeftNull = leftNulls.NullAt(i)
-				if isLeftNull || leftColVals[i] != knownResult {
-					// We add the tuple into the selection vector if the left value is NULL or
-					// it is different from knownResult.
-					sel[curIdx] = i
-					curIdx++
+				{
+					var __retval_0 int
+					{
+						if (true && leftNulls.NullAt(i)) || leftColVals[i] != knownResult {
+							// We add the tuple into the selection vector if the left value is NULL or
+							// it is different from knownResult.
+							sel[curIdx] = i
+							curIdx++
+						}
+						{
+							__retval_0 = curIdx
+						}
+					}
+					curIdx = __retval_0
 				}
 			}
 		} else {
 			for i := 0; i < origLen; i++ {
-				isLeftNull = false
-				if isLeftNull || leftColVals[i] != knownResult {
-					// We add the tuple into the selection vector if the left value is NULL or
-					// it is different from knownResult.
-					sel[curIdx] = i
-					curIdx++
+				{
+					var __retval_0 int
+					{
+						if (false && leftNulls.NullAt(i)) || leftColVals[i] != knownResult {
+							// We add the tuple into the selection vector if the left value is NULL or
+							// it is different from knownResult.
+							sel[curIdx] = i
+							curIdx++
+						}
+						{
+							__retval_0 = curIdx
+						}
+					}
+					curIdx = __retval_0
 				}
 			}
 		}
@@ -638,10 +481,12 @@ func (o *orProjOp) Next(ctx context.Context) coldata.Batch {
 	var (
 		rightCol     coldata.Vec
 		rightColVals []bool
+		rightNulls   *coldata.Nulls
 	)
 	if ranRightSide {
 		rightCol = batch.ColVec(o.rightIdx)
 		rightColVals = rightCol.Bool()
+		rightNulls = rightCol.Nulls()
 	}
 	outputCol := batch.ColVec(o.outputIdx)
 	outputColVals := outputCol.Bool()
@@ -654,245 +499,672 @@ func (o *orProjOp) Next(ctx context.Context) coldata.Batch {
 	// This is where we populate the output - do the actual evaluation of the
 	// logical operation.
 	if leftCol.MaybeHasNulls() {
-		leftNulls := leftCol.Nulls()
 		if rightCol != nil && rightCol.MaybeHasNulls() {
-			rightNulls := rightCol.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				for _, idx := range sel[:origLen] {
-					isLeftNull = leftNulls.NullAt(idx)
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = rightNulls.NullAt(idx)
-						rightVal := rightColVals[idx]
-						// The rules for OR'ing two booleans are:
-						// 1. if at least one of the values is TRUE, then the result is also TRUE
-						// 2. if both values are FALSE, then the result is also FALSE
-						// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is TRUE.
-							outputColVals[idx] = true
-						} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
-							// Rule 2: both booleans are FALSE.
-							outputColVals[idx] = false
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			} else {
-				if ranRightSide {
-					_ = rightColVals[origLen-1]
-				}
-				_ = outputColVals[origLen-1]
-				for idx := range leftColVals[:origLen] {
-					isLeftNull = leftNulls.NullAt(idx)
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = rightNulls.NullAt(idx)
-						rightVal := rightColVals[idx]
-						// The rules for OR'ing two booleans are:
-						// 1. if at least one of the values is TRUE, then the result is also TRUE
-						// 2. if both values are FALSE, then the result is also FALSE
-						// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is TRUE.
-							outputColVals[idx] = true
-						} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
-							// Rule 2: both booleans are FALSE.
-							outputColVals[idx] = false
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			}
+			setValues_true_true_true(batch, knownResult, leftNulls, rightNulls, outputNulls,
+				leftColVals, rightColVals, outputColVals, ranRightSide, origLen,
+			)
 		} else {
-			if sel := batch.Selection(); sel != nil {
-				for _, idx := range sel[:origLen] {
-					isLeftNull = leftNulls.NullAt(idx)
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = false
-						rightVal := rightColVals[idx]
-						// The rules for OR'ing two booleans are:
-						// 1. if at least one of the values is TRUE, then the result is also TRUE
-						// 2. if both values are FALSE, then the result is also FALSE
-						// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is TRUE.
-							outputColVals[idx] = true
-						} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
-							// Rule 2: both booleans are FALSE.
-							outputColVals[idx] = false
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			} else {
-				if ranRightSide {
-					_ = rightColVals[origLen-1]
-				}
-				_ = outputColVals[origLen-1]
-				for idx := range leftColVals[:origLen] {
-					isLeftNull = leftNulls.NullAt(idx)
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = false
-						rightVal := rightColVals[idx]
-						// The rules for OR'ing two booleans are:
-						// 1. if at least one of the values is TRUE, then the result is also TRUE
-						// 2. if both values are FALSE, then the result is also FALSE
-						// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is TRUE.
-							outputColVals[idx] = true
-						} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
-							// Rule 2: both booleans are FALSE.
-							outputColVals[idx] = false
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			}
+			setValues_true_true_false(batch, knownResult, leftNulls, rightNulls, outputNulls,
+				leftColVals, rightColVals, outputColVals, ranRightSide, origLen,
+			)
 		}
 	} else {
 		if rightCol != nil && rightCol.MaybeHasNulls() {
-			rightNulls := rightCol.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				for _, idx := range sel[:origLen] {
-					isLeftNull = false
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = rightNulls.NullAt(idx)
-						rightVal := rightColVals[idx]
-						// The rules for OR'ing two booleans are:
-						// 1. if at least one of the values is TRUE, then the result is also TRUE
-						// 2. if both values are FALSE, then the result is also FALSE
-						// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is TRUE.
-							outputColVals[idx] = true
-						} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
-							// Rule 2: both booleans are FALSE.
-							outputColVals[idx] = false
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			} else {
-				if ranRightSide {
-					_ = rightColVals[origLen-1]
-				}
-				_ = outputColVals[origLen-1]
-				for idx := range leftColVals[:origLen] {
-					isLeftNull = false
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = rightNulls.NullAt(idx)
-						rightVal := rightColVals[idx]
-						// The rules for OR'ing two booleans are:
-						// 1. if at least one of the values is TRUE, then the result is also TRUE
-						// 2. if both values are FALSE, then the result is also FALSE
-						// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is TRUE.
-							outputColVals[idx] = true
-						} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
-							// Rule 2: both booleans are FALSE.
-							outputColVals[idx] = false
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			}
+			setValues_true_false_true(batch, knownResult, leftNulls, rightNulls, outputNulls,
+				leftColVals, rightColVals, outputColVals, ranRightSide, origLen,
+			)
 		} else {
-			if sel := batch.Selection(); sel != nil {
-				for _, idx := range sel[:origLen] {
-					isLeftNull = false
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = false
-						rightVal := rightColVals[idx]
-						// The rules for OR'ing two booleans are:
-						// 1. if at least one of the values is TRUE, then the result is also TRUE
-						// 2. if both values are FALSE, then the result is also FALSE
-						// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is TRUE.
-							outputColVals[idx] = true
-						} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
-							// Rule 2: both booleans are FALSE.
-							outputColVals[idx] = false
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			} else {
-				if ranRightSide {
-					_ = rightColVals[origLen-1]
-				}
-				_ = outputColVals[origLen-1]
-				for idx := range leftColVals[:origLen] {
-					isLeftNull = false
-					leftVal := leftColVals[idx]
-					if !isLeftNull && leftVal == knownResult {
-						outputColVals[idx] = leftVal
-					} else {
-						isRightNull = false
-						rightVal := rightColVals[idx]
-						// The rules for OR'ing two booleans are:
-						// 1. if at least one of the values is TRUE, then the result is also TRUE
-						// 2. if both values are FALSE, then the result is also FALSE
-						// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
-						//    the result is NULL.
-						if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
-							// Rule 1: at least one boolean is TRUE.
-							outputColVals[idx] = true
-						} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
-							// Rule 2: both booleans are FALSE.
-							outputColVals[idx] = false
-						} else {
-							// Rule 3.
-							outputNulls.SetNull(idx)
-						}
-					}
-				}
-			}
+			setValues_true_false_false(batch, knownResult, leftNulls, rightNulls, outputNulls,
+				leftColVals, rightColVals, outputColVals, ranRightSide, origLen,
+			)
 		}
 	}
 
 	return batch
 }
+
+// This code snippet decides whether to include the tuple with index i into
+// the selection vector to be used by the right side projection. The tuple is
+// excluded if we already know the result of logical operation (i.e. we do the
+// short-circuiting for it).
+// execgen:inline
+const _ = "template_addTupleForRight"
+
+// execgen:inline
+const _ = "inlined_addTupleForRight_false"
+
+// execgen:inline
+const _ = "inlined_addTupleForRight_true"
+
+// This code snippet sets the result of applying a logical operation AND or OR
+// to two boolean vectors while paying attention to null values.
+const _ = "template_setValues"
+
+func setValues_false_false_false(
+	batch coldata.Batch,
+	knownResult bool,
+	leftNulls *coldata.Nulls,
+	rightNulls *coldata.Nulls,
+	outputNulls *coldata.Nulls,
+	leftColVals coldata.Bools,
+	rightColVals coldata.Bools,
+	outputColVals coldata.Bools,
+	ranRightSide bool,
+	origLen int,
+) {
+	if sel := batch.Selection(); sel != nil {
+		for _, idx := range sel[:origLen] {
+			{
+				isLeftNull := false && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := false && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for AND'ing two booleans are:
+					// 1. if at least one of the values is FALSE, then the result is also FALSE
+					// 2. if both values are TRUE, then the result is also TRUE
+					// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is FALSE.
+						outputColVals[idx] = false
+					} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
+						// Rule 2: both booleans are TRUE.
+						outputColVals[idx] = true
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	} else {
+		if ranRightSide {
+			_ = rightColVals[origLen-1]
+		}
+		_ = outputColVals[origLen-1]
+		for idx := range leftColVals[:origLen] {
+			{
+				isLeftNull := false && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := false && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for AND'ing two booleans are:
+					// 1. if at least one of the values is FALSE, then the result is also FALSE
+					// 2. if both values are TRUE, then the result is also TRUE
+					// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is FALSE.
+						outputColVals[idx] = false
+					} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
+						// Rule 2: both booleans are TRUE.
+						outputColVals[idx] = true
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	}
+}
+
+func setValues_true_false_false(
+	batch coldata.Batch,
+	knownResult bool,
+	leftNulls *coldata.Nulls,
+	rightNulls *coldata.Nulls,
+	outputNulls *coldata.Nulls,
+	leftColVals coldata.Bools,
+	rightColVals coldata.Bools,
+	outputColVals coldata.Bools,
+	ranRightSide bool,
+	origLen int,
+) {
+	if sel := batch.Selection(); sel != nil {
+		for _, idx := range sel[:origLen] {
+			{
+				isLeftNull := false && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := false && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for OR'ing two booleans are:
+					// 1. if at least one of the values is TRUE, then the result is also TRUE
+					// 2. if both values are FALSE, then the result is also FALSE
+					// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is TRUE.
+						outputColVals[idx] = true
+					} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
+						// Rule 2: both booleans are FALSE.
+						outputColVals[idx] = false
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	} else {
+		if ranRightSide {
+			_ = rightColVals[origLen-1]
+		}
+		_ = outputColVals[origLen-1]
+		for idx := range leftColVals[:origLen] {
+			{
+				isLeftNull := false && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := false && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for OR'ing two booleans are:
+					// 1. if at least one of the values is TRUE, then the result is also TRUE
+					// 2. if both values are FALSE, then the result is also FALSE
+					// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is TRUE.
+						outputColVals[idx] = true
+					} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
+						// Rule 2: both booleans are FALSE.
+						outputColVals[idx] = false
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	}
+}
+
+func setValues_false_true_false(
+	batch coldata.Batch,
+	knownResult bool,
+	leftNulls *coldata.Nulls,
+	rightNulls *coldata.Nulls,
+	outputNulls *coldata.Nulls,
+	leftColVals coldata.Bools,
+	rightColVals coldata.Bools,
+	outputColVals coldata.Bools,
+	ranRightSide bool,
+	origLen int,
+) {
+	if sel := batch.Selection(); sel != nil {
+		for _, idx := range sel[:origLen] {
+			{
+				isLeftNull := true && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := false && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for AND'ing two booleans are:
+					// 1. if at least one of the values is FALSE, then the result is also FALSE
+					// 2. if both values are TRUE, then the result is also TRUE
+					// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is FALSE.
+						outputColVals[idx] = false
+					} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
+						// Rule 2: both booleans are TRUE.
+						outputColVals[idx] = true
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	} else {
+		if ranRightSide {
+			_ = rightColVals[origLen-1]
+		}
+		_ = outputColVals[origLen-1]
+		for idx := range leftColVals[:origLen] {
+			{
+				isLeftNull := true && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := false && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for AND'ing two booleans are:
+					// 1. if at least one of the values is FALSE, then the result is also FALSE
+					// 2. if both values are TRUE, then the result is also TRUE
+					// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is FALSE.
+						outputColVals[idx] = false
+					} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
+						// Rule 2: both booleans are TRUE.
+						outputColVals[idx] = true
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	}
+}
+
+func setValues_true_true_false(
+	batch coldata.Batch,
+	knownResult bool,
+	leftNulls *coldata.Nulls,
+	rightNulls *coldata.Nulls,
+	outputNulls *coldata.Nulls,
+	leftColVals coldata.Bools,
+	rightColVals coldata.Bools,
+	outputColVals coldata.Bools,
+	ranRightSide bool,
+	origLen int,
+) {
+	if sel := batch.Selection(); sel != nil {
+		for _, idx := range sel[:origLen] {
+			{
+				isLeftNull := true && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := false && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for OR'ing two booleans are:
+					// 1. if at least one of the values is TRUE, then the result is also TRUE
+					// 2. if both values are FALSE, then the result is also FALSE
+					// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is TRUE.
+						outputColVals[idx] = true
+					} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
+						// Rule 2: both booleans are FALSE.
+						outputColVals[idx] = false
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	} else {
+		if ranRightSide {
+			_ = rightColVals[origLen-1]
+		}
+		_ = outputColVals[origLen-1]
+		for idx := range leftColVals[:origLen] {
+			{
+				isLeftNull := true && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := false && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for OR'ing two booleans are:
+					// 1. if at least one of the values is TRUE, then the result is also TRUE
+					// 2. if both values are FALSE, then the result is also FALSE
+					// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is TRUE.
+						outputColVals[idx] = true
+					} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
+						// Rule 2: both booleans are FALSE.
+						outputColVals[idx] = false
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	}
+}
+
+func setValues_false_false_true(
+	batch coldata.Batch,
+	knownResult bool,
+	leftNulls *coldata.Nulls,
+	rightNulls *coldata.Nulls,
+	outputNulls *coldata.Nulls,
+	leftColVals coldata.Bools,
+	rightColVals coldata.Bools,
+	outputColVals coldata.Bools,
+	ranRightSide bool,
+	origLen int,
+) {
+	if sel := batch.Selection(); sel != nil {
+		for _, idx := range sel[:origLen] {
+			{
+				isLeftNull := false && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := true && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for AND'ing two booleans are:
+					// 1. if at least one of the values is FALSE, then the result is also FALSE
+					// 2. if both values are TRUE, then the result is also TRUE
+					// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is FALSE.
+						outputColVals[idx] = false
+					} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
+						// Rule 2: both booleans are TRUE.
+						outputColVals[idx] = true
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	} else {
+		if ranRightSide {
+			_ = rightColVals[origLen-1]
+		}
+		_ = outputColVals[origLen-1]
+		for idx := range leftColVals[:origLen] {
+			{
+				isLeftNull := false && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := true && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for AND'ing two booleans are:
+					// 1. if at least one of the values is FALSE, then the result is also FALSE
+					// 2. if both values are TRUE, then the result is also TRUE
+					// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is FALSE.
+						outputColVals[idx] = false
+					} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
+						// Rule 2: both booleans are TRUE.
+						outputColVals[idx] = true
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	}
+}
+
+func setValues_true_false_true(
+	batch coldata.Batch,
+	knownResult bool,
+	leftNulls *coldata.Nulls,
+	rightNulls *coldata.Nulls,
+	outputNulls *coldata.Nulls,
+	leftColVals coldata.Bools,
+	rightColVals coldata.Bools,
+	outputColVals coldata.Bools,
+	ranRightSide bool,
+	origLen int,
+) {
+	if sel := batch.Selection(); sel != nil {
+		for _, idx := range sel[:origLen] {
+			{
+				isLeftNull := false && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := true && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for OR'ing two booleans are:
+					// 1. if at least one of the values is TRUE, then the result is also TRUE
+					// 2. if both values are FALSE, then the result is also FALSE
+					// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is TRUE.
+						outputColVals[idx] = true
+					} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
+						// Rule 2: both booleans are FALSE.
+						outputColVals[idx] = false
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	} else {
+		if ranRightSide {
+			_ = rightColVals[origLen-1]
+		}
+		_ = outputColVals[origLen-1]
+		for idx := range leftColVals[:origLen] {
+			{
+				isLeftNull := false && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := true && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for OR'ing two booleans are:
+					// 1. if at least one of the values is TRUE, then the result is also TRUE
+					// 2. if both values are FALSE, then the result is also FALSE
+					// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is TRUE.
+						outputColVals[idx] = true
+					} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
+						// Rule 2: both booleans are FALSE.
+						outputColVals[idx] = false
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	}
+}
+
+func setValues_false_true_true(
+	batch coldata.Batch,
+	knownResult bool,
+	leftNulls *coldata.Nulls,
+	rightNulls *coldata.Nulls,
+	outputNulls *coldata.Nulls,
+	leftColVals coldata.Bools,
+	rightColVals coldata.Bools,
+	outputColVals coldata.Bools,
+	ranRightSide bool,
+	origLen int,
+) {
+	if sel := batch.Selection(); sel != nil {
+		for _, idx := range sel[:origLen] {
+			{
+				isLeftNull := true && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := true && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for AND'ing two booleans are:
+					// 1. if at least one of the values is FALSE, then the result is also FALSE
+					// 2. if both values are TRUE, then the result is also TRUE
+					// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is FALSE.
+						outputColVals[idx] = false
+					} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
+						// Rule 2: both booleans are TRUE.
+						outputColVals[idx] = true
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	} else {
+		if ranRightSide {
+			_ = rightColVals[origLen-1]
+		}
+		_ = outputColVals[origLen-1]
+		for idx := range leftColVals[:origLen] {
+			{
+				isLeftNull := true && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := true && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for AND'ing two booleans are:
+					// 1. if at least one of the values is FALSE, then the result is also FALSE
+					// 2. if both values are TRUE, then the result is also TRUE
+					// 3. in all other cases (one is TRUE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (!leftVal && !isLeftNull) || (!rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is FALSE.
+						outputColVals[idx] = false
+					} else if (leftVal && !isLeftNull) && (rightVal && !isRightNull) {
+						// Rule 2: both booleans are TRUE.
+						outputColVals[idx] = true
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	}
+}
+
+func setValues_true_true_true(
+	batch coldata.Batch,
+	knownResult bool,
+	leftNulls *coldata.Nulls,
+	rightNulls *coldata.Nulls,
+	outputNulls *coldata.Nulls,
+	leftColVals coldata.Bools,
+	rightColVals coldata.Bools,
+	outputColVals coldata.Bools,
+	ranRightSide bool,
+	origLen int,
+) {
+	if sel := batch.Selection(); sel != nil {
+		for _, idx := range sel[:origLen] {
+			{
+				isLeftNull := true && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := true && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for OR'ing two booleans are:
+					// 1. if at least one of the values is TRUE, then the result is also TRUE
+					// 2. if both values are FALSE, then the result is also FALSE
+					// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is TRUE.
+						outputColVals[idx] = true
+					} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
+						// Rule 2: both booleans are FALSE.
+						outputColVals[idx] = false
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	} else {
+		if ranRightSide {
+			_ = rightColVals[origLen-1]
+		}
+		_ = outputColVals[origLen-1]
+		for idx := range leftColVals[:origLen] {
+			{
+				isLeftNull := true && leftNulls.NullAt(idx)
+				leftVal := leftColVals[idx]
+				if !isLeftNull && leftVal == knownResult {
+					outputColVals[idx] = leftVal
+				} else {
+					isRightNull := true && rightNulls.NullAt(idx)
+					rightVal := rightColVals[idx]
+					// The rules for OR'ing two booleans are:
+					// 1. if at least one of the values is TRUE, then the result is also TRUE
+					// 2. if both values are FALSE, then the result is also FALSE
+					// 3. in all other cases (one is FALSE and the other is NULL or both are NULL),
+					//    the result is NULL.
+					if (leftVal && !isLeftNull) || (rightVal && !isRightNull) {
+						// Rule 1: at least one boolean is TRUE.
+						outputColVals[idx] = true
+					} else if (!leftVal && !isLeftNull) && (!rightVal && !isRightNull) {
+						// Rule 2: both booleans are FALSE.
+						outputColVals[idx] = false
+					} else {
+						// Rule 3.
+						outputNulls.SetNull(idx)
+					}
+				}
+			}
+		}
+	}
+}
+
+// This code snippet sets the result of applying a logical operation AND or OR
+// to two boolean values which can be null.
+// execgen:inline
+const _ = "template_setSingleValue"
+
+// execgen:inline
+const _ = "inlined_setSingleValue_false_false_false"
+
+// execgen:inline
+const _ = "inlined_setSingleValue_true_false_false"
+
+// execgen:inline
+const _ = "inlined_setSingleValue_false_true_false"
+
+// execgen:inline
+const _ = "inlined_setSingleValue_true_true_false"
+
+// execgen:inline
+const _ = "inlined_setSingleValue_false_false_true"
+
+// execgen:inline
+const _ = "inlined_setSingleValue_true_false_true"
+
+// execgen:inline
+const _ = "inlined_setSingleValue_false_true_true"
+
+// execgen:inline
+const _ = "inlined_setSingleValue_true_true_true"

--- a/pkg/sql/colexec/execgen/cmd/execgen/and_or_projection_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/and_or_projection_gen.go
@@ -30,18 +30,11 @@ func genAndOrProjectionOps(inputFileContents string, wr io.Writer) error {
 	r := strings.NewReplacer(
 		"_OP_LOWER", "{{.Lower}}",
 		"_OP_TITLE", "{{.Title}}",
-		"_IS_OR_OP", ".IsOr",
+		"_IS_OR_OP", "{{.IsOr}}",
 		"_L_HAS_NULLS", "$.lHasNulls",
 		"_R_HAS_NULLS", "$.rHasNulls",
 	)
 	s := r.Replace(inputFileContents)
-
-	addTupleForRight := makeFunctionRegex("_ADD_TUPLE_FOR_RIGHT", 1)
-	s = addTupleForRight.ReplaceAllString(s, `{{template "addTupleForRight" buildDict "Global" $ "lHasNulls" $1}}`)
-	setValues := makeFunctionRegex("_SET_VALUES", 3)
-	s = setValues.ReplaceAllString(s, `{{template "setValues" buildDict "Global" $ "IsOr" $1 "lHasNulls" $2 "rHasNulls" $3}}`)
-	setSingleValue := makeFunctionRegex("_SET_SINGLE_VALUE", 3)
-	s = setSingleValue.ReplaceAllString(s, `{{template "setSingleValue" buildDict "Global" $ "IsOr" $1 "lHasNulls" $2 "rHasNulls" $3}}`)
 
 	tmpl, err := template.New("and").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {


### PR DESCRIPTION
This is a pretty good example of how we can use execgen:inline/template
even on functions that need type templating, which I didn't realize
before. It works fine because the template variables are left alone.

This allows some nice flexibility. For helper functions that needed
templating but didn't want inlining (there are many like this that are
not in inner loops, throughout the codebase), we needed to use the full
text/template inlining hammer which made enormous function bodies for no
good reason.

Now, we can use execgen:template on its own when inlining isn't
necessary, and add inlining only for the function bodies that need to
live in inner loops.

The performance differences here I'm pretty sure are just random noise.
I can't justify why we'd get 2x speed increase in some cases at all.

```
name                                              old time/op    new time/op    delta
LogicalProjOp/AND,useSel=true,hasNulls=true-24      9.62µs ± 1%   11.52µs ± 3%   +19.72%  (p=0.000 n=10+10)
LogicalProjOp/AND,useSel=true,hasNulls=false-24     4.45µs ± 3%    4.97µs ± 1%   +11.78%  (p=0.000 n=9+9)
LogicalProjOp/AND,useSel=false,hasNulls=true-24     9.52µs ± 1%   10.59µs ± 1%   +11.15%  (p=0.000 n=10+10)
LogicalProjOp/AND,useSel=false,hasNulls=false-24    10.5µs ± 4%     4.9µs ± 2%   -53.48%  (p=0.000 n=10+10)
LogicalProjOp/OR,useSel=true,hasNulls=true-24       12.0µs ± 4%    11.0µs ± 3%    -8.38%  (p=0.000 n=10+10)
LogicalProjOp/OR,useSel=true,hasNulls=false-24      3.78µs ± 2%    4.36µs ± 2%   +15.14%  (p=0.000 n=10+9)
LogicalProjOp/OR,useSel=false,hasNulls=true-24      10.1µs ± 2%    11.2µs ± 2%   +11.26%  (p=0.000 n=10+10)
LogicalProjOp/OR,useSel=false,hasNulls=false-24     6.00µs ± 2%    4.37µs ± 4%   -27.23%  (p=0.000 n=10+9)

name                                              old speed      new speed      delta
LogicalProjOp/AND,useSel=true,hasNulls=true-24     851MB/s ± 1%   711MB/s ± 3%   -16.44%  (p=0.000 n=10+10)
LogicalProjOp/AND,useSel=true,hasNulls=false-24   1.84GB/s ± 3%  1.65GB/s ± 1%   -10.56%  (p=0.000 n=9+9)
LogicalProjOp/AND,useSel=false,hasNulls=true-24    860MB/s ± 1%   773MB/s ± 1%   -10.16%  (p=0.000 n=10+9)
LogicalProjOp/AND,useSel=false,hasNulls=false-24   783MB/s ± 4%  1683MB/s ± 2%  +114.92%  (p=0.000 n=10+10)
LogicalProjOp/OR,useSel=true,hasNulls=true-24      682MB/s ± 4%   744MB/s ± 3%    +9.12%  (p=0.000 n=10+10)
LogicalProjOp/OR,useSel=true,hasNulls=false-24    2.16GB/s ± 2%  1.88GB/s ± 2%   -13.13%  (p=0.000 n=10+9)
LogicalProjOp/OR,useSel=false,hasNulls=true-24     815MB/s ± 2%   732MB/s ± 2%   -10.12%  (p=0.000 n=10+10)
LogicalProjOp/OR,useSel=false,hasNulls=false-24   1.36GB/s ± 1%  1.86GB/s ± 5%   +36.64%  (p=0.000 n=10+10)
```

Release note: None