### PR TITLE
sql: clean up EXPLAIN output generation

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -11,19 +11,16 @@
 package sql
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"strings"
-	"text/tabwriter"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 	"github.com/cockroachdb/errors"
 )
 
@@ -72,13 +69,21 @@ func (p *planner) makeExplainPlanNodeWithPlan(
 	// Make a copy (to allow changes through planMutableColumns).
 	columns = append(sqlbase.ResultColumns(nil), columns...)
 
-	e := explainer{explainFlags: flags}
+	node := &explainPlanNode{
+		plan:     *plan,
+		stmtType: stmtType,
+		run: explainPlanRun{
+			results: p.newContainerValuesNode(columns, 0),
+		},
+	}
+
+	node.explainer.init(flags)
 
 	noPlaceholderFlags := tree.FmtExpr(
 		tree.FmtSymbolicSubqueries, flags.showTypes, flags.symbolicVars, flags.qualifyNames,
 	)
-	e.fmtFlags = noPlaceholderFlags
-	e.showPlaceholderValues = func(ctx *tree.FmtCtx, placeholder *tree.Placeholder) {
+	node.explainer.fmtFlags = noPlaceholderFlags
+	node.explainer.showPlaceholderValues = func(ctx *tree.FmtCtx, placeholder *tree.Placeholder) {
 		d, err := placeholder.Eval(p.EvalContext())
 		if err != nil {
 			// Disable the placeholder formatter so that
@@ -93,15 +98,6 @@ func (p *planner) makeExplainPlanNodeWithPlan(
 			return
 		}
 		ctx.FormatNode(d)
-	}
-
-	node := &explainPlanNode{
-		explainer: e,
-		plan:      *plan,
-		stmtType:  stmtType,
-		run: explainPlanRun{
-			results: p.newContainerValuesNode(columns, 0),
-		},
 	}
 	return node, nil
 }
@@ -128,15 +124,6 @@ func (e *explainPlanNode) Close(ctx context.Context) {
 		e.plan.checkPlans[i].plan.Close(ctx)
 	}
 	e.run.results.Close(ctx)
-}
-
-// explainEntry is a representation of the info that makes it into an output row
-// of an EXPLAIN statement.
-type explainEntry struct {
-	isNode                bool
-	level                 int
-	node, field, fieldVal string
-	plan                  planNode
 }
 
 // explainFlags contains parameters for the EXPLAIN logic.
@@ -172,11 +159,12 @@ type explainer struct {
 	// Meant for use with FmtCtx.WithPlaceholderFormat().
 	showPlaceholderValues func(ctx *tree.FmtCtx, placeholder *tree.Placeholder)
 
-	// level is the current depth in the tree of planNodes.
-	level int
+	ob *explain.OutputBuilder
+}
 
-	// explainEntry accumulates entries (nodes or attributes).
-	entries []explainEntry
+func (e *explainer) init(flags explainFlags) {
+	*e = explainer{explainFlags: flags}
+	e.ob = explain.NewOutputBuilder(flags.showMetadata, flags.showTypes)
 }
 
 // populateExplain walks the plan and generates rows in a valuesNode.
@@ -229,47 +217,23 @@ func populateExplain(
 		}
 	}
 
-	emitRow := func(
-		treeStr string, level int, node, field, fieldVal, columns, ordering string,
-	) error {
-		var row tree.Datums
-		if !e.showMetadata {
-			row = tree.Datums{
-				tree.NewDString(treeStr),  // Tree
-				tree.NewDString(field),    // Field
-				tree.NewDString(fieldVal), // Description
-			}
-		} else {
-			row = tree.Datums{
-				tree.NewDString(treeStr),       // Tree
-				tree.NewDInt(tree.DInt(level)), // Level
-				tree.NewDString(node),          // Type
-				tree.NewDString(field),         // Field
-				tree.NewDString(fieldVal),      // Description
-				tree.NewDString(columns),       // Columns
-				tree.NewDString(ordering),      // Ordering
-			}
-		}
-		_, err := v.rows.AddRow(params.ctx, row)
-		return err
-	}
-
 	// First, emit the "distribution" and "vectorized" information rows.
