### PR TITLE
release-19.2: builtins: fix possible out of bounds in regexp_replace

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1211,6 +1211,22 @@ SELECT regexp_replace('ReRe','R(e)','1\\1','g');
 ----
 1\11\1
 
+# Regression test for #51289.
+query T
+SELECT regexp_replace('TIMESTAMP(6)', '.*(\((\d+)\))?.*', '\2')
+----
+·
+
+query T
+SELECT regexp_replace('TIMESTAMP(6)', '.*(\((\d+)\)).*', '\2')
+----
+6
+
+query T
+SELECT regexp_replace('TIMESTAMP(6)', '.*(\((\d+)\)?).*', '\2')
+----
+6
+
 query B
 SELECT unique_rowid() < unique_rowid()
 ----

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4360,11 +4360,16 @@ func regexpReplace(ctx *tree.EvalContext, s, pattern, to, sqlFlags string) (tree
 						// & refers to the entire match.
 						newString.WriteString(s[matchStart:matchEnd])
 					} else {
-						idx := int(to[i] - '0')
-						// regexpReplace expects references to "out-of-bounds" capture groups
-						// to be ignored.
-						if 2*idx < len(matchIndex) {
-							newString.WriteString(s[matchIndex[2*idx]:matchIndex[2*idx+1]])
+						captureGroupNumber := int(to[i] - '0')
+						// regexpReplace expects references to "out-of-bounds"
+						// and empty (when the corresponding match indices
+						// are negative) capture groups to be ignored.
+						if matchIndexPos := 2 * captureGroupNumber; matchIndexPos < len(matchIndex) {
+							startPos := matchIndex[matchIndexPos]
+							endPos := matchIndex[matchIndexPos+1]
+							if startPos >= 0 {
+								newString.WriteString(s[startPos:endPos])
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Backport 1/1 commits from #51303.

/cc @cockroachdb/release

---

It is possible that a regex matches the input string yet capture
groups end up being empty. Previously, in such cases we would hit an
internal error (due to out of bounds panic because values in
`matchIndex` would be negative), and now this is fixed by making sure
that capture groups are not empty.

Fixes: #51289.

Release note (bug fix): Previously, CockroachDB could hit an
internal error when executing `regexp_replace` builtin, and
this has been fixed.
