### PR TITLE
colexec: switch tests from using subtests to logging the info

### DIFF
--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -72,15 +72,14 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			runTests(t, []tuples{tc.inputTuples}, tc.outputTuples, orderedVerifier,
-				func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-					return createTestProjectingOperator(
-						ctx, flowCtx, input[0], tc.inputTypes,
-						tc.expr, false, /* canFallbackToRowexec */
-					)
-				})
-		})
+		log.Infof(ctx, "%s", tc.desc)
+		runTests(t, []tuples{tc.inputTuples}, tc.outputTuples, orderedVerifier,
+			func(input []colexecbase.Operator) (colexecbase.Operator, error) {
+				return createTestProjectingOperator(
+					ctx, flowCtx, input[0], tc.inputTypes,
+					tc.expr, false, /* canFallbackToRowexec */
+				)
+			})
 	}
 }
 

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -64,46 +64,43 @@ func TestExternalHashJoiner(t *testing.T) {
 		for _, tcs := range [][]*joinTestCase{hjTestCases, mjTestCases} {
 			for _, tc := range tcs {
 				delegateFDAcquisitions := rng.Float64() < 0.5
-				func(t *testing.T) {
-					t.Logf("spillForced=%t/%s/delegateFDAcquisitions=%t", spillForced, tc.description, delegateFDAcquisitions)
-					var semsToCheck []semaphore.Semaphore
-					if !tc.onExpr.Empty() {
-						// When we have ON expression, there might be other operators (like
-						// selections) on top of the external hash joiner in
-						// diskSpiller.diskBackedOp chain. This will not allow for Close()
-						// call to propagate to the external hash joiner, so we will skip
-						// allNullsInjection test for now.
-						defer func(oldValue bool) {
-							tc.skipAllNullsInjection = oldValue
-						}(tc.skipAllNullsInjection)
-						tc.skipAllNullsInjection = true
-					}
-					runHashJoinTestCase(t, tc, func(sources []colexecbase.Operator) (colexecbase.Operator, error) {
-						sem := colexecbase.NewTestingSemaphore(externalHJMinPartitions)
-						semsToCheck = append(semsToCheck, sem)
-						spec := createSpecForHashJoiner(tc)
-						// TODO(asubiotto): Pass in the testing.T of the caller to this
-						//  function and do substring matching on the test name to
-						//  conditionally explicitly call Close() on the hash joiner
-						//  (through result.ToClose) in cases where it is known the sorter
-						//  will not be drained.
-						hjOp, newAccounts, newMonitors, closers, err := createDiskBackedHashJoiner(
-							ctx, flowCtx, spec, sources, func() {}, queueCfg,
-							2 /* numForcedPartitions */, delegateFDAcquisitions, sem,
-						)
-						// Expect three closers. These are the external hash joiner, and
-						// one external sorter for each input.
-						// TODO(asubiotto): Explicitly Close when testing.T is passed into
-						//  this constructor and we do a substring match.
-						require.Equal(t, 3, len(closers))
-						accounts = append(accounts, newAccounts...)
-						monitors = append(monitors, newMonitors...)
-						return hjOp, err
-					})
-					for i, sem := range semsToCheck {
-						require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
-					}
-				}(t)
+				log.Infof(ctx, "spillForced=%t/%s/delegateFDAcquisitions=%t", spillForced, tc.description, delegateFDAcquisitions)
+				var semsToCheck []semaphore.Semaphore
+				oldSkipAllNullsInjection := tc.skipAllNullsInjection
+				if !tc.onExpr.Empty() {
+					// When we have ON expression, there might be other operators (like
+					// selections) on top of the external hash joiner in
+					// diskSpiller.diskBackedOp chain. This will not allow for Close()
+					// call to propagate to the external hash joiner, so we will skip
+					// allNullsInjection test for now.
+					tc.skipAllNullsInjection = true
+				}
+				runHashJoinTestCase(t, tc, func(sources []colexecbase.Operator) (colexecbase.Operator, error) {
+					sem := colexecbase.NewTestingSemaphore(externalHJMinPartitions)
+					semsToCheck = append(semsToCheck, sem)
+					spec := createSpecForHashJoiner(tc)
+					// TODO(asubiotto): Pass in the testing.T of the caller to this
+					//  function and do substring matching on the test name to
+					//  conditionally explicitly call Close() on the hash joiner
+					//  (through result.ToClose) in cases where it is known the sorter
+					//  will not be drained.
+					hjOp, newAccounts, newMonitors, closers, err := createDiskBackedHashJoiner(
+						ctx, flowCtx, spec, sources, func() {}, queueCfg,
+						2 /* numForcedPartitions */, delegateFDAcquisitions, sem,
+					)
+					// Expect three closers. These are the external hash joiner, and
+					// one external sorter for each input.
+					// TODO(asubiotto): Explicitly Close when testing.T is passed into
+					//  this constructor and we do a substring match.
+					require.Equal(t, 3, len(closers))
+					accounts = append(accounts, newAccounts...)
+					monitors = append(monitors, newMonitors...)
+					return hjOp, err
+				})
+				for i, sem := range semsToCheck {
+					require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
+				}
+				tc.skipAllNullsInjection = oldSkipAllNullsInjection
 			}
 		}
 	}

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -975,9 +975,8 @@ func runHashJoinTestCase(
 	} else {
 		runner = runTestsWithTyps
 	}
