### PR TITLE
opt: build partial index predicates as FiltersExprs

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1956,8 +1956,11 @@ delete partial_indexes
       ├── scan partial_indexes
       │    ├── columns: a:4!null b:5 c:6
       │    ├── partial index predicates
-      │    │    ├── secondary: c:6 = 'foo'
-      │    │    └── secondary: (a:4 > b:5) AND (c:6 = 'bar')
+      │    │    ├── secondary: filters
+      │    │    │    └── c:6 = 'foo' [outer=(6), constraints=(/6: [/'foo' - /'foo']; tight), fd=()-->(6)]
+      │    │    └── secondary: filters
+      │    │         ├── a:4 > b:5 [outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ])]
+      │    │         └── c:6 = 'bar' [outer=(6), constraints=(/6: [/'bar' - /'bar']; tight), fd=()-->(6)]
       │    ├── key: (4)
       │    └── fd: (4)-->(5,6)
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -464,8 +464,11 @@ delete partial_indexes
       ├── scan partial_indexes
       │    ├── columns: a:4!null b:5 c:6
       │    └── partial index predicates
-      │         ├── secondary: c:6 = 'foo'
-      │         └── secondary: (a:4 > b:5) AND (c:6 = 'bar')
+      │         ├── secondary: filters
+      │         │    └── c:6 = 'foo'
+      │         └── secondary: filters
+      │              ├── a:4 > b:5
+      │              └── c:6 = 'bar'
       └── projections
            ├── c:6 = 'foo' [as=partial_index_del1:7]
            └── (a:4 > b:5) AND (c:6 = 'bar') [as=partial_index_del2:8]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1289,5 +1289,8 @@ project
  └── scan partial_index
       ├── columns: k:1!null u:2 v:3
       └── partial index predicates
-           ├── u: u:2 = 1
-           └── v: ((v:3 > 100) AND (v:3 < 200)) AND (u:2 > 50)
+           ├── u: filters
+           │    └── u:2 = 1
+           └── v: filters
+                ├── (v:3 > 100) AND (v:3 < 200)
+                └── u:2 > 50

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -101,7 +101,7 @@ func TestImplicator(t *testing.T) {
 			}
 
 			// Build the predicate from the second split, everything after "=>".
-			pred, err := makeScalarExpr(splitInput[1], &semaCtx, &evalCtx, &f)
+			pred, err := makeFiltersExpr(splitInput[1], &semaCtx, &evalCtx, &f)
 			if err != nil {
 				d.Fatalf(t, "unexpected error while building predicate: %v\n", err)
 			}
@@ -266,7 +266,7 @@ func BenchmarkImplicator(b *testing.B) {
 		}
 
 		// Build the predicate.
-		pred, err := makeScalarExpr(tc.pred, &semaCtx, &evalCtx, &f)
+		pred, err := makeFiltersExpr(tc.pred, &semaCtx, &evalCtx, &f)
 		if err != nil {
 			b.Fatalf("unexpected error while building predicate: %v\n", err)
 		}

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -203,7 +203,7 @@ func (c *CustomFuncs) GeneratePartialIndexScans(
 	iter := makeScanIndexIter(c.e.mem, scanPrivate, rejectNonPartialIndexes)
 	for iter.Next() {
 		pred := tabMeta.PartialIndexPredicates[iter.IndexOrdinal()]
-		remainingFilters, ok := c.im.FiltersImplyPredicate(filters, pred)
+		remainingFilters, ok := c.im.FiltersImplyPredicate(filters, *pred.(*memo.FiltersExpr))
 		if !ok {
 			// The filters do not imply the predicate, so the partial index
 			// cannot be used.


### PR DESCRIPTION
This commit updates optbuilder to build a partial index predicate as
`FiltersExpr` instead of an arbitrary ScalarExpr. The primary reason for
doing so is to make it easier to calculate statistics for partial index
scans. By representing the predicate as a `FiltersExpr`, the statistics
builder can generate stats for partial index scans using existing
functions that help generate statistics for Selects.

`SimplifyFilters` and `ConsolidateFilters` are manually called on the
predicate so that it is similar in form to a normalized Select filter.
Flattening the expression and generating constraints for each top-level
conjunction will make it simpler and cheaper to calculate stats
accurately for unapplied conjunctions.

This commit also updates `Implicator` to handle predicates that are
`FiltersExpr`s and have `RangeExpr`s in them. This change benefits the
performance of `Implicator` significantly in some of the slowest
benchmark cases because flattening predicate conjunctions means that the
exact-match fast path can prove implication in more cases. This change
only worsens performance significantly in some of the fastest cases that
take <400ns/op.

    name                                               old time/op  new time/op  delta
    Implicator/single-exact-match-16                   61.7ns ± 0%  89.1ns ± 0%  +44.47%  (p=0.008 n=5+5)
    Implicator/single-inexact-match-16                  878ns ± 0%   912ns ± 1%   +3.94%  (p=0.008 n=5+5)
    Implicator/range-inexact-match-16                  2.32µs ± 2%  2.40µs ± 1%   +3.78%  (p=0.008 n=5+5)
    Implicator/single-exact-match-extra-filters-16      321ns ± 1%   371ns ± 1%  +15.70%  (p=0.008 n=5+5)
    Implicator/single-inexact-match-extra-filters-16   4.00µs ± 0%  4.11µs ± 1%   +2.78%  (p=0.008 n=5+5)
    Implicator/multi-column-and-exact-match-16          455ns ± 0%   100ns ± 1%  -78.02%  (p=0.016 n=4+5)
    Implicator/multi-column-and-inexact-match-16       1.94µs ± 1%  1.97µs ± 0%   +1.32%  (p=0.040 n=5+5)
    Implicator/multi-column-or-exact-match-16          62.1ns ± 0%  91.4ns ± 0%  +47.23%  (p=0.008 n=5+5)
    Implicator/multi-column-or-exact-match-reverse-16  1.72µs ± 0%  1.79µs ± 0%   +4.08%  (p=0.008 n=5+5)
    Implicator/multi-column-or-inexact-match-16        2.18µs ± 0%  2.25µs ± 1%   +3.56%  (p=0.008 n=5+5)
    Implicator/and-filters-do-not-imply-pred-16        3.65µs ± 2%  3.76µs ± 5%     ~     (p=0.056 n=5+5)
    Implicator/or-filters-do-not-imply-pred-16          774ns ± 1%   850ns ± 1%   +9.71%  (p=0.008 n=5+5)
    Implicator/many-columns-exact-match10-16           4.93µs ± 1%  0.30µs ± 1%  -93.87%  (p=0.008 n=5+5)
    Implicator/many-columns-inexact-match10-16         11.3µs ± 1%  11.1µs ± 0%   -1.86%  (p=0.008 n=5+5)
    Implicator/many-columns-exact-match100-16           352µs ± 1%    18µs ± 1%  -94.92%  (p=0.008 n=5+5)
    Implicator/many-columns-inexact-match100-16         382µs ± 1%   372µs ± 1%   -2.47%  (p=0.008 n=5+5)

Release note: None