### PR TITLE
opt: retype AND/OR/NOT arguments as Bool

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -243,3 +243,16 @@ query T
 SELECT CASE WHEN true THEN 1234:::OID ELSE COALESCE(NULL, NULL) END
 ----
 1234
+
+# Regression test for #51099.
+query B rowsort
+SELECT CASE WHEN x > 1 THEN true ELSE NULL AND true END FROM (VALUES (1), (2)) AS v(x)
+----
+NULL
+true
+
+query B rowsort
+SELECT CASE WHEN x > 1 THEN true ELSE NULL OR false END FROM (VALUES (1), (2)) AS v(x)
+----
+NULL
+true

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -285,8 +285,8 @@ project
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      ├── NULL OR (k:1 = 1) [as=r:6, outer=(1)]
-      └── NULL AND (k:1 = 1) [as=s:7, outer=(1)]
+      ├── CAST(NULL AS BOOL) OR (k:1 = 1) [as=r:6, outer=(1)]
+      └── CAST(NULL AS BOOL) AND (k:1 = 1) [as=s:7, outer=(1)]
 
 # --------------------------------------------------
 # FoldNotTrue + FoldNotFalse + FoldNotNull
@@ -667,7 +667,7 @@ project
  ├── fd: ()-->(6)
  ├── scan a
  └── projections
-      └── NULL [as=r:6]
+      └── CAST(NULL AS BOOL) [as=r:6]
 
 norm expect=(ExtractRedundantConjunct)
 SELECT (null and k=2) or (null and k=1) AS r FROM a
@@ -678,7 +678,7 @@ project
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      └── NULL AND ((k:1 = 2) OR (k:1 = 1)) [as=r:6, outer=(1)]
+      └── CAST(NULL AS BOOL) AND ((k:1 = 2) OR (k:1 = 1)) [as=r:6, outer=(1)]
 
 # Check that we don't match non-redundant cases.
 norm expect-not=(ExtractRedundantConjunct)

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -113,8 +113,8 @@ func (b *Builder) buildScalar(
 		return b.finishBuildScalarRef(t.col, inScope, outScope, outCol, colRefs)
 
 	case *tree.AndExpr:
-		left := b.buildScalar(t.TypedLeft(), inScope, nil, nil, colRefs)
-		right := b.buildScalar(t.TypedRight(), inScope, nil, nil, colRefs)
+		left := b.buildScalar(tree.ReType(t.TypedLeft(), types.Bool), inScope, nil, nil, colRefs)
+		right := b.buildScalar(tree.ReType(t.TypedRight(), types.Bool), inScope, nil, nil, colRefs)
 		out = b.factory.ConstructAnd(left, right)
 
 	case *tree.Array:
@@ -311,7 +311,7 @@ func (b *Builder) buildScalar(
 		out = b.factory.ConstructVariable(inScope.cols[t.Idx].id)
 
 	case *tree.NotExpr:
-		input := b.buildScalar(t.TypedInnerExpr(), inScope, nil, nil, colRefs)
+		input := b.buildScalar(tree.ReType(t.TypedInnerExpr(), types.Bool), inScope, nil, nil, colRefs)
 		out = b.factory.ConstructNot(input)
 
 	case *tree.IsNullExpr:
@@ -345,8 +345,8 @@ func (b *Builder) buildScalar(
 		out = b.factory.ConstructCase(input, whens, input)
 
 	case *tree.OrExpr:
-		left := b.buildScalar(t.TypedLeft(), inScope, nil, nil, colRefs)
-		right := b.buildScalar(t.TypedRight(), inScope, nil, nil, colRefs)
+		left := b.buildScalar(tree.ReType(t.TypedLeft(), types.Bool), inScope, nil, nil, colRefs)
+		right := b.buildScalar(tree.ReType(t.TypedRight(), types.Bool), inScope, nil, nil, colRefs)
 		out = b.factory.ConstructOr(left, right)
 
 	case *tree.ParenExpr:

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -1259,3 +1259,27 @@ case [type=oid]
       │    └── null [type=unknown]
       └── cast: OID [type=oid]
            └── null [type=unknown]
+
+# Make sure NULL arguments for AND/OR/NOT are typed as boolean.
+build-scalar
+NULL AND true
+----
+and [type=bool]
+ ├── cast: BOOL [type=bool]
+ │    └── null [type=unknown]
+ └── true [type=bool]
+
+build-scalar
+false OR NULL
+----
+or [type=bool]
+ ├── false [type=bool]
+ └── cast: BOOL [type=bool]
+      └── null [type=unknown]
+
+build-scalar
+NOT NULL
+----
+not [type=bool]
+ └── cast: BOOL [type=bool]
+      └── null [type=unknown]


### PR DESCRIPTION
We have made CASE more strict in terms of input types, and this is uncovering
other cases. We will need to have more strict assertions about the types of
scalars in the optimizer instead of sqlsmith weeding out these issues.

Fixes #51099.

Release note (bug fix): fixed an internal error involving CASE and boolean
expressions with NULL operands.