### PR TITLE
builtins: add underscore variant for each index builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -679,6 +679,78 @@ has no relationship with the commit order of concurrent transactions.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
 <tbody>
+<tr><td><a name="_st_contains"></a><code>_st_contains(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no points of geometry_b lie in the exterior of geometry_a, and there is at least one point in the interior of geometry_b that lies in the interior of geometry_a.</p>
+<p>This function utilizes the GEOS module.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_containsproperly"></a><code>_st_containsproperly(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_b intersects the interior of geometry_a but not the boundary or exterior of geometry_a.</p>
+<p>This function utilizes the GEOS module.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_coveredby"></a><code>_st_coveredby(geography_a: geography, geography_b: geography) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no point in geography_a is outside geography_b.</p>
+<p>The calculations performed are have a precision of 1cm.</p>
+<p>This function utilizes the S2 library for spherical calculations.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_coveredby"></a><code>_st_coveredby(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no point in geometry_a is outside geometry_b</p>
+<p>This function utilizes the GEOS module.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_covers"></a><code>_st_covers(geography_a: geography, geography_b: geography) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no point in geography_b is outside geography_a.</p>
+<p>This function utilizes the S2 library for spherical calculations.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_covers"></a><code>_st_covers(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no point in geometry_b is outside geometry_a.</p>
+<p>This function utilizes the GEOS module.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_crosses"></a><code>_st_crosses(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a has some - but not all - interior points in common with geometry_b.</p>
+<p>This function utilizes the GEOS module.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_dfullywithin"></a><code>_st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<p>The calculations performed are have a precision of 1cm.</p>
+<p>This function utilizes the GeographicLib library for spheroid calculations.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>, use_spheroid: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
+<p>The calculations performed are have a precision of 1cm.</p>
+<p>This function utilizes the S2 library for spherical calculations.</p>
+<p>This function utilizes the GeographicLib library for spheroid calculations.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_dwithin"></a><code>_st_dwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_equals"></a><code>_st_equals(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a is spatially equal to geometry_b, i.e. ST_Within(geometry_a, geometry_b) = ST_Within(geometry_b, geometry_a) = true.</p>
+<p>This function utilizes the GEOS module.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_intersects"></a><code>_st_intersects(geography_a: geography, geography_b: geography) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geography_a shares any portion of space with geography_b.</p>
+<p>The calculations performed are have a precision of 1cm.</p>
+<p>This function utilizes the S2 library for spherical calculations.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_intersects"></a><code>_st_intersects(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a shares any portion of space with geometry_b.</p>
+<p>The calculations performed are have a precision of 1cm.</p>
+<p>This function utilizes the GEOS module.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_overlaps"></a><code>_st_overlaps(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a intersects but does not completely contain geometry_b, or vice versa. “Does not completely” implies ST_Within(geometry_a, geometry_b) = ST_Within(geometry_b, geometry_a) = false.</p>
+<p>This function utilizes the GEOS module.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_touches"></a><code>_st_touches(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if the only points in common between geometry_a and geometry_b are on the boundary. Note points do not touch other points.</p>
+<p>This function utilizes the GEOS module.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
+<tr><td><a name="_st_within"></a><code>_st_within(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a is completely inside geometry_b.</p>
+<p>This function utilizes the GEOS module.</p>
+<p>This function variant does not utilize any geospatial index.</p>
+</span></td></tr>
 <tr><td><a name="addgeometrycolumn"></a><code>addgeometrycolumn(catalog_name: <a href="string.html">string</a>, schema_name: <a href="string.html">string</a>, table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>, srid: <a href="int.html">int</a>, type: <a href="string.html">string</a>, dimension: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Adds a new geometry column to an existing table and returns metadata about the column created.</p>
 </span></td></tr>
 <tr><td><a name="addgeometrycolumn"></a><code>addgeometrycolumn(catalog_name: <a href="string.html">string</a>, schema_name: <a href="string.html">string</a>, table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>, srid: <a href="int.html">int</a>, type: <a href="string.html">string</a>, dimension: <a href="int.html">int</a>, use_typmod: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Adds a new geometry column to an existing table and returns metadata about the column created.</p>
@@ -896,64 +968,64 @@ given Geometry.</p>
 </span></td></tr>
 <tr><td><a name="st_contains"></a><code>st_contains(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no points of geometry_b lie in the exterior of geometry_a, and there is at least one point in the interior of geometry_b that lies in the interior of geometry_a.</p>
 <p>This function utilizes the GEOS module.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_containsproperly"></a><code>st_containsproperly(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_b intersects the interior of geometry_a but not the boundary or exterior of geometry_a.</p>
 <p>This function utilizes the GEOS module.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_coveredby"></a><code>st_coveredby(geography_a: geography, geography_b: geography) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no point in geography_a is outside geography_b.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_coveredby"></a><code>st_coveredby(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no point in geometry_a is outside geometry_b</p>
 <p>This function utilizes the GEOS module.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_covers"></a><code>st_covers(geography_a: geography, geography_b: geography) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no point in geography_b is outside geography_a.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_covers"></a><code>st_covers(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no point in geometry_b is outside geometry_a.</p>
 <p>This function utilizes the GEOS module.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_crosses"></a><code>st_crosses(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a has some - but not all - interior points in common with geometry_b.</p>
 <p>This function utilizes the GEOS module.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_dfullywithin"></a><code>st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_distance"></a><code>st_distance(geography_a: geography, geography_b: geography) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the distance in meters between geography_a and geography_b.  Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
-<p>This function will automatically use any available index.</p>
 </span></td></tr>
 <tr><td><a name="st_distance"></a><code>st_distance(geography_a: geography, geography_b: geography, use_spheroid: <a href="bool.html">bool</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the distance in meters between geography_a and geography_b.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
-<p>This function will automatically use any available index.</p>
 </span></td></tr>
 <tr><td><a name="st_distance"></a><code>st_distance(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the distance between the given geometries.</p>
 </span></td></tr>
 <tr><td><a name="st_dwithin"></a><code>st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b. Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_dwithin"></a><code>st_dwithin(geography_a: geography, geography_b: geography, distance: <a href="float.html">float</a>, use_spheroid: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geography_a is within distance meters of geography_b.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_dwithin"></a><code>st_dwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_endpoint"></a><code>st_endpoint(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the last point of a geometry which has shape LineString. Returns NULL if the geometry is not a LineString.</p>
 </span></td></tr>
 <tr><td><a name="st_equals"></a><code>st_equals(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a is spatially equal to geometry_b, i.e. ST_Within(geometry_a, geometry_b) = ST_Within(geometry_b, geometry_a) = true.</p>
 <p>This function utilizes the GEOS module.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_exteriorring"></a><code>st_exteriorring(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the exterior ring of a Polygon as a LineString. Returns NULL if the shape is not a Polygon.</p>
 </span></td></tr>
@@ -1018,12 +1090,12 @@ given Geometry.</p>
 <tr><td><a name="st_intersects"></a><code>st_intersects(geography_a: geography, geography_b: geography) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geography_a shares any portion of space with geography_b.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_intersects"></a><code>st_intersects(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a shares any portion of space with geometry_b.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
 <p>This function utilizes the GEOS module.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_length"></a><code>st_length(geography: geography) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the length of the given geography in meters. Uses a spheroid to perform the operation.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
@@ -1154,7 +1226,7 @@ given Geometry.</p>
 </span></td></tr>
 <tr><td><a name="st_overlaps"></a><code>st_overlaps(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a intersects but does not completely contain geometry_b, or vice versa. “Does not completely” implies ST_Within(geometry_a, geometry_b) = ST_Within(geometry_b, geometry_a) = false.</p>
 <p>This function utilizes the GEOS module.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_perimeter"></a><code>st_perimeter(geography: geography) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the perimeter of the given geography in meters. Uses a spheroid to perform the operation.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
@@ -1252,7 +1324,7 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 </span></td></tr>
 <tr><td><a name="st_touches"></a><code>st_touches(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if the only points in common between geometry_a and geometry_b are on the boundary. Note points do not touch other points.</p>
 <p>This function utilizes the GEOS module.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_transform"></a><code>st_transform(geometry: geometry, from_proj_text: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Transforms a geometry into the coordinate reference system assuming the from_proj_text to the new to_proj_text by projecting its coordinates. The supplied SRID is set on the new geometry.</p>
 <p>This function utilizes the PROJ library for coordinate projections.</p>
@@ -1271,7 +1343,7 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 </span></td></tr>
 <tr><td><a name="st_within"></a><code>st_within(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a is completely inside geometry_b.</p>
 <p>This function utilizes the GEOS module.</p>
-<p>This function will automatically use any available index.</p>
+<p>This function variant will attempt to utilize any available geospatial index.</p>
 </span></td></tr>
 <tr><td><a name="st_wkbtosql"></a><code>st_wkbtosql(val: <a href="bytes.html">bytes</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB (or EWKB) representation.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1314,6 +1314,146 @@ Square overlapping left and right square  Square (left)                         
 Square overlapping left and right square  Square (right)                            true   false  true   false  false  false  true   false  false  false
 Square overlapping left and right square  Square overlapping left and right square  true   true   true   false  false  true   true   false  false  true
 
+query TTBBBBBBBBBB
+SELECT
+  a.dsc,
+  b.dsc,
+  _ST_Covers(a.geom, b.geom),
+  _ST_CoveredBy(a.geom, b.geom),
+  _ST_Contains(a.geom, b.geom),
+  _ST_ContainsProperly(a.geom, b.geom),
+  _ST_Crosses(a.geom, b.geom),
+  _ST_Equals(a.geom, b.geom),
+  _ST_Intersects(a.geom, b.geom),
+  _ST_Overlaps(a.geom, b.geom),
+  _ST_Touches(a.geom, b.geom),
+  _ST_Within(a.geom, b.geom)
+FROM geom_operators_test a
+JOIN geom_operators_test b ON (1=1)
+ORDER BY a.dsc, b.dsc
+----
+Empty GeometryCollection                  Empty GeometryCollection                  false  false  false  false  false  true   false  false  false  false
+Empty GeometryCollection                  Empty LineString                          false  false  false  false  false  true   false  false  false  false
+Empty GeometryCollection                  Empty Point                               false  false  false  false  false  true   false  false  false  false
+Empty GeometryCollection                  Faraway point                             false  false  false  false  false  false  false  false  false  false
+Empty GeometryCollection                  Line going through left and right square  false  false  false  false  false  false  false  false  false  false
+Empty GeometryCollection                  NULL                                      NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+Empty GeometryCollection                  Point middle of Left Square               false  false  false  false  false  false  false  false  false  false
+Empty GeometryCollection                  Point middle of Right Square              false  false  false  false  false  false  false  false  false  false
+Empty GeometryCollection                  Square (left)                             false  false  false  false  false  false  false  false  false  false
+Empty GeometryCollection                  Square (right)                            false  false  false  false  false  false  false  false  false  false
+Empty GeometryCollection                  Square overlapping left and right square  false  false  false  false  false  false  false  false  false  false
+Empty LineString                          Empty GeometryCollection                  false  false  false  false  false  true   false  false  false  false
+Empty LineString                          Empty LineString                          false  false  false  false  false  true   false  false  false  false
+Empty LineString                          Empty Point                               false  false  false  false  false  true   false  false  false  false
+Empty LineString                          Faraway point                             false  false  false  false  false  false  false  false  false  false
+Empty LineString                          Line going through left and right square  false  false  false  false  false  false  false  false  false  false
+Empty LineString                          NULL                                      NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+Empty LineString                          Point middle of Left Square               false  false  false  false  false  false  false  false  false  false
+Empty LineString                          Point middle of Right Square              false  false  false  false  false  false  false  false  false  false
+Empty LineString                          Square (left)                             false  false  false  false  false  false  false  false  false  false
+Empty LineString                          Square (right)                            false  false  false  false  false  false  false  false  false  false
+Empty LineString                          Square overlapping left and right square  false  false  false  false  false  false  false  false  false  false
+Empty Point                               Empty GeometryCollection                  false  false  false  false  false  true   false  false  false  false
+Empty Point                               Empty LineString                          false  false  false  false  false  true   false  false  false  false
+Empty Point                               Empty Point                               false  false  false  false  false  true   false  false  false  false
+Empty Point                               Faraway point                             false  false  false  false  false  false  false  false  false  false
+Empty Point                               Line going through left and right square  false  false  false  false  false  false  false  false  false  false
+Empty Point                               NULL                                      NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+Empty Point                               Point middle of Left Square               false  false  false  false  false  false  false  false  false  false
+Empty Point                               Point middle of Right Square              false  false  false  false  false  false  false  false  false  false
+Empty Point                               Square (left)                             false  false  false  false  false  false  false  false  false  false
+Empty Point                               Square (right)                            false  false  false  false  false  false  false  false  false  false
+Empty Point                               Square overlapping left and right square  false  false  false  false  false  false  false  false  false  false
+Faraway point                             Empty GeometryCollection                  false  false  false  false  false  false  false  false  false  false
+Faraway point                             Empty LineString                          false  false  false  false  false  false  false  false  false  false
+Faraway point                             Empty Point                               false  false  false  false  false  false  false  false  false  false
+Faraway point                             Faraway point                             true   true   true   true   false  true   true   false  false  true
+Faraway point                             Line going through left and right square  false  false  false  false  false  false  false  false  false  false
+Faraway point                             NULL                                      NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+Faraway point                             Point middle of Left Square               false  false  false  false  false  false  false  false  false  false
+Faraway point                             Point middle of Right Square              false  false  false  false  false  false  false  false  false  false
+Faraway point                             Square (left)                             false  false  false  false  false  false  false  false  false  false
+Faraway point                             Square (right)                            false  false  false  false  false  false  false  false  false  false
+Faraway point                             Square overlapping left and right square  false  false  false  false  false  false  false  false  false  false
+Line going through left and right square  Empty GeometryCollection                  false  false  false  false  false  false  false  false  false  false
+Line going through left and right square  Empty LineString                          false  false  false  false  false  false  false  false  false  false
+Line going through left and right square  Empty Point                               false  false  false  false  false  false  false  false  false  false
+Line going through left and right square  Faraway point                             false  false  false  false  false  false  false  false  false  false
+Line going through left and right square  Line going through left and right square  true   true   true   false  false  true   true   false  false  true
+Line going through left and right square  NULL                                      NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+Line going through left and right square  Point middle of Left Square               true   false  false  false  false  false  true   false  true   false
+Line going through left and right square  Point middle of Right Square              true   false  false  false  false  false  true   false  true   false
+Line going through left and right square  Square (left)                             false  false  false  false  true   false  true   false  false  false
+Line going through left and right square  Square (right)                            false  false  false  false  true   false  true   false  false  false
+Line going through left and right square  Square overlapping left and right square  false  false  false  false  true   false  true   false  false  false
+NULL                                      Empty GeometryCollection                  NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+NULL                                      Empty LineString                          NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+NULL                                      Empty Point                               NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+NULL                                      Faraway point                             NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+NULL                                      Line going through left and right square  NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+NULL                                      NULL                                      NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+NULL                                      Point middle of Left Square               NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+NULL                                      Point middle of Right Square              NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+NULL                                      Square (left)                             NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+NULL                                      Square (right)                            NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+NULL                                      Square overlapping left and right square  NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+Point middle of Left Square               Empty GeometryCollection                  false  false  false  false  false  false  false  false  false  false
+Point middle of Left Square               Empty LineString                          false  false  false  false  false  false  false  false  false  false
+Point middle of Left Square               Empty Point                               false  false  false  false  false  false  false  false  false  false
+Point middle of Left Square               Faraway point                             false  false  false  false  false  false  false  false  false  false
+Point middle of Left Square               Line going through left and right square  false  true   false  false  false  false  true   false  true   false
+Point middle of Left Square               NULL                                      NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+Point middle of Left Square               Point middle of Left Square               true   true   true   true   false  true   true   false  false  true
+Point middle of Left Square               Point middle of Right Square              false  false  false  false  false  false  false  false  false  false
+Point middle of Left Square               Square (left)                             false  true   false  false  false  false  true   false  false  true
+Point middle of Left Square               Square (right)                            false  false  false  false  false  false  false  false  false  false
+Point middle of Left Square               Square overlapping left and right square  false  false  false  false  false  false  false  false  false  false
+Point middle of Right Square              Empty GeometryCollection                  false  false  false  false  false  false  false  false  false  false
+Point middle of Right Square              Empty LineString                          false  false  false  false  false  false  false  false  false  false
+Point middle of Right Square              Empty Point                               false  false  false  false  false  false  false  false  false  false
+Point middle of Right Square              Faraway point                             false  false  false  false  false  false  false  false  false  false
+Point middle of Right Square              Line going through left and right square  false  true   false  false  false  false  true   false  true   false
+Point middle of Right Square              NULL                                      NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+Point middle of Right Square              Point middle of Left Square               false  false  false  false  false  false  false  false  false  false
+Point middle of Right Square              Point middle of Right Square              true   true   true   true   false  true   true   false  false  true
+Point middle of Right Square              Square (left)                             false  false  false  false  false  false  false  false  false  false
+Point middle of Right Square              Square (right)                            false  true   false  false  false  false  true   false  false  true
+Point middle of Right Square              Square overlapping left and right square  false  true   false  false  false  false  true   false  false  true
+Square (left)                             Empty GeometryCollection                  false  false  false  false  false  false  false  false  false  false
+Square (left)                             Empty LineString                          false  false  false  false  false  false  false  false  false  false
+Square (left)                             Empty Point                               false  false  false  false  false  false  false  false  false  false
+Square (left)                             Faraway point                             false  false  false  false  false  false  false  false  false  false
+Square (left)                             Line going through left and right square  false  false  false  false  true   false  true   false  false  false
+Square (left)                             NULL                                      NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+Square (left)                             Point middle of Left Square               true   false  true   true   false  false  true   false  false  false
+Square (left)                             Point middle of Right Square              false  false  false  false  false  false  false  false  false  false
+Square (left)                             Square (left)                             true   true   true   false  false  true   true   false  false  true
+Square (left)                             Square (right)                            false  false  false  false  false  false  true   false  true   false
+Square (left)                             Square overlapping left and right square  false  false  false  false  false  false  true   true   false  false
+Square (right)                            Empty GeometryCollection                  false  false  false  false  false  false  false  false  false  false
+Square (right)                            Empty LineString                          false  false  false  false  false  false  false  false  false  false
+Square (right)                            Empty Point                               false  false  false  false  false  false  false  false  false  false
+Square (right)                            Faraway point                             false  false  false  false  false  false  false  false  false  false
+Square (right)                            Line going through left and right square  false  false  false  false  true   false  true   false  false  false
+Square (right)                            NULL                                      NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+Square (right)                            Point middle of Left Square               false  false  false  false  false  false  false  false  false  false
+Square (right)                            Point middle of Right Square              true   false  true   true   false  false  true   false  false  false
+Square (right)                            Square (left)                             false  false  false  false  false  false  true   false  true   false
+Square (right)                            Square (right)                            true   true   true   false  false  true   true   false  false  true
+Square (right)                            Square overlapping left and right square  false  true   false  false  false  false  true   false  false  true
+Square overlapping left and right square  Empty GeometryCollection                  false  false  false  false  false  false  false  false  false  false
+Square overlapping left and right square  Empty LineString                          false  false  false  false  false  false  false  false  false  false
+Square overlapping left and right square  Empty Point                               false  false  false  false  false  false  false  false  false  false
+Square overlapping left and right square  Faraway point                             false  false  false  false  false  false  false  false  false  false
+Square overlapping left and right square  Line going through left and right square  false  false  false  false  true   false  true   false  false  false
+Square overlapping left and right square  NULL                                      NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+Square overlapping left and right square  Point middle of Left Square               false  false  false  false  false  false  false  false  false  false
+Square overlapping left and right square  Point middle of Right Square              true   false  true   true   false  false  true   false  false  false
+Square overlapping left and right square  Square (left)                             false  false  false  false  false  false  true   true   false  false
+Square overlapping left and right square  Square (right)                            true   false  true   false  false  false  true   false  false  false
+Square overlapping left and right square  Square overlapping left and right square  true   true   true   false  false  true   true   false  false  true
+
 # DWithin
 query TTBB
 SELECT
@@ -1447,6 +1587,139 @@ Square overlapping left and right square  Square (left)                         
 Square overlapping left and right square  Square (right)                            true   false
 Square overlapping left and right square  Square overlapping left and right square  true   false
 
+query TTBB
+SELECT
+  a.dsc,
+  b.dsc,
+  _ST_DWithin(a.geom, b.geom, 1),
+  _ST_DFullyWithin(a.geom, b.geom, 1)
+FROM geom_operators_test a
+JOIN geom_operators_test b ON (1=1)
+ORDER BY a.dsc, b.dsc
+----
+Empty GeometryCollection                  Empty GeometryCollection                  false  false
+Empty GeometryCollection                  Empty LineString                          false  false
+Empty GeometryCollection                  Empty Point                               false  false
+Empty GeometryCollection                  Faraway point                             false  false
+Empty GeometryCollection                  Line going through left and right square  false  false
+Empty GeometryCollection                  NULL                                      NULL   NULL
+Empty GeometryCollection                  Point middle of Left Square               false  false
+Empty GeometryCollection                  Point middle of Right Square              false  false
+Empty GeometryCollection                  Square (left)                             false  false
+Empty GeometryCollection                  Square (right)                            false  false
+Empty GeometryCollection                  Square overlapping left and right square  false  false
+Empty LineString                          Empty GeometryCollection                  false  false
+Empty LineString                          Empty LineString                          false  false
+Empty LineString                          Empty Point                               false  false
+Empty LineString                          Faraway point                             false  false
+Empty LineString                          Line going through left and right square  false  false
+Empty LineString                          NULL                                      NULL   NULL
+Empty LineString                          Point middle of Left Square               false  false
+Empty LineString                          Point middle of Right Square              false  false
+Empty LineString                          Square (left)                             false  false
+Empty LineString                          Square (right)                            false  false
+Empty LineString                          Square overlapping left and right square  false  false
+Empty Point                               Empty GeometryCollection                  false  false
+Empty Point                               Empty LineString                          false  false
+Empty Point                               Empty Point                               false  false
+Empty Point                               Faraway point                             false  false
+Empty Point                               Line going through left and right square  false  false
+Empty Point                               NULL                                      NULL   NULL
+Empty Point                               Point middle of Left Square               false  false
+Empty Point                               Point middle of Right Square              false  false
+Empty Point                               Square (left)                             false  false
+Empty Point                               Square (right)                            false  false
+Empty Point                               Square overlapping left and right square  false  false
+Faraway point                             Empty GeometryCollection                  false  false
+Faraway point                             Empty LineString                          false  false
+Faraway point                             Empty Point                               false  false
+Faraway point                             Faraway point                             true   true
+Faraway point                             Line going through left and right square  false  false
+Faraway point                             NULL                                      NULL   NULL
+Faraway point                             Point middle of Left Square               false  false
+Faraway point                             Point middle of Right Square              false  false
+Faraway point                             Square (left)                             false  false
+Faraway point                             Square (right)                            false  false
+Faraway point                             Square overlapping left and right square  false  false
+Line going through left and right square  Empty GeometryCollection                  false  false
+Line going through left and right square  Empty LineString                          false  false
+Line going through left and right square  Empty Point                               false  false
+Line going through left and right square  Faraway point                             false  false
+Line going through left and right square  Line going through left and right square  true   true
+Line going through left and right square  NULL                                      NULL   NULL
+Line going through left and right square  Point middle of Left Square               true   true
+Line going through left and right square  Point middle of Right Square              true   true
+Line going through left and right square  Square (left)                             true   false
+Line going through left and right square  Square (right)                            true   false
+Line going through left and right square  Square overlapping left and right square  true   false
+NULL                                      Empty GeometryCollection                  NULL   NULL
+NULL                                      Empty LineString                          NULL   NULL
+NULL                                      Empty Point                               NULL   NULL
+NULL                                      Faraway point                             NULL   NULL
+NULL                                      Line going through left and right square  NULL   NULL
+NULL                                      NULL                                      NULL   NULL
+NULL                                      Point middle of Left Square               NULL   NULL
+NULL                                      Point middle of Right Square              NULL   NULL
+NULL                                      Square (left)                             NULL   NULL
+NULL                                      Square (right)                            NULL   NULL
+NULL                                      Square overlapping left and right square  NULL   NULL
+Point middle of Left Square               Empty GeometryCollection                  false  false
+Point middle of Left Square               Empty LineString                          false  false
+Point middle of Left Square               Empty Point                               false  false
+Point middle of Left Square               Faraway point                             false  false
+Point middle of Left Square               Line going through left and right square  true   true
+Point middle of Left Square               NULL                                      NULL   NULL
+Point middle of Left Square               Point middle of Left Square               true   true
+Point middle of Left Square               Point middle of Right Square              true   true
+Point middle of Left Square               Square (left)                             true   true
+Point middle of Left Square               Square (right)                            true   false
+Point middle of Left Square               Square overlapping left and right square  true   false
+Point middle of Right Square              Empty GeometryCollection                  false  false
+Point middle of Right Square              Empty LineString                          false  false
+Point middle of Right Square              Empty Point                               false  false
+Point middle of Right Square              Faraway point                             false  false
+Point middle of Right Square              Line going through left and right square  true   true
+Point middle of Right Square              NULL                                      NULL   NULL
+Point middle of Right Square              Point middle of Left Square               true   true
+Point middle of Right Square              Point middle of Right Square              true   true
+Point middle of Right Square              Square (left)                             true   false
+Point middle of Right Square              Square (right)                            true   true
+Point middle of Right Square              Square overlapping left and right square  true   true
+Square (left)                             Empty GeometryCollection                  false  false
+Square (left)                             Empty LineString                          false  false
+Square (left)                             Empty Point                               false  false
+Square (left)                             Faraway point                             false  false
+Square (left)                             Line going through left and right square  true   false
+Square (left)                             NULL                                      NULL   NULL
+Square (left)                             Point middle of Left Square               true   true
+Square (left)                             Point middle of Right Square              true   false
+Square (left)                             Square (left)                             true   false
+Square (left)                             Square (right)                            true   false
+Square (left)                             Square overlapping left and right square  true   false
+Square (right)                            Empty GeometryCollection                  false  false
+Square (right)                            Empty LineString                          false  false
+Square (right)                            Empty Point                               false  false
+Square (right)                            Faraway point                             false  false
+Square (right)                            Line going through left and right square  true   false
+Square (right)                            NULL                                      NULL   NULL
+Square (right)                            Point middle of Left Square               true   false
+Square (right)                            Point middle of Right Square              true   true
+Square (right)                            Square (left)                             true   false
+Square (right)                            Square (right)                            true   false
+Square (right)                            Square overlapping left and right square  true   false
+Square overlapping left and right square  Empty GeometryCollection                  false  false
+Square overlapping left and right square  Empty LineString                          false  false
+Square overlapping left and right square  Empty Point                               false  false
+Square overlapping left and right square  Faraway point                             false  false
+Square overlapping left and right square  Line going through left and right square  true   false
+Square overlapping left and right square  NULL                                      NULL   NULL
+Square overlapping left and right square  Point middle of Left Square               true   false
+Square overlapping left and right square  Point middle of Right Square              true   true
+Square overlapping left and right square  Square (left)                             true   false
+Square overlapping left and right square  Square (right)                            true   false
+Square overlapping left and right square  Square overlapping left and right square  true   false
+
+# ST_Buffer
 query TTTT
 SELECT
   a.dsc,
@@ -2256,6 +2529,139 @@ Square overlapping left and right square  Square (left)                         
 Square overlapping left and right square  Square (right)                            false  false  true
 Square overlapping left and right square  Square overlapping left and right square  true   true   true
 
+query TTBBB
+SELECT
+  a.dsc,
+  b.dsc,
+  _ST_Covers(a.geog, b.geog),
+  _ST_CoveredBy(a.geog, b.geog),
+  _ST_Intersects(a.geog, b.geog)
+FROM geog_operators_test a
+JOIN geog_operators_test b ON (1=1)
+ORDER BY a.dsc, b.dsc
+----
+Empty GeometryCollection                  Empty GeometryCollection                  false  false  false
+Empty GeometryCollection                  Empty LineString                          false  false  false
+Empty GeometryCollection                  Empty Point                               false  false  false
+Empty GeometryCollection                  Faraway point                             false  false  false
+Empty GeometryCollection                  Line going through left and right square  false  false  false
+Empty GeometryCollection                  NULL                                      NULL   NULL   NULL
+Empty GeometryCollection                  Point middle of Left Square               false  false  false
+Empty GeometryCollection                  Point middle of Right Square              false  false  false
+Empty GeometryCollection                  Square (left)                             false  false  false
+Empty GeometryCollection                  Square (right)                            false  false  false
+Empty GeometryCollection                  Square overlapping left and right square  false  false  false
+Empty LineString                          Empty GeometryCollection                  false  false  false
+Empty LineString                          Empty LineString                          false  false  false
+Empty LineString                          Empty Point                               false  false  false
+Empty LineString                          Faraway point                             false  false  false
+Empty LineString                          Line going through left and right square  false  false  false
+Empty LineString                          NULL                                      NULL   NULL   NULL
+Empty LineString                          Point middle of Left Square               false  false  false
+Empty LineString                          Point middle of Right Square              false  false  false
+Empty LineString                          Square (left)                             false  false  false
+Empty LineString                          Square (right)                            false  false  false
+Empty LineString                          Square overlapping left and right square  false  false  false
+Empty Point                               Empty GeometryCollection                  false  false  false
+Empty Point                               Empty LineString                          false  false  false
+Empty Point                               Empty Point                               false  false  false
+Empty Point                               Faraway point                             false  false  false
+Empty Point                               Line going through left and right square  false  false  false
+Empty Point                               NULL                                      NULL   NULL   NULL
+Empty Point                               Point middle of Left Square               false  false  false
+Empty Point                               Point middle of Right Square              false  false  false
+Empty Point                               Square (left)                             false  false  false
+Empty Point                               Square (right)                            false  false  false
+Empty Point                               Square overlapping left and right square  false  false  false
+Faraway point                             Empty GeometryCollection                  false  false  false
+Faraway point                             Empty LineString                          false  false  false
+Faraway point                             Empty Point                               false  false  false
+Faraway point                             Faraway point                             true   true   true
+Faraway point                             Line going through left and right square  false  false  false
+Faraway point                             NULL                                      NULL   NULL   NULL
+Faraway point                             Point middle of Left Square               false  false  false
+Faraway point                             Point middle of Right Square              false  false  false
+Faraway point                             Square (left)                             false  false  false
+Faraway point                             Square (right)                            false  false  false
+Faraway point                             Square overlapping left and right square  false  false  false
+Line going through left and right square  Empty GeometryCollection                  false  false  false
+Line going through left and right square  Empty LineString                          false  false  false
+Line going through left and right square  Empty Point                               false  false  false
+Line going through left and right square  Faraway point                             false  false  false
+Line going through left and right square  Line going through left and right square  true   true   true
+Line going through left and right square  NULL                                      NULL   NULL   NULL
+Line going through left and right square  Point middle of Left Square               true   false  true
+Line going through left and right square  Point middle of Right Square              true   false  true
+Line going through left and right square  Square (left)                             false  false  true
+Line going through left and right square  Square (right)                            false  false  true
+Line going through left and right square  Square overlapping left and right square  false  false  true
+NULL                                      Empty GeometryCollection                  NULL   NULL   NULL
+NULL                                      Empty LineString                          NULL   NULL   NULL
+NULL                                      Empty Point                               NULL   NULL   NULL
+NULL                                      Faraway point                             NULL   NULL   NULL
+NULL                                      Line going through left and right square  NULL   NULL   NULL
+NULL                                      NULL                                      NULL   NULL   NULL
+NULL                                      Point middle of Left Square               NULL   NULL   NULL
+NULL                                      Point middle of Right Square              NULL   NULL   NULL
+NULL                                      Square (left)                             NULL   NULL   NULL
+NULL                                      Square (right)                            NULL   NULL   NULL
+NULL                                      Square overlapping left and right square  NULL   NULL   NULL
+Point middle of Left Square               Empty GeometryCollection                  false  false  false
+Point middle of Left Square               Empty LineString                          false  false  false
+Point middle of Left Square               Empty Point                               false  false  false
+Point middle of Left Square               Faraway point                             false  false  false
+Point middle of Left Square               Line going through left and right square  false  true   true
+Point middle of Left Square               NULL                                      NULL   NULL   NULL
+Point middle of Left Square               Point middle of Left Square               true   true   true
+Point middle of Left Square               Point middle of Right Square              false  false  false
+Point middle of Left Square               Square (left)                             false  true   true
+Point middle of Left Square               Square (right)                            false  false  false
+Point middle of Left Square               Square overlapping left and right square  false  false  false
+Point middle of Right Square              Empty GeometryCollection                  false  false  false
+Point middle of Right Square              Empty LineString                          false  false  false
+Point middle of Right Square              Empty Point                               false  false  false
+Point middle of Right Square              Faraway point                             false  false  false
+Point middle of Right Square              Line going through left and right square  false  true   true
+Point middle of Right Square              NULL                                      NULL   NULL   NULL
+Point middle of Right Square              Point middle of Left Square               false  false  false
+Point middle of Right Square              Point middle of Right Square              true   true   true
+Point middle of Right Square              Square (left)                             false  false  false
+Point middle of Right Square              Square (right)                            false  true   true
+Point middle of Right Square              Square overlapping left and right square  false  true   true
+Square (left)                             Empty GeometryCollection                  false  false  false
+Square (left)                             Empty LineString                          false  false  false
+Square (left)                             Empty Point                               false  false  false
+Square (left)                             Faraway point                             false  false  false
+Square (left)                             Line going through left and right square  false  false  true
+Square (left)                             NULL                                      NULL   NULL   NULL
+Square (left)                             Point middle of Left Square               true   false  true
+Square (left)                             Point middle of Right Square              false  false  false
+Square (left)                             Square (left)                             true   true   true
+Square (left)                             Square (right)                            false  false  true
+Square (left)                             Square overlapping left and right square  false  false  true
+Square (right)                            Empty GeometryCollection                  false  false  false
+Square (right)                            Empty LineString                          false  false  false
+Square (right)                            Empty Point                               false  false  false
+Square (right)                            Faraway point                             false  false  false
+Square (right)                            Line going through left and right square  false  false  true
+Square (right)                            NULL                                      NULL   NULL   NULL
+Square (right)                            Point middle of Left Square               false  false  false
+Square (right)                            Point middle of Right Square              true   false  true
+Square (right)                            Square (left)                             false  false  true
+Square (right)                            Square (right)                            true   true   true
+Square (right)                            Square overlapping left and right square  false  false  true
+Square overlapping left and right square  Empty GeometryCollection                  false  false  false
+Square overlapping left and right square  Empty LineString                          false  false  false
+Square overlapping left and right square  Empty Point                               false  false  false
+Square overlapping left and right square  Faraway point                             false  false  false
+Square overlapping left and right square  Line going through left and right square  false  false  true
+Square overlapping left and right square  NULL                                      NULL   NULL   NULL
+Square overlapping left and right square  Point middle of Left Square               false  false  false
+Square overlapping left and right square  Point middle of Right Square              true   false  true
+Square overlapping left and right square  Square (left)                             false  false  true
+Square overlapping left and right square  Square (right)                            false  false  true
+Square overlapping left and right square  Square overlapping left and right square  true   true   true
+
 # DWithin
 query TTBBB
 SELECT
@@ -2264,6 +2670,139 @@ SELECT
   ST_DWithin(a.geog, b.geog, 70558),
   ST_DWithin(a.geog, b.geog, 70558, false),
   ST_DWithin(a.geog, b.geog, 70558, true)
+FROM geog_operators_test a
+JOIN geog_operators_test b ON (1=1)
+ORDER BY a.dsc, b.dsc
+----
+Empty GeometryCollection                  Empty GeometryCollection                  false  false  false
+Empty GeometryCollection                  Empty LineString                          false  false  false
+Empty GeometryCollection                  Empty Point                               false  false  false
+Empty GeometryCollection                  Faraway point                             false  false  false
+Empty GeometryCollection                  Line going through left and right square  false  false  false
+Empty GeometryCollection                  NULL                                      NULL   NULL   NULL
+Empty GeometryCollection                  Point middle of Left Square               false  false  false
+Empty GeometryCollection                  Point middle of Right Square              false  false  false
+Empty GeometryCollection                  Square (left)                             false  false  false
+Empty GeometryCollection                  Square (right)                            false  false  false
+Empty GeometryCollection                  Square overlapping left and right square  false  false  false
+Empty LineString                          Empty GeometryCollection                  false  false  false
+Empty LineString                          Empty LineString                          false  false  false
+Empty LineString                          Empty Point                               false  false  false
+Empty LineString                          Faraway point                             false  false  false
+Empty LineString                          Line going through left and right square  false  false  false
+Empty LineString                          NULL                                      NULL   NULL   NULL
+Empty LineString                          Point middle of Left Square               false  false  false
+Empty LineString                          Point middle of Right Square              false  false  false
+Empty LineString                          Square (left)                             false  false  false
+Empty LineString                          Square (right)                            false  false  false
+Empty LineString                          Square overlapping left and right square  false  false  false
+Empty Point                               Empty GeometryCollection                  false  false  false
+Empty Point                               Empty LineString                          false  false  false
+Empty Point                               Empty Point                               false  false  false
+Empty Point                               Faraway point                             false  false  false
+Empty Point                               Line going through left and right square  false  false  false
+Empty Point                               NULL                                      NULL   NULL   NULL
+Empty Point                               Point middle of Left Square               false  false  false
+Empty Point                               Point middle of Right Square              false  false  false
+Empty Point                               Square (left)                             false  false  false
+Empty Point                               Square (right)                            false  false  false
+Empty Point                               Square overlapping left and right square  false  false  false
+Faraway point                             Empty GeometryCollection                  false  false  false
+Faraway point                             Empty LineString                          false  false  false
+Faraway point                             Empty Point                               false  false  false
+Faraway point                             Faraway point                             true   true   true
+Faraway point                             Line going through left and right square  false  false  false
+Faraway point                             NULL                                      NULL   NULL   NULL
+Faraway point                             Point middle of Left Square               false  false  false
+Faraway point                             Point middle of Right Square              false  false  false
+Faraway point                             Square (left)                             false  false  false
+Faraway point                             Square (right)                            false  false  false
+Faraway point                             Square overlapping left and right square  false  false  false
+Line going through left and right square  Empty GeometryCollection                  false  false  false
+Line going through left and right square  Empty LineString                          false  false  false
+Line going through left and right square  Empty Point                               false  false  false
+Line going through left and right square  Faraway point                             false  false  false
+Line going through left and right square  Line going through left and right square  true   true   true
+Line going through left and right square  NULL                                      NULL   NULL   NULL
+Line going through left and right square  Point middle of Left Square               true   true   true
+Line going through left and right square  Point middle of Right Square              true   true   true
+Line going through left and right square  Square (left)                             true   true   true
+Line going through left and right square  Square (right)                            true   true   true
+Line going through left and right square  Square overlapping left and right square  true   true   true
+NULL                                      Empty GeometryCollection                  NULL   NULL   NULL
+NULL                                      Empty LineString                          NULL   NULL   NULL
+NULL                                      Empty Point                               NULL   NULL   NULL
+NULL                                      Faraway point                             NULL   NULL   NULL
+NULL                                      Line going through left and right square  NULL   NULL   NULL
+NULL                                      NULL                                      NULL   NULL   NULL
+NULL                                      Point middle of Left Square               NULL   NULL   NULL
+NULL                                      Point middle of Right Square              NULL   NULL   NULL
+NULL                                      Square (left)                             NULL   NULL   NULL
+NULL                                      Square (right)                            NULL   NULL   NULL
+NULL                                      Square overlapping left and right square  NULL   NULL   NULL
+Point middle of Left Square               Empty GeometryCollection                  false  false  false
+Point middle of Left Square               Empty LineString                          false  false  false
+Point middle of Left Square               Empty Point                               false  false  false
+Point middle of Left Square               Faraway point                             false  false  false
+Point middle of Left Square               Line going through left and right square  true   true   true
+Point middle of Left Square               NULL                                      NULL   NULL   NULL
+Point middle of Left Square               Point middle of Left Square               true   true   true
+Point middle of Left Square               Point middle of Right Square              false  false  false
+Point middle of Left Square               Square (left)                             true   true   true
+Point middle of Left Square               Square (right)                            true   true   true
+Point middle of Left Square               Square overlapping left and right square  true   true   true
+Point middle of Right Square              Empty GeometryCollection                  false  false  false
+Point middle of Right Square              Empty LineString                          false  false  false
+Point middle of Right Square              Empty Point                               false  false  false
+Point middle of Right Square              Faraway point                             false  false  false
+Point middle of Right Square              Line going through left and right square  true   true   true
+Point middle of Right Square              NULL                                      NULL   NULL   NULL
+Point middle of Right Square              Point middle of Left Square               false  false  false
+Point middle of Right Square              Point middle of Right Square              true   true   true
+Point middle of Right Square              Square (left)                             true   true   true
+Point middle of Right Square              Square (right)                            true   true   true
+Point middle of Right Square              Square overlapping left and right square  true   true   true
+Square (left)                             Empty GeometryCollection                  false  false  false
+Square (left)                             Empty LineString                          false  false  false
+Square (left)                             Empty Point                               false  false  false
+Square (left)                             Faraway point                             false  false  false
+Square (left)                             Line going through left and right square  true   true   true
+Square (left)                             NULL                                      NULL   NULL   NULL
+Square (left)                             Point middle of Left Square               true   true   true
+Square (left)                             Point middle of Right Square              true   true   true
+Square (left)                             Square (left)                             true   true   true
+Square (left)                             Square (right)                            true   true   true
+Square (left)                             Square overlapping left and right square  true   true   true
+Square (right)                            Empty GeometryCollection                  false  false  false
+Square (right)                            Empty LineString                          false  false  false
+Square (right)                            Empty Point                               false  false  false
+Square (right)                            Faraway point                             false  false  false
+Square (right)                            Line going through left and right square  true   true   true
+Square (right)                            NULL                                      NULL   NULL   NULL
+Square (right)                            Point middle of Left Square               true   true   true
+Square (right)                            Point middle of Right Square              true   true   true
+Square (right)                            Square (left)                             true   true   true
+Square (right)                            Square (right)                            true   true   true
+Square (right)                            Square overlapping left and right square  true   true   true
+Square overlapping left and right square  Empty GeometryCollection                  false  false  false
+Square overlapping left and right square  Empty LineString                          false  false  false
+Square overlapping left and right square  Empty Point                               false  false  false
+Square overlapping left and right square  Faraway point                             false  false  false
+Square overlapping left and right square  Line going through left and right square  true   true   true
+Square overlapping left and right square  NULL                                      NULL   NULL   NULL
+Square overlapping left and right square  Point middle of Left Square               true   true   true
+Square overlapping left and right square  Point middle of Right Square              true   true   true
+Square overlapping left and right square  Square (left)                             true   true   true
+Square overlapping left and right square  Square (right)                            true   true   true
+Square overlapping left and right square  Square overlapping left and right square  true   true   true
+
+query TTBBB
+SELECT
+  a.dsc,
+  b.dsc,
+  _ST_DWithin(a.geog, b.geog, 70558),
+  _ST_DWithin(a.geog, b.geog, 70558, false),
+  _ST_DWithin(a.geog, b.geog, 70558, true)
 FROM geog_operators_test a
 JOIN geog_operators_test b ON (1=1)
 ORDER BY a.dsc, b.dsc

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -652,3 +652,16 @@ lookup-join              ·                      ·                          (k,
            └── scan      ·                      ·                          (k, geom)           ·
 ·                        table                  geo_table2@primary         ·                   ·
 ·                        spans                  FULL SCAN                  ·                   ·
+
+# Do not use the index when using a _ prefixed builtin.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT k FROM geo_table WHERE _ST_Intersects('POINT(3.0 3.0)'::geometry, geom)
+----
+·          distribution  local                                                               ·          ·
+·          vectorized    true                                                                ·          ·
+render     ·             ·                                                                   (k)        ·
+ │         render 0      k                                                                   ·          ·
+ └── scan  ·             ·                                                                   (k, geom)  ·
+·          table         geo_table@primary                                                   ·          ·
+·          spans         FULL SCAN                                                           ·          ·
+·          filter        _st_intersects('010100000000000000000008400000000000000840', geom)  ·          ·

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geogfn"
+	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/geo/geomfn"
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoprojbase"
@@ -59,7 +60,6 @@ type infoBuilder struct {
 	info         string
 	libraryUsage libraryUsage
 	precision    string
-	canUseIndex  bool
 }
 
 func (ib infoBuilder) String() string {
@@ -79,9 +79,6 @@ func (ib infoBuilder) String() string {
 	}
 	if ib.libraryUsage&usesPROJ != 0 {
 		sb.WriteString("\n\nThis function utilizes the PROJ library for coordinate projections.")
-	}
-	if ib.canUseIndex {
-		sb.WriteString("\n\nThis function will automatically use any available index.")
 	}
 	return sb.String()
 }
@@ -1951,7 +1948,6 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 			infoBuilder{
 				info:         "Returns the distance in meters between geography_a and geography_b. " + usesSpheroidMessage + spheroidDistanceMessage,
 				libraryUsage: usesGeographicLib,
-				canUseIndex:  true,
 			},
 			tree.VolatilityImmutable,
 		),
@@ -1979,7 +1975,6 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 			Info: infoBuilder{
 				info:         "Returns the distance in meters between geography_a and geography_b." + spheroidDistanceMessage,
 				libraryUsage: usesGeographicLib | usesS2,
-				canUseIndex:  true,
 			}.String(),
 			Volatility: tree.VolatilityImmutable,
 		},
@@ -2067,7 +2062,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 			infoBuilder{
 				info:         "Returns true if no point in geometry_b is outside geometry_a.",
 				libraryUsage: usesGEOS,
-				canUseIndex:  true,
 			},
 		),
 		geographyOverload2BinaryPredicate(
@@ -2075,7 +2069,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 			infoBuilder{
 				info:         `Returns true if no point in geography_b is outside geography_a.`,
 				libraryUsage: usesS2,
-				canUseIndex:  true,
 			},
 		),
 	),
@@ -2086,7 +2079,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 			infoBuilder{
 				info:         `Returns true if no point in geometry_a is outside geometry_b`,
 				libraryUsage: usesGEOS,
-				canUseIndex:  true,
 			},
 		),
 		geographyOverload2BinaryPredicate(
@@ -2095,7 +2087,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				info:         `Returns true if no point in geography_a is outside geography_b.`,
 				libraryUsage: usesS2,
 				precision:    "1cm",
-				canUseIndex:  true,
 			},
 		),
 	),
@@ -2107,7 +2098,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				info: "Returns true if no points of geometry_b lie in the exterior of geometry_a, " +
 					"and there is at least one point in the interior of geometry_b that lies in the interior of geometry_a.",
 				libraryUsage: usesGEOS,
-				canUseIndex:  true,
 			},
 		),
 	),
@@ -2118,7 +2108,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 			infoBuilder{
 				info:         "Returns true if geometry_b intersects the interior of geometry_a but not the boundary or exterior of geometry_a.",
 				libraryUsage: usesGEOS,
-				canUseIndex:  true,
 			},
 		),
 	),
@@ -2129,7 +2118,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 			infoBuilder{
 				info:         "Returns true if geometry_a has some - but not all - interior points in common with geometry_b.",
 				libraryUsage: usesGEOS,
-				canUseIndex:  true,
 			},
 		),
 	),
@@ -2204,7 +2192,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				info:         "Returns true if any of geography_a is within distance meters of geography_b." + usesSpheroidMessage + spheroidDistanceMessage,
 				libraryUsage: usesGeographicLib,
 				precision:    "1cm",
-				canUseIndex:  true,
 			}.String(),
 			Volatility: tree.VolatilityImmutable,
 		},
