### PR TITLE
sql: implement idle_in_session_timeout setting to cancel sessions

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2108,6 +2108,10 @@ func (m *sessionDataMutator) SetStmtTimeout(timeout time.Duration) {
 	m.data.StmtTimeout = timeout
 }
 
+func (m *sessionDataMutator) SetIdleInSessionTimeout(timeout time.Duration) {
+	m.data.IdleInSessionTimeout = timeout
+}
+
 func (m *sessionDataMutator) SetAllowPrepareAsOptPlan(val bool) {
 	m.data.AllowPrepareAsOptPlan = val
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -246,6 +246,14 @@ var experimentalAlterColumnTypeGeneralMode = settings.RegisterBoolSetting(
 	false,
 )
 
+var clusterIdleInSessionTimeout = settings.RegisterNonNegativeDurationSetting(
+	"sql.defaults.idle_in_session_timeout",
+	"default value for the idle_in_session_timeout; "+
+		"enables automatically killing sessions that exceed the "+
+		"idle_in_session_timeout threshold",
+	0,
+)
+
 // ExperimentalDistSQLPlanningClusterSettingName is the name for the cluster
 // setting that controls experimentalDistSQLPlanningClusterMode below.
 const ExperimentalDistSQLPlanningClusterSettingName = "sql.defaults.experimental_distsql_planning"

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1811,7 +1811,7 @@ experimental_partial_indexes                   off                 NULL  user   
 extra_float_digits                             0                   NULL  user     NULL      0                   2
 force_savepoint_restart                        off                 NULL  user     NULL      off                 off
 foreign_key_cascades_limit                     10000               NULL  user     NULL      10000               10000
-idle_in_session_timeout                        0                   NULL  user     NULL      0                   0
+idle_in_session_timeout                        0                   NULL  user     NULL      0s                  0s
 idle_in_transaction_session_timeout            0                   NULL  user     NULL      0                   0
 integer_datetimes                              on                  NULL  user     NULL      on                  on
 intervalstyle                                  postgres            NULL  user     NULL      postgres            postgres

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1742,6 +1742,7 @@ experimental_partial_indexes                   off                 NULL      NUL
 extra_float_digits                             0                   NULL      NULL        NULL        string
 force_savepoint_restart                        off                 NULL      NULL        NULL        string
 foreign_key_cascades_limit                     10000               NULL      NULL        NULL        string
+idle_in_session_timeout                        0                   NULL      NULL        NULL        string
 idle_in_transaction_session_timeout            0                   NULL      NULL        NULL        string
 integer_datetimes                              on                  NULL      NULL        NULL        string
 intervalstyle                                  postgres            NULL      NULL        NULL        string
@@ -1810,6 +1811,7 @@ experimental_partial_indexes                   off                 NULL  user   
 extra_float_digits                             0                   NULL  user     NULL      0                   2
 force_savepoint_restart                        off                 NULL  user     NULL      off                 off
 foreign_key_cascades_limit                     10000               NULL  user     NULL      10000               10000
+idle_in_session_timeout                        0                   NULL  user     NULL      0                   0
 idle_in_transaction_session_timeout            0                   NULL  user     NULL      0                   0
 integer_datetimes                              on                  NULL  user     NULL      on                  on
 intervalstyle                                  postgres            NULL  user     NULL      postgres            postgres
@@ -1874,6 +1876,7 @@ experimental_partial_indexes                   NULL    NULL     NULL     NULL   
 extra_float_digits                             NULL    NULL     NULL     NULL        NULL
 force_savepoint_restart                        NULL    NULL     NULL     NULL        NULL
 foreign_key_cascades_limit                     NULL    NULL     NULL     NULL        NULL
+idle_in_session_timeout                        NULL    NULL     NULL     NULL        NULL
 idle_in_transaction_session_timeout            NULL    NULL     NULL     NULL        NULL
 integer_datetimes                              NULL    NULL     NULL     NULL        NULL
 intervalstyle                                  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -52,6 +52,7 @@ experimental_partial_indexes                   off
 extra_float_digits                             0
 force_savepoint_restart                        off
 foreign_key_cascades_limit                     10000
+idle_in_session_timeout                        0
 idle_in_transaction_session_timeout            0
 integer_datetimes                              on
 intervalstyle                                  postgres

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -358,3 +358,64 @@ func isClientsideQueryCanceledErr(err error) bool {
 	}
 	return pgerror.GetPGCode(err) == pgcode.QueryCanceled
 }
