### PR TITLE
sql: do not fallback to old namespace table for non-public schema

### DIFF
--- a/pkg/sql/catalog/catalogkv/physical_accessor.go
+++ b/pkg/sql/catalog/catalogkv/physical_accessor.go
@@ -104,29 +104,6 @@ func (a UncachedPhysicalAccessor) GetObjectNames(
 	if err != nil {
 		return nil, err
 	}
-	// We scan both the deprecated and new system.namespace table to get the
-	// complete list of tables. Duplicate entries may be present in both the tables,
-	// so we filter those out. If a duplicate entry is present, it doesn't matter
-	// which table it is read from -- system.namespace entries are never modified,
-	// they are only added/deleted. Entries are written to only one table, so
-	// duplicate entries must have been copied over during migration. Thus, it
-	// doesn't matter which table (newer/deprecated) the value is read from.
-	//
-	// It may seem counter-intuitive to read both tables if we have found data in
-	// the newer version. The migration copied all entries from the deprecated
-	// system.namespace and all new entries after the cluster version bump are added
-	// to the new system.namespace. Why do we do this then?
-	// This is to account the scenario where a table was created before
-	// the cluster version was bumped, but after the older system.namespace was
-	// copied into the newer system.namespace. Objects created in this window
-	// will only be present in the older system.namespace. To account for this
-	// scenario, we must do this filtering logic.
-	// TODO(solon): This complexity can be removed in  20.2.
-	dprefix := sqlbase.NewDeprecatedTableKey(dbDesc.GetID(), "").Key(codec)
-	dsr, err := txn.Scan(ctx, dprefix, dprefix.PrefixEnd(), 0)
-	if err != nil {
-		return nil, err
-	}
 
 	alreadySeen := make(map[string]bool)
 	var tableNames tree.TableNames
@@ -144,6 +121,36 @@ func (a UncachedPhysicalAccessor) GetObjectNames(
 		tableNames = append(tableNames, tn)
 	}
 
+	// When constructing the list of entries under the `public` schema (and only
+	// when constructing the list for the `public` schema), We scan both the
+	// deprecated and new system.namespace table to get the complete list of
+	// tables. Duplicate entries may be present in both the tables, so we filter
+	// those out. If a duplicate entry is present, it doesn't matter which table
+	// it is read from -- system.namespace entries are never modified, they are
+	// only added/deleted. Entries are written to only one table, so duplicate
+	// entries must have been copied over during migration. Thus, it doesn't
+	// matter which table (newer/deprecated) the value is read from.
+	//
+	// It may seem counter-intuitive to read both tables if we have found data in
+	// the newer version. The migration copied all entries from the deprecated
+	// system.namespace and all new entries after the cluster version bump are added
+	// to the new system.namespace. Why do we do this then?
+	// This is to account the scenario where a table was created before
+	// the cluster version was bumped, but after the older system.namespace was
+	// copied into the newer system.namespace. Objects created in this window
+	// will only be present in the older system.namespace. To account for this
+	// scenario, we must do this filtering logic.
+	// TODO(solon): This complexity can be removed in  20.2.
+	if scName != tree.PublicSchema {
+		return tableNames, nil
+	}
+
+	dprefix := sqlbase.NewDeprecatedTableKey(dbDesc.GetID(), "").Key(codec)
+	dsr, err := txn.Scan(ctx, dprefix, dprefix.PrefixEnd(), 0)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, row := range dsr {
 		// Decode using the deprecated key prefix.
 		_, tableName, err := encoding.DecodeUnsafeStringAscending(
@@ -159,6 +166,7 @@ func (a UncachedPhysicalAccessor) GetObjectNames(
 		tn.ExplicitSchema = flags.ExplicitPrefix
 		tableNames = append(tableNames, tn)
 	}
+
 	return tableNames, nil
 }
 

--- a/pkg/sql/temporary_schema_test.go
+++ b/pkg/sql/temporary_schema_test.go
@@ -19,7 +19,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -37,6 +39,10 @@ import (
 func TestCleanupSchemaObjects(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	// TODO(arul): Investigate why we need this -- the job executes serially
+	// and we are just running drop statements in the job. Ideally this should
+	// not require disabling leases, but the test fails if we don't. See #52412.
+	defer lease.TestingDisableTableLeases()()
 
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
@@ -58,24 +64,10 @@ INSERT INTO perm_table VALUES (DEFAULT, 1);
 `)
 	require.NoError(t, err)
 
-	rows, err := conn.QueryContext(ctx, `SELECT id, name FROM system.namespace`)
-	require.NoError(t, err)
-
-	namesToID := make(map[string]sqlbase.ID)
-	var schemaName string
-	for rows.Next() {
-		var id int64
-		var name string
-		err := rows.Scan(&id, &name)
-		require.NoError(t, err)
-
-		namesToID[name] = sqlbase.ID(id)
-		if strings.HasPrefix(name, sessiondata.PgTempSchemaName) {
-			schemaName = name
-		}
-	}
-
-	require.NotEqual(t, "", schemaName)
+	namesToID, tempSchemaNames := constructNameToIDMapping(ctx, t, conn)
+	require.Equal(t, len(tempSchemaNames), 1, "unexpected number of temp schemas")
+	tempSchemaName := tempSchemaNames[0]
+	require.NotEqual(t, "", tempSchemaName)
 
 	tempNames := []string{
 		"a",
@@ -85,12 +77,12 @@ INSERT INTO perm_table VALUES (DEFAULT, 1);
 		"a_b_seq",
 	}
 	selectableTempNames := []string{"a", "a_view"}
-	for _, name := range append(tempNames, schemaName) {
+	for _, name := range append(tempNames, tempSchemaName) {
 		require.Contains(t, namesToID, name)
 	}
 	for _, name := range selectableTempNames {
 		// Check tables are accessible.
-		_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.%s", schemaName, name))
+		_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.%s", tempSchemaName, name))
 		require.NoError(t, err)
 	}
 
@@ -105,27 +97,14 @@ INSERT INTO perm_table VALUES (DEFAULT, 1);
 				execCfg.Codec,
 				s.InternalExecutor().(*InternalExecutor),
 				namesToID["defaultdb"],
-				schemaName,
+				tempSchemaName,
 			)
 			require.NoError(t, err)
 			return nil
 		}),
 	)
 
-	for _, name := range selectableTempNames {
-		// Ensure all the entries for the given temporary structures are gone.
-		// This can take a longer amount of time if the job takes time / lease doesn't expire in time.
-		testutils.SucceedsSoon(t, func() error {
-			_, err := conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.%s", schemaName, name))
-			if err != nil {
-				if !strings.Contains(err.Error(), fmt.Sprintf(`relation "%s.%s" does not exist`, schemaName, name)) {
-					return errors.Errorf("expected %s.%s error to resolve relation not existing", schemaName, name)
-				}
-				return nil //nolint:returnerrcheck
-			}
-			return errors.Errorf("expected %s.%s to be deleted", schemaName, name)
-		})
-	}
+	ensureTemporaryObjectsAreDeleted(ctx, t, conn, tempSchemaName, tempNames)
 
 	// Check perm_table performs correctly, and has the right schema.
 	_, err = db.Query("SELECT * FROM perm_table")
@@ -138,6 +117,89 @@ INSERT INTO perm_table VALUES (DEFAULT, 1);
 	).Scan(&colDefault)
 	require.NoError(t, err)
 	assert.False(t, colDefault.Valid)
+}
+
+// Regression test for #51219, where the TempSchemaObject cleaner was trying to
+// clean up some objects under the public schema which had been present before
+// 19.2 upgrade because of a bug in the namespace fallback logic.
+func TestCleanupSchemaObjectsAfterVersionUpgrade(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	// TODO(arul): Same comment as above about testing leases. See #52412.
+	defer lease.TestingDisableTableLeases()()
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	s, db, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+
+	_, err = conn.ExecContext(ctx, `
+SET experimental_enable_temp_tables=true;
+CREATE TEMP TABLE a_temp (a INT, c INT);
+CREATE SEQUENCE perm_sequence;
+CREATE TABLE perm_table (a INT, b INT);
+INSERT INTO perm_table VALUES (3, 4);
+`)
+	require.NoError(t, err)
+
+	namesToID, tempSchemaNames := constructNameToIDMapping(ctx, t, conn)
+	require.Equal(t, len(tempSchemaNames), 1, "unexpected number of temp schemas")
+	tempSchemaName := tempSchemaNames[0]
+	require.NotEqual(t, "", tempSchemaName)
+
+	// Simulate 19.2 -> 20.1 upgrade by placing perm_table and perm_sequence in
+	// the old namespace table.
+	deprecatedTbKey := sqlbase.NewDeprecatedTableKey(
+		namesToID["defaultdb"], "perm_table").Key(keys.SystemSQLCodec)
+	deprecatedSeqKey := sqlbase.NewDeprecatedTableKey(
+		namesToID["defaultdb"], "perm_sequence").Key(keys.SystemSQLCodec)
+	err = kvDB.CPut(ctx, deprecatedTbKey, namesToID["perm_table"], nil)
+	require.NoError(t, err)
+	err = kvDB.CPut(ctx, deprecatedSeqKey, namesToID["perm_sequence"], nil)
+	require.NoError(t, err)
+
+	tempNames := []string{
+		"a_temp",
+	}
+	for _, name := range append(tempNames, tempSchemaName) {
+		require.Contains(t, namesToID, name)
+	}
+	for _, name := range tempNames {
+		// Check tables are accessible.
+		_, err = conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.%s", tempSchemaName, name))
+		require.NoError(t, err)
+	}
+
+	require.NoError(
+		t,
+		kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			execCfg := s.ExecutorConfig().(ExecutorConfig)
+			err = cleanupSchemaObjects(
+				ctx,
+				execCfg.Settings,
+				txn,
+				execCfg.Codec,
+				s.InternalExecutor().(*InternalExecutor),
+				namesToID["defaultdb"],
+				tempSchemaName,
+			)
+			require.NoError(t, err)
+			return nil
+		}),
+	)
+
+	ensureTemporaryObjectsAreDeleted(ctx, t, conn, tempSchemaName, tempNames)
+
+	// Check perm_table performs correctly, and has the right schema.
+	_, err = db.Query("SELECT * FROM perm_table")
+	require.NoError(t, err)
+
+	// Check perm_sequence performs correctly and has the right schema.
+	_, err = db.Query("SELECT * FROM perm_sequence")
+	require.NoError(t, err)
 }
 
 func TestTemporaryObjectCleaner(t *testing.T) {
@@ -271,4 +333,43 @@ func TestTemporarySchemaDropDatabase(t *testing.T) {
 		).Scan(&tempObjectCount)
 		assert.Equal(t, 0, tempObjectCount)
 	}
+}
+
+// ensureTemporaryObjectsAreDeleted ensures all the tempNames have been deleted.
+// This can take a longer amount of time if the job takes time.
+func ensureTemporaryObjectsAreDeleted(
+	ctx context.Context, t *testing.T, conn *gosql.Conn, schemaName string, tempNames []string,
+) {
+	for _, name := range tempNames {
+		_, err := conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s.%s", schemaName, name))
+		if err != nil {
+			if !strings.Contains(err.Error(), fmt.Sprintf(`relation "%s.%s" does not exist`, schemaName, name)) {
+				t.Fatal(errors.Errorf("expected %s.%s error to resolve relation not existing", schemaName, name))
+			}
+		}
+	}
+}
+
+// constructNameToIDMapping constructs and returns a mapping of names to IDs for
+// all objects in system.namespace along with the temp schemas.
+func constructNameToIDMapping(
+	ctx context.Context, t *testing.T, conn *gosql.Conn,
+) (map[string]sqlbase.ID, []string) {
+	rows, err := conn.QueryContext(ctx, `SELECT id, name FROM system.namespace`)
+	require.NoError(t, err)
+
+	namesToID := make(map[string]sqlbase.ID)
+	tempSchemaNames := make([]string, 0)
+	for rows.Next() {
+		var id int64
+		var name string
+		err := rows.Scan(&id, &name)
+		require.NoError(t, err)
+
+		namesToID[name] = sqlbase.ID(id)
+		if strings.HasPrefix(name, sessiondata.PgTempSchemaName) {
+			tempSchemaNames = append(tempSchemaNames, name)
+		}
+	}
+	return namesToID, tempSchemaNames
 }


### PR DESCRIPTION
Previously, `GetObjectNames` would fallback to the old namespace table
unconditionally. This was incorrect when looking for objects under a
schema which wasn't `public`, as entries in the old namespace table are
implied to exist under the `public` schema. This manifested itself in
unintended scenarios, such as #51219, where we would try to delete all
objects constructed before 20.1 upgrade -- erroneously assuming they
are temporary objects.

This PR fixes that by ensuring the fallback logic only applies to
the `public` schema name case. Additionally this patch adds tests
to guard against the aforementioned bug.

Closes #51358

Release note (bug fix): A bug with temporary object cleaner was stuck
trying to remove objects that it mistakenly thought were temporary is
fixed. Note that no persistent data was deleted -- the temporary
cleaner simply errored out because it thought certain persistent data
was temporary.