-	t.Run(tc.description, func(t *testing.T) {
-		runner(t, inputs, typs, tc.expected, unorderedVerifier, hjOpConstructor)
-	})
+	log.Infof(context.Background(), "%s", tc.description)
+	runner(t, inputs, typs, tc.expected, unorderedVerifier, hjOpConstructor)
 }
 
 func TestHashJoiner(t *testing.T) {

--- a/pkg/sql/colexec/is_null_ops_test.go
+++ b/pkg/sql/colexec/is_null_ops_test.go
@@ -120,15 +120,14 @@ func TestIsNullProjOp(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		t.Run(c.desc, func(t *testing.T) {
-			opConstructor := func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-				return createTestProjectingOperator(
-					ctx, flowCtx, input[0], []*types.T{types.Int},
-					fmt.Sprintf("@1 %s", c.projExpr), false, /* canFallbackToRowexec */
-				)
-			}
-			runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, opConstructor)
-		})
+		log.Infof(ctx, "%s", c.desc)
+		opConstructor := func(input []colexecbase.Operator) (colexecbase.Operator, error) {
+			return createTestProjectingOperator(
+				ctx, flowCtx, input[0], []*types.T{types.Int},
+				fmt.Sprintf("@1 %s", c.projExpr), false, /* canFallbackToRowexec */
+			)
+		}
+		runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, opConstructor)
 	}
 }
 
@@ -227,30 +226,29 @@ func TestIsNullSelOp(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		t.Run(c.desc, func(t *testing.T) {
-			opConstructor := func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-				spec := &execinfrapb.ProcessorSpec{
-					Input: []execinfrapb.InputSyncSpec{{ColumnTypes: []*types.T{types.Int}}},
-					Core: execinfrapb.ProcessorCoreUnion{
-						Noop: &execinfrapb.NoopCoreSpec{},
-					},
-					Post: execinfrapb.PostProcessSpec{
-						Filter: execinfrapb.Expression{Expr: fmt.Sprintf("@1 %s", c.selExpr)},
-					},
-				}
-				args := &NewColOperatorArgs{
-					Spec:                spec,
-					Inputs:              input,
-					StreamingMemAccount: testMemAcc,
-				}
-				args.TestingKnobs.UseStreamingMemAccountForBuffering = true
-				result, err := TestNewColOperator(ctx, flowCtx, args)
-				if err != nil {
-					return nil, err
-				}
-				return result.Op, nil
+		log.Infof(ctx, "%s", c.desc)
+		opConstructor := func(input []colexecbase.Operator) (colexecbase.Operator, error) {
+			spec := &execinfrapb.ProcessorSpec{
+				Input: []execinfrapb.InputSyncSpec{{ColumnTypes: []*types.T{types.Int}}},
+				Core: execinfrapb.ProcessorCoreUnion{
+					Noop: &execinfrapb.NoopCoreSpec{},
+				},
+				Post: execinfrapb.PostProcessSpec{
+					Filter: execinfrapb.Expression{Expr: fmt.Sprintf("@1 %s", c.selExpr)},
+				},
 			}
-			runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, opConstructor)
-		})
+			args := &NewColOperatorArgs{
+				Spec:                spec,
+				Inputs:              input,
+				StreamingMemAccount: testMemAcc,
+			}
+			args.TestingKnobs.UseStreamingMemAccountForBuffering = true
+			result, err := TestNewColOperator(ctx, flowCtx, args)
+			if err != nil {
+				return nil, err
+			}
+			return result.Op, nil
+		}
+		runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, opConstructor)
 	}
 }

