### PR TITLE
opt: modify JoinMultiplicity to model inner join properties

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -78,22 +78,23 @@ root                         ·             ·                                  
 
 # IN expression transformed into semi-join.
 query TTTTT
-EXPLAIN (VERBOSE) SELECT a FROM abc WHERE a IN (SELECT a FROM abc)
+EXPLAIN (VERBOSE) SELECT a FROM abc WHERE a IN (SELECT a FROM abc WHERE b < 0)
 ----
-·           distribution        local        ·    ·
-·           vectorized          true         ·    ·
-merge-join  ·                   ·            (a)  ·
- │          type                semi         ·    ·
- │          equality            (a) = (a)    ·    ·
- │          left cols are key   ·            ·    ·
- │          right cols are key  ·            ·    ·
- │          mergeJoinOrder      +"(a=a)"     ·    ·
- ├── scan   ·                   ·            (a)  +a
- │          table               abc@primary  ·    ·
- │          spans               FULL SCAN    ·    ·
- └── scan   ·                   ·            (a)  +a
-·           table               abc@primary  ·    ·
-·           spans               FULL SCAN    ·    ·
+·           distribution        local        ·       ·
+·           vectorized          true         ·       ·
+merge-join  ·                   ·            (a)     ·
+ │          type                semi         ·       ·
+ │          equality            (a) = (a)    ·       ·
+ │          left cols are key   ·            ·       ·
+ │          right cols are key  ·            ·       ·
+ │          mergeJoinOrder      +"(a=a)"     ·       ·
+ ├── scan   ·                   ·            (a)     +a
+ │          table               abc@primary  ·       ·
+ │          spans               FULL SCAN    ·       ·
+ └── scan   ·                   ·            (a, b)  +a
+·           table               abc@primary  ·       ·
+·           spans               FULL SCAN    ·       ·
+·           filter              b < 0        ·       ·
 
 query TTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -449,6 +449,10 @@ func (fj *FullJoinExpr) initUnexportedFields(mem *Memo) {
 	initJoinMultiplicity(fj)
 }
 
+func (sj *SemiJoinExpr) initUnexportedFields(mem *Memo) {
+	initJoinMultiplicity(sj)
+}
+
 func (lj *LookupJoinExpr) initUnexportedFields(mem *Memo) {
 	// lookupProps are initialized as necessary by the logical props builder.
 }
@@ -473,6 +477,7 @@ type joinWithMultiplicity interface {
 var _ joinWithMultiplicity = &InnerJoinExpr{}
 var _ joinWithMultiplicity = &LeftJoinExpr{}
 var _ joinWithMultiplicity = &FullJoinExpr{}
+var _ joinWithMultiplicity = &SemiJoinExpr{}
 
 func (ij *InnerJoinExpr) setMultiplicity(multiplicity props.JoinMultiplicity) {
 	ij.multiplicity = multiplicity
@@ -496,6 +501,14 @@ func (fj *FullJoinExpr) setMultiplicity(multiplicity props.JoinMultiplicity) {
 
 func (fj *FullJoinExpr) getMultiplicity() props.JoinMultiplicity {
 	return fj.multiplicity
+}
+
+func (sj *SemiJoinExpr) setMultiplicity(multiplicity props.JoinMultiplicity) {
+	sj.multiplicity = multiplicity
+}
+
+func (sj *SemiJoinExpr) getMultiplicity() props.JoinMultiplicity {
+	return sj.multiplicity
 }
 
 // WindowFrame denotes the definition of a window frame for an individual

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -646,7 +646,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 		if join, ok := e.(joinWithMultiplicity); ok {
 			mult := join.getMultiplicity()
-			if s := mult.String(); s != "" {
+			if s := mult.Format(e.Op()); s != "" {
 				tp.Childf("multiplicity: %s", s)
 			}
 		}

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -849,7 +849,6 @@ SELECT * FROM (VALUES (1), (2), (3)) LEFT JOIN (SELECT * FROM uv LIMIT 2) ON Tru
 left-join (cross)
  ├── columns: column1:1(int!null) u:2(int) v:3(int)
  ├── cardinality: [3 - 6]
- ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  ├── prune: (1-3)
  ├── reject-nulls: (2,3)
  ├── values
@@ -926,7 +925,6 @@ SELECT * FROM (VALUES (NULL), (NULL)) a FULL JOIN (VALUES (NULL), (NULL)) b ON T
 full-join (cross)
  ├── columns: column1:1(unknown) column1:2(unknown)
  ├── cardinality: [2 - 4]
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── prune: (1,2)
  ├── reject-nulls: (1,2)
  ├── values
@@ -988,7 +986,6 @@ SELECT * FROM (VALUES (NULL), (NULL)) a FULL JOIN (VALUES (NULL), (NULL)) b ON a
 full-join (cross)
  ├── columns: column1:1(unknown) column1:2(unknown)
  ├── cardinality: [2 - 4]
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── immutable
  ├── prune: (1,2)
  ├── reject-nulls: (1,2)
@@ -1019,7 +1016,6 @@ SELECT * FROM xysd FULL JOIN (SELECT * FROM (VALUES (1), (2))) ON True
 full-join (cross)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) column1:5(int)
  ├── cardinality: [2 - ]
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-5)
  ├── reject-nulls: (1-5)
@@ -1092,7 +1088,6 @@ SELECT * FROM xysd LEFT JOIN (SELECT u, sum(v) FROM uv GROUP BY u) ON u IS NOT N
 ----
 left-join (cross)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) sum:8(decimal)
- ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)~~>(8), (1,5)-->(8)
  ├── prune: (1-4,8)
@@ -1134,7 +1129,6 @@ SELECT * FROM xysd LEFT JOIN (SELECT u, sum(v) FROM uv WHERE u IS NOT NULL GROUP
 ----
 left-join (cross)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) sum:8(decimal)
- ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)-->(8)
  ├── prune: (1-4,8)
@@ -1272,7 +1266,6 @@ SELECT * FROM xysd FULL JOIN (SELECT u, sum(v) FROM uv GROUP BY u) ON u IS NOT N
 ----
 full-join (cross)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) sum:8(decimal)
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)~~>(8), (1,5)-->(8)
  ├── prune: (1-4,8)
@@ -1314,7 +1307,6 @@ SELECT * FROM (SELECT u, sum(v) FROM uv GROUP BY u) FULL JOIN xysd ON u IS NOT N
 ----
 full-join (cross)
  ├── columns: u:1(int) sum:4(decimal) x:5(int) y:6(int) s:7(string) d:8(decimal)
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── key: (1,5)
  ├── fd: (5)-->(6-8), (7,8)~~>(5,6), (1)~~>(4), (1,5)-->(4)
  ├── prune: (4-8)
@@ -1924,7 +1916,6 @@ inner-join (hash)
  ├── full-join (cross)
  │    ├── columns: x:5(int) y:6(int) s:7(string) d:8(decimal) column1:9(int)
  │    ├── cardinality: [2 - ]
- │    ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  │    ├── fd: (5)-->(6-8), (7,8)~~>(5,6)
  │    ├── prune: (5-9)
  │    ├── reject-nulls: (5-9)
@@ -2062,7 +2053,6 @@ project
  ├── interesting orderings: (+1) (+2,+1) (+3) (-5,+6,+3)
  └── left-join (hash)
       ├── columns: m:1(int!null) n:2(int) x:3(int) y:4(int) s:5(string) d:6(decimal) column7:7(int)
-      ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       ├── immutable
       ├── key: (1,3)
       ├── fd: (1)-->(2), (2)~~>(1), (2)-->(7), (3)-->(4-6), (5,6)~~>(3,4)

--- a/pkg/sql/opt/memo/testdata/logprops/virtual-scan
+++ b/pkg/sql/opt/memo/testdata/logprops/virtual-scan
@@ -9,7 +9,6 @@ project
  ├── prune: (2,5)
  └── left-join (cross)
       ├── columns: catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string) information_schema.tables.crdb_internal_vtable_pk:6(int) table_catalog:7(string) table_schema:8(string) table_name:9(string) table_type:10(string) is_insertable_into:11(string) version:12(int)
