### PR TITLE
dump: add dump-public option to skip non-public schema

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -235,6 +235,12 @@ What to dump. "schema" dumps the schema only. "data" dumps the data only.
 "both" (default) dumps the schema then the data.`,
 	}
 
+	DumpPublic = FlagInfo{
+		Name: "dump-public",
+		Description: `
+Dump *only* public schema, skipping e.g. temp tables and sequences`,
+	}
+
 	DumpTime = FlagInfo{
 		Name: "as-of",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -259,6 +259,9 @@ var dumpCtx struct {
 
 	// dumpAll determines whenever we going to dump all databases
 	dumpAll bool
+
+	// dumpPublic determines whether to skip non-public schema
+	dumpPublic bool
 }
 
 // setDumpContextDefaults set the default values in dumpCtx.  This
@@ -268,6 +271,7 @@ func setDumpContextDefaults() {
 	dumpCtx.dumpMode = dumpBoth
 	dumpCtx.asOf = ""
 	dumpCtx.dumpAll = false
+	dumpCtx.dumpPublic = false
 }
 
 // authCtx captures the command-line parameters of the `auth-session`

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -640,6 +640,7 @@ func init() {
 	varFlag(dumpCmd.Flags(), &dumpCtx.dumpMode, cliflags.DumpMode)
 	stringFlag(dumpCmd.Flags(), &dumpCtx.asOf, cliflags.DumpTime)
 	boolFlag(dumpCmd.Flags(), &dumpCtx.dumpAll, cliflags.DumpAll)
+	boolFlag(dumpCmd.Flags(), &dumpCtx.dumpPublic, cliflags.DumpPublic)
 
 	// Commands that establish a SQL connection.
 	sqlCmds := []*cobra.Command{sqlShellCmd, dumpCmd, demoCmd}


### PR DESCRIPTION
This resolves #51166. Previously, when doing a dump,
if TEMP SEQUENCE are present, we can get multiple rows
back for a given name, and crash.

This adds a new option, --dump-public, which restricts
the dump to the public schema only.

Release note (sql change): The dump command is extended with
a --dump-public option to restrict the dump to the public
schema only.