@@ -2232,7 +2219,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				info:         "Returns true if any of geography_a is within distance meters of geography_b." + spheroidDistanceMessage,
 				libraryUsage: usesGeographicLib | usesS2,
 				precision:    "1cm",
-				canUseIndex:  true,
 			}.String(),
 			Volatility: tree.VolatilityImmutable,
 		},
@@ -2245,7 +2231,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				info: "Returns true if geometry_a is spatially equal to geometry_b, " +
 					"i.e. ST_Within(geometry_a, geometry_b) = ST_Within(geometry_b, geometry_a) = true.",
 				libraryUsage: usesGEOS,
-				canUseIndex:  true,
 			},
 		),
 	),
@@ -2257,7 +2242,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				info:         "Returns true if geometry_a shares any portion of space with geometry_b.",
 				libraryUsage: usesGEOS,
 				precision:    "1cm",
-				canUseIndex:  true,
 			},
 		),
 		geographyOverload2BinaryPredicate(
@@ -2266,7 +2250,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				info:         `Returns true if geography_a shares any portion of space with geography_b.`,
 				libraryUsage: usesS2,
 				precision:    "1cm",
-				canUseIndex:  true,
 			},
 		),
 	),
@@ -2278,7 +2261,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				info: "Returns true if geometry_a intersects but does not completely contain geometry_b, or vice versa. " +
 					`"Does not completely" implies ST_Within(geometry_a, geometry_b) = ST_Within(geometry_b, geometry_a) = false.`,
 				libraryUsage: usesGEOS,
