### PR TITLE
sql: clean up explain flags

### DIFF
--- a/pkg/sql/opt/exec/explain/flags.go
+++ b/pkg/sql/opt/exec/explain/flags.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package explain
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
+// Flags are modifiers for EXPLAIN (PLAN).
+type Flags struct {
+	// Verbose indicates that more metadata is shown, and plan columns and
+	// ordering are shown.
+	Verbose bool
+	// ShowTypes indicates that the types of columns are shown.
+	// If ShowTypes is true, then Verbose is also true.
+	ShowTypes bool
+}
+
+// MakeFlags crates Flags from ExplainOptions.
+func MakeFlags(options *tree.ExplainOptions) Flags {
+	var f Flags
+	if options.Flags[tree.ExplainFlagVerbose] {
+		f.Verbose = true
+	}
+	if options.Flags[tree.ExplainFlagTypes] {
+		f.Verbose = true
+		f.ShowTypes = true
+	}
+	return f
+}

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -24,7 +24,8 @@ import (
 )
 
 func ExampleOutputBuilder() {
-	example := func(name string, ob *explain.OutputBuilder) {
+	example := func(name string, flags explain.Flags) {
+		ob := explain.NewOutputBuilder(flags)
 		ob.AddField("distributed", "true")
 		ob.EnterMetaNode("meta")
 		{
@@ -82,9 +83,9 @@ func ExampleOutputBuilder() {
 		fmt.Printf("\n")
 	}
 
-	example("basic", explain.NewOutputBuilder(false /* verbose */, false /* showTypes */))
-	example("verbose", explain.NewOutputBuilder(true /* verbose */, false /* showTypes */))
-	example("verbose+types", explain.NewOutputBuilder(true /* verbose */, true /* showTypes */))
+	example("basic", explain.Flags{})
+	example("verbose", explain.Flags{Verbose: true})
+	example("verbose+types", explain.Flags{Verbose: true, ShowTypes: true})
 
 	// Output:
 	// -- basic (datums) --


### PR DESCRIPTION
This change simplifies explain flags and moves them to `exec/explain`.

Release note: None