### PR TITLE
sql: disallow row-level locking in READ-ONLY txns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1277,3 +1277,71 @@ query I
 EXECUTE tview_prep
 ----
 2
+
+# Use of SELECT FOR UPDATE/SHARE in ReadOnly Transaction
+
+statement ok
+CREATE TABLE t3 (i INT PRIMARY KEY)
+
+statement ok
+PREPARE a1 AS SELECT * FROM t3 FOR UPDATE
+
+statement ok
+BEGIN READ ONLY
+
+statement error cannot execute FOR UPDATE in a read-only transaction
+EXECUTE a1
+
+statement ok
+ROLLBACK
+
+statement ok
+DEALLOCATE a1
+
+statement ok
+PREPARE a1 AS SELECT * FROM t3 FOR NO KEY UPDATE
+
+statement ok
+BEGIN READ ONLY
+
+statement error cannot execute FOR NO KEY UPDATE in a read-only transaction
+EXECUTE a1
+
+statement ok
+ROLLBACK
+
+statement ok
+DEALLOCATE a1
+
+statement ok
+PREPARE a1 AS SELECT * FROM t3 FOR SHARE
+
+statement ok
+BEGIN READ ONLY
+
+statement error cannot execute FOR SHARE in a read-only transaction
+EXECUTE a1
+
+statement ok
+ROLLBACK
+
+statement ok
+DEALLOCATE a1
+
+statement ok
+PREPARE a1 AS SELECT * FROM t3 FOR KEY SHARE
+
+statement ok
+BEGIN READ ONLY
+
+statement error cannot execute FOR KEY SHARE in a read-only transaction
+EXECUTE a1
+
+statement ok
+ROLLBACK
+
+statement ok
+DEALLOCATE a1
+
+statement ok
+DROP TABLE t3

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -222,3 +222,47 @@ user root
 
 statement ok
 DROP TABLE t
+
+# Use of SELECT FOR UPDATE/SHARE in ReadOnly Transaction
+
+statement ok
+CREATE TABLE t (i INT PRIMARY KEY)
+
+statement ok
+BEGIN READ ONLY
+
+statement error cannot execute FOR UPDATE in a read-only transaction
+SELECT * FROM t FOR UPDATE
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN READ ONLY
+
+statement error cannot execute FOR NO KEY UPDATE in a read-only transaction
+SELECT * FROM t FOR NO KEY UPDATE
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN READ ONLY
+
+statement error cannot execute FOR SHARE in a read-only transaction
+SELECT * FROM t FOR SHARE
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN READ ONLY
+
+statement error cannot execute FOR KEY SHARE in a read-only transaction
+SELECT * FROM t FOR KEY SHARE
+
+statement ok
+ROLLBACK
+
+statement ok
+DROP TABLE t

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -465,6 +465,17 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		return execPlan{}, err
 	}
 
+	locking := scan.Locking
+	if b.forceForUpdateLocking {
+		locking = forUpdateLocking
+	}
+
+	// Raise error if row-level locking is part of a read-only transaction.
+	if locking != nil && locking.Strength > tree.ForNone && b.evalCtx.TxnReadOnly {
+		return execPlan{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
+			"cannot execute %s in a read-only transaction", locking.Strength.String())
+	}
+
 	needed, output := b.getColumns(scan.Cols, scan.Table)
 	res := execPlan{outputCols: output}
 
@@ -486,11 +497,6 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 
 	softLimit := int64(math.Ceil(scan.RequiredPhysical().LimitHint))
 	hardLimit := scan.HardLimit.RowCount()
-
-	locking := scan.Locking
-	if b.forceForUpdateLocking {
-		locking = forUpdateLocking
-	}
 
 	parallelize := false
 	if hardLimit == 0 && softLimit == 0 {


### PR DESCRIPTION
Closes #50476

Release note (sql change): Disallow row-level locking in READ-ONLY txns
                    to be consistent with Postgres behavior