### PR TITLE
sql: allow drops on tables/sequences that have invalid ownership states

### DIFF
--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 type dropSequenceNode struct {
@@ -159,6 +161,13 @@ func (p *planner) canRemoveOwnedSequencesImpl(
 	for _, sequenceID := range col.OwnsSequenceIds {
 		seqLookup, err := p.LookupTableByID(ctx, sequenceID)
 		if err != nil {
+			// Special case error swallowing for #50711 and #50781, which can cause a
+			// column to own sequences that have been dropped/do not exist.
+			if errors.Is(err, sqlbase.ErrTableDropped) ||
+				pgerror.GetPGCode(err) == pgcode.UndefinedTable {
+				log.Eventf(ctx, "swallowing error ensuring owned sequences can be removed: %s", err.Error())
+				continue
+			}
 			return err
 		}
 		seqDesc := seqLookup.Desc

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/sequence"
 	"github.com/cockroachdb/errors"
 )
@@ -336,6 +337,12 @@ func removeSequenceOwnerIfExists(
 	}
 	tableDesc, err := p.Tables().GetMutableTableVersionByID(ctx, opts.SequenceOwner.OwnerTableID, p.txn)
 	if err != nil {
+		// Special case error swallowing for #50711 and #50781, which can cause a
+		// column to own sequences that have been dropped/do not exist.
+		if errors.Is(err, sqlbase.ErrDescriptorNotFound) {
+			log.Eventf(ctx, "swallowing error during sequence ownership unlinking: %s", err.Error())
+			return nil
+		}
 		return err
 	}
 	// If the table descriptor has already been dropped, there is no need to
@@ -485,7 +492,13 @@ func (p *planner) dropSequencesOwnedByCol(
 ) error {
 	for _, sequenceID := range col.OwnsSequenceIds {
 		seqDesc, err := p.Tables().GetMutableTableVersionByID(ctx, sequenceID, p.txn)
+		// Special case error swallowing for #50781, which can cause a
+		// column to own sequences that do not exist.
 		if err != nil {
+			if errors.Is(err, sqlbase.ErrDescriptorNotFound) {
+				log.Eventf(ctx, "swallowing error dropping owned sequences: %s", err.Error())
+				continue
+			}
 			return err
 		}
 		// This sequence is already getting dropped. Don't do it twice.

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -626,7 +626,7 @@ func ConditionalGetTableDescFromTxn(
 func FilterTableState(tableDesc *TableDescriptor) error {
 	switch tableDesc.State {
 	case TableDescriptor_DROP:
-		return &inactiveTableError{errors.New("table is being dropped")}
+		return &inactiveTableError{ErrTableDropped}
 	case TableDescriptor_OFFLINE:
 		err := errors.Errorf("table %q is offline", tableDesc.Name)
 		if tableDesc.OfflineReason != "" {
@@ -643,6 +643,10 @@ func FilterTableState(tableDesc *TableDescriptor) error {
 }
 
 var errTableAdding = errors.New("table is being added")
+
+// ErrTableDropped is returned when the state of the table is
+// TableDescriptor_DROP.
+var ErrTableDropped = errors.New("table is being dropped")
 
 type inactiveTableError struct {
 	cause error


### PR DESCRIPTION
Previously, when dropping a sequence or a table that had an ownership
relationship, we would lookup corresponding table descriptors to unlink
the relationship. In the case of tables, the owned sequence needed to
be dropped as well, so we would lookup the sequence descriptor. If the
corresponding descriptor was not found/had already been dropped, it
would result in an error -- thereby making it impossible to drop the
object.

This wasn't an issue, because you don't expect descriptors to be
dropped/not found if an ownership relationship still exists. However,
this integrity constraint was violated by a couple of sequence
ownership bugs. See #51170 for more details.

It should be possible to drop tables/sequences that have descriptors
in such invalid state. This PR adds support for this by swallowing
specific errors that users may find themselves in due to invalid
descriptors. It also adds tests to simulate these invalid states users
may find themselves in.

closes #51170

Release note (bug fix): Previously users who found themselves with
descriptors in an invalid state due to the ownership issues linked in
that contained them. This is now fixed.