### PR TITLE
sql: implement datetime_precision column in information_schema.columns

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -572,9 +572,17 @@ func numericScale(colType *types.T) tree.Datum {
 	})
 }
 
+// datetimePrecision returns the declared or implicit precision of Time,
+// Timestamp or Interval data types. Returns false if the data type is not
+// a Time, Timestamp or Interval.
 func datetimePrecision(colType *types.T) tree.Datum {
-	// We currently do not support a datetime precision.
-	return tree.DNull
+	return dIntFnOrNull(func() (int32, bool) {
+		switch colType.Family() {
+		case types.TimeFamily, types.TimeTZFamily, types.TimestampFamily, types.TimestampTZFamily, types.IntervalFamily:
+			return colType.Precision(), true
+		}
+		return 0, false
+	})
 }
 
 var informationSchemaConstraintColumnUsageTable = virtualSchemaTable{

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1478,6 +1478,40 @@ num_prec    rowid        64                 2                        0          
 statement ok
 DROP TABLE num_prec
 
+statement ok
+CREATE TABLE time_prec (
+  a TIME, 
+  b TIME(0),
+  c TIMETZ,
+  d TIMETZ(1),
+  e TIMESTAMP, 
+  f TIMESTAMP(2), 
+  g TIMESTAMPTZ,
+  h TIMESTAMPTZ(3),
+  i INTERVAL,
+  j INTERVAL(6))
+
+query TTIIII colnames
+SELECT table_name, column_name, numeric_precision, numeric_precision_radix, numeric_scale, datetime_precision
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'time_prec'
+----
+table_name  column_name  numeric_precision  numeric_precision_radix  numeric_scale  datetime_precision
+time_prec   a            NULL               NULL                     NULL           6
+time_prec   b            NULL               NULL                     NULL           0
+time_prec   c            NULL               NULL                     NULL           6
+time_prec   d            NULL               NULL                     NULL           1
+time_prec   e            NULL               NULL                     NULL           6
+time_prec   f            NULL               NULL                     NULL           2
+time_prec   g            NULL               NULL                     NULL           6
+time_prec   h            NULL               NULL                     NULL           3
+time_prec   i            NULL               NULL                     NULL           6
+time_prec   j            NULL               NULL                     NULL           6
+time_prec   rowid        64                 2                        0              NULL
+
+statement ok
+DROP TABLE time_prec
+
 ## information_schema.key_column_usage
 ## information_schema.referential_constraints
 


### PR DESCRIPTION
Before: The datetime_precision column was null for all types.

Why: Useful for users to reverse engineer the data type of columns in
a user table.

Now: The datetime_precision column shows the precision for columns with
type `TIME`/`TIMETZ`, `TIMESTAMP`/`TIMESTAMPTZ` and `INTERVAL`, and is null for
any other types.

Resolves #51286

Release note (sql change): Implement the datetime_precision column in
the information_schema.columns table for time-stored values.