### PR TITLE
opt: support geospatial index usage with commuted function args

### DIFF
--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -53,12 +55,143 @@ var geoRelationshipMap = map[string]geoindex.RelationshipType{
 	"st_within":           geoindex.CoveredBy,
 }
 
+// geoRelationshipReverseMap contains a default function for each of the
+// possible geospatial relationships.
+var geoRelationshipReverseMap = map[geoindex.RelationshipType]string{
+	geoindex.Covers:       "st_covers",
+	geoindex.CoveredBy:    "st_coveredby",
+	geoindex.DWithin:      "st_dwithin",
+	geoindex.DFullyWithin: "st_dfullywithin",
+	geoindex.Intersects:   "st_intersects",
+}
+
+// commuteGeoRelationshipMap is used to determine how the geospatial
+// relationship changes if the arguments to the index-accelerated function are
+// commuted.
+//
+// The relationships in the geoRelationshipMap map above only apply when the
+// second argument to the function is the indexed column. If the arguments are
+// commuted so that the first argument is the indexed column, the relationship
+// may change.
+var commuteGeoRelationshipMap = map[geoindex.RelationshipType]geoindex.RelationshipType{
+	geoindex.Covers:       geoindex.CoveredBy,
+	geoindex.CoveredBy:    geoindex.Covers,
+	geoindex.DWithin:      geoindex.DWithin,
+	geoindex.DFullyWithin: geoindex.DFullyWithin,
+	geoindex.Intersects:   geoindex.Intersects,
+}
+
 // IsGeoIndexFunction returns true if the given function is a geospatial
 // function that can be index-accelerated.
 func IsGeoIndexFunction(fn opt.ScalarExpr) bool {
 	function := fn.(*memo.FunctionExpr)
 	_, ok := geoRelationshipMap[function.Name]
 	return ok
+}
+
+// TryGetInvertedJoinCondFromGeoFunc tries to extract an inverted join
+// condition from the given geospatial function. If commuteArgs is true,
+// TryGetInvertedJoinCondFromGeoFunc tries to extract an inverted join
+// condition from an equivalent version of the given function in which the
+// first two arguments are swapped.
+//
+// Returns the original function if commuteArgs is false, or a new function
+// representing the same relationship but with commuted arguments if
+// commuteArgs is true. For example:
+//
+//   ST_Intersects(g1, g2) <-> ST_Intersects(g2, g1)
+//   ST_Covers(g1, g2) <-> ST_CoveredBy(g2, g1)
+//
+// See commuteGeoRelationshipMap for the full list of mappings.
+//
+// Also returns the column ID corresponding to the input geospatial column
+// as well as the column ID corresponding to the inverted index key column,
+// which are the two columns relevant for the join condition. Returns ok=true
+// if a join condition was successfully extracted or ok=false otherwise.
+//
+// The given function must be a valid geospatial function that can be index-
+// accelerated, and must contain two variable arguments. Otherwise,
+// TryGetInvertedJoinCondFromGeoFunc will panic.
+func TryGetInvertedJoinCondFromGeoFunc(
+	factory *norm.Factory, fn opt.ScalarExpr, commuteArgs bool, inputProps *props.Relational,
+) (_ opt.ScalarExpr, inputGeoCol, indexGeoCol opt.ColumnID, ok bool) {
+	if !IsGeoIndexFunction(fn) {
+		panic(errors.AssertionFailedf(
+			"TryGetInvertedJoinCondFromGeoFunc called on a function that cannot be index-accelerated",
+		))
+	}
+	function := fn.(*memo.FunctionExpr)
+
+	// Extract the the variable inputs to the geospatial function.
+	if function.Args.ChildCount() < 2 {
+		panic(errors.AssertionFailedf(
+			"all index-accelerated geospatial functions should have at least two arguments",
+		))
+	}
+
+	arg1, arg2 := function.Args.Child(0), function.Args.Child(1)
+	if commuteArgs {
+		arg1, arg2 = arg2, arg1
+	}
+
+	// The first argument should come from the input.
+	variable, ok := arg1.(*memo.VariableExpr)
+	if !ok {
+		panic(errors.AssertionFailedf(
+			"TryGetInvertedJoinCondFromGeoFunc called on function containing non-variable inputs",
+		))
+	}
+	if !inputProps.OutputCols.Contains(variable.Col) {
+		return nil, 0, 0, false
+	}
+	inputGeoCol = variable.Col
+
+	// The second argument should be a variable corresponding to the index
+	// column. The caller must verify that this column is actually the key column
+	// of an inverted geospatial index.
+	variable, ok = arg2.(*memo.VariableExpr)
+	if !ok {
+		panic(errors.AssertionFailedf(
+			"TryGetInvertedJoinCondFromGeoFunc called on function containing non-variable inputs",
+		))
+	}
+	indexGeoCol = variable.Col
+
+	if commuteArgs {
+		// Get the geospatial relationship that is equivalent to this one with the
+		// arguments commuted, and construct a new function that represents that
+		// relationship.
+		rel := geoRelationshipMap[function.Name]
+		commutedRel, ok := commuteGeoRelationshipMap[rel]
+		if !ok {
+			// It's not possible to commute this relationship.
+			return nil, 0, 0, false
+		}
+		if rel != commutedRel {
+			// If the commuted relationship is not the same as the original
+			// relationship, we can't use the same function overload.
+			name := geoRelationshipReverseMap[commutedRel]
+
+			// Copy the original arguments into a new list, and swap the first two
+			// arguments.
+			args := make(memo.ScalarListExpr, len(function.Args))
+			copy(args, function.Args)
+			args[0], args[1] = args[1], args[0]
+
+			props, overload, ok := memo.FindFunction(&args, name)
+			if !ok {
+				panic(errors.AssertionFailedf("could not find overload for %s", name))
+			}
+			fn = factory.ConstructFunction(args, &memo.FunctionPrivate{
+				Name:       name,
+				Typ:        function.Typ,
+				Properties: props,
+				Overload:   overload,
+			})
+		}
+	}
+
+	return fn, inputGeoCol, indexGeoCol, true
 }
 
 // getSpanExprForGeoIndexFn is a function that returns a SpanExpression that
