### PR TITLE
roachtest: fix parsing of django test results

### DIFF
--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -225,6 +225,9 @@ RUNNING_COCKROACH_BACKEND_TESTS=1 python3 runtests.py %[1]s --settings cockroach
 `
 
 const cockroachDjangoSettings = `
+from django.test.runner import DiscoverRunner
+
+
 DATABASES = {
     'default': {
         'ENGINE': 'django_cockroachdb',
@@ -247,4 +250,14 @@ SECRET_KEY = 'django_tests_secret_key'
 PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.MD5PasswordHasher',
 ]
+TEST_RUNNER = '.cockroach_settings.NonDescribingDiscoverRunner'
+
+class NonDescribingDiscoverRunner(DiscoverRunner):
+    def get_test_runner_kwargs(self):
+        return {
+            'failfast': self.failfast,
+            'resultclass': self.get_resultclass(),
+            'verbosity': self.verbosity,
+            'descriptions': False,
+        }
 `

--- a/pkg/cmd/roachtest/django_blocklist.go
+++ b/pkg/cmd/roachtest/django_blocklist.go
@@ -173,9 +173,6 @@ var djangoBlocklist20_2 = blocklist{}
 var djangoBlocklist20_1 = blocklist{}
 
 var djangoBlocklist19_2 = blocklist{
-	"admin_views.tests.AdminViewBasicTest.test_date_hierarchy_timezone_dst":                      "unknown",
-	"admin_views.tests.SecureViewTests.test_secure_view_shows_login_if_not_logged_in":            "unknown",
-	"admin_views.tests.SecureViewTests.test_staff_member_required_decorator_works_with_argument": "unknown",
 	// TODO (rohany): The postgres_tests suite within Django is not in a automatically
 	//  runnable state right now.
 	//"postgres_tests.test_aggregates.TestGeneralAggregate.test_bit_and_empty_result":                                 "41334",

--- a/pkg/cmd/roachtest/python_helpers.go
+++ b/pkg/cmd/roachtest/python_helpers.go
@@ -17,7 +17,7 @@ import (
 	"regexp"
 )
 
-var pythonUnitTestOutputRegex = regexp.MustCompile(`(?P<name>.*) \((?P<class>.*)\) \.\.\. (?P<result>[^ ']*)(?: u?['"](?P<reason>.*)['"])?`)
+var pythonUnitTestOutputRegex = regexp.MustCompile(`(?P<name>.*) \((?P<class>.*)\) \.\.\. (?P<result>[^'"]*)(?: u?['"](?P<reason>.*)['"])?`)
 
 func (r *ormTestsResults) parsePythonUnitTestOutput(
 	input []byte, expectedFailures blocklist, ignoredList blocklist,
@@ -31,11 +31,12 @@ func (r *ormTestsResults) parsePythonUnitTestOutput(
 				groups[pythonUnitTestOutputRegex.SubexpNames()[i]] = name
 			}
 			test := fmt.Sprintf("%s.%s", groups["class"], groups["name"])
-			var skipReason string
-			if groups["result"] == "skipped" {
+			skipped := groups["result"] == "skipped" || groups["result"] == "expected failure"
+			skipReason := ""
+			if skipped {
 				skipReason = groups["reason"]
 			}
-			pass := groups["result"] == "ok"
+			pass := groups["result"] == "ok" || groups["result"] == "unexpected success"
 			r.allTests = append(r.allTests, test)
 
 			ignoredIssue, expectedIgnored := ignoredList[test]


### PR DESCRIPTION
Use a custom test runner class to avoid printing out descriptions of
test cases, which make it impossible to parse test results in some
cases.

Also, update the parsing logic to look for "expected failure" and
"unexpected success" and handle these results appropriately.

Release note: None