### PR TITLE
roachprod: correctly classify all ssh connection errors

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -502,9 +502,7 @@ func (c *SyncedCluster) Run(stdout, stderr io.Writer, nodes []int, title, cmd st
 			errs[i] = sess.Run(nodeCmd)
 			if errs[i] != nil {
 				detailMsg := fmt.Sprintf("Node %d. Command with error:\n```\n%s\n```\n", nodes[i], cmd)
-				err = errors.WithDetail(errs[i], detailMsg)
-				err = rperrors.ClassifyCmdError(err)
-				errs[i] = err
+				errs[i] = errors.WithDetail(errs[i], detailMsg)
 			}
 			return nil, nil
 		}
@@ -514,7 +512,6 @@ func (c *SyncedCluster) Run(stdout, stderr io.Writer, nodes []int, title, cmd st
 		if err != nil {
 			detailMsg := fmt.Sprintf("Node %d. Command with error:\n```\n%s\n```\n", nodes[i], cmd)
 			err = errors.WithDetail(err, detailMsg)
-			err = rperrors.ClassifyCmdError(err)
 			errs[i] = err
 			msg += fmt.Sprintf("\n%v", err)
 		}

--- a/pkg/cmd/roachprod/install/session.go
+++ b/pkg/cmd/roachprod/install/session.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/config"
+	rperrors "github.com/cockroachdb/cockroach/pkg/cmd/roachprod/errors"
 	"github.com/cockroachdb/errors"
 )
 
@@ -88,12 +89,12 @@ func (s *remoteSession) errWithDebug(err error) error {
 func (s *remoteSession) CombinedOutput(cmd string) ([]byte, error) {
 	s.Cmd.Args = append(s.Cmd.Args, cmd)
 	b, err := s.Cmd.CombinedOutput()
-	return b, s.errWithDebug(err)
+	return b, rperrors.ClassifyCmdError(s.errWithDebug(err))
 }
 
 func (s *remoteSession) Run(cmd string) error {
 	s.Cmd.Args = append(s.Cmd.Args, cmd)
-	return s.errWithDebug(s.Cmd.Run())
+	return rperrors.ClassifyCmdError(s.errWithDebug(s.Cmd.Run()))
 }
 
 func (s *remoteSession) Start(cmd string) error {
@@ -133,7 +134,7 @@ func (s *remoteSession) RequestPty() error {
 }
 
 func (s *remoteSession) Wait() error {
-	return s.Cmd.Wait()
+	return rperrors.ClassifyCmdError(s.Cmd.Wait())
 }
 
 func (s *remoteSession) Close() {


### PR DESCRIPTION
Before:

Only some SSH connection types had their errors correctly classified.

Why:

So all errors from remote calls over SSH connections are classified in a
way that tells someone investigating a problem whether it comes from SSH
or from the command being run on the remote server.

Now:

All errors from SSH connections are correctly classified as a
COMMAND_PROBLEM or SSH_PROBLEM.

Release note: None