### PR TITLE
geo: validate geospatial objects

### DIFF
--- a/pkg/geo/geomfn/make_geometry.go
+++ b/pkg/geo/geomfn/make_geometry.go
@@ -28,12 +28,6 @@ func MakePolygon(outer *geo.Geometry, interior ...*geo.Geometry) (*geo.Geometry,
 	if !ok {
 		return nil, errors.Newf("argument must be LINESTRING geometries")
 	}
-	if outerRing.NumCoords() < 4 {
-		return nil, errors.Newf("shell must have at least 4 points")
-	}
-	if !isClosed(layout, outerRing) {
-		return nil, errors.Newf("shell must be closed")
-	}
 	srid := outerRing.SRID()
 	coords := make([][]geom.Coord, len(interior)+1)
 	coords[0] = outerRing.Coords()
@@ -49,12 +43,6 @@ func MakePolygon(outer *geo.Geometry, interior ...*geo.Geometry) (*geo.Geometry,
 		if interiorRing.SRID() != srid {
 			return nil, errors.Newf("mixed SRIDs are not allowed")
 		}
-		if interiorRing.NumCoords() < 4 {
-			return nil, errors.Newf("holes must have at least 4 points")
-		}
-		if !isClosed(layout, interiorRing) {
-			return nil, errors.Newf("holes must be closed")
-		}
 		coords[i+1] = interiorRing.Coords()
 	}
 
@@ -63,10 +51,4 @@ func MakePolygon(outer *geo.Geometry, interior ...*geo.Geometry) (*geo.Geometry,
 		return nil, err
 	}
 	return geo.NewGeometryFromGeomT(polygon)
-}
-
-// isClosed checks if a LineString is closed to make a valid Polygon.
-// Returns whether the last coordinate is the same as the first.
-func isClosed(layout geom.Layout, g *geom.LineString) bool {
-	return g.Coord(0).Equal(layout, g.Coord(g.NumCoords()-1))
 }

--- a/pkg/geo/geomfn/make_geometry_test.go
+++ b/pkg/geo/geomfn/make_geometry_test.go
@@ -176,7 +176,7 @@ func TestMakePolygon(t *testing.T) {
 			[]geopb.SRID{},
 			"",
 			geopb.DefaultGeometrySRID,
-			errors.Newf("shell must be closed"),
+			errors.Newf("Polygon LinearRing at position 1 is not closed"),
 		},
 		{
 			"ERROR: Unclosed interior ring",
@@ -188,7 +188,7 @@ func TestMakePolygon(t *testing.T) {
 			[]geopb.SRID{geopb.SRID(4326), geopb.SRID(26918)},
 			"",
 			geopb.DefaultGeometrySRID,
-			errors.Newf("holes must be closed"),
+			errors.Newf("Polygon LinearRing at position 2 is not closed"),
 		},
 		{
 			"ERROR: Shell has 3 points",
@@ -198,7 +198,7 @@ func TestMakePolygon(t *testing.T) {
 			[]geopb.SRID{},
 			"",
 			geopb.DefaultGeometrySRID,
-			errors.Newf("shell must have at least 4 points"),
+			errors.Newf("Polygon LinearRing must have at least 4 points, found 3 at position 1"),
 		},
 		{
 			"ERROR: Shell has 2 points",
@@ -208,7 +208,7 @@ func TestMakePolygon(t *testing.T) {
 			[]geopb.SRID{},
 			"",
 			geopb.DefaultGeometrySRID,
-			errors.Newf("shell must have at least 4 points"),
+			errors.Newf("Polygon LinearRing must have at least 4 points, found 2 at position 1"),
 		},
 		{
 			"ERROR: Interior ring has 3 points",
@@ -220,7 +220,7 @@ func TestMakePolygon(t *testing.T) {
 			[]geopb.SRID{geopb.SRID(4326), geopb.SRID(26918)},
 			"",
 			geopb.DefaultGeometrySRID,
-			errors.Newf("holes must have at least 4 points"),
+			errors.Newf("Polygon LinearRing must have at least 4 points, found 3 at position 2"),
 		},
 		{
 			"ERROR: Interior ring has 2 points",
@@ -232,7 +232,7 @@ func TestMakePolygon(t *testing.T) {
 			[]geopb.SRID{geopb.SRID(4326), geopb.SRID(26918)},
 			"",
 			geopb.DefaultGeometrySRID,
-			errors.Newf("holes must have at least 4 points"),
+			errors.Newf("Polygon LinearRing must have at least 4 points, found 2 at position 2"),
 		},
 	}
 
@@ -249,6 +249,7 @@ func TestMakePolygon(t *testing.T) {
 			polygon, err := MakePolygon(outer, interior...)
 			if tc.err != nil {
 				require.Errorf(t, err, tc.err.Error())
+				require.EqualError(t, err, tc.err.Error())
 			} else {
 				require.NoError(t, err)
 				expected, err := geo.MustParseGeometry(tc.expected).CloneWithSRID(tc.expectedSRID)

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1770,34 +1770,24 @@ SELECT ST_MakePolygon(
       ST_GeomFromText('LINESTRING(60 60, 75 60, 75 45, 60 45, 60 60)', 3857)
     ]);
 
-statement error shell must be closed
+statement error Polygon LinearRing at position 1 is not closed
 SELECT ST_MakePolygon(ST_GeomFromText('LINESTRING(40 80, 80 80, 80 40, 40 40, 40 70)'));
 
-statement error shell must have at least 4 points
+statement error Polygon LinearRing must have at least 4 points, found 3 at position 1
 SELECT ST_MakePolygon(ST_GeomFromText('LINESTRING(40 80, 80 80, 40 80)'));
 
-statement error shell must have at least 4 points
-SELECT ST_MakePolygon(ST_GeomFromText('LINESTRING(40 80, 40 80)'));
-
-statement error holes must be closed
+statement error Polygon LinearRing at position 2 is not closed
 SELECT ST_MakePolygon(
     ST_GeomFromText('LINESTRING(40 80, 80 80, 80 40, 40 40, 40 80)'),
     ARRAY[
       ST_GeomFromText('LINESTRING(50 70, 70 70, 70 50, 50 50, 50 60)')
     ]);
 
-statement error holes must have at least 4 points
+statement error Polygon LinearRing must have at least 4 points, found 3 at position 2
 SELECT ST_MakePolygon(
     ST_GeomFromText('LINESTRING(40 80, 80 80, 80 40, 40 40, 40 80)'),
     ARRAY[
       ST_GeomFromText('LINESTRING(50 70, 70 70, 50 70)')
-    ]);
-
-statement error holes must have at least 4 points
-SELECT ST_MakePolygon(
-    ST_GeomFromText('LINESTRING(40 80, 80 80, 80 40, 40 40, 40 80)'),
-    ARRAY[
-      ST_GeomFromText('LINESTRING(50 70, 50 70)')
     ]);
 
 query T


### PR DESCRIPTION
This commit validate geospatial objects properties before their
creation. LineStrings should have at least 2 points, Polygons at least
4 per LinearRing and must be closed.

Resolves #51074.

Release note: None