@@ -265,8 +398,7 @@ func constrainGeoIndex(
 	tabID opt.TableID,
 	index cat.Index,
 	getSpanExpr getSpanExprForGeoIndexFn,
-) (_ invertedexpr.InvertedExpression) {
-	var fn *memo.FunctionExpr
+) invertedexpr.InvertedExpression {
 	switch t := expr.(type) {
 	case *memo.AndExpr:
 		return invertedexpr.And(
@@ -281,12 +413,43 @@ func constrainGeoIndex(
 		)
 
 	case *memo.FunctionExpr:
-		fn = t
+		// Try to constrain the index with the given function. If the resulting
+		// inverted expression is not a SpanExpression, try constraining the index
+		// with an equivalent function in which the arguments are commuted. For
+		// example:
+		//
+		//   ST_Intersects(g1, g2) <-> ST_Intersects(g2, g1)
+		//   ST_Covers(g1, g2) <-> ST_CoveredBy(g2, g1)
+		//
+		// See commuteGeoRelationshipMap for the full list of mappings.
+		invertedExpr := constrainGeoIndexFromFunction(
+			ctx, t, false /* commuteArgs */, tabID, index, getSpanExpr,
+		)
+		if _, ok := invertedExpr.(invertedexpr.NonInvertedColExpression); ok {
+			invertedExpr = constrainGeoIndexFromFunction(
+				ctx, t, true /* commuteArgs */, tabID, index, getSpanExpr,
+			)
+		}
+		return invertedExpr
 
 	default:
 		return invertedexpr.NonInvertedColExpression{}
 	}
+}
 
+// constrainGeoIndexFromFunction returns an InvertedExpression representing a
+// constraint of the given geospatial index, based on the given function.
+// If commuteArgs is true, constrainGeoIndexFromFunction constrains the index
+// based on an equivalent version of the given function in which the first two
+// arguments are swapped.
+func constrainGeoIndexFromFunction(
+	ctx context.Context,
+	fn *memo.FunctionExpr,
+	commuteArgs bool,
+	tabID opt.TableID,
+	index cat.Index,
+	getSpanExpr getSpanExprForGeoIndexFn,
+) invertedexpr.InvertedExpression {
 	if !IsGeoIndexFunction(fn) {
 		return invertedexpr.NonInvertedColExpression{}
 	}
@@ -297,27 +460,28 @@ func constrainGeoIndex(
 		))
 	}
 
