### PR TITLE
importccl: fix db privilege related import bug

### DIFF
--- a/pkg/ccl/importccl/testdata/csv/empty.schema
+++ b/pkg/ccl/importccl/testdata/csv/empty.schema
@@ -1,2 +1,0 @@
-/* non-zero length file without any statements */
-


### PR DESCRIPTION
Previously, the following series of events would result in a CPUT error:
```
CREATE DATABASE b;
USE b;
CREATE USER foo;
GRANT ALL ON DATABASE b TO foo;

// Upload a CSV file to ExternalIODir/test.csv
IMPORT TABLE bar (id INT, name STRING) CSV DATA ('nodelocal://0/test.csv')
```
The default behavior is for `bar` to inherit the PrivilegeDescriptor of the
parent DB `b` i.e with users {admin, root, foo}.

The CPUT error was being triggered when the imported table was being
published i.e moved from an offline to online state. While the `bar`
TableDescriptor written to KV had `foo` as a user in its
PrivilegeDescriptor, the TableDescriptor being used at the time of
publishing `bar` did not.

The changes made to the privileges of the TableDescriptor while writing
to KV via `WriteDescriptors()` was not being correctly bubbled up to the
import job `details.Tables`. When we went to publish the table (which
uses the import job `details.Tables`) the users in the
PrivilegeDescriptor would not match those written to KV.

Added a unit test which was failing prior to this fix.

Informs: #51371

Release note (bug fix): Import no longer fails when run in a database
which has a user with privileges on the database.