-				canUseIndex:  true,
 			},
 		),
 	),
@@ -2290,7 +2272,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				info: "Returns true if the only points in common between geometry_a and geometry_b are on the boundary. " +
 					"Note points do not touch other points.",
 				libraryUsage: usesGEOS,
-				canUseIndex:  true,
 			},
 		),
 	),
@@ -2301,7 +2282,6 @@ Note if geometries are the same, it will return the LineString with the minimum 
 			infoBuilder{
 				info:         "Returns true if geometry_a is completely inside geometry_b.",
 				libraryUsage: usesGEOS,
-				canUseIndex:  true,
 			},
 		),
 	),
@@ -3408,6 +3388,26 @@ func toUseSphereOrSpheroid(useSpheroid *tree.DBool) geogfn.UseSphereOrSpheroid {
 }
 
 func initGeoBuiltins() {
+	for indexBuiltinName := range geoindex.RelationshipMap {
+		builtin, exists := geoBuiltins[indexBuiltinName]
+		if !exists {
+			panic("expected builtin: " + indexBuiltinName)
+		}
+		// Copy the builtin and add an underscore on the name.
+		overloads := make([]tree.Overload, len(builtin.overloads))
+		for i, ovCopy := range builtin.overloads {
+			builtin.overloads[i].Info += "\n\nThis function variant will attempt to utilize any available geospatial index."
+
+			ovCopy.Info += "\n\nThis function variant does not utilize any geospatial index."
+			overloads[i] = ovCopy
+		}
+		underscoreBuiltin := makeBuiltin(
+			builtin.props,
+			overloads...,
+		)
+		geoBuiltins["_"+indexBuiltinName] = underscoreBuiltin
+	}
+
 	for k, v := range geoBuiltins {
 		if _, exists := builtins[k]; exists {
 			panic("duplicate builtin: " + k)


### PR DESCRIPTION
Add underscore variants for each spatial predicate builtin, which does
not utilize the index.

Release note (sql change): Add a _ prefix to index backed geospatial
functions, which avoids using the index whilst applying the same
functionality.