### PR TITLE
sql: allow global access for pg_namespace table

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_view
+++ b/pkg/sql/logictest/testdata/logic_test/drop_view
@@ -95,6 +95,9 @@ DROP VIEW testuser3
 query TTTI
 SHOW TABLES FROM test
 ----
+public  d          view
+public  testuser1  view
+public  testuser2  view
 
 statement error cannot drop relation "testuser1" because view "testuser2" depends on it
 DROP VIEW testuser1
@@ -108,6 +111,7 @@ DROP VIEW testuser1 CASCADE
 query TTTI
 SHOW TABLES FROM test
 ----
+public  d          view
 
 statement error pgcode 42P01 relation "testuser2" does not exist
 DROP VIEW testuser2

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -235,6 +235,21 @@ oid         nspname             nspowner  nspacl
 1841002695  pg_extension        NULL      NULL
 3426283741  public              NULL      NULL
 
+user testuser
+
+# Should be globally visible
+query OTOT colnames
+SELECT * FROM pg_catalog.pg_namespace
+----
+oid         nspname             nspowner  nspacl
+3604332469  crdb_internal       NULL      NULL
+3672231114  information_schema  NULL      NULL
+2508829085  pg_catalog          NULL      NULL
+1841002695  pg_extension        NULL      NULL
+3426283741  public              NULL      NULL
+
+user root
+
 ## pg_catalog.pg_database
 
 query OTOITTBB colnames

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1174,6 +1174,7 @@ public  publictable  table  NULL
 query TTTI
 SHOW TABLES FROM privatedb
 ----
+public  publictable  table
 
 statement ok
 SELECT * FROM publicdb.publictable

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1919,7 +1919,7 @@ CREATE TABLE pg_catalog.pg_namespace (
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
+		return forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
 			func(db *dbdesc.Immutable) error {
 				return forEachSchemaName(ctx, p, db, func(s string, _ bool) error {
 					return addRow(


### PR DESCRIPTION
The pg_namespace is world-readable in Postgres.

Fixes #49313

Release note (sql change): The pg_namespace table no longer require
privileges on any database in order for the data to be visible.