### PR TITLE
pgwire: minor cleanup

### DIFF
--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx"
 	"github.com/jackc/pgx/pgproto3"
@@ -112,7 +111,7 @@ func TestConn(t *testing.T) {
 			nil,
 			mon.BoundAccount{}, /* reserved */
 			authOptions{testingSkipAuth: true},
-			s.Stopper())
+		)
 		return nil
 	})
 	defer stopServe()
@@ -836,9 +835,6 @@ func TestMaliciousInputs(t *testing.T) {
 				close(errChan)
 			}()
 
-			stopper := stop.NewStopper()
-			defer stopper.Stop(ctx)
-
 			sqlMetrics := sql.MakeMemMetrics("test" /* endpoint */, time.Second /* histogramWindow */)
 			metrics := makeServerMetrics(sqlMetrics, time.Second /* histogramWindow */)
 
@@ -856,7 +852,6 @@ func TestMaliciousInputs(t *testing.T) {
 				nil,                          /* sqlServer */
 				mon.BoundAccount{},           /* reserved */
 				authOptions{testingSkipAuth: true},
-				stopper,
 			)
 			if err := <-errChan; err != nil {
 				t.Fatal(err)

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -180,8 +180,6 @@ type Server struct {
 	sqlMemoryPool mon.BytesMonitor
 	connMonitor   mon.BytesMonitor
 
-	stopper *stop.Stopper
-
 	// testingLogEnabled is used in unit tests in this package to
 	// force-enable conn/auth logging without dancing around the
 	// asynchronicity of cluster settings.
@@ -283,7 +281,6 @@ func Match(rd io.Reader) bool {
 
 // Start makes the Server ready for serving connections.
 func (s *Server) Start(ctx context.Context, stopper *stop.Stopper) {
-	s.stopper = stopper
 	s.SQLServer.Start(ctx, stopper)
 }
 


### PR DESCRIPTION
This commit removes some unused arguments and fixes some typos.

Release note: None