+	arg1, arg2 := fn.Args.Child(0), fn.Args.Child(1)
+	if commuteArgs {
+		arg1, arg2 = arg2, arg1
+	}
+
 	// The first argument should be a constant.
-	if !memo.CanExtractConstDatum(fn.Args.Child(0)) {
+	if !memo.CanExtractConstDatum(arg1) {
 		return invertedexpr.NonInvertedColExpression{}
 	}
-	d := memo.ExtractConstDatum(fn.Args.Child(0))
+	d := memo.ExtractConstDatum(arg1)
 
 	// The second argument should be a variable corresponding to the index
 	// column.
-	variable, ok := fn.Args.Child(1).(*memo.VariableExpr)
+	variable, ok := arg2.(*memo.VariableExpr)
 	if !ok {
-		// TODO(rytaft): Commute the geospatial function in this case.
-		//   Covers       <->  CoveredBy
-		//   DWithin      <->  DWithin
-		//   DFullyWithin <->  DFullyWithin
-		//   Intersects   <->  Intersects
 		return invertedexpr.NonInvertedColExpression{}
 	}
 	if variable.Col != tabID.ColumnID(index.Column(0).Ordinal) {
 		// The column in the function does not match the index column.
 		return invertedexpr.NonInvertedColExpression{}
 	}
+
 	// Any additional params must be constant.
 	var additionalParams []tree.Datum
 	for i := 2; i < fn.Args.ChildCount(); i++ {
@@ -326,7 +490,16 @@ func constrainGeoIndex(
 		}
 		additionalParams = append(additionalParams, memo.ExtractConstDatum(fn.Args.Child(i)))
 	}
+
 	relationship := geoRelationshipMap[fn.Name]
+	if commuteArgs {
+		relationship, ok = commuteGeoRelationshipMap[relationship]
+		if !ok {
+			// It's not possible to commute this relationship.
+			return invertedexpr.NonInvertedColExpression{}
+		}
+	}
+
 	return getSpanExpr(ctx, d, additionalParams, relationship, index.GeoConfig())
 }
 

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package xform
+package invertedidx
 
 import (
 	"context"
@@ -69,11 +69,11 @@ type getSpanExprForGeoIndexFn func(
 	context.Context, tree.Datum, []tree.Datum, geoindex.RelationshipType, *geoindex.Config,
 ) *invertedexpr.SpanExpression
 
-// tryConstrainGeoIndex tries to derive an inverted index constraint for the
+// TryConstrainGeoIndex tries to derive an inverted index constraint for the
 // given geospatial index from the specified filters. If a constraint is
 // derived, it is returned with ok=true. If no constraint can be derived,
-// then tryConstrainGeoIndex returns ok=false.
-func tryConstrainGeoIndex(
+// then TryConstrainGeoIndex returns ok=false.
+func TryConstrainGeoIndex(
 	ctx context.Context, filters memo.FiltersExpr, tabID opt.TableID, index cat.Index,
 ) (invertedConstraint *invertedexpr.SpanExpression, ok bool) {
 	config := index.GeoConfig()

--- a/pkg/sql/opt/invertedidx/geo_test.go
+++ b/pkg/sql/opt/invertedidx/geo_test.go
@@ -1,0 +1,314 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package invertedidx_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedidx"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+)
+
+func TestTryGetInvertedJoinCondFromGeoFunc(t *testing.T) {
+	semaCtx := tree.MakeSemaContext()
+	evalCtx := tree.NewTestingEvalContext(nil /* st */)
+
+	var f norm.Factory
+	f.Init(evalCtx, testcat.New())
+	md := f.Metadata()
+	md.AddColumn("geom1", types.Geometry)
+	md.AddColumn("geog1", types.Geography)
+	md.AddColumn("geom2", types.Geometry)
+	md.AddColumn("geog2", types.Geography)
+
+	testCases := []struct {
+		inFunc         string
+		commuteArgs    bool
+		expOk          bool
+		expOutFunc     string
+		expInputGeoCol opt.ColumnID
+		expIndexGeoCol opt.ColumnID
+	}{
+		{
+			inFunc:         "st_covers(geom1, geom2)",
+			commuteArgs:    false,
+			expOk:          true,
+			expOutFunc:     "st_covers(geom1, geom2)",
+			expInputGeoCol: 1,
+			expIndexGeoCol: 3,
+		},
+		{
+			inFunc:      "st_covers(geom2, geom1)",
+			commuteArgs: false,
+			expOk:       false,
+		},
+		{
+			inFunc:      "st_covers(geom1, geom2)",
+			commuteArgs: true,
+			expOk:       false,
+		},
+		{
+			inFunc:         "st_covers(geom2, geom1)",
+			commuteArgs:    true,
+			expOk:          true,
+			expOutFunc:     "st_coveredby(geom1, geom2)",
+			expInputGeoCol: 1,
+			expIndexGeoCol: 3,
+		},
+		{
+			inFunc:         "st_coveredby(geog1, geog2)",
+			commuteArgs:    false,
+			expOk:          true,
+			expOutFunc:     "st_coveredby(geog1, geog2)",
+			expInputGeoCol: 2,
+			expIndexGeoCol: 4,
+		},
+		{
+			inFunc:         "st_coveredby(geog2, geog1)",
+			commuteArgs:    true,
+			expOk:          true,
+			expOutFunc:     "st_covers(geog1, geog2)",
+			expInputGeoCol: 2,
+			expIndexGeoCol: 4,
+		},
+		{
+			inFunc:         "st_containsproperly(geom2, geom1)",
+			commuteArgs:    true,
+			expOk:          true,
+			expOutFunc:     "st_coveredby(geom1, geom2)",
+			expInputGeoCol: 1,
+			expIndexGeoCol: 3,
+		},
+		{
+			inFunc:         "st_dwithin(geog2, geog1, 1)",
+			commuteArgs:    true,
+			expOk:          true,
+			expOutFunc:     "st_dwithin(geog2, geog1, 1)",
+			expInputGeoCol: 2,
+			expIndexGeoCol: 4,
+		},
+		{
+			inFunc:         "st_dfullywithin(geom2, geom1, 1)",
+			commuteArgs:    true,
+			expOk:          true,
+			expOutFunc:     "st_dfullywithin(geom2, geom1, 1)",
+			expInputGeoCol: 1,
+			expIndexGeoCol: 3,
+		},
+		{
+			inFunc:         "st_intersects(geom1, geom2)",
+			commuteArgs:    false,
+			expOk:          true,
+			expOutFunc:     "st_intersects(geom1, geom2)",
+			expInputGeoCol: 1,
+			expIndexGeoCol: 3,
+		},
+		{
+			inFunc:         "st_overlaps(geom2, geom1)",
+			commuteArgs:    true,
+			expOk:          true,
+			expOutFunc:     "st_overlaps(geom2, geom1)",
+			expInputGeoCol: 1,
+			expIndexGeoCol: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("test case: %v", tc)
+		inFunc, err := buildScalar(tc.inFunc, &semaCtx, evalCtx, &f)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The only part of inputProps that is used here is the OutputCols.
+		// We just need to make sure the inputGeoCol is part of the OutputCols.
+		inputProps := props.Relational{OutputCols: opt.MakeColSet(1, 2)}
+
+		actOutFunc, actInputGeoCol, actIndexGeoCol, actOk := invertedidx.TryGetInvertedJoinCondFromGeoFunc(
+			&f, inFunc, tc.commuteArgs, &inputProps,
+		)
+
+		if tc.expOk != actOk {
+			t.Fatalf("expected %v, got %v", tc.expOk, actOk)
+		}
+		if !tc.expOk {
+			continue
+		}
+
+		expOutFunc, err := buildScalar(tc.expOutFunc, &semaCtx, evalCtx, &f)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// We have to test the Args and FunctionPrivate individually, since the
+		// ScalarID may be different (due to building with the ScalarBuilder).
+		if !reflect.DeepEqual(
+			expOutFunc.(*memo.FunctionExpr).Args, actOutFunc.(*memo.FunctionExpr).Args,
+		) {
+			t.Errorf("expected %v, got %v", expOutFunc, actOutFunc)
+		}
+		if !reflect.DeepEqual(
+			expOutFunc.(*memo.FunctionExpr).FunctionPrivate,
+			actOutFunc.(*memo.FunctionExpr).FunctionPrivate,
+		) {
+			t.Errorf("expected %v, got %v", expOutFunc, actOutFunc)
+		}
+		if tc.expInputGeoCol != actInputGeoCol {
+			t.Errorf("expected %v, got %v", tc.expInputGeoCol, actInputGeoCol)
+		}
+		if tc.expIndexGeoCol != actIndexGeoCol {
+			t.Errorf("expected %v, got %v", tc.expIndexGeoCol, actIndexGeoCol)
+		}
+	}
+}
+
+func TestTryConstrainGeoIndex(t *testing.T) {
+	semaCtx := tree.MakeSemaContext()
+	evalCtx := tree.NewTestingEvalContext(nil /* st */)
+
+	tc := testcat.New()
+	if _, err := tc.ExecuteDDL(
+		"CREATE TABLE t (geom GEOMETRY, geog GEOGRAPHY, INVERTED INDEX (geom), INVERTED INDEX (geog))",
+	); err != nil {
+		t.Fatal(err)
+	}
+	var f norm.Factory
+	f.Init(evalCtx, tc)
+	md := f.Metadata()
+	tn := tree.NewUnqualifiedTableName("t")
+	tab := md.AddTable(tc.Table(tn), tn)
+	geomOrd, geogOrd := 1, 2
+
+	testCases := []struct {
+		filters  string
+		indexOrd int
+		ok       bool
+	}{
+		{
+			filters:  "st_intersects('LINESTRING ( 0 0, 0 2 )'::geometry, geom)",
+			indexOrd: geomOrd,
+			ok:       true,
+		},
+		{
+			// Still works with arguments commuted.
+			filters:  "st_intersects(geom, 'LINESTRING ( 0 0, 0 2 )'::geometry)",
+			indexOrd: geomOrd,
+			ok:       true,
+		},
+		{
+			filters:  "st_covers('SRID=4326;POINT(-40.23456 70.4567772)'::geography, geog)",
+			indexOrd: geogOrd,
+			ok:       true,
+		},
+		{
+			// Still works with arguments commuted.
+			filters:  "st_covers(geog, 'SRID=4326;POINT(-40.23456 70.4567772)'::geography)",
+			indexOrd: geogOrd,
+			ok:       true,
+		},
+		{
+			// Wrong index ordinal.
+			filters:  "st_covers('SRID=4326;POINT(-40.23456 70.4567772)'::geography, geog)",
+			indexOrd: geomOrd,
+			ok:       false,
+		},
+		{
+			// Wrong index ordinal.
+			filters:  "st_covers('LINESTRING ( 0 0, 0 2 )'::geometry, geom)",
+			indexOrd: geogOrd,
+			ok:       false,
+		},
+		{
+			// When functions affecting two different geospatial variables are OR-ed,
+			// we cannot constrain either index.
+			filters: "st_equals('LINESTRING ( 0 0, 0 2 )'::geometry, geom) OR " +
+				"st_coveredby(geog, 'SRID=4326;POINT(-40.23456 70.4567772)'::geography)",
+			indexOrd: geomOrd,
+			ok:       false,
+		},
+		{
+			// We can constrain either index when the functions are AND-ed.
+			filters: "st_equals('LINESTRING ( 0 0, 0 2 )'::geometry, geom) AND " +
+				"st_coveredby(geog, 'SRID=4326;POINT(-40.23456 70.4567772)'::geography)",
+			indexOrd: geomOrd,
+			ok:       true,
+		},
+		{
+			// We can constrain either index when the functions are AND-ed.
+			filters: "st_equals('LINESTRING ( 0 0, 0 2 )'::geometry, geom) AND " +
+				"st_coveredby(geog, 'SRID=4326;POINT(-40.23456 70.4567772)'::geography)",
+			indexOrd: geogOrd,
+			ok:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("test case: %v", tc)
+		filters, err := buildFilters(tc.filters, &semaCtx, evalCtx, &f)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// We're not testing that the correct SpanExpression is returned here;
+		// that is tested elsewhere. This is just testing that we are constraining
+		// the index when we expect to.
+		_, ok := invertedidx.TryConstrainGeoIndex(evalCtx.Context, filters, tab, md.Table(tab).Index(tc.indexOrd))
+		if tc.ok != ok {
+			t.Fatalf("expected %v, got %v", tc.ok, ok)
+		}
+	}
+}
+
+func buildScalar(
+	input string, semaCtx *tree.SemaContext, evalCtx *tree.EvalContext, f *norm.Factory,
+) (opt.ScalarExpr, error) {
+	expr, err := parser.ParseExpr(input)
+	if err != nil {
+		return nil, errors.Newf("falsed to parse %s: %v", input, err)
+	}
+
+	b := optbuilder.NewScalar(context.Background(), semaCtx, evalCtx, f)
+	if err := b.Build(expr); err != nil {
+		return nil, err
+	}
+
+	return f.Memo().RootExpr().(opt.ScalarExpr), nil
+}
+
+func buildFilters(
+	input string, semaCtx *tree.SemaContext, evalCtx *tree.EvalContext, f *norm.Factory,
+) (memo.FiltersExpr, error) {
+	if input == "" {
+		return memo.TrueFilter, nil
+	}
+	root, err := buildScalar(input, semaCtx, evalCtx, f)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := root.(*memo.TrueExpr); ok {
+		return memo.TrueFilter, nil
+	}
+	filters := memo.FiltersExpr{f.ConstructFiltersItem(root)}
+	filters = f.CustomFuncs().SimplifyFilters(filters)
+	filters = f.CustomFuncs().ConsolidateFilters(filters)
+	return filters, nil
+}

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package invertedidx
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// NewDatumToInvertedExpr returns a new DatumToInvertedExpr. Currently there
+// is only one possible implementation returned, geoDatumToInvertedExpr.
+func NewDatumToInvertedExpr(
+	expr tree.TypedExpr, desc *sqlbase.IndexDescriptor,
+) (invertedexpr.DatumToInvertedExpr, error) {
+	if geoindex.IsEmptyConfig(&desc.GeoConfig) {
+		return nil, fmt.Errorf("inverted joins are currently only supported for geospatial indexes")
+	}
+
+	return NewGeoDatumToInvertedExpr(expr, &desc.GeoConfig)
+}

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedidx"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
@@ -582,7 +583,7 @@ func (c *coster) computeFiltersCost(filters memo.FiltersExpr, eqMap util.FastInt
 				continue
 			}
 		case opt.FunctionOp:
-			if IsGeoIndexFunction(f.Condition) {
+			if invertedidx.IsGeoIndexFunction(f.Condition) {
 				cost += geoFnCost
 			}
 			// TODO(mjibson): do we need to cost other functions?

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -1917,46 +1917,29 @@ func (c *CustomFuncs) GenerateGeoLookupJoins(
 		return
 	}
 
-	if !invertedidx.IsGeoIndexFunction(fn) {
-		panic(errors.AssertionFailedf(
-			"GenerateGeoLookupJoins called on a function that cannot be index-accelerated",
-		))
-	}
-
-	function := fn.(*memo.FunctionExpr)
 	inputProps := input.Relational()
+	function := fn.(*memo.FunctionExpr)
 
-	// Extract the the variable inputs to the geospatial function.
-	if function.Args.ChildCount() < 2 {
-		panic(errors.AssertionFailedf(
-			"all index-accelerated geospatial functions should have at least two arguments",
-		))
-	}
-
-	// The first argument should come from the input.
-	variable, ok := function.Args.Child(0).(*memo.VariableExpr)
+	// Try to extract an inverted join condition from the given function. If
+	// unsuccessful, try to extract a join condition from an equivalent function
+	// in which the arguments are commuted. For example:
+	//
+	//   ST_Intersects(g1, g2) <-> ST_Intersects(g2, g1)
+	//   ST_Covers(g1, g2) <-> ST_CoveredBy(g2, g1)
+	//
+	// See TryGetInvertedJoinCondFromGeoFunc for more details.
+	fn, inputGeoCol, indexGeoCol, ok := invertedidx.TryGetInvertedJoinCondFromGeoFunc(
+		c.e.f, function, false /* commuteArgs */, inputProps,
+	)
 	if !ok {
-		panic(errors.AssertionFailedf(
-			"GenerateGeoLookupJoins called on function containing non-variable inputs",
-		))
+		fn, inputGeoCol, indexGeoCol, ok = invertedidx.TryGetInvertedJoinCondFromGeoFunc(
+			c.e.f, function, true /* commuteArgs */, inputProps,
+		)
+		if !ok {
+			// This function cannot serve as a join condition.
+			return
+		}
 	}
-	if !inputProps.OutputCols.Contains(variable.Col) {
-		// TODO(rytaft): Commute the geospatial function in this case.
-		//   Covers      <->  CoveredBy
-		//   Intersects  <->  Intersects
-		return
-	}
-	inputGeoCol := variable.Col
-
-	// The second argument should be a variable corresponding to the index
-	// column.
-	variable, ok = function.Args.Child(1).(*memo.VariableExpr)
-	if !ok {
-		panic(errors.AssertionFailedf(
-			"GenerateGeoLookupJoins called on function containing non-variable inputs",
-		))
-	}
-	indexGeoCol := variable.Col
 
 	var pkCols opt.ColList
 
@@ -1987,7 +1970,7 @@ func (c *CustomFuncs) GenerateGeoLookupJoins(
 		lookupJoin.JoinType = joinType
 		lookupJoin.Table = scanPrivate.Table
 		lookupJoin.Index = iter.IndexOrdinal()
-		lookupJoin.InvertedExpr = function
+		lookupJoin.InvertedExpr = fn
 		lookupJoin.InvertedCol = indexGeoCol
 		lookupJoin.InputCol = inputGeoCol
 		lookupJoin.Cols = indexCols.Union(inputProps.OutputCols)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1892,6 +1892,82 @@ project
       └── filters
            └── st_dwithin(c.geom:10, n.geom:14, 50.0) [outer=(10,14), immutable]
 
+# Same test as above, but with arguments commuted.
+opt expect=GenerateGeoLookupJoins
+SELECT
+  n.name, c.boroname
+FROM nyc_census_blocks AS c
+JOIN nyc_neighborhoods@nyc_neighborhoods_geo_idx AS n
+ON ST_DWithin(n.geom, c.geom, 50)
+----
+project
+ ├── columns: name:13 boroname:9
+ ├── immutable
+ └── inner-join (lookup nyc_neighborhoods)
+      ├── columns: c.boroname:9 c.geom:10 name:13 n.geom:14
+      ├── key columns: [11] = [11]
+      ├── lookup columns are key
+      ├── immutable
+      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx)
+      │    ├── columns: c.boroname:9 c.geom:10 n.gid:11!null
+      │    ├── inverted-expr
+      │    │    └── st_dwithin(n.geom:14, c.geom:10, 50.0)
+      │    ├── scan c
+      │    │    └── columns: c.boroname:9 c.geom:10
+      │    └── filters (true)
+      └── filters
+           └── st_dwithin(n.geom:14, c.geom:10, 50.0) [outer=(10,14), immutable]
+
+opt expect=GenerateGeoLookupJoins
+SELECT
+  n.name, c.boroname
+FROM nyc_census_blocks AS c
+JOIN nyc_neighborhoods@nyc_neighborhoods_geo_idx AS n
+ON ST_Covers(c.geom, n.geom)
+----
+project
+ ├── columns: name:13 boroname:9
+ ├── immutable
+ └── inner-join (lookup nyc_neighborhoods)
+      ├── columns: c.boroname:9 c.geom:10 name:13 n.geom:14
+      ├── key columns: [11] = [11]
+      ├── lookup columns are key
+      ├── immutable
+      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx)
+      │    ├── columns: c.boroname:9 c.geom:10 n.gid:11!null
+      │    ├── inverted-expr
+      │    │    └── st_covers(c.geom:10, n.geom:14)
+      │    ├── scan c
+      │    │    └── columns: c.boroname:9 c.geom:10
+      │    └── filters (true)
+      └── filters
+           └── st_covers(c.geom:10, n.geom:14) [outer=(10,14), immutable]
+
+# Same test as above, but with arguments commuted.
+opt expect=GenerateGeoLookupJoins
+SELECT
+  n.name, c.boroname
+FROM nyc_census_blocks AS c
+JOIN nyc_neighborhoods@nyc_neighborhoods_geo_idx AS n
+ON ST_Covers(n.geom, c.geom)
+----
+project
+ ├── columns: name:13 boroname:9
+ ├── immutable
+ └── inner-join (lookup nyc_neighborhoods)
+      ├── columns: c.boroname:9 c.geom:10 name:13 n.geom:14
+      ├── key columns: [11] = [11]
+      ├── lookup columns are key
+      ├── immutable
+      ├── inner-join (inverted-lookup nyc_neighborhoods@nyc_neighborhoods_geo_idx)
+      │    ├── columns: c.boroname:9 c.geom:10 n.gid:11!null
+      │    ├── inverted-expr
+      │    │    └── st_coveredby(c.geom:10, n.geom:14)
+      │    ├── scan c
+      │    │    └── columns: c.boroname:9 c.geom:10
+      │    └── filters (true)
+      └── filters
+           └── st_covers(n.geom:14, c.geom:10) [outer=(10,14), immutable]
 
 # --------------------------------------------------
 # GenerateZigZagJoins

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1414,6 +1414,44 @@ project
       └── filters
            └── st_intersects('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) [outer=(4), immutable]
 
+# Same test as above, but with commuted arguments.
+opt
+SELECT k FROM g WHERE ST_Intersects(geog, 'SRID=4326;POINT(-43.23456 72.4567772)'::geography)
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null geog:4
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── index-join g
+      │    ├── columns: k:1!null geog:4
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(4)
+      │    └── inverted-filter
+      │         ├── columns: k:1!null
+      │         ├── inverted expression: /4
+      │         │    ├── tight: false
+      │         │    └── union spans
+      │         │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
+      │         │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │         │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │         ├── key: (1)
+      │         └── scan g@geog_idx
+      │              ├── columns: k:1!null geog:4
+      │              ├── inverted constraint: /4/1
+      │              │    └── spans
+      │              │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
+      │              │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │              ├── key: (1)
+      │              └── fd: (1)-->(4)
+      └── filters
+           └── st_intersects(geog:4, '0101000020E61000009279E40F069E45C0BEE36FD63B1D5240') [outer=(4), immutable]
+
 opt
 SELECT k FROM g WHERE ST_CoveredBy('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom)
 ----
@@ -1450,6 +1488,38 @@ project
       │              └── fd: (1)-->(3)
       └── filters
            └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3) [outer=(3), immutable]
+
+# Same test as above, but with commuted arguments.
+opt
+SELECT k FROM g WHERE ST_CoveredBy(geom, 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry)
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null geom:3
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(3)
+      ├── index-join g
+      │    ├── columns: k:1!null geom:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(3)
+      │    └── inverted-filter
+      │         ├── columns: k:1!null
+      │         ├── inverted expression: /3
+      │         │    ├── tight: false
+      │         │    └── union spans: ["\x89", "\xfd ")
+      │         ├── key: (1)
+      │         └── scan g@geom_idx
+      │              ├── columns: k:1!null geom:3
+      │              ├── inverted constraint: /3/1
+      │              │    └── spans: ["\x89", "\xfd ")
+      │              ├── key: (1)
+      │              └── fd: (1)-->(3)
+      └── filters
+           └── st_coveredby(geom:3, '0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000') [outer=(3), immutable]
 
 opt
 SELECT k FROM g WHERE ST_DWithin('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry, geom, 2)

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedidx"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
@@ -232,7 +232,7 @@ func newInvertedJoiner(
 		if err := invertedExprHelper.Init(spec.InvertedExpr, onExprColTypes, ij.EvalCtx); err != nil {
 			return nil, err
 		}
-		ij.datumToInvertedExpr, err = xform.NewDatumToInvertedExpr(invertedExprHelper.Expr, ij.index)
+		ij.datumToInvertedExpr, err = invertedidx.NewDatumToInvertedExpr(invertedExprHelper.Expr, ij.index)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**opt: refactor inverted index code into new invertedidx package**

This commit creates a new package, `invertedidx`, and refactors some of the
code in `xform` that was dealing with inverted indexes into this package.
This new package is analagous to the `idxconstraint` package: In the same way
that the code in the `idxconstraint` package uses the `constraint` package for
constraining forward indexes, `invertedidx` uses `invertedexpr` for constraining
inverted indexes.

**opt: support geospatial index usage with commuted function args**

Prior to this commit, the optimizer only supported using geospatial
indexes for eligible functions when the indexed column was the second
argument. This commit adds support for using an index even when the
indexed column is the first argument.