+
+func TestIdleInSessionTimeout(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	numNodes := 1
+	tc := serverutils.StartTestCluster(t, numNodes,
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+		})
+	defer tc.Stopper().Stop(ctx)
+
+	var err error
+	conn, err := tc.ServerConn(0).Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = conn.ExecContext(ctx, `SET idle_in_session_timeout = '4s'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(2 * time.Second)
+	// Make sure executing a statement resets the idle timer.
+	_, err = conn.ExecContext(ctx, `SELECT 1`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(2 * time.Second)
+	// The connection should still be alive.
+	err = conn.PingContext(ctx)
+	if err != nil {
+		t.Fatalf("expected the connection to be alive but the connection"+
+			"is dead, %v", err)
+	}
+
+	// Make sure executing BEGIN resets the idle timer.
+	// BEGIN is the only statement that is not run by execStmtInOpenState.
+	_, err = conn.ExecContext(ctx, `BEGIN`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(2 * time.Second)
+	// The connection should still be alive.
+	err = conn.PingContext(ctx)
+	if err != nil {
+		t.Fatalf("expected the connection to be alive but the connection"+
+			"is dead, %v", err)
+	}
+
+	time.Sleep(5 * time.Second)
+	err = conn.PingContext(ctx)
+
+	if err == nil {
+		t.Fatal("expected the connection to be killed " +
+			"but the connection is still alive")
+	}
+}

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -376,19 +376,19 @@ func TestIdleInSessionTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = conn.ExecContext(ctx, `SET idle_in_session_timeout = '4s'`)
+	_, err = conn.ExecContext(ctx, `SET idle_in_session_timeout = '2s'`)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(time.Second)
 	// Make sure executing a statement resets the idle timer.
 	_, err = conn.ExecContext(ctx, `SELECT 1`)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(time.Second)
 	// The connection should still be alive.
 	err = conn.PingContext(ctx)
 	if err != nil {
@@ -403,7 +403,7 @@ func TestIdleInSessionTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(time.Second)
 	// The connection should still be alive.
 	err = conn.PingContext(ctx)
 	if err != nil {
@@ -411,7 +411,7 @@ func TestIdleInSessionTimeout(t *testing.T) {
 			"is dead, %v", err)
 	}
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(3 * time.Second)
 	err = conn.PingContext(ctx)
 
 	if err == nil {

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -74,6 +74,9 @@ type SessionData struct {
 	// StmtTimeout is the duration a query is permitted to run before it is
 	// canceled by the session. If set to 0, there is no timeout.
 	StmtTimeout time.Duration
+	// IdleInSessionTimeout is the duration a session is permitted to idle before
+	// the session is canceled. If set to 0, there is no timeout.
+	IdleInSessionTimeout time.Duration
 	// User is the name of the user logged into the session.
 	User string
 	// SafeUpdates causes errors when the client

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -270,51 +270,76 @@ func timeZoneVarSet(_ context.Context, m *sessionDataMutator, s string) error {
 	return nil
 }
 
-func stmtTimeoutVarGetStringVal(
-	ctx context.Context, evalCtx *extendedEvalContext, values []tree.TypedExpr,
-) (string, error) {
-	if len(values) != 1 {
-		return "", newSingleArgVarError("statement_timeout")
-	}
-	d, err := values[0].Eval(&evalCtx.EvalContext)
-	if err != nil {
-		return "", err
-	}
-
-	var timeout time.Duration
-	switch v := tree.UnwrapDatum(&evalCtx.EvalContext, d).(type) {
-	case *tree.DString:
-		return string(*v), nil
-	case *tree.DInterval:
-		timeout, err = intervalToDuration(v)
-		if err != nil {
-			return "", wrapSetVarError("statement_timeout", values[0].String(), "%v", err)
+func makeTimeoutVarGetter(
+	varName string,
+) func(
+	ctx context.Context, evalCtx *extendedEvalContext, values []tree.TypedExpr) (string, error) {
+	return func(
+		ctx context.Context, evalCtx *extendedEvalContext, values []tree.TypedExpr,
+	) (string, error) {
+		if len(values) != 1 {
+			return "", newSingleArgVarError(varName)
 		}
-	case *tree.DInt:
-		timeout = time.Duration(*v) * time.Millisecond
+		d, err := values[0].Eval(&evalCtx.EvalContext)
+		if err != nil {
+			return "", err
+		}
+
+		var timeout time.Duration
+		switch v := tree.UnwrapDatum(&evalCtx.EvalContext, d).(type) {
+		case *tree.DString:
+			return string(*v), nil
+		case *tree.DInterval:
+			timeout, err = intervalToDuration(v)
+			if err != nil {
+				return "", wrapSetVarError(varName, values[0].String(), "%v", err)
+			}
+		case *tree.DInt:
+			timeout = time.Duration(*v) * time.Millisecond
+		}
+		return timeout.String(), nil
 	}
-	return timeout.String(), nil
 }
 
-func stmtTimeoutVarSet(ctx context.Context, m *sessionDataMutator, s string) error {
-	interval, err := tree.ParseDIntervalWithTypeMetadata(s, types.IntervalTypeMetadata{
+func validateTimeoutVar(timeString string, varName string) (time.Duration, error) {
+	interval, err := tree.ParseDIntervalWithTypeMetadata(timeString, types.IntervalTypeMetadata{
 		DurationField: types.IntervalDurationField{
 			DurationType: types.IntervalDurationType_MILLISECOND,
 		},
 	})
 	if err != nil {
-		return wrapSetVarError("statement_timeout", s, "%v", err)
+		return 0, wrapSetVarError(varName, timeString, "%v", err)
 	}
 	timeout, err := intervalToDuration(interval)
 	if err != nil {
-		return wrapSetVarError("statement_timeout", s, "%v", err)
+		return 0, wrapSetVarError(varName, timeString, "%v", err)
 	}
 
 	if timeout < 0 {
-		return wrapSetVarError("statement_timeout", s,
-			"statement_timeout cannot have a negative duration")
+		return 0, wrapSetVarError(varName, timeString,
+			"%v cannot have a negative duration", varName)
 	}
+
+	return timeout, nil
+}
+
+func stmtTimeoutVarSet(ctx context.Context, m *sessionDataMutator, s string) error {
+	timeout, err := validateTimeoutVar(s, "statement_timeout")
+	if err != nil {
+		return err
+	}
+
 	m.SetStmtTimeout(timeout)
+	return nil
+}
+
+func idleInSessionTimeoutVarSet(ctx context.Context, m *sessionDataMutator, s string) error {
+	timeout, err := validateTimeoutVar(s, "idle_in_session_timeout")
+	if err != nil {
+		return err
+	}
+
+	m.SetIdleInSessionTimeout(timeout)
 	return nil
 }
 

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -931,6 +931,11 @@ func TestLintClusterSettingNames(t *testing.T) {
 				// TODO(knz): remove these cases when these settings are retired.
 				"timeseries.storage.10s_resolution_ttl": `timeseries.storage.10s_resolution_ttl: part "10s_resolution_ttl" has invalid structure`,
 				"timeseries.storage.30m_resolution_ttl": `timeseries.storage.30m_resolution_ttl: part "30m_resolution_ttl" has invalid structure`,
+
+				// sql.defaults.idle_in_session_timeout uses the _timeout suffix stay
+				// consistent with the corresponding session variable
+				// idle_in_session_timeout.
+				"sql.defaults.idle_in_session_timeout": `sql.defaults.idle_in_session_timeout: use ".timeout" instead of "_timeout"`,
 			}
 			expectedErr, found := grandFathered[varName]
 			if !found || expectedErr != nameErr.Error() {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -952,7 +952,9 @@ var varGen = map[string]sessionVar{
 			ms := evalCtx.SessionData.StmtTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10)
 		},
-		GlobalDefault: func(sv *settings.Values) string { return "0" },
+		GlobalDefault: func(sv *settings.Values) string {
+			return clusterIdleInSessionTimeout.String(sv)
+		},
 	},
 
 	// See https://www.postgresql.org/docs/10/static/runtime-config-client.html#GUC-TIMEZONE

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -936,8 +936,18 @@ var varGen = map[string]sessionVar{
 	`row_security`: makeCompatBoolVar(`row_security`, false, true /* anyAllowed */),
 
 	`statement_timeout`: {
-		GetStringVal: stmtTimeoutVarGetStringVal,
+		GetStringVal: makeTimeoutVarGetter(`statement_timeout`),
 		Set:          stmtTimeoutVarSet,
+		Get: func(evalCtx *extendedEvalContext) string {
+			ms := evalCtx.SessionData.StmtTimeout.Nanoseconds() / int64(time.Millisecond)
+			return strconv.FormatInt(ms, 10)
+		},
+		GlobalDefault: func(sv *settings.Values) string { return "0" },
+	},
+
+	`idle_in_session_timeout`: {
+		GetStringVal: makeTimeoutVarGetter(`idle_in_session_timeout`),
+		Set:          idleInSessionTimeoutVarSet,
 		Get: func(evalCtx *extendedEvalContext) string {
 			ms := evalCtx.SessionData.StmtTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10)


### PR DESCRIPTION
sql: implement idle_in_session_timeout setting to cancel sessions 
that exceed a given idle threshold.

Release note (sql change): Add support for idle_in_session_timeout
variable to allow automatically terminating sessions that idle past
a certain threshold.

Release note (sql change): Added cluster setting sql.defaults.idle_in_session_timeout
for setting a default idle_in_session_timeout value for new sessions.
This gives users the ability to set idle_in_session_timeout values for all
newly created sessions.

We've decided not to let being able to send an notice message block us for this, created separate issue about being able to send a notice when cancelling a session.
https://github.com/cockroachdb/cockroach/issues/51237

Fixes #https://github.com/cockroachdb/cockroach/issues/50706, #36054 