### PR TITLE
opt: make partial index predicate implication tests more robust

### DIFF
--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -729,18 +729,10 @@ func (b *Builder) addPartialIndexPredicatesForTable(tabMeta *opt.TableMeta) {
 			return
 		}
 
-		// Wrap the filter in a FiltersExpr.
-		//
-		// Run SimplifyFilters so that adjacent top-level AND expressions are
-		// flattened into individual FiltersItems, like they would be during
-		// normalization of a SELECT query.
-		//
-		// Run ConsolidateFilters so that adjacent top-level FiltersItems that
-		// constrain a single variable are combined into a RangeExpr, like they
-		// would be during normalization of a SELECT query.
+		// Wrap the predicate filter expression in a FiltersExpr and normalize
+		// it.
 		filters := memo.FiltersExpr{filter}
-		filters = b.factory.CustomFuncs().SimplifyFilters(filters)
-		filters = b.factory.CustomFuncs().ConsolidateFilters(filters)
+		filters = b.factory.NormalizePartialIndexPredicate(filters)
 
 		// Add the filters to the table metadata.
 		tabMeta.AddPartialIndexPredicate(indexOrd, &filters)

--- a/pkg/sql/opt/partialidx/testdata/implicator/and-expr
+++ b/pkg/sql/opt/partialidx/testdata/implicator/and-expr
@@ -82,6 +82,16 @@ predtest vars=(bool, bool, bool)
 true
 └── remaining filters: none
 
+# Regression for #51177. The InlineConstVars normalization rule must be applied
+# to the predicate if it is applied to the filters.
+predtest vars=(string, string)
+@1 = 'foo' and @1 = @2
+=>
+@1 = 'foo' and @1 = @2
+----
+true
+└── remaining filters: none
+
 predtest vars=(bool, bool)
 @1 AND NOT @2
 =>


### PR DESCRIPTION
#### opt: make partial index predicate implication tests more robust

This commit makes the partial index predicate implication more robust by
ensuring that predicates are normalized in `Implicator` tests the same
way that they are normalized during Select queries. A new function,
`factory.NormalizePartialIndexPredicate`, performs predicate-specific
normalization and is called both in `partialidx` tests and in
`optbuilder/select.go`.

This commit also changes the `partialidx` tests so that query filters
are normalized in the context of a Select expression. This allows
normalization rules specific to filters within Selects to be performed.
The resulting filters better mimic filters in a real Select query.

These two changes should help prevent cases where implication proofs in
tests differ from proofs in real Select queries.

Release note: None

#### opt: fix partial index predicate implication for inlined const vars

This commit fixes a false-negative in partial index predicate
implication due to constant variables being inlined in the query filter
but not in the predicate.

Fixes #51177.

Release note: None