-	if err := emitRow("", 0, "", "distribution", distribution.String(), "", ""); err != nil {
-		return err
-	}
-	if err := emitRow("", 0, "", "vectorized", fmt.Sprintf("%t", willVectorize), "", ""); err != nil {
-		return err
-	}
+	e.ob.AddField("distribution", distribution.String())
+	e.ob.AddField("vectorized", fmt.Sprintf("%t", willVectorize))
 
-	e.populateEntries(params.ctx, plan, explainSubqueryFmtFlags)
-	return e.emitRows(emitRow)
+	e.populate(params.ctx, plan, explainSubqueryFmtFlags)
+	rows := e.ob.BuildExplainRows()
+	for _, r := range rows {
+		if _, err := v.rows.AddRow(params.ctx, r); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func (e *explainer) populateEntries(
+func (e *explainer) populate(
 	ctx context.Context, plan *planComponents, subqueryFmtFlags tree.FmtFlags,
 ) {
-	e.entries = nil
 	observer := planObserver{
 		enterNode: e.enterNode,
 		expr:      e.expr,
@@ -371,75 +335,18 @@ func observePlan(
 	return nil
 }
 
-// emitExplainRowFn is used to emit an EXPLAIN row.
-type emitExplainRowFn func(treeStr string, level int, node, field, fieldVal, columns, ordering string) error
-
-// emitRows calls the given function for each populated entry.
-func (e *explainer) emitRows(emitRow emitExplainRowFn) error {
-	tp := treeprinter.New()
-	// n keeps track of the current node on each level.
-	n := []treeprinter.Node{tp}
-
-	for _, entry := range e.entries {
-		if entry.isNode {
-			n = append(n[:entry.level+1], n[entry.level].Child(entry.node))
-		} else {
-			tp.AddEmptyLine()
-		}
-	}
-
-	treeRows := tp.FormattedRows()
-
-	for i, entry := range e.entries {
-		var columns, ordering string
-		if e.showMetadata && entry.plan != nil {
-			cols := planColumns(entry.plan)
-			columns = formatColumns(cols, e.showTypes)
-			ordering = formatOrdering(planReqOrdering(entry.plan), cols)
-		}
-		if err := emitRow(
-			treeRows[i], entry.level, entry.node, entry.field, entry.fieldVal, columns, ordering,
-		); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // planToString builds a string representation of a plan using the EXPLAIN
 // infrastructure.
 func planToString(ctx context.Context, p *planTop) string {
-	e := explainer{
-		explainFlags: explainFlags{
-			showMetadata: true,
-			showTypes:    true,
-		},
-		fmtFlags: tree.FmtExpr(tree.FmtSymbolicSubqueries, true, true, true),
-	}
+	var e explainer
+	e.init(explainFlags{
+		showMetadata: true,
+		showTypes:    true,
+	})
+	e.fmtFlags = tree.FmtExpr(tree.FmtSymbolicSubqueries, true, true, true)
 
-	var buf bytes.Buffer
-	tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
-
-	emitRow := func(
-		treeStr string, level int, node, field, fieldVal, columns, ordering string,
-	) error {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", treeStr, field, fieldVal, columns, ordering)
-		return nil
-	}
-
-	e.populateEntries(ctx, &p.planComponents, explainSubqueryFmtFlags)
-
-	// Our emitRow function never returns errors, so neither will emitRows().
-	_ = e.emitRows(emitRow)
-	_ = tw.Flush()
-
-	// Remove trailing whitespace from each line.
-	result := strings.TrimRight(buf.String(), "\n")
-	buf.Reset()
-	for _, line := range strings.Split(result, "\n") {
-		fmt.Fprintf(&buf, "%s\n", strings.TrimRight(line, " "))
-	}
-	return buf.String()
+	e.populate(ctx, &p.planComponents, explainSubqueryFmtFlags)
+	return e.ob.BuildString()
 }
 
 func getAttrForSpansAll(hardLimitSet bool) string {
@@ -489,68 +396,21 @@ func (e *explainer) expr(v observeVerbosity, nodeName, fieldName string, n int, 
 
 // enterNode implements the planObserver interface.
 func (e *explainer) enterNode(_ context.Context, name string, plan planNode) (bool, error) {
-	e.entries = append(e.entries, explainEntry{
-		isNode: true,
-		level:  e.level,
-		node:   name,
-		plan:   plan,
-	})
-
-	e.level++
+	if plan == nil {
+		e.ob.EnterMetaNode(name)
+	} else {
+		e.ob.EnterNode(name, planColumns(plan), planReqOrdering(plan))
+	}
 	return true, nil
 }
 
 // attr implements the planObserver interface.
 func (e *explainer) attr(nodeName, fieldName, attr string) {
-	e.entries = append(e.entries, explainEntry{
-		isNode:   false,
-		level:    e.level - 1,
-		field:    fieldName,
-		fieldVal: attr,
-	})
+	e.ob.AddField(fieldName, attr)
 }
 
 // leaveNode implements the planObserver interface.
 func (e *explainer) leaveNode(name string, _ planNode) error {
-	e.level--
+	e.ob.LeaveNode()
 	return nil
-}
-
-// formatColumns converts a column signature for a data source /
-// planNode to a string. The column types are printed iff the 2nd
-// argument specifies so.
-func formatColumns(cols sqlbase.ResultColumns, printTypes bool) string {
-	f := tree.NewFmtCtx(tree.FmtSimple)
-	f.WriteByte('(')
-	for i := range cols {
-		rCol := &cols[i]
-		if i > 0 {
-			f.WriteString(", ")
-		}
-		f.FormatNameP(&rCol.Name)
-		// Output extra properties like [hidden,omitted].
-		hasProps := false
-		outputProp := func(prop string) {
-			if hasProps {
-				f.WriteByte(',')
-			} else {
-				f.WriteByte('[')
-			}
-			hasProps = true
-			f.WriteString(prop)
-		}
-		if rCol.Hidden {
-			outputProp("hidden")
-		}
-		if hasProps {
-			f.WriteByte(']')
-		}
-
-		if printTypes {
-			f.WriteByte(' ')
-			f.WriteString(rCol.Typ.String())
-		}
-	}
-	f.WriteByte(')')
-	return f.CloseAndGetString()
 }

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -1,0 +1,174 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package explain
+
+import (
+	"bytes"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
+)
+
+// OutputBuilder is used to build the output of an explain tree.
+//
+// See ExampleOutputBuilder for sample usage.
+type OutputBuilder struct {
+	verbose   bool
+	showTypes bool
+	entries   []entry
+
+	// Current depth level (# of EnterNode() calls - # of LeaveNode() calls).
+	level int
+}
+
+// NewOutputBuilder creates a new OutputBuilder.
+//
+// EnterNode / EnterMetaNode and AddField should be used to populate data, after
+// which a Build* method should be used.
+func NewOutputBuilder(verbose bool, showTypes bool) *OutputBuilder {
+	return &OutputBuilder{verbose: verbose, showTypes: showTypes, level: 0}
+}
+
+type entry struct {
+	// level is non-zero for node entries, zero for field entries.
+	level    int
+	node     string
+	columns  string
+	ordering string
+
+	field    string
+	fieldVal string
+}
+
+func (e *entry) isNode() bool {
+	return e.level > 0
+}
+
+// EnterNode creates a new node as a child of the current node.
+func (ob *OutputBuilder) EnterNode(
+	name string, columns sqlbase.ResultColumns, ordering sqlbase.ColumnOrdering,
+) {
+	var colStr, ordStr string
+	if ob.verbose {
+		colStr = columns.String(ob.showTypes)
+		ordStr = ordering.String(columns)
+	}
+	ob.enterNode(name, colStr, ordStr)
+}
+
+// EnterMetaNode is like EnterNode, but the output will always have empty
+// strings for the columns and ordering. This is used for "meta nodes" like
+// "fk-cascade".
+func (ob *OutputBuilder) EnterMetaNode(name string) {
+	ob.enterNode(name, "", "")
+}
+
+func (ob *OutputBuilder) enterNode(name, columns, ordering string) {
+	ob.level++
+	ob.entries = append(ob.entries, entry{
+		level:    ob.level,
+		node:     name,
+		columns:  columns,
+		ordering: ordering,
+	})
+}
+
+// LeaveNode moves the current node back up the tree by one level.
+func (ob *OutputBuilder) LeaveNode() {
+	ob.level--
+}
+
+// AddField adds an information field under the current node.
+func (ob *OutputBuilder) AddField(key, value string) {
+	ob.entries = append(ob.entries, entry{field: key, fieldVal: value})
+}
+
+// buildTreeRows creates the treeprinter structure; returns one string for each
+// entry in ob.entries.
+func (ob *OutputBuilder) buildTreeRows() []string {
+	// We reconstruct the hierarchy using the levels.
+	// n keeps track of the current node on each level.
+	tp := treeprinter.New()
+	n := []treeprinter.Node{tp}
+
+	for _, entry := range ob.entries {
+		if entry.isNode() {
+			n = append(n[:entry.level], n[entry.level-1].Child(entry.node))
+		} else {
+			tp.AddEmptyLine()
+		}
+	}
+
+	treeRows := tp.FormattedRows()
+	for len(treeRows) < len(ob.entries) {
+		// This shouldn't happen - the formatter should emit one row per entry.
+		// But just in case, add empty strings if necessary to avoid a panic later.
+		treeRows = append(treeRows, "")
+	}
+
+	return treeRows
+}
+
+// BuildExplainRows builds the output rows for an EXPLAIN (PLAN) statement.
+//
+// The columns are:
+//   verbose=false:  Tree Field Description
+//   verbose=true:   Tree Level Type Field Description
+func (ob *OutputBuilder) BuildExplainRows() []tree.Datums {
+	treeRows := ob.buildTreeRows()
+	rows := make([]tree.Datums, len(ob.entries))
+	level := 1
+	for i, e := range ob.entries {
+		if e.isNode() {
+			level = e.level
+		}
+		if !ob.verbose {
+			rows[i] = tree.Datums{
+				tree.NewDString(treeRows[i]), // Tree
+				tree.NewDString(e.field),     // Field
+				tree.NewDString(e.fieldVal),  // Description
+			}
+		} else {
+			rows[i] = tree.Datums{
+				tree.NewDString(treeRows[i]),       // Tree
+				tree.NewDInt(tree.DInt(level - 1)), // Level
+				tree.NewDString(e.node),            // Type
+				tree.NewDString(e.field),           // Field
+				tree.NewDString(e.fieldVal),        // Description
+				tree.NewDString(e.columns),         // Columns
+				tree.NewDString(e.ordering),        // Ordering
+			}
+		}
+	}
+	return rows
+}
+
+// BuildString creates a string representation of the plan information.
+// The output string always ends in a newline.
+func (ob *OutputBuilder) BuildString() string {
+	var buf bytes.Buffer
+	tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
+
+	treeRows := ob.buildTreeRows()
+	for i, e := range ob.entries {
+		fmt.Fprintf(tw, "%s\t%s\t%s", treeRows[i], e.field, e.fieldVal)
+		if ob.verbose {
+			fmt.Fprintf(tw, "\t%s\t%s", e.columns, e.ordering)
+		}
+		fmt.Fprintf(tw, "\n")
+	}
+	_ = tw.Flush()
+	return util.RemoveTrailingSpaces(buf.String())
+}

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -1,0 +1,167 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package explain_test
+
+import (
+	"bytes"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+)
+
+func ExampleOutputBuilder() {
+	example := func(name string, ob *explain.OutputBuilder) {
+		ob.AddField("distributed", "true")
+		ob.EnterMetaNode("meta")
+		{
+			ob.EnterNode(
+				"render",
+				sqlbase.ResultColumns{{Name: "a", Typ: types.Int}, {Name: "b", Typ: types.String}},
+				sqlbase.ColumnOrdering{
+					{ColIdx: 0, Direction: encoding.Ascending},
+					{ColIdx: 1, Direction: encoding.Descending},
+				},
+			)
+			ob.AddField("render 0", "foo")
+			ob.AddField("render 1", "bar")
+			{
+				ob.EnterNode("join", sqlbase.ResultColumns{{Name: "x", Typ: types.Int}}, nil)
+				ob.AddField("type", "outer")
+				{
+					{
+						ob.EnterNode("scan", sqlbase.ResultColumns{{Name: "x", Typ: types.Int}}, nil)
+						ob.AddField("table", "foo")
+						ob.LeaveNode()
+					}
+					{
+						ob.EnterNode("scan", nil, nil) // Columns should show up as "()".
+						ob.AddField("table", "bar")
+						ob.LeaveNode()
+					}
+				}
+				ob.LeaveNode()
+			}
+			ob.LeaveNode()
+		}
+		ob.LeaveNode()
+
+		rows := ob.BuildExplainRows()
+
+		var buf bytes.Buffer
+		tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
+		for _, r := range rows {
+			for j := range r {
+				if j > 0 {
+					fmt.Fprint(tw, "\t")
+				}
+				fmt.Fprint(tw, tree.AsStringWithFlags(r[j], tree.FmtExport))
+			}
+			fmt.Fprint(tw, "\n")
+		}
+		_ = tw.Flush()
+
+		fmt.Printf("-- %s (datums) --\n", name)
+		fmt.Print(util.RemoveTrailingSpaces(buf.String()))
+
+		fmt.Printf("\n-- %s (string) --\n", name)
+		fmt.Print(ob.BuildString())
+		fmt.Printf("\n")
+	}
+
+	example("basic", explain.NewOutputBuilder(false /* verbose */, false /* showTypes */))
+	example("verbose", explain.NewOutputBuilder(true /* verbose */, false /* showTypes */))
+	example("verbose+types", explain.NewOutputBuilder(true /* verbose */, true /* showTypes */))
+
+	// Output:
+	// -- basic (datums) --
+	//                      distributed  true
+	// meta
+	//  └── render
+	//       │              render 0     foo
+	//       │              render 1     bar
+	//       └── join
+	//            │         type         outer
+	//            ├── scan
+	//            │         table        foo
+	//            └── scan
+	//                      table        bar
+	//
+	// -- basic (string) --
+	//                      distributed  true
+	// meta
+	//  └── render
+	//       │              render 0     foo
+	//       │              render 1     bar
+	//       └── join
+	//            │         type         outer
+	//            ├── scan
+	//            │         table        foo
+	//            └── scan
+	//                      table        bar
+	//
+	// -- verbose (datums) --
+	//                      0          distributed  true
+	// meta                 0  meta
+	//  └── render          1  render                      (a, b)  +a,-b
+	//       │              1          render 0     foo
+	//       │              1          render 1     bar
+	//       └── join       2  join                        (x)
+	//            │         2          type         outer
+	//            ├── scan  3  scan                        (x)
+	//            │         3          table        foo
+	//            └── scan  3  scan                        ()
+	//                      3          table        bar
+	//
+	// -- verbose (string) --
+	//                      distributed  true
+	// meta
+	//  └── render                              (a, b)  +a,-b
+	//       │              render 0     foo
+	//       │              render 1     bar
+	//       └── join                           (x)
+	//            │         type         outer
+	//            ├── scan                      (x)
+	//            │         table        foo
+	//            └── scan                      ()
+	//                      table        bar
+	//
+	// -- verbose+types (datums) --
+	//                      0          distributed  true
+	// meta                 0  meta
+	//  └── render          1  render                      (a int, b string)  +a,-b
+	//       │              1          render 0     foo
+	//       │              1          render 1     bar
+	//       └── join       2  join                        (x int)
+	//            │         2          type         outer
+	//            ├── scan  3  scan                        (x int)
+	//            │         3          table        foo
+	//            └── scan  3  scan                        ()
+	//                      3          table        bar
+	//
+	// -- verbose+types (string) --
+	//                      distributed  true
+	// meta
+	//  └── render                              (a int, b string)  +a,-b
+	//       │              render 0     foo
+	//       │              render 1     bar
+	//       └── join                           (x int)
+	//            │         type         outer
+	//            ├── scan                      (x int)
+	//            │         table        foo
+	//            └── scan                      ()
+	//                      table        bar
+}

--- a/pkg/sql/sqlbase/ordering.go
+++ b/pkg/sql/sqlbase/ordering.go
@@ -11,6 +11,8 @@
 package sqlbase
 
 import (
+	"bytes"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
@@ -26,6 +28,26 @@ type ColumnOrderInfo struct {
 //     []ColumnOrderInfo{ {3, encoding.Descending}, {1, encoding.Ascending} }
 // represents an ordering first by column 3 (descending), then by column 1 (ascending).
 type ColumnOrdering []ColumnOrderInfo
+
+func (ordering ColumnOrdering) String(columns ResultColumns) string {
+	var buf bytes.Buffer
+	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
+	for i, o := range ordering {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		prefix := byte('+')
+		if o.Direction == encoding.Descending {
+			prefix = byte('-')
+		}
+		buf.WriteByte(prefix)
+
+		fmtCtx.FormatNameP(&columns[o.ColIdx].Name)
+		_, _ = fmtCtx.WriteTo(&buf)
+	}
+	fmtCtx.Close()
+	return buf.String()
+}
 
 // NoOrdering is used to indicate an empty ColumnOrdering.
 var NoOrdering ColumnOrdering

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -11,6 +11,9 @@
 package util
 
 import (
+	"bytes"
+	"fmt"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/cockroachdb/errors"
@@ -63,4 +66,19 @@ func TruncateString(s string, maxRunes int) string {
 	}
 	// This code should be unreachable.
 	return s
+}
+
+// RemoveTrailingSpaces splits the input string into lines, trims any trailing
+// spaces from each line, then puts the lines back together.
+//
+// Any newlines at the end of the input string are ignored.
+//
+// The output string always ends in a newline.
+func RemoveTrailingSpaces(input string) string {
+	lines := strings.TrimRight(input, "\n")
+	var buf bytes.Buffer
+	for _, line := range strings.Split(lines, "\n") {
+		fmt.Fprintf(&buf, "%s\n", strings.TrimRight(line, " "))
+	}
+	return buf.String()
 }

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -87,3 +87,29 @@ func TestTruncateString(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoveTrailingSpaces(t *testing.T) {
+	for _, tc := range []struct{ input, expected string }{
+		{
+			input:    "",
+			expected: "\n",
+		},
+		{
+			input:    "line 1  \nline 2   \nline 3 \n\n",
+			expected: "line 1\nline 2\nline 3\n",
+		},
+		{
+			input:    " line 1  \nline 2   \nline 3  ",
+			expected: " line 1\nline 2\nline 3\n",
+		},
+		{
+			input:    "line 1\n\n  \nline 2   \nline 3",
+			expected: "line 1\n\n\nline 2\nline 3\n",
+		},
+	} {
+		output := RemoveTrailingSpaces(tc.input)
+		if output != tc.expected {
+			t.Errorf("expected:\n%s\ngot:\n%s", tc.expected, output)
+		}
+	}
+}


### PR DESCRIPTION
This change reimplements the code that generates EXPLAIN output as a
separate library with a simple API. See `ExampleOutputBuilder` for an
example. This cleans up the sql code and will allow reuse from the new
explain factory.

The change also moves columns and ordering formatting routines to sqlbase.

Release note: None