### PR TITLE
opt: fix error in case of casted NULL arguments to AddGeometryColumn

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
@@ -248,3 +248,8 @@ query T
 SELECT addgeometrycolumn('a', 'b', 3, NULL, 2);
 ----
 NULL
+
+query T
+SELECT addgeometrycolumn('a', 'b', NULL::string, 'c', 9223372036854775807:::INT8, 'd', NULL::int)
+----
+NULL

--- a/pkg/sql/opt/optbuilder/sql_fn.go
+++ b/pkg/sql/opt/optbuilder/sql_fn.go
@@ -62,6 +62,9 @@ func (b *Builder) buildSQLFn(
 			))
 		}
 		exprs[i] = memo.ExtractConstDatum(info.args[i])
+		if exprs[i] == tree.DNull && !info.def.Properties.NullableArgs {
+			return b.factory.ConstructNull(info.ResolvedType())
+		}
 	}
 
 	// Get the SQL statement and parse it.


### PR DESCRIPTION
This commit fixes an error that occurred when `AddGeometryColumn` was
called with `NULL` arguments that were cast to the type specified by the
function signature. #50992 already fixed the case when `AddGeometryColumn`
was called with bare `NULL` arguments, since those were detected by `TypeCheck`.
`TypeCheck` does not detect `NULL` arguments if they are cast to the correct
type.

This commit fixes the error by adding an explicit check in the `optbuilder`
that each argument is not null before calling the `SQLFn` of the
`AddGeometryColumn` overload.

Informs #50296

Release note (bug fix): Fixed an internal error that occurred when
AddGeometryColumn was called with NULL arguments. This now results in
a no-op and returns NULL.