### PR TITLE
release-20.1: sql: fix rename temporary table bug

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -227,3 +227,26 @@ query I
 SELECT * FROM regression_47030
 ----
 2
+
+# renaming a temp table should not move it to the public schema.
+subtest regression_48233
+
+statement ok
+CREATE TEMP TABLE regression_48233(a int)
+
+statement ok
+ALTER TABLE regression_48233 RENAME TO reg_48233
+
+query IITI rowsort
+SELECT * FROM system.namespace WHERE name LIKE '%48233'
+----
+50  64  reg_48233  78
+
+statement error cannot convert a temporary table to a persistent table during renames
+ALTER TABLE reg_48233 RENAME TO public.reg_48233
+
+statement ok
+CREATE TABLE persistent_48233(a int)
+
+statement error schema cannot be modified: "pg_temp"
+ALTER TABLE persistent_48233 RENAME TO pg_temp.pers_48233


### PR DESCRIPTION
Backport 1/1 commits from #50500.

/cc @cockroachdb/release

---

Previously, when a temporary table was renamed, it was moved out of the
temp schema and into the `public` schema, thus making it a persistent
table. This patch fixes that.

Additionally, we also disallow a user from explicitly moving a temp
table into the `public` schema by providing a FQN during rename. This
is more in line with PG, which doesn't allow changing schemas during
rename.

Fixes #48233

peer programmed w @otan

Release note (bug fix): Renaming a temporary table no longer converts
it to a persistent table -- the table continues to remain temporary
after a rename. Moreover, this patch disallows users to convert a
temp table to a persistent table by renaming using an fully qualified
name with the schema reffering to `public`.