--- a/pkg/sql/colexec/select_in_test.go
+++ b/pkg/sql/colexec/select_in_test.go
@@ -75,29 +75,28 @@ func TestSelectInInt64(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		t.Run(c.desc, func(t *testing.T) {
-			opConstructor := func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-				op := selectInOpInt64{
-					OneInputNode: NewOneInputNode(input[0]),
-					colIdx:       0,
-					filterRow:    c.filterRow,
-					negate:       c.negate,
-					hasNulls:     c.hasNulls,
-				}
-				return &op, nil
+		log.Infof(context.Background(), "%s", c.desc)
+		opConstructor := func(input []colexecbase.Operator) (colexecbase.Operator, error) {
+			op := selectInOpInt64{
+				OneInputNode: NewOneInputNode(input[0]),
+				colIdx:       0,
+				filterRow:    c.filterRow,
+				negate:       c.negate,
+				hasNulls:     c.hasNulls,
 			}
-			if !c.hasNulls || !c.negate {
-				runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, opConstructor)
-			} else {
-				// When the input tuples already have nulls and we have NOT IN
-				// operator, then the nulls injection might not change the output. For
-				// example, we have this test case "1 NOT IN (NULL, 1, 2)" with the
-				// output of length 0; similarly, we will get the same zero-length
-				// output for the corresponding nulls injection test case
-				// "1 NOT IN (NULL, NULL, NULL)".
-				runTestsWithoutAllNullsInjection(t, []tuples{c.inputTuples}, nil /* typs */, c.outputTuples, orderedVerifier, opConstructor)
-			}
-		})
+			return &op, nil
+		}
+		if !c.hasNulls || !c.negate {
+			runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, opConstructor)
+		} else {
+			// When the input tuples already have nulls and we have NOT IN
+			// operator, then the nulls injection might not change the output. For
+			// example, we have this test case "1 NOT IN (NULL, 1, 2)" with the
+			// output of length 0; similarly, we will get the same zero-length
+			// output for the corresponding nulls injection test case
+			// "1 NOT IN (NULL, NULL, NULL)".
+			runTestsWithoutAllNullsInjection(t, []tuples{c.inputTuples}, nil /* typs */, c.outputTuples, orderedVerifier, opConstructor)
+		}
 	}
 }
 
@@ -217,50 +216,49 @@ func TestProjectInInt64(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		t.Run(c.desc, func(t *testing.T) {
-			runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier,
-				func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-					expr, err := parser.ParseExpr(fmt.Sprintf("@1 %s", c.inClause))
-					if err != nil {
-						return nil, err
-					}
-					p := &mockTypeContext{typs: []*types.T{types.Int, types.MakeTuple([]*types.T{types.Int})}}
-					semaCtx := tree.MakeSemaContext()
-					semaCtx.IVarContainer = p
-					typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
-					if err != nil {
-						return nil, err
-					}
-					spec := &execinfrapb.ProcessorSpec{
-						Input: []execinfrapb.InputSyncSpec{{ColumnTypes: []*types.T{types.Int}}},
-						Core: execinfrapb.ProcessorCoreUnion{
-							Noop: &execinfrapb.NoopCoreSpec{},
+		log.Infof(ctx, "%s", c.desc)
+		runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier,
+			func(input []colexecbase.Operator) (colexecbase.Operator, error) {
+				expr, err := parser.ParseExpr(fmt.Sprintf("@1 %s", c.inClause))
+				if err != nil {
+					return nil, err
+				}
+				p := &mockTypeContext{typs: []*types.T{types.Int, types.MakeTuple([]*types.T{types.Int})}}
+				semaCtx := tree.MakeSemaContext()
+				semaCtx.IVarContainer = p
+				typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+				if err != nil {
+					return nil, err
+				}
+				spec := &execinfrapb.ProcessorSpec{
+					Input: []execinfrapb.InputSyncSpec{{ColumnTypes: []*types.T{types.Int}}},
+					Core: execinfrapb.ProcessorCoreUnion{
+						Noop: &execinfrapb.NoopCoreSpec{},
+					},
+					Post: execinfrapb.PostProcessSpec{
+						RenderExprs: []execinfrapb.Expression{
+							{Expr: "@1"},
+							{LocalExpr: typedExpr},
 						},
-						Post: execinfrapb.PostProcessSpec{
-							RenderExprs: []execinfrapb.Expression{
-								{Expr: "@1"},
-								{LocalExpr: typedExpr},
-							},
-						},
-					}
-					args := &NewColOperatorArgs{
-						Spec:                spec,
-						Inputs:              input,
-						StreamingMemAccount: testMemAcc,
-						// TODO(yuzefovich): figure out how to make the second
-						// argument of IN comparison as DTuple not Tuple.
-						// TODO(yuzefovich): reuse createTestProjectingOperator
-						// once we don't need to provide the processor
-						// constructor.
-						ProcessorConstructor: rowexec.NewProcessor,
-					}
-					args.TestingKnobs.UseStreamingMemAccountForBuffering = true
-					result, err := TestNewColOperator(ctx, flowCtx, args)
-					if err != nil {
-						return nil, err
-					}
-					return result.Op, nil
-				})
-		})
+					},
+				}
+				args := &NewColOperatorArgs{
+					Spec:                spec,
+					Inputs:              input,
+					StreamingMemAccount: testMemAcc,
+					// TODO(yuzefovich): figure out how to make the second
+					// argument of IN comparison as DTuple not Tuple.
+					// TODO(yuzefovich): reuse createTestProjectingOperator
+					// once we don't need to provide the processor
+					// constructor.
+					ProcessorConstructor: rowexec.NewProcessor,
+				}
+				args.TestingKnobs.UseStreamingMemAccountForBuffering = true
+				result, err := TestNewColOperator(ctx, flowCtx, args)
+				if err != nil {
+					return nil, err
+				}
+				return result.Op, nil
+			})
 	}
 }

