### PR TITLE
geoviz: add improvements

### DIFF
--- a/pkg/cmd/geoviz/main.go
+++ b/pkg/cmd/geoviz/main.go
@@ -12,11 +12,14 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
+	"go/build"
 	"html/template"
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -35,15 +38,19 @@ type indexTemplate struct {
 
 // handleIndex serves the HTML page that contains the map.
 func handleIndex(w http.ResponseWriter, r *http.Request) {
-	templates := template.Must(template.ParseFiles("pkg/cmd/geoviz/templates/index.tmpl.html"))
-	err := templates.ExecuteTemplate(
+	pkg, err := build.Import("github.com/cockroachdb/cockroach", "", build.FindOnly)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	templates := template.Must(template.ParseFiles(filepath.Join(pkg.Dir, "pkg/cmd/geoviz/templates/index.tmpl.html")))
+	if err := templates.ExecuteTemplate(
 		w,
 		"index.tmpl.html",
 		indexTemplate{
 			APIKey: APIKey,
 		},
-	)
-	if err != nil {
+	); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -78,6 +85,8 @@ func handleLoad(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	flag.Parse()
+
 	http.HandleFunc("/", handleIndex)
 	http.HandleFunc("/load", handleLoad)
 

--- a/pkg/cmd/geoviz/templates/index.tmpl.html
+++ b/pkg/cmd/geoviz/templates/index.tmpl.html
@@ -54,6 +54,9 @@
           <input type="checkbox" id="show-labels" name="show-labels" checked>
           Show Labels
         </label>
+        <div>
+          <button onclick="copyURL()">Share GeoVIZ</button>
+        </div>
       </div>
     </div>
     <div id="geoviz-input">
@@ -90,6 +93,13 @@ covering,New Mexico Covering,purple,"POLYGON((-109.0448 36.9971,-109.0489 31.333
           center: {lat: -34.397, lng: 150.644},
           zoom: 2
         });
+
+        // Populate GeoVIZ from URL if available.
+        const loc = $(location).attr('hash');
+        if (loc) {
+          $('textarea[name="data"]').val(atob(loc.substring(1)));
+        }
+
         $("#form-geoviz-input").submit();
       }
 
@@ -121,6 +131,19 @@ covering,New Mexico Covering,purple,"POLYGON((-109.0448 36.9971,-109.0489 31.333
         for (const label of objItems.labels) {
           label.setMap((labelChecked && visible) ? map : null);
         }
+      }
+
+      function copyURL() {
+        const el = document.createElement('textarea');
+        el.value = window.location;
+        el.setAttribute('readonly', '');
+        el.style.position = 'absolute';
+        el.style.left = '-9999px';
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand('copy');
+        document.body.removeChild(el);
+        alert("URL copied to clipboard!");
       }
 
       $("#form-geoviz-input").submit(function(event) {
@@ -251,6 +274,8 @@ covering,New Mexico Covering,purple,"POLYGON((-109.0448 36.9971,-109.0489 31.333
               const idx = $(this).attr('value');
               setMapOnObjs(allObjItems[idx], checked);
             });
+
+            window.location.hash = '#' + btoa($('textarea[name="data"]').val());
           },
           error: function(xhr) {
             alert(xhr.responseText);


### PR DESCRIPTION
* Made geoviz parse flags properly.
* Make geoviz use the anchor to interpret the b64 text as initial input.
* Make geoviz change anchor each reload of the page to b64 of the
  text field entered.
* Add a "Share URL" button with GeoVIZ.

Share links with all your friends!
![image](https://user-images.githubusercontent.com/3646147/87200603-c185e900-c2b1-11ea-84b9-ec287400f4ee.png)

Release note: None