### PR TITLE
util/mon: some cleanup around bytes monitors

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -532,7 +532,7 @@ func TempStorageConfigFromEnv(
 	} else {
 		monitorName = "temp disk storage"
 	}
-	monitor := mon.MakeMonitor(
+	monitor := mon.NewMonitor(
 		monitorName,
 		mon.DiskResource,
 		nil,             /* curCount */
@@ -544,7 +544,7 @@ func TempStorageConfigFromEnv(
 	monitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(maxSizeBytes))
 	return TempStorageConfig{
 		InMemory: inMem,
-		Mon:      &monitor,
+		Mon:      monitor,
 		Spec:     useStore,
 	}
 }

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -158,7 +158,7 @@ func DefaultTestTempStorageConfig(st *cluster.Settings) TempStorageConfig {
 func DefaultTestTempStorageConfigWithSize(
 	st *cluster.Settings, maxSizeBytes int64,
 ) TempStorageConfig {
-	monitor := mon.MakeMonitor(
+	monitor := mon.NewMonitor(
 		"in-mem temp storage",
 		mon.DiskResource,
 		nil,             /* curCount */
@@ -170,7 +170,7 @@ func DefaultTestTempStorageConfigWithSize(
 	monitor.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(maxSizeBytes))
 	return TempStorageConfig{
 		InMemory: true,
-		Mon:      &monitor,
+		Mon:      monitor,
 	}
 }
 

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -205,7 +205,7 @@ func createBenchmarkChangefeed(
 	metrics := MakeMetrics(base.DefaultHistogramWindowInterval()).(*Metrics)
 	buf := kvfeed.MakeChanBuffer()
 	leaseMgr := s.LeaseManager().(*lease.Manager)
-	mm := mon.MakeUnlimitedMonitor(
+	mm := mon.NewUnlimitedMonitor(
 		context.Background(), "test", mon.MemoryResource,
 		nil /* curCount */, nil /* maxHist */, math.MaxInt64, settings,
 	)
@@ -224,7 +224,7 @@ func createBenchmarkChangefeed(
 		Sink:             buf,
 		LeaseMgr:         leaseMgr,
 		Metrics:          &metrics.KVFeedMetrics,
-		MM:               &mm,
+		MM:               mm,
 		InitialHighWater: initialHighWater,
 		WithDiff:         withDiff,
 		NeedsInitialScan: needsInitialScan,

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -196,9 +196,9 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	if knobs.MemBufferCapacity != 0 {
 		kvFeedMemMonCapacity = knobs.MemBufferCapacity
 	}
-	kvFeedMemMon := mon.MakeMonitorInheritWithLimit("kvFeed", math.MaxInt64, ca.ProcessorBase.MemMonitor)
+	kvFeedMemMon := mon.NewMonitorInheritWithLimit("kvFeed", math.MaxInt64, ca.ProcessorBase.MemMonitor)
 	kvFeedMemMon.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(kvFeedMemMonCapacity))
-	ca.kvFeedMemMon = &kvFeedMemMon
+	ca.kvFeedMemMon = kvFeedMemMon
 
 	buf := kvfeed.MakeChanBuffer()
 	leaseMgr := ca.flowCtx.Cfg.LeaseManager.(*lease.Manager)

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -91,7 +91,7 @@ func TestKVFeed(t *testing.T) {
 	runTest := func(t *testing.T, tc testCase) {
 		settings := cluster.MakeTestingClusterSettings()
 		buf := MakeChanBuffer()
-		mm := mon.MakeUnlimitedMonitor(
+		mm := mon.NewUnlimitedMonitor(
 			context.Background(), "test", mon.MemoryResource,
 			nil /* curCount */, nil /* maxHist */, math.MaxInt64, settings,
 		)

--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -82,7 +82,7 @@ type timeSeriesMaintenanceQueue struct {
 	tsData         TimeSeriesDataStore
 	replicaCountFn func() int
 	db             *kv.DB
-	mem            mon.BytesMonitor
+	mem            *mon.BytesMonitor
 }
 
 // newTimeSeriesMaintenanceQueue returns a new instance of
@@ -94,7 +94,7 @@ func newTimeSeriesMaintenanceQueue(
 		tsData:         tsData,
 		replicaCountFn: store.ReplicaCount,
 		db:             db,
-		mem: mon.MakeUnlimitedMonitor(
+		mem: mon.NewUnlimitedMonitor(
 			context.Background(),
 			"timeseries-maintenance-queue",
 			mon.MemoryResource,
@@ -151,7 +151,7 @@ func (q *timeSeriesMaintenanceQueue) process(
 	now := repl.store.Clock().Now()
 	defer snap.Close()
 	if err := q.tsData.MaintainTimeSeries(
-		ctx, snap, desc.StartKey, desc.EndKey, q.db, &q.mem, TimeSeriesMaintenanceMemoryBudget, now,
+		ctx, snap, desc.StartKey, desc.EndKey, q.db, q.mem, TimeSeriesMaintenanceMemoryBudget, now,
 	); err != nil {
 		return false, err
 	}

--- a/pkg/kv/kvserver/ts_maintenance_queue_test.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue_test.go
@@ -275,7 +275,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	memMon := mon.MakeMonitor(
+	memMon := mon.NewMonitor(
 		"test",
 		mon.MemoryResource,
 		nil,           /* curCount */
@@ -287,8 +287,8 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 	memMon.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	defer memMon.Stop(context.Background())
 	memContext := ts.MakeQueryMemoryContext(
-		&memMon,
-		&memMon,
+		memMon,
+		memMon,
 		ts.QueryMemoryOptions{
 			BudgetBytes:             math.MaxInt64 / 8,
 			EstimatedSources:        1,

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -90,7 +90,7 @@ var errAdminAPIError = status.Errorf(codes.Internal, "An internal server error "
 // the cockroach cluster.
 type adminServer struct {
 	server     *Server
-	memMonitor mon.BytesMonitor
+	memMonitor *mon.BytesMonitor
 }
 
 // noteworthyAdminMemoryUsageBytes is the minimum size tracked by the
@@ -104,7 +104,7 @@ func newAdminServer(s *Server) *adminServer {
 	server := &adminServer{server: s}
 	// TODO(knz): We do not limit memory usage by admin operations
 	// yet. Is this wise?
-	server.memMonitor = mon.MakeUnlimitedMonitor(
+	server.memMonitor = mon.NewUnlimitedMonitor(
 		context.Background(),
 		"admin",
 		mon.MemoryResource,

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1282,7 +1282,7 @@ func (r opResult) createBufferingUnlimitedMemAccount(
 func (r opResult) createStandaloneMemAccount(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, name string,
 ) *mon.BoundAccount {
-	standaloneMemMonitor := mon.MakeMonitor(
+	standaloneMemMonitor := mon.NewMonitor(
 		name+"-standalone",
 		mon.MemoryResource,
 		nil,           /* curCount */
@@ -1291,7 +1291,7 @@ func (r opResult) createStandaloneMemAccount(
 		math.MaxInt64, /* noteworthy */
 		flowCtx.Cfg.Settings,
 	)
-	r.OpMonitors = append(r.OpMonitors, &standaloneMemMonitor)
+	r.OpMonitors = append(r.OpMonitors, standaloneMemMonitor)
 	standaloneMemMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
 	standaloneMemAccount := standaloneMemMonitor.MakeBoundAccount()
 	r.OpAccounts = append(r.OpAccounts, &standaloneMemAccount)

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1261,7 +1261,7 @@ func SupportsVectorized(
 	// flow is supported via the vectorized engine in general (without paying
 	// attention to the memory since it is node-dependent in the distributed
 	// case).
-	memoryMonitor := mon.MakeMonitor(
+	memoryMonitor := mon.NewMonitor(
 		"supports-vectorized",
 		mon.MemoryResource,
 		nil,           /* curCount */

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -87,7 +87,7 @@ func TestVectorizeInternalMemorySpaceError(t *testing.T) {
 				if len(tc.spec.Input) > 1 {
 					inputs = append(inputs, colexec.NewZeroOpNoInput())
 				}
-				memMon := mon.MakeMonitor("MemoryMonitor", mon.MemoryResource, nil, nil, 0, math.MaxInt64, st)
+				memMon := mon.NewMonitor("MemoryMonitor", mon.MemoryResource, nil, nil, 0, math.MaxInt64, st)
 				if success {
 					memMon.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
 				} else {
@@ -205,7 +205,7 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 				if len(tc.spec.Input) > 1 {
 					inputs = append(inputs, colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs))
 				}
-				memMon := mon.MakeMonitor("MemoryMonitor", mon.MemoryResource, nil, nil, 0, math.MaxInt64, st)
+				memMon := mon.NewMonitor("MemoryMonitor", mon.MemoryResource, nil, nil, 0, math.MaxInt64, st)
 				flowCtx.Cfg.TestingKnobs = execinfra.TestingKnobs{}
 				if expectNoMemoryError {
 					memMon.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -547,14 +547,14 @@ func (s *Server) newConnExecutor(
 ) *connExecutor {
 	// Create the various monitors.
 	// The session monitors are started in activate().
-	sessionRootMon := mon.MakeMonitor(
+	sessionRootMon := mon.NewMonitor(
 		"session root",
 		mon.MemoryResource,
 		memMetrics.CurBytesCount,
 		memMetrics.MaxBytesHist,
 		-1 /* increment */, math.MaxInt64, s.cfg.Settings,
 	)
-	sessionMon := mon.MakeMonitor(
+	sessionMon := mon.NewMonitor(
 		"session",
 		mon.MemoryResource,
 		memMetrics.SessionCurBytesCount,
@@ -562,7 +562,7 @@ func (s *Server) newConnExecutor(
 		-1 /* increment */, noteworthyMemoryUsageBytes, s.cfg.Settings,
 	)
 	// The txn monitor is started in txnState.resetForNewSQLTxn().
-	txnMon := mon.MakeMonitor(
+	txnMon := mon.NewMonitor(
 		"txn",
 		mon.MemoryResource,
 		memMetrics.TxnCurBytesCount,
@@ -579,12 +579,12 @@ func (s *Server) newConnExecutor(
 		metrics:     srvMetrics,
 		stmtBuf:     stmtBuf,
 		clientComm:  clientComm,
-		mon:         &sessionRootMon,
-		sessionMon:  &sessionMon,
+		mon:         sessionRootMon,
+		sessionMon:  sessionMon,
 		sessionData: sd,
 		dataMutator: sdMutator,
 		state: txnState{
-			mon:     &txnMon,
+			mon:     txnMon,
 			connCtx: ctx,
 		},
 		transitionCtx: transitionCtx{
@@ -592,7 +592,7 @@ func (s *Server) newConnExecutor(
 			nodeIDOrZero: nodeIDOrZero,
 			clock:        s.cfg.Clock,
 			// Future transaction's monitors will inherits from sessionRootMon.
-			connMon:  &sessionRootMon,
+			connMon:  sessionRootMon,
 			tracer:   s.cfg.AmbientCtx.Tracer,
 			settings: s.cfg.Settings,
 		},

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -282,14 +282,14 @@ func startConnExecutor(
 		TestingKnobs:            ExecutorTestingKnobs{},
 		StmtDiagnosticsRecorder: stmtdiagnostics.NewRegistry(nil, nil, gw, st),
 	}
-	pool := mon.MakeUnlimitedMonitor(
+	pool := mon.NewUnlimitedMonitor(
 		context.Background(), "test", mon.MemoryResource,
 		nil /* curCount */, nil /* maxHist */, math.MaxInt64, st,
 	)
 	// This pool should never be Stop()ed because, if the test is failing, memory
 	// is not properly released.
 
-	s := NewServer(cfg, &pool)
+	s := NewServer(cfg, pool)
 	buf := NewStmtBuf()
 	syncResults := make(chan []resWithPos, 1)
 	var cc ClientComm = &internalClientComm{

--- a/pkg/sql/distsql/sync_flow_after_drain_test.go
+++ b/pkg/sql/distsql/sync_flow_after_drain_test.go
@@ -70,7 +70,7 @@ func TestSyncFlowAfterDrain(t *testing.T) {
 
 	types := make([]*types.T, 0)
 	rb := distsqlutils.NewRowBuffer(types, nil /* rows */, distsqlutils.RowBufferArgs{})
-	ctx, flow, err := distSQLSrv.SetupSyncFlow(ctx, &distSQLSrv.memMonitor, &req, rb)
+	ctx, flow, err := distSQLSrv.SetupSyncFlow(ctx, distSQLSrv.memMonitor, &req, rb)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -834,7 +834,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	recv *DistSQLReceiver,
 	maybeDistribute bool,
 ) error {
-	subqueryMonitor := mon.MakeMonitor(
+	subqueryMonitor := mon.NewMonitor(
 		"subquery",
 		mon.MemoryResource,
 		dsp.distSQLSrv.Metrics.CurBytesCount,
@@ -1127,7 +1127,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	recv *DistSQLReceiver,
 	maybeDistribute bool,
 ) error {
-	postqueryMonitor := mon.MakeMonitor(
+	postqueryMonitor := mon.NewMonitor(
 		"postquery",
 		mon.MemoryResource,
 		dsp.distSQLSrv.Metrics.CurBytesCount,

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -877,9 +877,9 @@ func (pb *ProcessorBase) ConsumerDone() {
 // memory monitor with the given name and start it. The returned monitor must
 // be closed.
 func NewMonitor(ctx context.Context, parent *mon.BytesMonitor, name string) *mon.BytesMonitor {
-	monitor := mon.MakeMonitorInheritWithLimit(name, 0 /* limit */, parent)
+	monitor := mon.NewMonitorInheritWithLimit(name, 0 /* limit */, parent)
 	monitor.Start(ctx, parent, mon.BoundAccount{})
-	return &monitor
+	return monitor
 }
 
 // NewLimitedMonitor is a utility function used by processors to create a new
@@ -894,9 +894,9 @@ func NewLimitedMonitor(
 	if config.TestingKnobs.ForceDiskSpill {
 		limit = 1
 	}
-	limitedMon := mon.MakeMonitorInheritWithLimit(name, limit, parent)
+	limitedMon := mon.NewMonitorInheritWithLimit(name, limit, parent)
 	limitedMon.Start(ctx, parent, mon.BoundAccount{})
-	return &limitedMon
+	return limitedMon
 }
 
 // LocalProcessor is a RowSourcedProcessor that needs to be initialized with

--- a/pkg/sql/execinfra/testutils.go
+++ b/pkg/sql/execinfra/testutils.go
@@ -84,7 +84,7 @@ func (r *RepeatableRowSource) ConsumerClosed() {}
 // (currently it would create an import cycle, so this code will need to be
 // moved).
 func NewTestMemMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMonitor {
-	memMonitor := mon.MakeMonitor(
+	memMonitor := mon.NewMonitor(
 		"test-mem",
 		mon.MemoryResource,
 		nil,           /* curCount */
@@ -94,13 +94,13 @@ func NewTestMemMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMoni
 		st,
 	)
 	memMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
-	return &memMonitor
+	return memMonitor
 }
 
 // NewTestDiskMonitor creates and starts a new disk monitor to be used in
 // tests.
 func NewTestDiskMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMonitor {
-	diskMonitor := mon.MakeMonitor(
+	diskMonitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil, /* curCount */
@@ -110,7 +110,7 @@ func NewTestDiskMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMon
 		st,
 	)
 	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
-	return &diskMonitor
+	return diskMonitor
 }
 
 // GenerateValuesSpec generates a ValuesCoreSpec that encodes the given rows.

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -76,7 +76,7 @@ type InternalExecutor struct {
 func MakeInternalExecutor(
 	ctx context.Context, s *Server, memMetrics MemoryMetrics, settings *cluster.Settings,
 ) InternalExecutor {
-	monitor := mon.MakeUnlimitedMonitor(
+	monitor := mon.NewUnlimitedMonitor(
 		ctx,
 		"internal SQL executor",
 		mon.MemoryResource,
@@ -87,7 +87,7 @@ func MakeInternalExecutor(
 	)
 	return InternalExecutor{
 		s:          s,
-		mon:        &monitor,
+		mon:        monitor,
 		memMetrics: memMetrics,
 	}
 }

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -291,14 +291,14 @@ func newInternalPlanner(
 	p.semaCtx.SearchPath = sd.SearchPath
 	p.semaCtx.TypeResolver = p
 
-	plannerMon := mon.MakeUnlimitedMonitor(ctx,
+	plannerMon := mon.NewUnlimitedMonitor(ctx,
 		fmt.Sprintf("internal-planner.%s.%s", user, opName),
 		mon.MemoryResource,
 		memMetrics.CurBytesCount, memMetrics.MaxBytesHist,
 		noteworthyInternalMemoryUsageBytes, execCfg.Settings)
 
 	p.extendedEvalCtx = internalExtendedEvalCtx(
-		ctx, sd, dataMutator, tables, txn, ts, ts, execCfg, &plannerMon,
+		ctx, sd, dataMutator, tables, txn, ts, ts, execCfg, plannerMon,
 	)
 	p.extendedEvalCtx.Planner = p
 	p.extendedEvalCtx.PrivilegedAccessor = p

--- a/pkg/sql/rowcontainer/datum_row_container_test.go
+++ b/pkg/sql/rowcontainer/datum_row_container_test.go
@@ -34,7 +34,7 @@ func TestRowContainer(t *testing.T) {
 					resCol[i] = sqlbase.ResultColumn{Typ: types.Int}
 				}
 				st := cluster.MakeTestingClusterSettings()
-				m := mon.MakeUnlimitedMonitor(
+				m := mon.NewUnlimitedMonitor(
 					context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64, st,
 				)
 				rc := NewRowContainer(m.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(resCol), 0)
@@ -80,7 +80,7 @@ func TestRowContainerAtOutOfRange(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	m := mon.MakeUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, math.MaxInt64, st)
+	m := mon.NewUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, math.MaxInt64, st)
 	defer m.Stop(ctx)
 
 	resCols := sqlbase.ResultColumns{sqlbase.ResultColumn{Typ: types.Int}}
@@ -107,7 +107,7 @@ func TestRowContainerZeroCols(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	m := mon.MakeUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, math.MaxInt64, st)
+	m := mon.NewUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, math.MaxInt64, st)
 	defer m.Stop(ctx)
 
 	rc := NewRowContainer(m.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(nil), 0)
@@ -136,7 +136,7 @@ func BenchmarkRowContainerAt(b *testing.B) {
 	const numRows = 1024
 
 	st := cluster.MakeTestingClusterSettings()
-	m := mon.MakeUnlimitedMonitor(
+	m := mon.NewUnlimitedMonitor(
 		context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64, st,
 	)
 	defer m.Stop(context.Background())

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -105,7 +105,7 @@ func TestDiskRowContainer(t *testing.T) {
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 
 	evalCtx := tree.MakeTestingEvalContext(st)
-	diskMonitor := mon.MakeMonitor(
+	diskMonitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil, /* curCount */
@@ -127,7 +127,7 @@ func TestDiskRowContainer(t *testing.T) {
 				}
 				row := sqlbase.RandEncDatumRowOfTypes(rng, typs)
 				func() {
-					d := MakeDiskRowContainer(&diskMonitor, typs, ordering, tempEngine)
+					d := MakeDiskRowContainer(diskMonitor, typs, ordering, tempEngine)
 					defer d.Close(ctx)
 					if err := d.AddRow(ctx, row); err != nil {
 						t.Fatal(err)
@@ -177,7 +177,7 @@ func TestDiskRowContainer(t *testing.T) {
 			types := sqlbase.RandSortingTypes(rng, numCols)
 			rows := sqlbase.RandEncDatumRowsOfTypes(rng, numRows, types)
 			func() {
-				d := MakeDiskRowContainer(&diskMonitor, types, ordering, tempEngine)
+				d := MakeDiskRowContainer(diskMonitor, types, ordering, tempEngine)
 				defer d.Close(ctx)
 				for i := 0; i < len(rows); i++ {
 					if err := d.AddRow(ctx, rows[i]); err != nil {
@@ -257,7 +257,7 @@ func TestDiskRowContainer(t *testing.T) {
 		// Use random types and random rows.
 		types := sqlbase.RandSortingTypes(rng, numCols)
 		numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
-		d := MakeDiskRowContainer(&diskMonitor, types, ordering, tempEngine)
+		d := MakeDiskRowContainer(diskMonitor, types, ordering, tempEngine)
 		defer d.Close(ctx)
 		d.DoDeDuplicate()
 		addRowsRepeatedly := func() {
@@ -299,7 +299,7 @@ func TestDiskRowContainer(t *testing.T) {
 		types := sqlbase.RandSortingTypes(rng, numCols)
 		rows := sqlbase.RandEncDatumRowsOfTypes(rng, numRows, types)
 		// There are no ordering columns when using the numberedRowIterator.
-		d := MakeDiskRowContainer(&diskMonitor, types, nil, tempEngine)
+		d := MakeDiskRowContainer(diskMonitor, types, nil, tempEngine)
 		defer d.Close(ctx)
 		for i := 0; i < numRows; i++ {
 			require.NoError(t, d.AddRow(ctx, rows[i]))
@@ -375,7 +375,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 	defer tempEngine.Close()
 
 	// Make a monitor with no capacity.
-	monitor := mon.MakeMonitor(
+	monitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil, /* curCount */
@@ -387,7 +387,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 	monitor.Start(ctx, nil, mon.MakeStandaloneBudget(0 /* capacity */))
 
 	d := MakeDiskRowContainer(
-		&monitor,
+		monitor,
 		[]*types.T{types.Int},
 		sqlbase.ColumnOrdering{sqlbase.ColumnOrderInfo{ColIdx: 0, Direction: encoding.Ascending}},
 		tempEngine,
@@ -414,7 +414,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 	}
 	defer tempEngine.Close()
 
-	diskMonitor := mon.MakeMonitor(
+	diskMonitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil, /* curCount */
@@ -426,7 +426,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 
-	d := MakeDiskRowContainer(&diskMonitor, sqlbase.OneIntCol, nil /* ordering */, tempEngine)
+	d := MakeDiskRowContainer(diskMonitor, sqlbase.OneIntCol, nil /* ordering */, tempEngine)
 	defer d.Close(ctx)
 
 	const numCols = 1
@@ -542,7 +542,7 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 	}
 	defer tempEngine.Close()
 
-	monitor := mon.MakeMonitor(
+	monitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil, /* curCount */
@@ -553,7 +553,7 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 	)
 	monitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
 
-	d := MakeDiskRowContainer(&monitor, sqlbase.OneIntCol, nil /* ordering */, tempEngine)
+	d := MakeDiskRowContainer(monitor, sqlbase.OneIntCol, nil /* ordering */, tempEngine)
 	defer d.Close(ctx)
 
 	const (

--- a/pkg/sql/rowcontainer/hash_row_container_test.go
+++ b/pkg/sql/rowcontainer/hash_row_container_test.go
@@ -42,7 +42,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 	defer tempEngine.Close()
 
 	// These monitors are started and stopped by subtests.
-	memoryMonitor := mon.MakeMonitor(
+	memoryMonitor := mon.NewMonitor(
 		"test-mem",
 		mon.MemoryResource,
 		nil,           /* curCount */
@@ -51,7 +51,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 		math.MaxInt64, /* noteworthy */
 		st,
 	)
-	diskMonitor := mon.MakeMonitor(
+	diskMonitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil,           /* curCount */
@@ -68,7 +68,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 	types := sqlbase.OneIntCol
 	ordering := sqlbase.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 
-	rc := NewHashDiskBackedRowContainer(nil, &evalCtx, &memoryMonitor, &diskMonitor, tempEngine)
+	rc := NewHashDiskBackedRowContainer(nil, &evalCtx, memoryMonitor, diskMonitor, tempEngine)
 	err = rc.Init(
 		ctx,
 		false, /* shouldMark */
@@ -346,7 +346,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 	defer tempEngine.Close()
 
 	// These monitors are started and stopped by subtests.
-	memoryMonitor := mon.MakeMonitor(
+	memoryMonitor := mon.NewMonitor(
 		"test-mem",
 		mon.MemoryResource,
 		nil,           /* curCount */
@@ -355,7 +355,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 		math.MaxInt64, /* noteworthy */
 		st,
 	)
-	diskMonitor := mon.MakeMonitor(
+	diskMonitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil,           /* curCount */
@@ -373,7 +373,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 	types := []*types.T{types.Int, types.Int}
 	ordering := sqlbase.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 
-	rc := NewHashDiskBackedRowContainer(nil, &evalCtx, &memoryMonitor, &diskMonitor, tempEngine)
+	rc := NewHashDiskBackedRowContainer(nil, &evalCtx, memoryMonitor, diskMonitor, tempEngine)
 	err = rc.Init(
 		ctx,
 		true, /* shouldMark */

--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -51,7 +51,7 @@ func TestNumberedRowContainerDeDuping(t *testing.T) {
 	const smallMemoryBudget = 40
 	rng, _ := randutil.NewPseudoRand()
 
-	memoryMonitor := mon.MakeMonitor(
+	memoryMonitor := mon.NewMonitor(
 		"test-mem",
 		mon.MemoryResource,
 		nil,           /* curCount */
@@ -85,7 +85,7 @@ func TestNumberedRowContainerDeDuping(t *testing.T) {
 	}
 	numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
 	rc := NewDiskBackedNumberedRowContainer(
-		true /*deDup*/, types, &evalCtx, tempEngine, &memoryMonitor, diskMonitor,
+		true /*deDup*/, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor,
 		0 /*rowCapacity*/)
 	defer rc.Close(ctx)
 
@@ -137,7 +137,7 @@ func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 	}
 	defer tempEngine.Close()
 
-	memoryMonitor := mon.MakeMonitor(
+	memoryMonitor := mon.NewMonitor(
 		"test-mem",
 		mon.MemoryResource,
 		nil,           /* curCount */
@@ -173,7 +173,7 @@ func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 	}
 	numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
 	rc := NewDiskBackedNumberedRowContainer(
-		false /*deDup*/, types, &evalCtx, tempEngine, &memoryMonitor, diskMonitor,
+		false /*deDup*/, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor,
 		0 /*rowCapacity*/)
 	defer rc.Close(ctx)
 
@@ -434,7 +434,7 @@ func makeNumberedContainerUsingIRC(
 func makeMemMonitorAndStart(
 	ctx context.Context, st *cluster.Settings, budget int64,
 ) *mon.BytesMonitor {
-	memoryMonitor := mon.MakeMonitor(
+	memoryMonitor := mon.NewMonitor(
 		"test-mem",
 		mon.MemoryResource,
 		nil,           /* curCount */
@@ -444,7 +444,7 @@ func makeMemMonitorAndStart(
 		st,
 	)
 	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(budget))
-	return &memoryMonitor
+	return memoryMonitor
 }
 
 // Assume that join is using a batch of 100 left rows.

--- a/pkg/sql/rowexec/hashjoiner_test.go
+++ b/pkg/sql/rowexec/hashjoiner_test.go
@@ -58,7 +58,7 @@ func TestHashJoiner(t *testing.T) {
 
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
-	diskMonitor := mon.MakeMonitor(
+	diskMonitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil, /* curCount */
@@ -88,7 +88,7 @@ func TestHashJoiner(t *testing.T) {
 					Cfg: &execinfra.ServerConfig{
 						Settings:    st,
 						TempStorage: tempEngine,
-						DiskMonitor: &diskMonitor,
+						DiskMonitor: diskMonitor,
 					},
 				}
 				if flowCtxSetup != nil {
@@ -174,7 +174,7 @@ func TestHashJoinerError(t *testing.T) {
 
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
-	diskMonitor := mon.MakeMonitor(
+	diskMonitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil, /* curCount */
@@ -198,7 +198,7 @@ func TestHashJoinerError(t *testing.T) {
 				Cfg: &execinfra.ServerConfig{
 					Settings:    st,
 					TempStorage: tempEngine,
-					DiskMonitor: &diskMonitor,
+					DiskMonitor: diskMonitor,
 				},
 			}
 

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -394,7 +394,7 @@ func TestJoinReader(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tempEngine.Close()
-	diskMonitor := mon.MakeMonitor(
+	diskMonitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil, /* curCount */
@@ -416,7 +416,7 @@ func TestJoinReader(t *testing.T) {
 						Cfg: &execinfra.ServerConfig{
 							Settings:    st,
 							TempStorage: tempEngine,
-							DiskMonitor: &diskMonitor,
+							DiskMonitor: diskMonitor,
 						},
 						Txn: kv.NewTxn(ctx, s.DB(), s.NodeID()),
 					}
@@ -533,7 +533,7 @@ CREATE TABLE test.t (a INT, s STRING, INDEX (a, s))`); err != nil {
 
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
-	diskMonitor := mon.MakeMonitor(
+	diskMonitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil, /* curCount */
@@ -549,7 +549,7 @@ CREATE TABLE test.t (a INT, s STRING, INDEX (a, s))`); err != nil {
 		Cfg: &execinfra.ServerConfig{
 			Settings:    st,
 			TempStorage: tempEngine,
-			DiskMonitor: &diskMonitor,
+			DiskMonitor: diskMonitor,
 		},
 		Txn: kv.NewTxn(ctx, s.DB(), s.NodeID()),
 	}
@@ -635,7 +635,7 @@ func TestJoinReaderDrain(t *testing.T) {
 
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
-	diskMonitor := mon.MakeMonitor(
+	diskMonitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
 		nil, /* curCount */
@@ -656,7 +656,7 @@ func TestJoinReaderDrain(t *testing.T) {
 		Cfg: &execinfra.ServerConfig{
 			Settings:    st,
 			TempStorage: tempEngine,
-			DiskMonitor: &diskMonitor,
+			DiskMonitor: diskMonitor,
 		},
 		Txn: leafTxn,
 	}

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -161,7 +161,7 @@ func newWindower(
 			limit = memRequiredByWindower
 		}
 	}
-	limitedMon := mon.MakeMonitorInheritWithLimit("windower-limited", limit, evalCtx.Mon)
+	limitedMon := mon.NewMonitorInheritWithLimit("windower-limited", limit, evalCtx.Mon)
 	limitedMon.Start(ctx, evalCtx.Mon, mon.BoundAccount{})
 
 	if err := w.InitWithEvalCtx(
@@ -172,7 +172,7 @@ func newWindower(
 		evalCtx,
 		processorID,
 		output,
-		&limitedMon,
+		limitedMon,
 		execinfra.ProcStateOpts{InputsToDrain: []execinfra.RowSource{w.input},
 			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
 				w.close()

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -34,7 +34,7 @@ func TestWindowerAccountingForResults(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	monitor := mon.MakeMonitorWithLimit(
+	monitor := mon.NewMonitorWithLimit(
 		"test-monitor",
 		mon.MemoryResource,
 		100000,        /* limit */
@@ -44,7 +44,7 @@ func TestWindowerAccountingForResults(t *testing.T) {
 		math.MaxInt64, /* noteworthy */
 		st,
 	)
-	evalCtx := tree.MakeTestingEvalContextWithMon(st, &monitor)
+	evalCtx := tree.MakeTestingEvalContextWithMon(st, monitor)
 	defer evalCtx.Stop(ctx)
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -720,7 +720,7 @@ func TestRouterDiskSpill(t *testing.T) {
 	// the number of rows that wil eventually be added to the underlying
 	// rowContainer. This is a bytes value that will ensure we fall back to disk
 	// but use memory for at least a couple of rows.
-	monitor := mon.MakeMonitorWithLimit(
+	monitor := mon.NewMonitorWithLimit(
 		"test-monitor",
 		mon.MemoryResource,
 		(numRows-routerRowBufSize)/2, /* limit */
@@ -730,7 +730,7 @@ func TestRouterDiskSpill(t *testing.T) {
 		math.MaxInt64,                /* noteworthy */
 		st,
 	)
-	evalCtx := tree.MakeTestingEvalContextWithMon(st, &monitor)
+	evalCtx := tree.MakeTestingEvalContextWithMon(st, monitor)
 	defer evalCtx.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3139,7 +3139,7 @@ type EvalContext struct {
 
 // MakeTestingEvalContext returns an EvalContext that includes a MemoryMonitor.
 func MakeTestingEvalContext(st *cluster.Settings) EvalContext {
-	monitor := mon.MakeMonitor(
+	monitor := mon.NewMonitor(
 		"test-monitor",
 		mon.MemoryResource,
 		nil,           /* curCount */
@@ -3148,7 +3148,7 @@ func MakeTestingEvalContext(st *cluster.Settings) EvalContext {
 		math.MaxInt64, /* noteworthy */
 		st,
 	)
-	return MakeTestingEvalContextWithMon(st, &monitor)
+	return MakeTestingEvalContextWithMon(st, monitor)
 }
 
 // MakeTestingEvalContextWithMon returns an EvalContext with the given

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -79,7 +79,7 @@ type testModelRunner struct {
 // be called before using it.
 func newTestModelRunner(t *testing.T) testModelRunner {
 	st := cluster.MakeTestingClusterSettings()
-	workerMonitor := mon.MakeUnlimitedMonitor(
+	workerMonitor := mon.NewUnlimitedMonitor(
 		context.Background(),
 		"timeseries-test-worker",
 		mon.MemoryResource,
@@ -88,7 +88,7 @@ func newTestModelRunner(t *testing.T) testModelRunner {
 		math.MaxInt64,
 		st,
 	)
-	resultMonitor := mon.MakeUnlimitedMonitor(
+	resultMonitor := mon.NewUnlimitedMonitor(
 		context.Background(),
 		"timeseries-test-result",
 		mon.MemoryResource,
@@ -101,8 +101,8 @@ func newTestModelRunner(t *testing.T) testModelRunner {
 		t:                      t,
 		model:                  testmodel.NewModelDB(),
 		LocalTestCluster:       &localtestcluster.LocalTestCluster{},
-		workerMemMonitor:       &workerMonitor,
-		resultMemMonitor:       &resultMonitor,
+		workerMemMonitor:       workerMonitor,
+		resultMemMonitor:       resultMonitor,
 		queryMemoryBudget:      math.MaxInt64,
 		firstColumnarTimestamp: make(map[string]int64),
 	}

--- a/pkg/ts/query_test.go
+++ b/pkg/ts/query_test.go
@@ -394,7 +394,7 @@ func TestQueryWorkerMemoryConstraint(t *testing.T) {
 		// Track the total maximum memory used for a query with no budget.
 		{
 			// Swap model's memory monitor in order to adjust allocation size.
-			adjustedMon := mon.MakeMonitor(
+			adjustedMon := mon.NewMonitor(
 				"timeseries-test-worker-adjusted",
 				mon.MemoryResource,
 				nil,
@@ -407,7 +407,7 @@ func TestQueryWorkerMemoryConstraint(t *testing.T) {
 			defer adjustedMon.Stop(context.Background())
 
 			query := tm.makeQuery("test.metric", resolution1ns, 11, 109)
-			query.workerMemMonitor = &adjustedMon
+			query.workerMemMonitor = adjustedMon
 			query.InterpolationLimitNanos = 10
 			query.assertSuccess(99, 3)
 			memoryUsed := adjustedMon.MaximumBytes()
@@ -471,7 +471,7 @@ func TestQueryWorkerMemoryMonitor(t *testing.T) {
 
 		// Create a limited bytes monitor.
 		memoryBudget := int64(100 * 1024)
-		limitedMon := mon.MakeMonitorWithLimit(
+		limitedMon := mon.NewMonitorWithLimit(
 			"timeseries-test-limited",
 			mon.MemoryResource,
 			memoryBudget,
@@ -486,7 +486,7 @@ func TestQueryWorkerMemoryMonitor(t *testing.T) {
 
 		// Assert correctness with no memory pressure.
 		query := tm.makeQuery("test.metric", resolution1ns, 0, 60)
-		query.workerMemMonitor = &limitedMon
+		query.workerMemMonitor = limitedMon
 		query.assertSuccess(7, 1)
 
 		// Assert failure with memory pressure.

--- a/pkg/ts/rollup_test.go
+++ b/pkg/ts/rollup_test.go
@@ -264,7 +264,7 @@ func TestRollupMemoryConstraint(t *testing.T) {
 
 	// Construct a memory monitor that will be used to measure the high-water
 	// mark of memory usage for the rollup process.
-	adjustedMon := mon.MakeMonitor(
+	adjustedMon := mon.NewMonitor(
 		"timeseries-test-worker-adjusted",
 		mon.MemoryResource,
 		nil,
@@ -278,7 +278,7 @@ func TestRollupMemoryConstraint(t *testing.T) {
 
 	// Roll up time series with the new monitor to measure high-water mark
 	// of
-	qmc := MakeQueryMemoryContext(&adjustedMon, &adjustedMon, QueryMemoryOptions{
+	qmc := MakeQueryMemoryContext(adjustedMon, adjustedMon, QueryMemoryOptions{
 		// Large budget, but not maximum to avoid overflows.
 		BudgetBytes:      math.MaxInt64,
 		EstimatedSources: 1, // Not needed for rollups
@@ -321,7 +321,7 @@ func TestRollupMemoryConstraint(t *testing.T) {
 		adjustedMon.Stop(context.Background())
 		adjustedMon.Start(context.Background(), tm.workerMemMonitor, mon.BoundAccount{})
 
-		qmc := MakeQueryMemoryContext(&adjustedMon, &adjustedMon, QueryMemoryOptions{
+		qmc := MakeQueryMemoryContext(adjustedMon, adjustedMon, QueryMemoryOptions{
 			// Large budget, but not maximum to avoid overflows.
 			BudgetBytes:      limit,
 			EstimatedSources: 1, // Not needed for rollups

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -239,7 +239,7 @@ var maxAllocatedButUnusedBlocks = envutil.EnvOrDefaultInt("COCKROACH_MAX_ALLOCAT
 // to reserve and release bytes to a pool.
 var DefaultPoolAllocationSize = envutil.EnvOrDefaultInt64("COCKROACH_ALLOCATION_CHUNK_SIZE", 10*1024)
 
-// MakeMonitor creates a new monitor.
+// NewMonitor creates a new monitor.
 // Arguments:
 // - name is used to annotate log messages, can be used to distinguish
 //   monitors.
@@ -257,7 +257,7 @@ var DefaultPoolAllocationSize = envutil.EnvOrDefaultInt64("COCKROACH_ALLOCATION_
 // - noteworthy determines the minimum total allocated size beyond
 //   which the monitor starts to log increases. Use 0 to always log
 //   or math.MaxInt64 to never log.
-func MakeMonitor(
+func NewMonitor(
 	name string,
 	res Resource,
 	curCount *metric.Gauge,
@@ -265,14 +265,14 @@ func MakeMonitor(
 	increment int64,
 	noteworthy int64,
 	settings *cluster.Settings,
-) BytesMonitor {
-	return MakeMonitorWithLimit(
+) *BytesMonitor {
+	return NewMonitorWithLimit(
 		name, res, math.MaxInt64, curCount, maxHist, increment, noteworthy, settings)
 }
 
-// MakeMonitorWithLimit creates a new monitor with a limit local to this
+// NewMonitorWithLimit creates a new monitor with a limit local to this
 // monitor.
-func MakeMonitorWithLimit(
+func NewMonitorWithLimit(
 	name string,
 	res Resource,
 	limit int64,
@@ -281,14 +281,14 @@ func MakeMonitorWithLimit(
 	increment int64,
 	noteworthy int64,
 	settings *cluster.Settings,
-) BytesMonitor {
+) *BytesMonitor {
 	if increment <= 0 {
 		increment = DefaultPoolAllocationSize
 	}
 	if limit <= 0 {
 		limit = math.MaxInt64
 	}
-	return BytesMonitor{
+	return &BytesMonitor{
 		name:                 name,
 		resource:             res,
 		limit:                limit,
@@ -300,10 +300,10 @@ func MakeMonitorWithLimit(
 	}
 }
 
-// MakeMonitorInheritWithLimit creates a new monitor with a limit local to this
+// NewMonitorInheritWithLimit creates a new monitor with a limit local to this
 // monitor with all other attributes inherited from the passed in monitor.
-func MakeMonitorInheritWithLimit(name string, limit int64, m *BytesMonitor) BytesMonitor {
-	return MakeMonitorWithLimit(
+func NewMonitorInheritWithLimit(name string, limit int64, m *BytesMonitor) *BytesMonitor {
+	return NewMonitorWithLimit(
 		name,
 		m.resource,
 		limit,
@@ -345,9 +345,9 @@ func (mm *BytesMonitor) Start(ctx context.Context, pool *BytesMonitor, reserved 
 	}
 }
 
-// MakeUnlimitedMonitor creates a new monitor and starts the monitor in
+// NewUnlimitedMonitor creates a new monitor and starts the monitor in
 // "detached" mode without a pool and without a maximum budget.
-func MakeUnlimitedMonitor(
+func NewUnlimitedMonitor(
 	ctx context.Context,
 	name string,
 	res Resource,
@@ -355,12 +355,12 @@ func MakeUnlimitedMonitor(
 	maxHist *metric.Histogram,
 	noteworthy int64,
 	settings *cluster.Settings,
-) BytesMonitor {
+) *BytesMonitor {
 	if log.V(2) {
 		log.InfofDepth(ctx, 1, "%s: starting unlimited monitor", name)
 
 	}
-	return BytesMonitor{
+	return &BytesMonitor{
 		name:                 name,
 		resource:             res,
 		limit:                math.MaxInt64,

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -42,10 +42,10 @@ func TestMemoryAllocations(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 
-	var pool BytesMonitor
-	var m BytesMonitor
+	var pool *BytesMonitor
 	var paramHeader func()
 
+	m := NewMonitor("test", MemoryResource, nil, nil, 0, 1000, st)
 	accs := make([]BoundAccount, 4)
 	for i := range accs {
 		accs[i] = m.MakeBoundAccount()
@@ -139,7 +139,7 @@ func TestMemoryAllocations(t *testing.T) {
 	}
 
 	for _, max := range maxs {
-		pool = MakeMonitor("test", MemoryResource, nil, nil, 1, 1000, st)
+		pool = NewMonitor("test", MemoryResource, nil, nil, 1, 1000, st)
 		pool.Start(ctx, nil, MakeStandaloneBudget(max))
 
 		for _, hf := range hysteresisFactors {
@@ -153,8 +153,8 @@ func TestMemoryAllocations(t *testing.T) {
 
 					// We start with a fresh monitor for every set of
 					// parameters.
-					m = MakeMonitor("test", MemoryResource, nil, nil, pa, 1000, st)
-					m.Start(ctx, &pool, MakeStandaloneBudget(pb))
+					m = NewMonitor("test", MemoryResource, nil, nil, pa, 1000, st)
+					m.Start(ctx, pool, MakeStandaloneBudget(pb))
 
 					for i := 0; i < numAccountOps; i++ {
 						if i%linesBetweenHeaderReminders == 0 {
@@ -218,7 +218,7 @@ func TestBoundAccount(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	m := MakeMonitor("test", MemoryResource, nil, nil, 1, 1000, st)
+	m := NewMonitor("test", MemoryResource, nil, nil, 1, 1000, st)
 	m.Start(ctx, nil, MakeStandaloneBudget(100))
 	m.poolAllocationSize = 1
 	maxAllocatedButUnusedBlocks = 1
@@ -266,7 +266,7 @@ func TestBoundAccount(t *testing.T) {
 		t.Fatal("closing spans leaves bytes in monitor")
 	}
 
-	if m2 := a1.Monitor(); m2 != &m {
+	if m2 := a1.Monitor(); m2 != m {
 		t.Fatalf("a1.Monitor() returned %v, wanted %v", m2, &m)
 	}
 
@@ -278,7 +278,7 @@ func TestBytesMonitor(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	m := MakeMonitor("test", MemoryResource, nil, nil, 1, 1000, st)
+	m := NewMonitor("test", MemoryResource, nil, nil, 1, 1000, st)
 	m.Start(ctx, nil, MakeStandaloneBudget(100))
 	maxAllocatedButUnusedBlocks = 1
 
@@ -311,9 +311,9 @@ func TestBytesMonitor(t *testing.T) {
 		t.Fatalf("incorrect current allocation: got %d, expected %d", m.mu.curAllocated, 0)
 	}
 
-	limitedMonitor := MakeMonitorWithLimit(
+	limitedMonitor := NewMonitorWithLimit(
 		"testlimit", MemoryResource, 10, nil, nil, 1, 1000, cluster.MakeTestingClusterSettings())
-	limitedMonitor.Start(ctx, &m, BoundAccount{})
+	limitedMonitor.Start(ctx, m, BoundAccount{})
 
 	if err := limitedMonitor.reserveBytes(ctx, 10); err != nil {
 		t.Fatalf("limited monitor refused small allocation: %v", err)
@@ -332,7 +332,7 @@ func TestMemoryAllocationEdgeCases(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	m := MakeMonitor("test", MemoryResource,
+	m := NewMonitor("test", MemoryResource,
 		nil /* curCount */, nil /* maxHist */, 1e9 /* increment */, 1e9 /* noteworthy */, st)
 	m.Start(ctx, nil, MakeStandaloneBudget(1e9))
 
@@ -350,7 +350,7 @@ func TestMemoryAllocationEdgeCases(t *testing.T) {
 
 func BenchmarkBoundAccountGrow(b *testing.B) {
 	ctx := context.Background()
-	m := MakeMonitor("test", MemoryResource,
+	m := NewMonitor("test", MemoryResource,
 		nil /* curCount */, nil /* maxHist */, 1e9 /* increment */, 1e9, /* noteworthy */
 		cluster.MakeTestingClusterSettings())
 	m.Start(ctx, nil, MakeStandaloneBudget(1e9))


### PR DESCRIPTION
**util/mon: switch to returning pointers to monitors**

This commit switches the bytes monitor constructors to return pointers
instead of values since we pretty much everywhere have been using
pointers anyway.

Release note: None

**util/mon: move metrics in bytes monitors behind the mutex**

We started hitting suspicious data races between using a monitor and
setting the metrics on it. This commit goes around that issue by
protecting the metrics with a lock. This shouldn't increase the
contention on the mutex since we're usually holding the lock already
when accessing the metrics.

Fixes: #51027.

Release note: None