### PR TITLE
opt: remove SYMVARS modifier to EXPLAIN

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -53,15 +53,12 @@ type explainPlanNode struct {
 func (p *planner) makeExplainPlanNodeWithPlan(
 	ctx context.Context, opts *tree.ExplainOptions, plan *planComponents, stmtType tree.StatementType,
 ) (planNode, error) {
-	flags := explainFlags{
-		symbolicVars: opts.Flags[tree.ExplainFlagSymVars],
-	}
-	if opts.Flags[tree.ExplainFlagVerbose] {
+	var flags explainFlags
+	if opts.Flags[tree.ExplainFlagVerbose] || opts.Flags[tree.ExplainFlagTypes] {
 		flags.showMetadata = true
 		flags.qualifyNames = true
 	}
 	if opts.Flags[tree.ExplainFlagTypes] {
-		flags.showMetadata = true
 		flags.showTypes = true
 	}
 
@@ -75,7 +72,7 @@ func (p *planner) makeExplainPlanNodeWithPlan(
 	e := explainer{explainFlags: flags}
 
 	noPlaceholderFlags := tree.FmtExpr(
-		tree.FmtSymbolicSubqueries, flags.showTypes, flags.symbolicVars, flags.qualifyNames,
+		tree.FmtSymbolicSubqueries, flags.showTypes, false /* symbolicVars */, flags.qualifyNames,
 	)
 	e.fmtFlags = noPlaceholderFlags
 	e.showPlaceholderValues = func(ctx *tree.FmtCtx, placeholder *tree.Placeholder) {
@@ -149,10 +146,6 @@ type explainFlags struct {
 	// qualifyNames determines whether column names in expressions
 	// should be fully qualified during pretty-printing.
 	qualifyNames bool
-
-	// symbolicVars determines whether ordinal column references
-	// should be printed numerically.
-	symbolicVars bool
 
 	// showTypes indicates whether to print the type of embedded
 	// expressions and result columns.

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -645,15 +645,6 @@ scan  ·             ·          (k int, v int)  ·
 ·     spans         FULL SCAN  ·               ·
 
 query TTTTT
-EXPLAIN (TYPES,SYMVARS) SELECT k FROM t
-----
-·     distribution  local      ·        ·
-·     vectorized    true       ·        ·
-scan  ·             ·          (k int)  ·
-·     table         t@primary  ·        ·
-·     spans         FULL SCAN  ·        ·
-
-query TTTTT
 EXPLAIN (TYPES,VERBOSE) SELECT k FROM t
 ----
 ·     distribution  local      ·        ·

--- a/pkg/sql/opt/optbuilder/testdata/explain
+++ b/pkg/sql/opt/optbuilder/testdata/explain
@@ -11,14 +11,6 @@ explain
       └── columns: x:1!null y:2
 
 build
-EXPLAIN (PLAN,SYMVARS) SELECT * FROM xy
-----
-explain
- ├── columns: tree:3 field:4 description:5
- └── scan xy
-      └── columns: x:1!null y:2
-
-build
 EXPLAIN (TYPES) SELECT * FROM xy
 ----
 explain

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -87,7 +87,6 @@ type ExplainFlag uint8
 // Explain flags.
 const (
 	ExplainFlagVerbose ExplainFlag = 1 + iota
-	ExplainFlagSymVars
 	ExplainFlagTypes
 	ExplainFlagAnalyze
 	ExplainFlagEnv
@@ -98,7 +97,6 @@ const (
 
 var explainFlagStrings = [...]string{
 	ExplainFlagVerbose: "VERBOSE",
-	ExplainFlagSymVars: "SYMVARS",
 	ExplainFlagTypes:   "TYPES",
 	ExplainFlagAnalyze: "ANALYZE",
 	ExplainFlagEnv:     "ENV",


### PR DESCRIPTION
Remove this modifier which is not useful anymore.

We also make TYPES a strict superset of VERBOSE (there was one
internal flag that was set for VERBOSE but not for TYPES).

Release note (sql change): removed the SYMVAR modifier to
EXPLAIN (PLAN).