### PR TITLE
roachtest: increase timeout for tpcc interleaved test

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -356,7 +356,7 @@ func registerTPCC(r *testRegistry) {
 		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		MinVersion: "v20.1.0",
-		Timeout:    3 * time.Hour,
+		Timeout:    6 * time.Hour,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				// Currently, we do not support import on interleaved tables which


### PR DESCRIPTION
Previously, the timeout was cutting it close as importing data for this
test takes a long time. This change increases the timeout from 3h to 6h.
Passes on stress with all runs under 4 hours, so this leaves enough of a
buffer to ensure the test doesn't timeout because of how long it takes to
setup.

Closes #51209

Release note: None