### PR TITLE
github-post: disable an assertion

### DIFF
--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -241,7 +241,13 @@ func listFailures(
 				}
 			case "pass", "skip":
 				if timedOutCulprit.name != "" {
-					panic(fmt.Sprintf("detected test timeout but test seems to have passed (%+v)", te))
+					// NB: we used to do this:
+					//   panic(fmt.Sprintf("detected test timeout but test seems to have passed (%+v)", te))
+					// but it would get hit. There is no good way to
+					// blame a timeout on a particular test. We should probably remove this
+					// logic in the first place, but for now make sure we don't panic as
+					// a result of it.
+					timedOutCulprit = scopedTest{}
 				}
 				delete(outstandingOutput, scoped(te))
 				if te.Elapsed > shortTestFilterSecs {


### PR DESCRIPTION
This gets hit regularly in CI. `github-post` makes the problematic
assumption that when a package times out, it can reasonably be blamed on
an individual test, which it then expects to not have passed. Alas,
thanks to `t.Parallel()` and friends, this is a fool's errand.

We should probably remove this logic altogether, but for now just
replace the assertion with a graceful reset of the timeout culprit.

Release note: None
