### PR TITLE
colrpc: propagate error immediately in Inbox

### DIFF
--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -315,6 +315,12 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 				if !ok {
 					continue
 				}
+				if meta.Err != nil {
+					// If an error was encountered, it needs to be propagated immediately.
+					// All other metadata will simply be buffered and returned in
+					// DrainMeta.
+					colexecerror.ExpectedError(meta.Err)
+				}
 				i.stateMu.bufferedMeta = append(i.stateMu.bufferedMeta, meta)
 			}
 			// Continue until we get the next batch or EOF.


### PR DESCRIPTION
The Inbox would previously buffer any metadata received from the remote side,
including errors. This could cause issues for special errors that are
swallowed during draining but not execution, because all errors would only be
returned during draining.

Release note: None (bug not present in release)

Fixes #50687 