### PR TITLE
jobs: do not include cancel jobs as running for scheduled jobs

### DIFF
--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -101,13 +101,15 @@ SELECT
    FROM %s J
    WHERE 
       J.created_by_type = '%s' AND J.created_by_id = S.schedule_id AND 
-      J.status NOT IN ('failed', 'succeeded', 'cancelled')
+      J.status NOT IN ('%s', '%s', '%s')
   ) AS num_running, S.*
 FROM %s S
 WHERE next_run < %s
 ORDER BY next_run
 %s
-`, env.SystemJobsTableName(), createdByName, env.ScheduledJobsTableName(), env.NowExpr(), limitClause)
+`, env.SystemJobsTableName(), createdByName,
+		StatusSucceeded, StatusCanceled, StatusFailed,
+		env.ScheduledJobsTableName(), env.NowExpr(), limitClause)
 }
 
 // unmarshalScheduledJob is a helper to deserialize a row returned by


### PR DESCRIPTION
Previously, the query that the job scheduling system would use to detect
if there were any already running jobs would include canceled jobs due
to using a the alternative spelling: 'cancelled'.

This commit changes the query to use the enums instead of manually
listing their state. It also adds a test to ensure that jobs are still
run, regardless of the wait policy when all previous runs are in a
terminal state.

Release note: None