--- a/pkg/sql/colexec/sorttopk_test.go
+++ b/pkg/sql/colexec/sorttopk_test.go
@@ -11,6 +11,7 @@
 package colexec
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
@@ -67,10 +68,9 @@ func TestTopKSorter(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	for _, tc := range topKSortTestCases {
-		t.Run(tc.description, func(t *testing.T) {
-			runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-				return NewTopKSorter(testAllocator, input[0], tc.typs, tc.ordCols, tc.k), nil
-			})
+		log.Infof(context.Background(), "%s", tc.description)
+		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, func(input []colexecbase.Operator) (colexecbase.Operator, error) {
+			return NewTopKSorter(testAllocator, input[0], tc.typs, tc.ordCols, tc.k), nil
 		})
 	}
 }

--- a/pkg/sql/colexec/spilling_queue_test.go
+++ b/pkg/sql/colexec/spilling_queue_test.go
@@ -12,7 +12,6 @@ package colexec
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -57,99 +56,98 @@ func TestSpillingQueue(t *testing.T) {
 				prefix = "Rewindable/"
 			}
 			numBatches := 1 + rng.Intn(1024)
-			t.Run(fmt.Sprintf("%sMemoryLimit=%s/DiskQueueCacheMode=%d/AlwaysCompress=%t/NumBatches=%d",
-				prefix, humanizeutil.IBytes(memoryLimit), diskQueueCacheMode, alwaysCompress, numBatches), func(t *testing.T) {
-				// Create random input.
-				batches := make([]coldata.Batch, 0, numBatches)
-				op := coldatatestutils.NewRandomDataOp(testAllocator, rng, coldatatestutils.RandomDataOpArgs{
-					NumBatches: cap(batches),
-					BatchSize:  1 + rng.Intn(coldata.BatchSize()),
-					Nulls:      true,
-					BatchAccumulator: func(b coldata.Batch, typs []*types.T) {
-						batches = append(batches, coldatatestutils.CopyBatch(b, typs, testColumnFactory))
-					},
-				})
-				typs := op.Typs()
-
-				queueCfg.CacheMode = diskQueueCacheMode
-				queueCfg.SetDefaultBufferSizeBytesForCacheMode()
-				queueCfg.TestingKnobs.AlwaysCompress = alwaysCompress
-
-				// Create queue.
-				var q *spillingQueue
-				if rewindable {
-					q = newRewindableSpillingQueue(
-						testAllocator, typs, memoryLimit, queueCfg,
-						colexecbase.NewTestingSemaphore(2), coldata.BatchSize(),
-						testDiskAcc,
-					)
-				} else {
-					q = newSpillingQueue(
-						testAllocator, typs, memoryLimit, queueCfg,
-						colexecbase.NewTestingSemaphore(2), coldata.BatchSize(),
-						testDiskAcc,
-					)
-				}
-
-				// Run verification.
-				var (
-					b   coldata.Batch
-					err error
-				)
-				ctx := context.Background()
-				for {
-					b = op.Next(ctx)
-					require.NoError(t, q.enqueue(ctx, b))
-					if b.Length() == 0 {
-						break
-					}
-					if rng.Float64() < dequeuedProbabilityBeforeAllEnqueuesAreDone {
-						if b, err = q.dequeue(ctx); err != nil {
-							t.Fatal(err)
-						} else if b.Length() == 0 {
-							t.Fatal("queue incorrectly considered empty")
-						}
-						coldata.AssertEquivalentBatches(t, batches[0], b)
-						batches = batches[1:]
-					}
-				}
-				numReadIterations := 1
-				if rewindable {
-					numReadIterations = 2
-				}
-				for i := 0; i < numReadIterations; i++ {
-					batchIdx := 0
-					for batches[batchIdx].Length() > 0 {
-						if b, err = q.dequeue(ctx); err != nil {
-							t.Fatal(err)
-						} else if b == nil {
-							t.Fatal("unexpectedly dequeued nil batch")
-						} else if b.Length() == 0 {
-							t.Fatal("queue incorrectly considered empty")
-						}
-						coldata.AssertEquivalentBatches(t, batches[batchIdx], b)
-						batchIdx++
-					}
-
-					if b, err := q.dequeue(ctx); err != nil {
-						t.Fatal(err)
-					} else if b.Length() != 0 {
-						t.Fatal("queue should be empty")
-					}
-
-					if rewindable {
-						require.NoError(t, q.rewind())
-					}
-				}
-
-				// Close queue.
-				require.NoError(t, q.close(ctx))
-
-				// Verify no directories are left over.
-				directories, err := queueCfg.FS.List(queueCfg.Path)
-				require.NoError(t, err)
-				require.Equal(t, 0, len(directories))
+			log.Infof(context.Background(), "%sMemoryLimit=%s/DiskQueueCacheMode=%d/AlwaysCompress=%t/NumBatches=%d",
+				prefix, humanizeutil.IBytes(memoryLimit), diskQueueCacheMode, alwaysCompress, numBatches)
+			// Create random input.
+			batches := make([]coldata.Batch, 0, numBatches)
+			op := coldatatestutils.NewRandomDataOp(testAllocator, rng, coldatatestutils.RandomDataOpArgs{
+				NumBatches: cap(batches),
+				BatchSize:  1 + rng.Intn(coldata.BatchSize()),
+				Nulls:      true,
+				BatchAccumulator: func(b coldata.Batch, typs []*types.T) {
+					batches = append(batches, coldatatestutils.CopyBatch(b, typs, testColumnFactory))
+				},
 			})
+			typs := op.Typs()
+
+			queueCfg.CacheMode = diskQueueCacheMode
+			queueCfg.SetDefaultBufferSizeBytesForCacheMode()
+			queueCfg.TestingKnobs.AlwaysCompress = alwaysCompress
+
+			// Create queue.
+			var q *spillingQueue
+			if rewindable {
+				q = newRewindableSpillingQueue(
+					testAllocator, typs, memoryLimit, queueCfg,
+					colexecbase.NewTestingSemaphore(2), coldata.BatchSize(),
+					testDiskAcc,
+				)
+			} else {
+				q = newSpillingQueue(
+					testAllocator, typs, memoryLimit, queueCfg,
+					colexecbase.NewTestingSemaphore(2), coldata.BatchSize(),
+					testDiskAcc,
+				)
+			}
+
+			// Run verification.
+			var (
+				b   coldata.Batch
+				err error
+			)
+			ctx := context.Background()
+			for {
+				b = op.Next(ctx)
+				require.NoError(t, q.enqueue(ctx, b))
+				if b.Length() == 0 {
+					break
+				}
+				if rng.Float64() < dequeuedProbabilityBeforeAllEnqueuesAreDone {
+					if b, err = q.dequeue(ctx); err != nil {
+						t.Fatal(err)
+					} else if b.Length() == 0 {
+						t.Fatal("queue incorrectly considered empty")
+					}
+					coldata.AssertEquivalentBatches(t, batches[0], b)
+					batches = batches[1:]
+				}
+			}
+			numReadIterations := 1
+			if rewindable {
+				numReadIterations = 2
+			}
+			for i := 0; i < numReadIterations; i++ {
+				batchIdx := 0
+				for batches[batchIdx].Length() > 0 {
+					if b, err = q.dequeue(ctx); err != nil {
+						t.Fatal(err)
+					} else if b == nil {
+						t.Fatal("unexpectedly dequeued nil batch")
+					} else if b.Length() == 0 {
+						t.Fatal("queue incorrectly considered empty")
+					}
+					coldata.AssertEquivalentBatches(t, batches[batchIdx], b)
+					batchIdx++
+				}
+
+				if b, err := q.dequeue(ctx); err != nil {
+					t.Fatal(err)
+				} else if b.Length() != 0 {
+					t.Fatal("queue should be empty")
+				}
+
+				if rewindable {
+					require.NoError(t, q.rewind())
+				}
+			}
+
+			// Close queue.
+			require.NoError(t, q.close(ctx))
+
+			// Verify no directories are left over.
+			directories, err := queueCfg.FS.List(queueCfg.Path)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(directories))
 		}
 	}
 }

