### PR TITLE
sql: wrap an error while handling `ObjectAlreadyExists` error

### DIFF
--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -705,7 +705,7 @@ func CheckObjectExists(
 		// Find what object we collided with.
 		desc, err := catalogkv.GetDescriptorByID(ctx, txn, codec, id)
 		if err != nil {
-			return err
+			return sqlbase.WrapErrorWhileConstructingObjectAlreadyExistsErr(err)
 		}
 		return sqlbase.MakeObjectAlreadyExistsError(desc.DescriptorProto(), name)
 	}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -200,7 +200,7 @@ func getTableCreateParams(
 		// Try and see what kind of object we collided with.
 		desc, err := catalogkv.GetDescriptorByID(params.ctx, params.p.txn, params.ExecCfg().Codec, id)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, sqlbase.WrapErrorWhileConstructingObjectAlreadyExistsErr(err)
 		}
 		// Still return data in this case.
 		return tKey, schemaID, sqlbase.MakeObjectAlreadyExistsError(desc.DescriptorProto(), tableName)

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -87,7 +87,7 @@ func getCreateTypeParams(
 		// Try and see what kind of object we collided with.
 		desc, err := catalogkv.GetDescriptorByID(params.ctx, params.p.txn, params.ExecCfg().Codec, collided)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, sqlbase.WrapErrorWhileConstructingObjectAlreadyExistsErr(err)
 		}
 		return nil, 0, sqlbase.MakeObjectAlreadyExistsError(desc.DescriptorProto(), name.String())
 	}

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -170,7 +170,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 		// Try and see what kind of object we collided with.
 		desc, err := catalogkv.GetDescriptorByID(params.ctx, params.p.txn, p.ExecCfg().Codec, id)
 		if err != nil {
-			return err
+			return sqlbase.WrapErrorWhileConstructingObjectAlreadyExistsErr(err)
 		}
 		return sqlbase.MakeObjectAlreadyExistsError(desc.DescriptorProto(), newTn.Table())
 	} else if err != nil {

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -129,6 +129,13 @@ func NewDatabaseAlreadyExistsError(name string) error {
 	return pgerror.Newf(pgcode.DuplicateDatabase, "database %q already exists", name)
 }
 
+// WrapErrorWhileConstructingObjectAlreadyExistsErr is used to wrap an error
+// when an error occurs while trying to get the colliding object for an
+// ObjectAlreadyExistsErr.
+func WrapErrorWhileConstructingObjectAlreadyExistsErr(err error) error {
+	return errors.Wrap(err, "object already exists")
+}
+
 // MakeObjectAlreadyExistsError creates an error for a namespace collision
 // with an arbitrary descriptor type.
 func MakeObjectAlreadyExistsError(collidingObject *Descriptor, name string) error {


### PR DESCRIPTION
Fixes #51010.

When creating an object that collides with another, we have to perform
another lookup to get the kind of object that it collided with. This
commits wraps the error that might be returned from that lookup with
more information about the context.

Release note: None