### PR TITLE
release-20.1: pgwire: de-strictify extended protocol handling

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -305,7 +305,6 @@ func (c *conn) serveImpl(
 
 	var err error
 	var terminateSeen bool
-	var doingExtendedQueryMessage bool
 
 	// We need an intSizer, which we're ultimately going to get from the
 	// authenticator once authentication succeeds (because it will actually be a
@@ -352,6 +351,12 @@ Loop:
 			}
 		}
 
+		// TODO(jordan): there's one big missing piece of implementation here.
+		// In Postgres, if an error is encountered during extended protocol mode,
+		// the protocol skips all messages until a Sync is received to "regain
+		// protocol synchronization". We don't do this. If this becomes a problem,
+		// we should copy their behavior.
+
 		switch typ {
 		case pgwirebase.ClientMsgPassword:
 			// This messages are only acceptable during the auth phase, handled above.
@@ -361,17 +366,6 @@ Loop:
 				&c.msgBuilder, &c.writerState.buf)
 			break Loop
 		case pgwirebase.ClientMsgSimpleQuery:
-			if doingExtendedQueryMessage {
-				if err = c.stmtBuf.Push(
-					ctx,
-					sql.SendError{
-						Err: pgwirebase.NewProtocolViolationErrorf(
-							"SimpleQuery not allowed while in extended protocol mode"),
-					},
-				); err != nil {
-					break
-				}
-			}
 			if err = c.handleSimpleQuery(
 				ctx, &c.readBuf, timeReceived, intSizer.GetUnqualifiedIntSize(),
 			); err != nil {
@@ -380,23 +374,18 @@ Loop:
 			err = c.stmtBuf.Push(ctx, sql.Sync{})
 
 		case pgwirebase.ClientMsgExecute:
-			doingExtendedQueryMessage = true
 			err = c.handleExecute(ctx, &c.readBuf, timeReceived)
 
 		case pgwirebase.ClientMsgParse:
-			doingExtendedQueryMessage = true
 			err = c.handleParse(ctx, &c.readBuf, intSizer.GetUnqualifiedIntSize())
 
 		case pgwirebase.ClientMsgDescribe:
-			doingExtendedQueryMessage = true
 			err = c.handleDescribe(ctx, &c.readBuf)
 
 		case pgwirebase.ClientMsgBind:
-			doingExtendedQueryMessage = true
 			err = c.handleBind(ctx, &c.readBuf)
 
 		case pgwirebase.ClientMsgClose:
-			doingExtendedQueryMessage = true
 			err = c.handleClose(ctx, &c.readBuf)
 
 		case pgwirebase.ClientMsgTerminate:
@@ -404,7 +393,6 @@ Loop:
 			break Loop
 
 		case pgwirebase.ClientMsgSync:
-			doingExtendedQueryMessage = false
 			// We're starting a batch here. If the client continues using the extended
 			// protocol and encounters an error, everything until the next sync
 			// message has to be skipped. See:
@@ -413,7 +401,6 @@ Loop:
 			err = c.stmtBuf.Push(ctx, sql.Sync{})
 
 		case pgwirebase.ClientMsgFlush:
-			doingExtendedQueryMessage = true
 			err = c.handleFlush(ctx)
 
 		case pgwirebase.ClientMsgCopyData, pgwirebase.ClientMsgCopyDone, pgwirebase.ClientMsgCopyFail:

--- a/pkg/sql/pgwire/testdata/pgtest/pgjdbc
+++ b/pkg/sql/pgwire/testdata/pgtest/pgjdbc
@@ -1,0 +1,18 @@
+# Send a simple query in the middle of extended protocol, which is apparently
+# allowed. (See #41511, #33693)
+send
+Parse {"Name": "S_3", "Query": "BEGIN"}
+Bind {"PreparedStatement": "S_3"}
+Execute
+Query {"String": "SAVEPOINT PGJDBC_AUTOSAVE"}
+----
+
+until
+CommandComplete
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"CommandComplete","CommandTag":"SAVEPOINT"}
+{"Type":"ReadyForQuery","TxStatus":"T"}


### PR DESCRIPTION
Backport 1/1 commits from #51194.

/cc @cockroachdb/release

---

Fixes #33693.
Fixes #41511.

Previously, the protocol handler didn't permit simple queries during the
extended protocol mode. I think this was done because the spec vaguely
says that extended protocol commands must be ended with a SYNC command:
https://www.postgresql.org/docs/9.3/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY

However, an examination of the PostgreSQL source code shows that the
extended protocol mode bit is only used for error recovery. If an error
is encountered during extended protocol mode in Postgres, all commands
are skipped until the next Sync.

CockroachDB never implemented that behavior - instead, it used the
extended protocol mode bit only to reject simple queries if they came
before the Sync.

This commit removes the extended protocol mode bit, as the use case we
used it for was incorrect. It's unclear to me whether we need to re-add
the bit for dealing with error cases, but we haven't needed it yet.
Adding that might be follow-on work, and won't come in this PR.

Release note (bug fix): prevent spurious "SimpleQuery not allowed while
in extended protocol mode" errors.