--- a/pkg/sql/colexec/window_functions_test.go
+++ b/pkg/sql/colexec/window_functions_test.go
@@ -12,7 +12,6 @@ package colexec
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -282,40 +281,39 @@ func TestWindowFunctions(t *testing.T) {
 				},
 			},
 		} {
-			t.Run(fmt.Sprintf("spillForced=%t/%s", spillForced, tc.windowerSpec.WindowFns[0].Func.String()), func(t *testing.T) {
-				var semsToCheck []semaphore.Semaphore
-				runTests(t, []tuples{tc.tuples}, tc.expected, unorderedVerifier, func(inputs []colexecbase.Operator) (colexecbase.Operator, error) {
-					tc.init()
-					ct := make([]*types.T, len(tc.tuples[0]))
-					for i := range ct {
-						ct[i] = types.Int
-					}
-					spec := &execinfrapb.ProcessorSpec{
-						Input: []execinfrapb.InputSyncSpec{{ColumnTypes: ct}},
-						Core: execinfrapb.ProcessorCoreUnion{
-							Windower: &tc.windowerSpec,
-						},
-					}
-					sem := colexecbase.NewTestingSemaphore(maxNumberFDs)
-					args := &NewColOperatorArgs{
-						Spec:                spec,
-						Inputs:              inputs,
-						StreamingMemAccount: testMemAcc,
-						DiskQueueCfg:        queueCfg,
-						FDSemaphore:         sem,
-					}
-					semsToCheck = append(semsToCheck, sem)
-					args.TestingKnobs.UseStreamingMemAccountForBuffering = true
-					args.TestingKnobs.NumForcedRepartitions = maxNumberFDs
-					result, err := TestNewColOperator(ctx, flowCtx, args)
-					accounts = append(accounts, result.OpAccounts...)
-					monitors = append(monitors, result.OpMonitors...)
-					return result.Op, err
-				})
-				for i, sem := range semsToCheck {
-					require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
+			log.Infof(ctx, "spillForced=%t/%s", spillForced, tc.windowerSpec.WindowFns[0].Func.String())
+			var semsToCheck []semaphore.Semaphore
+			runTests(t, []tuples{tc.tuples}, tc.expected, unorderedVerifier, func(inputs []colexecbase.Operator) (colexecbase.Operator, error) {
+				tc.init()
+				ct := make([]*types.T, len(tc.tuples[0]))
+				for i := range ct {
+					ct[i] = types.Int
 				}
+				spec := &execinfrapb.ProcessorSpec{
+					Input: []execinfrapb.InputSyncSpec{{ColumnTypes: ct}},
+					Core: execinfrapb.ProcessorCoreUnion{
+						Windower: &tc.windowerSpec,
+					},
+				}
+				sem := colexecbase.NewTestingSemaphore(maxNumberFDs)
+				args := &NewColOperatorArgs{
+					Spec:                spec,
+					Inputs:              inputs,
+					StreamingMemAccount: testMemAcc,
+					DiskQueueCfg:        queueCfg,
+					FDSemaphore:         sem,
+				}
+				semsToCheck = append(semsToCheck, sem)
+				args.TestingKnobs.UseStreamingMemAccountForBuffering = true
+				args.TestingKnobs.NumForcedRepartitions = maxNumberFDs
+				result, err := TestNewColOperator(ctx, flowCtx, args)
+				accounts = append(accounts, result.OpAccounts...)
+				monitors = append(monitors, result.OpMonitors...)
+				return result.Op, err
 			})
+			for i, sem := range semsToCheck {
+				require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
+			}
 		}
 	}
 


### PR DESCRIPTION
This change reduces the output size with `-test.v` option from 23k to
500, but there is no visible change in the running time of the whole
package - it still takes about 20s with disabled batch size
randomization.

Fixes: #50501.

Release note: None