### PR TITLE
sql: add a virtual index on the pg_catalog.pg_type.OID

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1373,6 +1373,29 @@ oid    typname  typowner  typlen  typbyval  typtype
 
 user root
 
+query OTOOIBT colnames
+SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype
+FROM pg_catalog.pg_type
+WHERE oid = 1000
+----
+oid     typname        typnamespace  typowner  typlen  typbyval  typtype
+1000    _bool          1307062959    NULL      -1      false     b
+
+query OTOOIBT colnames
+SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype
+FROM pg_catalog.pg_type
+WHERE oid = 100063
+----
+oid     typname        typnamespace  typowner  typlen  typbyval  typtype
+100063  newtype1       1307062959    NULL      -1      false     e
+
+query OTOOIBT colnames
+SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype
+FROM pg_catalog.pg_type
+WHERE oid = 1
+----
+oid     typname        typnamespace  typowner  typlen  typbyval  typtype
+
 ## pg_catalog.pg_proc
 
 query TOOOTTO colnames

--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -267,3 +267,9 @@ TABLE abx
            ├── table=59 index=1 (1 key column)
            └── table=60 index=1 (1 key column)
 scan abx
+
+query T
+EXPLAIN (OPT) select * from pg_type where oid = 1000
+----
+  scan pg_type@pg_type_oid_idx
+   └── constraint: /2: [/1000 - /1000]

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2710,13 +2710,12 @@ func addPGTypeRow(
 	)
 }
 
-// TODO (rohany): We should add a virtual index on OID here. See #49208.
 var pgCatalogTypeTable = virtualSchemaTable{
 	comment: `scalar types (incomplete)
 https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 	schema: `
 CREATE TABLE pg_catalog.pg_type (
-	oid OID,
+	oid OID NOT NULL,
 	typname NAME NOT NULL,
 	typnamespace OID,
 	typowner OID,
@@ -2746,7 +2745,8 @@ CREATE TABLE pg_catalog.pg_type (
 	typcollation OID,
 	typdefaultbin STRING,
 	typdefault STRING,
-	typacl STRING[]
+	typacl STRING[],
+  INDEX(oid)
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
@@ -2762,7 +2762,6 @@ CREATE TABLE pg_catalog.pg_type (
 				}
 
 				// Now generate rows for user defined types in this database.
-
 				return forEachTypeDesc(ctx, p, dbContext, func(_ *sqlbase.ImmutableDatabaseDescriptor, _ string, typDesc *sqlbase.ImmutableTypeDescriptor) error {
 					typ, err := typDesc.MakeTypesT(
 						tree.NewUnqualifiedTypeName(tree.Name(typDesc.GetName())),
@@ -2774,6 +2773,52 @@ CREATE TABLE pg_catalog.pg_type (
 					return addPGTypeRow(h, nspOid, typ, addRow)
 				})
 			})
+	},
+	indexes: []virtualIndex{
+		{
+			partial: false,
+			populate: func(ctx context.Context, constraint tree.Datum, p *planner, db *sqlbase.ImmutableDatabaseDescriptor,
+				addRow func(...tree.Datum) error) (bool, error) {
+
+				h := makeOidHasher()
+				nspOid := h.NamespaceOid(db, pgCatalogName)
+				coid := tree.MustBeDOid(constraint)
+				ooid := oid.Oid(int(coid.DInt))
+
+				// Check if it is a predefined type.
+				typ, ok := types.OidToType[ooid]
+				if ok {
+					if err := addPGTypeRow(h, nspOid, typ, addRow); err != nil {
+						return false, err
+					}
+					return true, nil
+				}
+
+				// Check if it is a user defined type.
+				id := sqlbase.ID(types.UserDefinedTypeOIDToID(ooid))
+				// TODO (rohany): This access should go through the desc.Collection.
+				typDesc, err := sqlbase.GetTypeDescFromID(ctx, p.txn, keys.SystemSQLCodec, id)
+				if err != nil {
+					if errors.Is(err, sqlbase.ErrDescriptorNotFound) {
+						return false, nil
+					}
+					return false, err
+				}
+				typ, err = typDesc.MakeTypesT(
+					tree.NewUnqualifiedTypeName(tree.Name(typDesc.GetName())),
+					p.makeTypeLookupFn(ctx),
+				)
+				if err != nil {
+					return false, err
+				}
+				if err := addPGTypeRow(h, nspOid, typ, addRow); err != nil {
+					return false, err
+				}
+
+				// No errors and matches.
+				return false, nil
+			},
+		},
 	},
 }
 


### PR DESCRIPTION
Fixes #49208

Release note (performance improvement): scans over virtual
table pg_type by OID column have improved performance in common cases.