### PR TITLE
colfetcher: assert that the colfetcher is not being used for SCRUB

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -249,7 +249,6 @@ func (rf *cFetcher) Init(
 	reverse bool,
 	lockStr sqlbase.ScanLockingStrength,
 	returnRangeInfo bool,
-	isCheck bool,
 	tables ...row.FetcherTableArgs,
 ) error {
 	rf.adapter.allocator = allocator

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -140,9 +140,13 @@ func NewColBatchScan(
 
 	columnIdxMap := spec.Table.ColumnIdxMapWithMutations(returnMutations)
 	fetcher := cFetcher{}
+	if spec.IsCheck {
+		// cFetchers don't support these checks.
+		return nil, errors.AssertionFailedf("attempting to create a cFetcher with the IsCheck flag set")
+	}
 	if _, _, err := initCRowFetcher(
 		flowCtx.Codec(), allocator, &fetcher, &spec.Table, int(spec.IndexIdx), columnIdxMap,
-		spec.Reverse, neededColumns, spec.IsCheck, spec.Visibility, spec.LockingStrength,
+		spec.Reverse, neededColumns, spec.Visibility, spec.LockingStrength,
 	); err != nil {
 		return nil, err
 	}
@@ -171,7 +175,6 @@ func initCRowFetcher(
 	colIdxMap map[sqlbase.ColumnID]int,
 	reverseScan bool,
 	valNeededForCol util.FastIntSet,
-	isCheck bool,
 	scanVisibility execinfrapb.ScanVisibility,
 	lockStr sqlbase.ScanLockingStrength,
 ) (index *sqlbase.IndexDescriptor, isSecondaryIndex bool, err error) {
@@ -194,7 +197,7 @@ func initCRowFetcher(
 		ValNeededForCol:  valNeededForCol,
 	}
 	if err := fetcher.Init(
-		codec, allocator, reverseScan, lockStr, true /* returnRangeInfo */, isCheck, tableArgs,
+		codec, allocator, reverseScan, lockStr, true /* returnRangeInfo */, tableArgs,
 	); err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
The colfetch ctor took an unused `check` arg, which is now removed.
That check comes from a TableReader spec, in particular one for a SCRUB
(I think). We now assert that a colfetcher is not created for such a
spec - hopefully there's something preventing it. Were it to be created,
I'm pretty sure the SCRUB was not getting what it wanted.

Release note: None