-      ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       ├── fd: ()-->(3)
       ├── prune: (4-6,9-12)
       ├── reject-nulls: (6-12)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -820,7 +820,6 @@ SELECT *, rowid FROM xysd FULL JOIN uv ON u > 4 AND u < 2
 ----
 full-join (cross)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int) rowid:7(int)
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── stats: [rows=50000000, distinct(2)=400, null(2)=25000000, distinct(3)=500, null(3)=500000, distinct(5)=500, null(5)=25000000, distinct(2,3)=5000, null(2,3)=250000, distinct(3,5)=250000, null(3,5)=250000, distinct(1,2,7)=50000000, null(1,2,7)=0]
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1437,7 +1437,6 @@ with &1 (t)
  │    ├── stats: [rows=4e+20]
  │    ├── left-join (cross)
  │    │    ├── columns: t1.x:1(bool) t2.x:3(bool)
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── stats: [rows=4e+20]
  │    │    ├── scan t1
  │    │    │    ├── columns: t1.x:1(bool)

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -881,7 +881,7 @@ func (c *CustomFuncs) MakeAggCols(aggOp opt.Operator, cols opt.ColSet) memo.Aggr
 // than once.
 func (c *CustomFuncs) JoinDoesNotDuplicateLeftRows(join memo.RelExpr) bool {
 	mult := memo.GetJoinMultiplicity(join)
-	return mult.JoinDoesNotDuplicateLeftRows()
+	return mult.JoinDoesNotDuplicateLeftRows(join.Op())
 }
 
 // JoinDoesNotDuplicateRightRows returns true if the given InnerJoin, LeftJoin
@@ -889,14 +889,14 @@ func (c *CustomFuncs) JoinDoesNotDuplicateLeftRows(join memo.RelExpr) bool {
 // more than once.
 func (c *CustomFuncs) JoinDoesNotDuplicateRightRows(join memo.RelExpr) bool {
 	mult := memo.GetJoinMultiplicity(join)
-	return mult.JoinDoesNotDuplicateRightRows()
+	return mult.JoinDoesNotDuplicateRightRows(join.Op())
 }
 
 // JoinPreservesLeftRows returns true if the given InnerJoin, LeftJoin or
 // FullJoin is guaranteed to output every row from its left input at least once.
 func (c *CustomFuncs) JoinPreservesLeftRows(join memo.RelExpr) bool {
 	mult := memo.GetJoinMultiplicity(join)
-	return mult.JoinPreservesLeftRows()
+	return mult.JoinPreservesLeftRows(join.Op())
 }
 
 // JoinPreservesRightRows returns true if the given InnerJoin, LeftJoin or
@@ -904,7 +904,7 @@ func (c *CustomFuncs) JoinPreservesLeftRows(join memo.RelExpr) bool {
 // once.
 func (c *CustomFuncs) JoinPreservesRightRows(join memo.RelExpr) bool {
 	mult := memo.GetJoinMultiplicity(join)
-	return mult.JoinPreservesRightRows()
+	return mult.JoinPreservesRightRows(join.Op())
 }
 
 // NoJoinHints returns true if no hints were specified for this join.

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -449,11 +449,8 @@ func (c *CustomFuncs) GetEquivFD(
 func (c *CustomFuncs) JoinFiltersMatchAllLeftRows(
 	left, right memo.RelExpr, on memo.FiltersExpr,
 ) bool {
-	// Asking whether a join will match all left rows is the same as asking
-	// whether an inner join with the same inputs would filter any rows from its
-	// left input.
-	multiplicity := memo.DeriveJoinMultiplicityFromInputs(opt.InnerJoinOp, left, right, on)
-	return multiplicity.JoinPreservesLeftRows()
+	multiplicity := memo.DeriveJoinMultiplicityFromInputs(left, right, on)
+	return multiplicity.JoinFiltersMatchAllLeftRows()
 }
 
 // CanExtractJoinEquality returns true if:

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -58,7 +58,7 @@
 # matching.
 [EliminateJoinUnderGroupByLeft, Normalize]
 (GroupBy | ScalarGroupBy | DistinctOn
-    $input:(InnerJoin | LeftJoin $left:*)
+    $input:(InnerJoin | LeftJoin | SemiJoin $left:*)
     $aggs:*
     $private:(GroupingPrivate $groupingCols:* $ordering:*) &
         (OrderingCanProjectCols
@@ -85,7 +85,7 @@
 )
 
 # EliminateJoinUnderGroupByRight is symmetric with
-# EliminateJoinUnderGroupByLeft, except that it only matches on InnerJoins.
+# EliminateJoinUnderGroupByLeft, except that it matches on InnerJoins.
 [EliminateJoinUnderGroupByRight, Normalize]
 (GroupBy | ScalarGroupBy | DistinctOn
     $input:(InnerJoin * $right:*)

--- a/pkg/sql/opt/norm/rules/project.opt
+++ b/pkg/sql/opt/norm/rules/project.opt
@@ -12,7 +12,7 @@
 # it has a chance to fire before the Project can be removed.
 [EliminateJoinUnderProjectLeft, Normalize]
 (Project
-    $join:(InnerJoin | LeftJoin $left:* $right:*) &
+    $join:(InnerJoin | LeftJoin | SemiJoin $left:* $right:*) &
         (JoinDoesNotDuplicateLeftRows $join) &
         (JoinPreservesLeftRows $join)
     $projections:* &

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -2168,7 +2168,6 @@ group-by
  │    │    ├── fd: (1)-->(2-5), (1,6)-->(2-5,11)
  │    │    ├── left-join (cross)
  │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6!null canary:12
- │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    │    ├── fd: (1)-->(2-5)
  │    │    │    ├── inner-join (cross)
  │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6!null
@@ -2341,7 +2340,6 @@ project
  │    ├── fd: (1)-->(10,11)
  │    ├── left-join (cross)
  │    │    ├── columns: k:1!null i:2 y:7 canary:10
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── fd: (1)-->(2)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null i:2
@@ -2382,7 +2380,6 @@ project
  │    │    ├── ordering: +7
  │    │    └── left-join (cross)
  │    │         ├── columns: k:1!null i:2 y:7 canary:10
- │    │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │         ├── fd: (1)-->(2)
  │    │         ├── scan a
  │    │         │    ├── columns: k:1!null i:2
@@ -2452,7 +2449,6 @@ project
       │    │    │    ├── left-join (cross)
       │    │    │    │    ├── columns: x:6!null y:7 u:8 v:9
       │    │    │    │    ├── outer: (1)
-      │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    │    │    ├── key: (6,8)
       │    │    │    │    ├── fd: (6)-->(7), (8)-->(9)
       │    │    │    │    ├── scan xy
@@ -2893,7 +2889,6 @@ project
  │    ├── fd: (1)-->(6)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null i:2 xy.x:6 y:7
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── key: (1,6)
  │    │    ├── fd: (1)-->(2), (6)-->(7)
  │    │    ├── scan a
@@ -2931,7 +2926,6 @@ project
       │    ├── fd: (1)-->(2-5,8)
       │    ├── left-join (hash)
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6!null u:8 v:9
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    ├── key: (1,8)
       │    │    ├── fd: (1)-->(2-5), (1)==(6), (6)==(1), (8)-->(9)
       │    │    ├── select
@@ -2945,7 +2939,6 @@ project
       │    │    │    │    ├── fd: (1)-->(2-6)
       │    │    │    │    ├── left-join (hash)
       │    │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:7
-      │    │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    │    │    │    ├── key: (1,6)
       │    │    │    │    │    ├── fd: (1)-->(2-5), (6)-->(7)
       │    │    │    │    │    ├── scan a
@@ -3021,7 +3014,6 @@ project
       │    ├── fd: (1)-->(2-6)
       │    ├── left-join (hash)
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:7 u:8
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    ├── key: (1,6)
       │    │    ├── fd: (1)-->(2-5), (6)-->(7), (6)==(8), (8)==(6)
       │    │    ├── scan a
@@ -3039,7 +3031,6 @@ project
       │    │    │    │    ├── fd: (6)-->(7,8)
       │    │    │    │    ├── left-join (hash)
       │    │    │    │    │    ├── columns: x:6!null y:7 u:8 v:9
-      │    │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    │    │    │    ├── key: (6,8)
       │    │    │    │    │    ├── fd: (6)-->(7), (8)-->(9)
       │    │    │    │    │    ├── scan xy
@@ -3150,7 +3141,6 @@ project
       │    │    ├── ordering: +5,+6 opt(4) [actual: +5,+6]
       │    │    └── left-join (hash)
       │    │         ├── columns: x:1!null y:2 k:3 i:4 f:5 s:6
-      │    │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │         ├── key: (1,3)
       │    │         ├── fd: (1)-->(2), (3)-->(4-6)
       │    │         ├── scan xy
@@ -3222,7 +3212,6 @@ project
       │    ├── fd: (1)-->(2,4)
       │    ├── left-join (hash)
       │    │    ├── columns: x:1!null y:2 d:4
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    ├── fd: (1)-->(2)
       │    │    ├── scan xy
       │    │    │    ├── columns: x:1!null y:2
@@ -3309,7 +3298,6 @@ project
       │    ├── left-join (cross)
       │    │    ├── columns: u:6!null v:7 bool:10
       │    │    ├── outer: (2)
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    ├── fd: (6)-->(7)
       │    │    ├── scan uv
       │    │    │    ├── columns: u:6!null v:7
@@ -3448,7 +3436,6 @@ project
       │    ├── left-join (cross)
       │    │    ├── columns: column1:1!null x:2 y:3 rownum:4!null
       │    │    ├── cardinality: [2 - ]
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    ├── key: (2,4)
       │    │    ├── fd: (4)-->(1), (2)-->(3)
       │    │    ├── ordinality
@@ -3991,7 +3978,6 @@ project
       │    ├── fd: (1)-->(2-5,9)
       │    ├── left-join (hash)
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 y:7 true:8
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    ├── fd: (1)-->(2-5)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
@@ -4336,7 +4322,6 @@ scalar-group-by
  │    │    ├── fd: (1)-->(7)
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: k:1!null i:2 y:7
- │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    │    ├── fd: (1)-->(2)
  │    │    │    ├── scan a
  │    │    │    │    ├── columns: k:1!null i:2
@@ -4368,7 +4353,6 @@ project
  │    ├── fd: (1)-->(10)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null i:2 y:7 true:9
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── fd: (1)-->(2)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null i:2
@@ -4402,7 +4386,6 @@ project
  │    ├── fd: (1)-->(10)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null i:2 y:7 notnull:9
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── fd: (1)-->(2), (7)~~>(9)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null i:2
@@ -5623,7 +5606,6 @@ project
  │    ├── fd: (1)-->(6)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null i:2 xy.x:6 y:7
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── key: (1,6)
  │    │    ├── fd: (1)-->(2), (6)-->(7)
  │    │    ├── scan a
@@ -5655,7 +5637,6 @@ project
  │    ├── fd: (3)-->(4)
  │    ├── left-join (hash)
  │    │    ├── columns: b:2 rowid:3!null xy.x:4 y:5
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── key: (3,4)
  │    │    ├── fd: (3)-->(2), (4)-->(5)
  │    │    ├── scan ab
@@ -5688,7 +5669,6 @@ project
  │    ├── fd: (11)-->(8)
  │    ├── left-join (hash)
  │    │    ├── columns: version:7 xy.x:8 y:9 rownum:11!null
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── key: (8,11)
  │    │    ├── fd: (11)-->(7), (8)-->(9)
  │    │    ├── ordinality

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -290,6 +290,21 @@ scan fks
  ├── key: (1)
  └── fd: (1)-->(2)
 
+# SemiJoin case.
+norm expect=EliminateJoinUnderGroupByLeft disable=EliminateJoinUnderProjectLeft
+SELECT max(v) FROM fks WHERE EXISTS (SELECT * FROM xy WHERE x = r1)
+----
+scalar-group-by
+ ├── columns: max:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── scan fks
+ │    └── columns: v:2
+ └── aggregations
+      └── max [as=max:7, outer=(2)]
+           └── v:2
+
 # No-op case because the InnerJoin will return no rows if fks is empty.
 norm expect-not=EliminateJoinUnderGroupByLeft
 SELECT DISTINCT ON (x) x, y FROM xy INNER JOIN fks ON True
@@ -1965,7 +1980,6 @@ distinct-on
  ├── left-join (hash)
  │    ├── columns: column1:1!null a:2
  │    ├── cardinality: [2 - ]
- │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    ├── values
  │    │    ├── columns: column1:1!null
  │    │    ├── cardinality: [2 - 2]
@@ -1996,7 +2010,6 @@ distinct-on
  ├── left-join (hash)
  │    ├── columns: column1:1!null column2:2!null a:3 b:4 c:5
  │    ├── cardinality: [2 - ]
- │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    ├── values
  │    │    ├── columns: column1:1!null column2:2!null
  │    │    ├── cardinality: [2 - 2]

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -771,7 +771,6 @@ project
  │    ├── fd: (13)-->(11)
  │    ├── left-join (cross)
  │    │    ├── columns: expr:6!null true:10 rownum:13!null
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── immutable
  │    │    ├── fd: (13)-->(6)
  │    │    ├── ordinality

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -103,7 +103,6 @@ SELECT * FROM a FULL JOIN b ON i=5 AND ((k<1 AND k>2) OR (k<4 AND k>5)) AND s='f
 ----
 full-join (cross)
  ├── columns: k:1 i:2 f:3 s:4 j:5 x:6 y:7
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
  ├── scan a
@@ -703,7 +702,6 @@ project
       │    ├── left-join (cross)
       │    │    ├── columns: x:6!null y:7 "?column?":10
       │    │    ├── outer: (1)
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    ├── immutable
       │    │    ├── fd: (6)-->(7)
       │    │    ├── scan b
@@ -826,7 +824,6 @@ project
  │    │    │    ├── full-join (cross)
  │    │    │    │    ├── columns: b.x:4
  │    │    │    │    ├── outer: (1)
- │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  │    │    │    │    ├── scan b
  │    │    │    │    │    ├── columns: b.x:4!null
  │    │    │    │    │    └── key: (4)
@@ -895,7 +892,6 @@ project
  │    │    │    ├── full-join (cross)
  │    │    │    │    ├── columns: b.x:9
  │    │    │    │    ├── outer: (1)
- │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  │    │    │    │    ├── scan b
  │    │    │    │    │    ├── columns: b.x:9!null
  │    │    │    │    │    └── key: (9)
@@ -1195,7 +1191,6 @@ project
  │    │    │    ├── fd: (10-13)-->(19,40)
  │    │    │    ├── left-join (cross)
  │    │    │    │    ├── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null ol_number:13!null ol_dist_info:19 true:39
- │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    │    │    ├── fd: (10-13)-->(19)
  │    │    │    │    ├── scan order_line
  │    │    │    │    │    ├── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null ol_number:13!null ol_dist_info:19
@@ -2061,7 +2056,6 @@ SELECT * FROM a FULL JOIN a AS a2 ON a.k<a2.k
 ----
 full-join (cross)
  ├── columns: k:1 i:2 f:3 s:4 j:5 k:6 i:7 f:8 s:9 j:10
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7-10)
  ├── scan a
@@ -2081,7 +2075,6 @@ SELECT * FROM a FULL JOIN a AS a2 ON a.f=1 AND a.f=a2.f
 ----
 full-join (hash)
  ├── columns: k:1 i:2 f:3 s:4 j:5 k:6 i:7 f:8 s:9 j:10
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7-10)
  ├── scan a
@@ -2102,7 +2095,6 @@ SELECT * FROM a FULL JOIN a AS a2 ON a.s=a2.s
 ----
 full-join (hash)
  ├── columns: k:1 i:2 f:3 s:4 j:5 k:6 i:7 f:8 s:9 j:10
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7-10)
  ├── scan a
@@ -2938,7 +2930,6 @@ SELECT * FROM xy FULL OUTER JOIN uv ON x+y=1
 ----
 full-join (cross)
  ├── columns: x:1 y:2 u:3 v:4
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── immutable
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
@@ -2958,7 +2949,6 @@ SELECT * FROM xy FULL OUTER JOIN uv ON 1=u+v
 ----
 full-join (cross)
  ├── columns: x:1 y:2 u:3 v:4
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── immutable
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
@@ -2998,7 +2988,6 @@ project
       │    ├── left-join (cross)
       │    │    ├── columns: u:3!null v:4 k:5 i:6
       │    │    ├── outer: (1)
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    ├── key: (3,5)
       │    │    ├── fd: (3)-->(4), (5)-->(6)
       │    │    ├── scan uv
@@ -3072,7 +3061,6 @@ SELECT * FROM xy FULL JOIN uv ON (substring('', ')') = '') = (u > 0)
 ----
 full-join (cross)
  ├── columns: x:1 y:2 u:3 v:4
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── immutable
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -983,7 +983,6 @@ limit
  │    ├── limit hint: 10.00
  │    └── left-join (hash)
  │         ├── columns: a:1!null b:2 u:3 v:4
- │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │         ├── key: (1,3)
  │         ├── fd: (1)-->(2), (3)-->(4)
  │         ├── scan ab

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -104,6 +104,13 @@ project
  └── projections
       └── 1 [as="?column?":8]
 
+# SemiJoin case.
+norm expect=EliminateJoinUnderProjectLeft
+SELECT v FROM fks WHERE EXISTS (SELECT * FROM a WHERE x = r1)
+----
+scan fks
+ └── columns: v:2
+
 # No-op case because the cross join may duplicate left rows.
 norm expect-not=EliminateJoinUnderProjectLeft
 SELECT 1 FROM b LEFT JOIN a ON True
@@ -112,7 +119,6 @@ project
  ├── columns: "?column?":8!null
  ├── fd: ()-->(8)
  ├── left-join (cross)
- │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    ├── scan b
  │    ├── scan a
  │    └── filters (true)
@@ -881,7 +887,6 @@ project
  │    ├── left-join (cross)
  │    │    ├── columns: column1:2 "?column?":3!null rownum:5!null
  │    │    ├── cardinality: [2 - 8]
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── fd: (5)-->(3)
  │    │    ├── ordinality
  │    │    │    ├── columns: "?column?":3!null rownum:5!null

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -756,7 +756,6 @@ project
  ├── fd: (5)-->(6)
  ├── full-join (cross)
  │    ├── columns: k:1 x:5 y:6
- │    ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  │    ├── key: (1,5)
  │    ├── fd: (5)-->(6)
  │    ├── scan a
@@ -1045,7 +1044,6 @@ project
  ├── fd: (1)-->(2)
  ├── full-join (cross)
  │    ├── columns: x:1 y:2 k:3
- │    ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  │    ├── key: (1,3)
  │    ├── fd: (1)-->(2)
  │    ├── scan xy
@@ -1294,7 +1292,6 @@ scalar-group-by
  │    │    ├── fd: (1)-->(6)
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: k:1!null i:2 y:6
- │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    │    ├── fd: (1)-->(2)
  │    │    │    ├── scan a
  │    │    │    │    ├── columns: k:1!null i:2

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -19,7 +19,6 @@ SELECT * FROM a FULL JOIN xy ON true WHERE a.k IS NOT NULL
 ----
 left-join (cross)
  ├── columns: k:1!null i:2 f:3 s:4 x:5 y:6
- ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (5)-->(6)
  ├── scan a
@@ -37,7 +36,6 @@ SELECT * FROM a FULL JOIN xy ON true WHERE xy.x > 5
 ----
 left-join (cross)
  ├── columns: k:1 i:2 f:3 s:4 x:5!null y:6
- ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  ├── key: (1,5)
  ├── fd: (5)-->(6), (1)-->(2-4)
  ├── select
@@ -185,7 +183,6 @@ SELECT * FROM a FULL JOIN xy ON true WHERE i IS NOT NULL
 ----
 left-join (cross)
  ├── columns: k:1!null i:2!null f:3 s:4 x:5 y:6
- ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (5)-->(6)
  ├── select
@@ -481,7 +478,6 @@ project
       │    ├── fd: (1)-->(7,8)
       │    ├── left-join (cross)
       │    │    ├── columns: k:1!null x:5 y:6
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    ├── key: (1,5)
       │    │    ├── fd: (5)-->(6)
       │    │    ├── scan a
@@ -524,7 +520,6 @@ project
       │    ├── fd: (1)-->(7)
       │    ├── left-join (cross)
       │    │    ├── columns: k:1!null x:5
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    ├── key: (1,5)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1!null
@@ -566,7 +561,6 @@ project
  │    │    │    ├── left-join (cross)
  │    │    │    │    ├── columns: ref_1.k:5!null true:14
  │    │    │    │    ├── outer: (4)
- │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    │    │    ├── scan ref_1
  │    │    │    │    │    ├── columns: ref_1.k:5!null
  │    │    │    │    │    └── key: (5)
@@ -674,7 +668,6 @@ project
       │    │    ├── fd: ()-->(8), (3)-->(7)
       │    │    ├── left-join (cross)
       │    │    │    ├── columns: k:3 s:6
-      │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    │    ├── fd: (3)-->(6)
       │    │    │    ├── scan xy
       │    │    │    ├── scan a

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1486,7 +1486,6 @@ project
  │    │    ├── ordering: +7 opt(8) [actual: +7]
  │    │    └── left-join (hash)
  │    │         ├── columns: b.k:1!null b.i:2 a.k:7 a.i:8
- │    │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │         ├── key: (1,7)
  │    │         ├── fd: (1)-->(2), (7)-->(8)
  │    │         ├── scan b
@@ -1839,7 +1838,6 @@ SELECT a.k FROM a FULL OUTER JOIN xy ON a.k = a.k
 ----
 full-join (cross)
  ├── columns: k:1
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
@@ -1852,7 +1850,6 @@ SELECT a.k FROM a FULL OUTER JOIN xy ON a.k >= a.k
 ----
 full-join (cross)
  ├── columns: k:1
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
@@ -1865,7 +1862,6 @@ SELECT a.k FROM a FULL OUTER JOIN xy ON a.k <= a.k
 ----
 full-join (cross)
  ├── columns: k:1
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
@@ -1920,7 +1916,6 @@ SELECT a.k FROM a FULL OUTER JOIN xy ON a.k != a.k
 ----
 full-join (cross)
  ├── columns: k:1
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
@@ -1933,7 +1928,6 @@ SELECT a.k FROM a FULL OUTER JOIN xy ON a.k > a.k
 ----
 full-join (cross)
  ├── columns: k:1
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
@@ -1946,7 +1940,6 @@ SELECT a.k FROM a FULL OUTER JOIN xy ON a.k < a.k
 ----
 full-join (cross)
  ├── columns: k:1
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -780,7 +780,6 @@ SELECT * FROM a LEFT JOIN xy ON True WHERE a.i=100 AND $1>'2000-01-01T1:00:00'
 ----
 left-join (cross)
  ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:6 y:7
- ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  ├── has-placeholder
  ├── key: (1,6)
  ├── fd: ()-->(2), (1)-->(3-5), (6)-->(7)
@@ -1023,7 +1022,6 @@ select
  ├── fd: (1)-->(2-5), (6)-->(7)
  ├── left-join (cross)
  │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:7
- │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2-5), (6)-->(7)
  │    ├── scan a
@@ -1048,7 +1046,6 @@ select
  ├── fd: (6)-->(7), (1)-->(2-5)
  ├── left-join (cross)
  │    ├── columns: k:1 i:2 f:3 s:4 j:5 x:6!null y:7
- │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    ├── key: (1,6)
  │    ├── fd: (6)-->(7), (1)-->(2-5)
  │    ├── scan xy
@@ -1073,7 +1070,6 @@ select
  ├── fd: (1)-->(2-5), (6)-->(7)
  ├── full-join (cross)
  │    ├── columns: k:1 i:2 f:3 s:4 j:5 x:6 y:7
- │    ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2-5), (6)-->(7)
  │    ├── scan a
@@ -1892,7 +1888,6 @@ project
  │    ├── fd: (1)-->(16)
  │    ├── left-join (cross)
  │    │    ├── columns: a.k:1!null a.i:2 k:16
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── fd: (1)-->(2)
  │    │    ├── scan a
  │    │    │    ├── columns: a.k:1!null a.i:2

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -231,6 +231,7 @@ define SemiJoin {
     Right RelExpr
     On FiltersExpr
     _ JoinPrivate
+    multiplicity JoinMultiplicity
 }
 
 [Relational, Join, JoinNonApply]

--- a/pkg/sql/opt/props/multiplicity.go
+++ b/pkg/sql/opt/props/multiplicity.go
@@ -10,29 +10,46 @@
 
 package props
 
-import "bytes"
+import (
+	"bytes"
 
-// MultiplicityValue is a bitfield that describes whether a join duplicates
-// and/or filters rows from a particular input.
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/errors"
+)
+
+// MultiplicityValue is a bit field that describes whether a join's filters
+// match all input rows at least once, as well as whether the filters match all
+// input rows at most once.
 type MultiplicityValue uint8
 
 const (
 	// MultiplicityIndeterminateVal indicates that no guarantees can be made about
-	// the effect the join will have on its input rows.
+	// the number of times any given input row will be matched by the join
+	// filters.
 	MultiplicityIndeterminateVal MultiplicityValue = 0
 
-	// MultiplicityNotDuplicatedVal indicates that the join will not include input
-	// rows in its output more than once.
+	// MultiplicityNotDuplicatedVal indicates that the join will not match any
+	// input rows more than once.
 	MultiplicityNotDuplicatedVal MultiplicityValue = 1 << (iota - 1)
 
-	// MultiplicityPreservedVal indicates that the join will include all input
-	// rows in its output.
+	// MultiplicityPreservedVal indicates that the join filters will match all
+	// left rows at least once.
 	MultiplicityPreservedVal
 )
 
-// JoinMultiplicity answers queries about how a join will affect the rows from
-// its inputs. Left and right input rows can be duplicated and/or filtered by
-// the join. As an example:
+// JoinMultiplicity stores properties that allow guarantees to be made about how
+// a join will affect rows from its inputs. Logical join operators can be
+// modeled as an inner join followed by some combination of additional
+// operations. For example, outer joins can be modeled as inner joins with the
+// unmatched rows added (null-extended) to the output. A semi-join can be
+// modeled as a combination of inner join, project and distinct operators. And
+// of course, an inner join can simply be modeled as an inner join.
+//
+// JoinMultiplicity stores properties for the hypothetical 'inner join' that is
+// a part of any logical join operator. These properties are used to answer
+// the aforementioned queries about how a join will affect the rows from its
+// inputs. Left and right input rows can be duplicated and/or filtered by the
+// join. As an example:
 //
 //   CREATE TABLE xy (x INT PRIMARY KEY, y INT);
 //   CREATE TABLE uv (u INT PRIMARY KEY, v INT);
@@ -41,24 +58,32 @@ const (
 // 1. Are rows from xy or uv being duplicated by the join?
 // 2. Are any rows being filtered from the join output?
 //
-// A JoinMultiplicity constructed for the join is able to answer either of the
-// above questions by checking one of the MultiplicityValue bit flags. The
-// not-duplicated and preserved flags are always unset for a join unless it can
-// be statically proven that no rows from the given input will be duplicated or
-// filtered respectively. As an example, take the following query:
+// A JoinMultiplicity constructed for the join is able to answer questions of
+// this type by calling a function like JoinDoesNotDuplicateLeftRows with the
+// corresponding join operator type. The operator type is used to derive the
+// final multiplicity properties from the inner join properties. This means that
+// the properties stored in the JoinMultiplicity can be different from the
+// output of the functions that return the final multiplicity properties; for
+// example, a left join may preserve left rows even if its ON condition doesn't
+// match all left rows.
+//
+// The not-duplicated and preserved flags are always unset for a join unless it
+// can be statically proven that no rows from the given input will be duplicated
+// or filtered respectively. As an example, take the following query:
 //
 //   SELECT * FROM xy INNER JOIN uv ON y = v;
 //
 // At execution time, it may be that every row from xy will be included in the
 // join output exactly once. However, since this cannot be proven before
-// runtime, the duplicated and filtered flags must be set.
+// runtime, neither the MultiplicityNotDuplicated nor the MultiplicityPreserved
+// flags can be set.
 //
 // After initial construction by multiplicity_builder.go, JoinMultiplicity
 // should be considered immutable.
 type JoinMultiplicity struct {
 	// LeftMultiplicity and RightMultiplicity describe how the left and right
-	// input rows respectively will be affected by the join operator.
-	// As an example, using the query from above:
+	// input rows respectively would be affected by an inner join with the same
+	// ON condition. As an example, using the tables from above:
 	//
 	//  SELECT * FROM xy FULL JOIN uv ON x=u;
 	//
@@ -66,42 +91,117 @@ type JoinMultiplicity struct {
 	// would set the not-duplicated flag because the equality is between key
 	// columns, which means that no row can match more than once.
 	//
-	// MultiplicityPreservedVal: both fields would set the preserved flag because
-	// the FullJoin will add back any rows that don't match on the filter
-	// conditions.
+	// MultiplicityPreservedVal: neither field would set the preserved flag
+	// because there is no relation between the x and u columns that would
+	// guarantee that every row has a match on the equality condition. However,
+	// because the full join would add back unmatched rows, JoinPreservesLeftRows
+	// and JoinPreservesRightRows would return true.
 	LeftMultiplicity  MultiplicityValue
 	RightMultiplicity MultiplicityValue
 }
 
+// JoinFiltersDoNotDuplicateLeftRows returns true when the join filters are
+// guaranteed to not return true for rows from the left input more than once.
+func (mp *JoinMultiplicity) JoinFiltersDoNotDuplicateLeftRows() bool {
+	return mp.LeftMultiplicity&MultiplicityNotDuplicatedVal != 0
+}
+
+// JoinFiltersDoNotDuplicateRightRows returns true when the join filters are
+// guaranteed to not return true for rows from the right input more than once.
+func (mp *JoinMultiplicity) JoinFiltersDoNotDuplicateRightRows() bool {
+	return mp.RightMultiplicity&MultiplicityNotDuplicatedVal != 0
+}
+
+// JoinFiltersMatchAllLeftRows returns true when the join filters are guaranteed
+// to return true for rows from the left input at least once.
+func (mp *JoinMultiplicity) JoinFiltersMatchAllLeftRows() bool {
+	return mp.LeftMultiplicity&MultiplicityPreservedVal != 0
+}
+
+// JoinFiltersMatchAllRightRows returns true when the join filters are
+// guaranteed to return true for rows from the right input at least once.
+func (mp *JoinMultiplicity) JoinFiltersMatchAllRightRows() bool {
+	return mp.RightMultiplicity&MultiplicityPreservedVal != 0
+}
+
 // JoinDoesNotDuplicateLeftRows returns true when rows from the left input will
 // not be included in the join output more than once.
-func (mp *JoinMultiplicity) JoinDoesNotDuplicateLeftRows() bool {
-	return mp.LeftMultiplicity&MultiplicityNotDuplicatedVal != 0
+func (mp *JoinMultiplicity) JoinDoesNotDuplicateLeftRows(op opt.Operator) bool {
+	switch op {
+	case opt.InnerJoinOp, opt.LeftJoinOp, opt.FullJoinOp:
+		break
+
+	case opt.SemiJoinOp:
+		return true
+
+	default:
+		panic(errors.AssertionFailedf("unsupported operator: %v", op))
+	}
+	return mp.JoinFiltersDoNotDuplicateLeftRows()
 }
 
 // JoinDoesNotDuplicateRightRows returns true when rows from the right input
 // will not be included in the join output more than once.
-func (mp *JoinMultiplicity) JoinDoesNotDuplicateRightRows() bool {
-	return mp.RightMultiplicity&MultiplicityNotDuplicatedVal != 0
+func (mp *JoinMultiplicity) JoinDoesNotDuplicateRightRows(op opt.Operator) bool {
+	switch op {
+	case opt.InnerJoinOp, opt.LeftJoinOp, opt.FullJoinOp:
+		break
+
+	case opt.SemiJoinOp:
+		panic(errors.AssertionFailedf("right rows are not included in the output of a %v", op))
+
+	default:
+		panic(errors.AssertionFailedf("unsupported operator: %v", op))
+	}
+	return mp.JoinFiltersDoNotDuplicateRightRows()
 }
 
 // JoinPreservesLeftRows returns true when all rows from the left input are
 // guaranteed to be included in the join output.
-func (mp *JoinMultiplicity) JoinPreservesLeftRows() bool {
-	return mp.LeftMultiplicity&MultiplicityPreservedVal != 0
+func (mp *JoinMultiplicity) JoinPreservesLeftRows(op opt.Operator) bool {
+	switch op {
+	case opt.InnerJoinOp, opt.SemiJoinOp:
+		break
+
+	case opt.LeftJoinOp, opt.FullJoinOp:
+		return true
+
+	default:
+		panic(errors.AssertionFailedf("unsupported operator: %v", op))
+	}
+	return mp.JoinFiltersMatchAllLeftRows()
 }
 
 // JoinPreservesRightRows returns true when all rows from the right input are
 // guaranteed to be included in the join output.
-func (mp *JoinMultiplicity) JoinPreservesRightRows() bool {
-	return mp.RightMultiplicity&MultiplicityPreservedVal != 0
+func (mp *JoinMultiplicity) JoinPreservesRightRows(op opt.Operator) bool {
+	switch op {
+	case opt.InnerJoinOp, opt.LeftJoinOp:
+		break
+
+	case opt.FullJoinOp:
+		return true
+
+	case opt.SemiJoinOp:
+		panic(errors.AssertionFailedf("right rows are not included in the output of a %v", op))
+
+	default:
+		panic(errors.AssertionFailedf("unsupported operator: %v", op))
+	}
+	return mp.JoinFiltersMatchAllRightRows()
 }
 
-// String returns a formatted string containing flags for the left and right
-// inputs that indicate how many times any given input row can be guaranteed to
-// show up in the join output.
-func (mp *JoinMultiplicity) String() string {
-	if !mp.isInteresting() {
+// Format returns a formatted string containing flags that describe the
+// multiplicity properties of the join, taking into account the join type.
+func (mp *JoinMultiplicity) Format(op opt.Operator) string {
+	switch op {
+	case opt.InnerJoinOp, opt.LeftJoinOp, opt.FullJoinOp, opt.SemiJoinOp:
+
+	default:
+		panic(errors.AssertionFailedf("unsupported operator: %v", op))
+	}
+
+	if !mp.isInteresting(op) {
 		return ""
 	}
 
@@ -138,19 +238,47 @@ func (mp *JoinMultiplicity) String() string {
 	}
 
 	buf.WriteString("left-rows(")
-	outputFlag(mp.JoinDoesNotDuplicateLeftRows(), mp.JoinPreservesLeftRows())
-
-	isFirstFlag = true
-	buf.WriteString("), right-rows(")
-	outputFlag(mp.JoinDoesNotDuplicateRightRows(), mp.JoinPreservesRightRows())
+	outputFlag(mp.JoinDoesNotDuplicateLeftRows(op), mp.JoinPreservesLeftRows(op))
 	buf.WriteString(")")
+
+	if op != opt.SemiJoinOp {
+		isFirstFlag = true
+		buf.WriteString(", right-rows(")
+		outputFlag(mp.JoinDoesNotDuplicateRightRows(op), mp.JoinPreservesRightRows(op))
+		buf.WriteString(")")
+	}
 
 	return buf.String()
 }
 
-// isInteresting returns true when rows from either of the inputs are guaranteed
-// not to be duplicated or filtered.
-func (mp *JoinMultiplicity) isInteresting() bool {
-	return mp.JoinDoesNotDuplicateLeftRows() || mp.JoinDoesNotDuplicateRightRows() ||
-		mp.JoinPreservesLeftRows() || mp.JoinPreservesRightRows()
+// String returns a formatted string containing flags for the left and right
+// inputs that indicate how many times any given input row is guaranteed to
+// match on the join filters.
+func (mp *JoinMultiplicity) String() string {
+	return mp.Format(opt.InnerJoinOp)
+}
+
+// isInteresting returns true when the multiplicity properties of an operator
+// differ from the default for that operator. For example, left rows being
+// preserved is interesting for an inner join or semi join, but not for a left
+// join or full join.
+func (mp *JoinMultiplicity) isInteresting(op opt.Operator) bool {
+	switch op {
+	case opt.InnerJoinOp:
+		return mp.JoinFiltersDoNotDuplicateLeftRows() || mp.JoinFiltersDoNotDuplicateRightRows() ||
+			mp.JoinFiltersMatchAllLeftRows() || mp.JoinFiltersMatchAllRightRows()
+
+	case opt.LeftJoinOp:
+		return mp.JoinFiltersDoNotDuplicateLeftRows() || mp.JoinFiltersDoNotDuplicateRightRows() ||
+			mp.JoinFiltersMatchAllRightRows()
+
+	case opt.FullJoinOp:
+		return mp.JoinFiltersDoNotDuplicateLeftRows() || mp.JoinFiltersDoNotDuplicateRightRows()
+
+	case opt.SemiJoinOp:
+		return mp.JoinFiltersMatchAllLeftRows()
+
+	default:
+		panic(errors.AssertionFailedf("invalid operator: %v", op))
+	}
 }

--- a/pkg/sql/opt/props/multiplicity_test.go
+++ b/pkg/sql/opt/props/multiplicity_test.go
@@ -13,6 +13,7 @@ package props
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,62 +77,116 @@ var bothPreservedRightNoDup = JoinMultiplicity{
 	RightMultiplicity: MultiplicityPreservedVal | MultiplicityNotDuplicatedVal,
 }
 
+func TestJoinMultiplicity_JoinFiltersDoNotDuplicateLeftRows(t *testing.T) {
+	require.Equal(t, false, bothIndeterminate.JoinFiltersDoNotDuplicateLeftRows())
+	require.Equal(t, true, bothNoDup.JoinFiltersDoNotDuplicateLeftRows())
+	require.Equal(t, false, bothPreserved.JoinFiltersDoNotDuplicateLeftRows())
+	require.Equal(t, true, bothNoDupBothPreserved.JoinFiltersDoNotDuplicateLeftRows())
+	require.Equal(t, false, leftIndeterminateRightPreserved.JoinFiltersDoNotDuplicateLeftRows())
+	require.Equal(t, false, leftIndeterminateRightNoDup.JoinFiltersDoNotDuplicateLeftRows())
+	require.Equal(t, false, rightIndeterminateLeftPreserved.JoinFiltersDoNotDuplicateLeftRows())
+	require.Equal(t, true, rightIndeterminateLeftNoDup.JoinFiltersDoNotDuplicateLeftRows())
+	require.Equal(t, true, bothNoDupLeftPreserved.JoinFiltersDoNotDuplicateLeftRows())
+	require.Equal(t, true, bothPreservedLeftNoDup.JoinFiltersDoNotDuplicateLeftRows())
+	require.Equal(t, true, bothNoDupRightPreserved.JoinFiltersDoNotDuplicateLeftRows())
+	require.Equal(t, false, bothPreservedRightNoDup.JoinFiltersDoNotDuplicateLeftRows())
+}
+
+func TestJoinMultiplicity_JoinFiltersDoNotDuplicateRightRows(t *testing.T) {
+	require.Equal(t, false, bothIndeterminate.JoinFiltersDoNotDuplicateRightRows())
+	require.Equal(t, true, bothNoDup.JoinFiltersDoNotDuplicateRightRows())
+	require.Equal(t, false, bothPreserved.JoinFiltersDoNotDuplicateRightRows())
+	require.Equal(t, true, bothNoDupBothPreserved.JoinFiltersDoNotDuplicateRightRows())
+	require.Equal(t, false, leftIndeterminateRightPreserved.JoinFiltersDoNotDuplicateRightRows())
+	require.Equal(t, true, leftIndeterminateRightNoDup.JoinFiltersDoNotDuplicateRightRows())
+	require.Equal(t, false, rightIndeterminateLeftPreserved.JoinFiltersDoNotDuplicateRightRows())
+	require.Equal(t, false, rightIndeterminateLeftNoDup.JoinFiltersDoNotDuplicateRightRows())
+	require.Equal(t, true, bothNoDupLeftPreserved.JoinFiltersDoNotDuplicateRightRows())
+	require.Equal(t, false, bothPreservedLeftNoDup.JoinFiltersDoNotDuplicateRightRows())
+	require.Equal(t, true, bothNoDupRightPreserved.JoinFiltersDoNotDuplicateRightRows())
+	require.Equal(t, true, bothPreservedRightNoDup.JoinFiltersDoNotDuplicateRightRows())
+}
+
+func TestJoinMultiplicity_JoinFiltersMatchAllLeftRows(t *testing.T) {
+	require.Equal(t, false, bothIndeterminate.JoinFiltersMatchAllLeftRows())
+	require.Equal(t, false, bothNoDup.JoinFiltersMatchAllLeftRows())
+	require.Equal(t, true, bothPreserved.JoinFiltersMatchAllLeftRows())
+	require.Equal(t, true, bothNoDupBothPreserved.JoinFiltersMatchAllLeftRows())
+	require.Equal(t, false, leftIndeterminateRightPreserved.JoinFiltersMatchAllLeftRows())
+	require.Equal(t, false, leftIndeterminateRightNoDup.JoinFiltersMatchAllLeftRows())
+	require.Equal(t, true, rightIndeterminateLeftPreserved.JoinFiltersMatchAllLeftRows())
+	require.Equal(t, false, rightIndeterminateLeftNoDup.JoinFiltersMatchAllLeftRows())
+	require.Equal(t, true, bothNoDupLeftPreserved.JoinFiltersMatchAllLeftRows())
+	require.Equal(t, true, bothPreservedLeftNoDup.JoinFiltersMatchAllLeftRows())
+	require.Equal(t, false, bothNoDupRightPreserved.JoinFiltersMatchAllLeftRows())
+	require.Equal(t, true, bothPreservedRightNoDup.JoinFiltersMatchAllLeftRows())
+}
+
+func TestJoinMultiplicity_JoinFiltersMatchAllRightRows(t *testing.T) {
+	require.Equal(t, false, bothIndeterminate.JoinFiltersMatchAllRightRows())
+	require.Equal(t, false, bothNoDup.JoinFiltersMatchAllRightRows())
+	require.Equal(t, true, bothPreserved.JoinFiltersMatchAllRightRows())
+	require.Equal(t, true, bothNoDupBothPreserved.JoinFiltersMatchAllRightRows())
+	require.Equal(t, true, leftIndeterminateRightPreserved.JoinFiltersMatchAllRightRows())
+	require.Equal(t, false, leftIndeterminateRightNoDup.JoinFiltersMatchAllRightRows())
+	require.Equal(t, false, rightIndeterminateLeftPreserved.JoinFiltersMatchAllRightRows())
+	require.Equal(t, false, rightIndeterminateLeftNoDup.JoinFiltersMatchAllRightRows())
+	require.Equal(t, false, bothNoDupLeftPreserved.JoinFiltersMatchAllRightRows())
+	require.Equal(t, true, bothPreservedLeftNoDup.JoinFiltersMatchAllRightRows())
+	require.Equal(t, true, bothNoDupRightPreserved.JoinFiltersMatchAllRightRows())
+	require.Equal(t, true, bothPreservedRightNoDup.JoinFiltersMatchAllRightRows())
+}
+
 func TestJoinMultiplicity_JoinDoesNotDuplicateLeftRows(t *testing.T) {
-	require.Equal(t, false, bothIndeterminate.JoinDoesNotDuplicateLeftRows())
-	require.Equal(t, true, bothNoDup.JoinDoesNotDuplicateLeftRows())
-	require.Equal(t, false, bothPreserved.JoinDoesNotDuplicateLeftRows())
-	require.Equal(t, true, bothNoDupBothPreserved.JoinDoesNotDuplicateLeftRows())
-	require.Equal(t, false, leftIndeterminateRightPreserved.JoinDoesNotDuplicateLeftRows())
-	require.Equal(t, false, leftIndeterminateRightNoDup.JoinDoesNotDuplicateLeftRows())
-	require.Equal(t, false, rightIndeterminateLeftPreserved.JoinDoesNotDuplicateLeftRows())
-	require.Equal(t, true, rightIndeterminateLeftNoDup.JoinDoesNotDuplicateLeftRows())
-	require.Equal(t, true, bothNoDupLeftPreserved.JoinDoesNotDuplicateLeftRows())
-	require.Equal(t, true, bothPreservedLeftNoDup.JoinDoesNotDuplicateLeftRows())
-	require.Equal(t, true, bothNoDupRightPreserved.JoinDoesNotDuplicateLeftRows())
-	require.Equal(t, false, bothPreservedRightNoDup.JoinDoesNotDuplicateLeftRows())
+	require.Equal(t, false, bothIndeterminate.JoinDoesNotDuplicateLeftRows(opt.InnerJoinOp))
+	require.Equal(t, false, bothIndeterminate.JoinDoesNotDuplicateLeftRows(opt.LeftJoinOp))
+	require.Equal(t, false, bothIndeterminate.JoinDoesNotDuplicateLeftRows(opt.FullJoinOp))
+	require.Equal(t, true, bothIndeterminate.JoinDoesNotDuplicateLeftRows(opt.SemiJoinOp))
+	require.Equal(
+		t, true, rightIndeterminateLeftNoDup.JoinDoesNotDuplicateLeftRows(opt.InnerJoinOp))
+	require.Equal(
+		t, true, rightIndeterminateLeftNoDup.JoinDoesNotDuplicateLeftRows(opt.LeftJoinOp))
+	require.Equal(
+		t, true, rightIndeterminateLeftNoDup.JoinDoesNotDuplicateLeftRows(opt.FullJoinOp))
+	require.Equal(
+		t, true, rightIndeterminateLeftNoDup.JoinDoesNotDuplicateLeftRows(opt.SemiJoinOp))
 }
 
 func TestJoinMultiplicity_JoinDoesNotDuplicateRightRows(t *testing.T) {
-	require.Equal(t, false, bothIndeterminate.JoinDoesNotDuplicateRightRows())
-	require.Equal(t, true, bothNoDup.JoinDoesNotDuplicateRightRows())
-	require.Equal(t, false, bothPreserved.JoinDoesNotDuplicateRightRows())
-	require.Equal(t, true, bothNoDupBothPreserved.JoinDoesNotDuplicateRightRows())
-	require.Equal(t, false, leftIndeterminateRightPreserved.JoinDoesNotDuplicateRightRows())
-	require.Equal(t, true, leftIndeterminateRightNoDup.JoinDoesNotDuplicateRightRows())
-	require.Equal(t, false, rightIndeterminateLeftPreserved.JoinDoesNotDuplicateRightRows())
-	require.Equal(t, false, rightIndeterminateLeftNoDup.JoinDoesNotDuplicateRightRows())
-	require.Equal(t, true, bothNoDupLeftPreserved.JoinDoesNotDuplicateRightRows())
-	require.Equal(t, false, bothPreservedLeftNoDup.JoinDoesNotDuplicateRightRows())
-	require.Equal(t, true, bothNoDupRightPreserved.JoinDoesNotDuplicateRightRows())
-	require.Equal(t, true, bothPreservedRightNoDup.JoinDoesNotDuplicateRightRows())
+	require.Equal(t, false, bothIndeterminate.JoinDoesNotDuplicateRightRows(opt.InnerJoinOp))
+	require.Equal(t, false, bothIndeterminate.JoinDoesNotDuplicateRightRows(opt.LeftJoinOp))
+	require.Equal(t, false, bothIndeterminate.JoinDoesNotDuplicateRightRows(opt.FullJoinOp))
+	require.Equal(
+		t, true, leftIndeterminateRightNoDup.JoinDoesNotDuplicateRightRows(opt.InnerJoinOp))
+	require.Equal(
+		t, true, leftIndeterminateRightNoDup.JoinDoesNotDuplicateRightRows(opt.LeftJoinOp))
+	require.Equal(
+		t, true, leftIndeterminateRightNoDup.JoinDoesNotDuplicateRightRows(opt.FullJoinOp))
 }
 
 func TestJoinMultiplicity_JoinPreservesLeftRows(t *testing.T) {
-	require.Equal(t, false, bothIndeterminate.JoinPreservesLeftRows())
-	require.Equal(t, false, bothNoDup.JoinPreservesLeftRows())
-	require.Equal(t, true, bothPreserved.JoinPreservesLeftRows())
-	require.Equal(t, true, bothNoDupBothPreserved.JoinPreservesLeftRows())
-	require.Equal(t, false, leftIndeterminateRightPreserved.JoinPreservesLeftRows())
-	require.Equal(t, false, leftIndeterminateRightNoDup.JoinPreservesLeftRows())
-	require.Equal(t, true, rightIndeterminateLeftPreserved.JoinPreservesLeftRows())
-	require.Equal(t, false, rightIndeterminateLeftNoDup.JoinPreservesLeftRows())
-	require.Equal(t, true, bothNoDupLeftPreserved.JoinPreservesLeftRows())
-	require.Equal(t, true, bothPreservedLeftNoDup.JoinPreservesLeftRows())
-	require.Equal(t, false, bothNoDupRightPreserved.JoinPreservesLeftRows())
-	require.Equal(t, true, bothPreservedRightNoDup.JoinPreservesLeftRows())
+	require.Equal(t, false, bothIndeterminate.JoinPreservesLeftRows(opt.InnerJoinOp))
+	require.Equal(t, true, bothIndeterminate.JoinPreservesLeftRows(opt.LeftJoinOp))
+	require.Equal(t, true, bothIndeterminate.JoinPreservesLeftRows(opt.FullJoinOp))
+	require.Equal(t, false, bothIndeterminate.JoinPreservesLeftRows(opt.SemiJoinOp))
+	require.Equal(
+		t, true, rightIndeterminateLeftPreserved.JoinPreservesLeftRows(opt.InnerJoinOp))
+	require.Equal(
+		t, true, rightIndeterminateLeftPreserved.JoinPreservesLeftRows(opt.LeftJoinOp))
+	require.Equal(
+		t, true, rightIndeterminateLeftPreserved.JoinPreservesLeftRows(opt.FullJoinOp))
+	require.Equal(
+		t, true, rightIndeterminateLeftPreserved.JoinPreservesLeftRows(opt.SemiJoinOp))
 }
 
 func TestJoinMultiplicity_JoinPreservesRightRows(t *testing.T) {
-	require.Equal(t, false, bothIndeterminate.JoinPreservesRightRows())
-	require.Equal(t, false, bothNoDup.JoinPreservesRightRows())
-	require.Equal(t, true, bothPreserved.JoinPreservesRightRows())
-	require.Equal(t, true, bothNoDupBothPreserved.JoinPreservesRightRows())
-	require.Equal(t, true, leftIndeterminateRightPreserved.JoinPreservesRightRows())
-	require.Equal(t, false, leftIndeterminateRightNoDup.JoinPreservesRightRows())
-	require.Equal(t, false, rightIndeterminateLeftPreserved.JoinPreservesRightRows())
-	require.Equal(t, false, rightIndeterminateLeftNoDup.JoinPreservesRightRows())
-	require.Equal(t, false, bothNoDupLeftPreserved.JoinPreservesRightRows())
-	require.Equal(t, true, bothPreservedLeftNoDup.JoinPreservesRightRows())
-	require.Equal(t, true, bothNoDupRightPreserved.JoinPreservesRightRows())
-	require.Equal(t, true, bothPreservedRightNoDup.JoinPreservesRightRows())
+	require.Equal(t, false, bothIndeterminate.JoinPreservesRightRows(opt.InnerJoinOp))
+	require.Equal(t, false, bothIndeterminate.JoinPreservesRightRows(opt.LeftJoinOp))
+	require.Equal(t, true, bothIndeterminate.JoinPreservesRightRows(opt.FullJoinOp))
+	require.Equal(
+		t, true, leftIndeterminateRightPreserved.JoinPreservesRightRows(opt.InnerJoinOp))
+	require.Equal(
+		t, true, leftIndeterminateRightPreserved.JoinPreservesRightRows(opt.LeftJoinOp))
+	require.Equal(
+		t, true, leftIndeterminateRightPreserved.JoinPreservesRightRows(opt.FullJoinOp))
 }

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -2125,7 +2125,6 @@ project
  │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(2,3,6,10-14,24,29)
  │    ├── left-join (hash)
  │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14 sum:24 li.productid:27 li.quantity:28
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── immutable
  │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(2,3,6,10-14,24)
  │    │    ├── group-by
@@ -2136,7 +2135,6 @@ project
  │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(2,3,6,10-14,24)
  │    │    │    ├── left-join (hash)
  │    │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14 li.customerid:15 li.ordernumber:16 column23:23
- │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    │    │    ├── immutable
  │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(11-14)
  │    │    │    │    ├── left-join (hash)
@@ -2146,7 +2144,6 @@ project
  │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(11-14)
  │    │    │    │    │    ├── left-join (hash)
  │    │    │    │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10
- │    │    │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    │    │    │    │    ├── key: (1,4,5,7-9)
  │    │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10)
  │    │    │    │    │    │    ├── left-join (merge)

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -92,7 +92,6 @@ project
  │    ├── fd: (75)-->(1,2,7,34,70)
  │    ├── left-join (hash)
  │    │    ├── columns: t.oid:1 t.typname:2!null t.typnamespace:3!null t.typtype:7 t.typbasetype:25 n.oid:33!null nspname:34!null pg_type.oid:38 case:70 rownum:75!null
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    ├── fd: (3)==(33), (33)==(3), (75)-->(1-3,7,25,33,34)
  │    │    ├── ordinality
  │    │    │    ├── columns: t.oid:1 t.typname:2!null t.typnamespace:3!null t.typtype:7 t.typbasetype:25 n.oid:33!null nspname:34!null rownum:75!null

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -175,7 +175,6 @@ SELECT * FROM (SELECT * FROM abc WHERE b=1) FULL OUTER JOIN xyz ON a=z
 ----
 full-join (hash)
  ├── columns: a:1 b:2 c:3 x:5 y:6 z:7
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  ├── scan xyz
  │    └── columns: x:5 y:6 z:7
  ├── scan abc@bc
@@ -294,7 +293,6 @@ SELECT * FROM (SELECT * FROM abc WHERE b=1) RIGHT OUTER JOIN xyz ON a=z
 ----
 left-join (hash)
  ├── columns: a:1 b:2 c:3 x:5 y:6 z:7
- ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  ├── scan xyz
  │    └── columns: x:5 y:6 z:7
  ├── scan abc@bc
@@ -1022,7 +1020,6 @@ GenerateLookupJoins
 Source expression:
   left-join (hash)
    ├── columns: a:1 b:2 c:3 x:5 y:6 z:7
-   ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
    ├── scan xyz
    │    └── columns: x:5 y:6 z:7
    ├── scan abc
@@ -1096,7 +1093,6 @@ GenerateLookupJoins
 Source expression:
   left-join (hash)
    ├── columns: a:1 b:2 c:3 x:5 y:6 z:7
-   ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
    ├── scan abc
    │    └── columns: a:1 b:2 c:3
    ├── scan xyz
@@ -1125,7 +1121,6 @@ GenerateLookupJoins
 Source expression:
   left-join (hash)
    ├── columns: a:1 b:2 c:3 x:5 y:6 z:7
-   ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
    ├── scan xyz
    │    └── columns: x:5 y:6 z:7
    ├── scan abc

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -484,7 +484,6 @@ project
  │    │    │    │    │    ├── fd: (1)-->(6)
  │    │    │    │    │    ├── left-join (cross)
  │    │    │    │    │    │    ├── columns: a1.id:1!null bool:6
- │    │    │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    │    │    │    │    │    ├── scan a1
  │    │    │    │    │    │    │    ├── columns: a1.id:1!null
  │    │    │    │    │    │    │    └── key: (1)


### PR DESCRIPTION
Logical join operators can be modeled as inner joins with additional
operations performed after the inner join. For example, outer joins
produce the same output as an inner join with unmatched rows added
back null-extended. A semi-join is equivalent to an inner join with
project and distinct operators.

Previously, the JoinMultiplicity struct stored information about the
effect a particular join operator has on the rows of its inputs. This
patch modifies JoinMultiplicity to store the hypothetical 'inner join'
properties that result from the join's filters. Take this query for
example:
```
CREATE TABLE xy (x INT PRIMARY KEY, y INT);
CREATE TABLE ab (a INT PRIMARY KEY, b INT);

SELECT * FROM xy LEFT JOIN ab ON x = b;
```
A JoinMultiplicity modeling an inner join with the same inputs as
this left join would assert that the filters are not guaranteed to
match every row for either side of the join. Left rows may be
duplicated because column "b" is not unique. Right rows may not be
duplicated because column "x" is unique.

In order to get the left join properties from the JoinMultiplicity,
all we have to do is set the LeftRowsArePreserved flag to true, since
the left join will add back unmatched left rows.

Modeling the hypothetical inner join properties of a join is useful
because it allows more complex logical operators like semi joins to
be handled in a simple and intuitive way.

In addition to modeling inner join properties, this patch extends
JoinMultiplicity to describe semi joins.

Fixes #47391

Release note: None