### PR TITLE
rowexec: add test to verify uncertainty errors are properly returned

### DIFF
--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -101,8 +101,12 @@ func (c *Columnarizer) Next(context.Context) coldata.Batch {
 	for ; nRows < coldata.BatchSize(); nRows++ {
 		row, meta := c.input.Next()
 		if meta != nil {
-			c.accumulatedMeta = append(c.accumulatedMeta, *meta)
 			nRows--
+			if meta.Err != nil {
+				// If an error occurs, return it immediately.
+				colexecerror.ExpectedError(meta.Err)
+			}
+			c.accumulatedMeta = append(c.accumulatedMeta, *meta)
 			continue
 		}
 		if row == nil {

--- a/pkg/sql/colexec/routers.go
+++ b/pkg/sql/colexec/routers.go
@@ -42,8 +42,16 @@ type routerOutput interface {
 	// the output. It returns whether or not the output changed its state to
 	// blocked (see implementations).
 	addBatch(context.Context, coldata.Batch, []int) bool
-	// cancel tells the output to stop producing batches.
-	cancel(ctx context.Context)
+	// cancel tells the output to stop producing batches. Optionally forwards an
+	// error if not nil.
+	cancel(context.Context, error)
+	// forwardErr forwards an error to the output. The output should call
+	// colexecerror.ExpectedError with this error on the next call to Next.
+	// Calling forwardErr multiple times will result in the most recent error
+	// overwriting the previous error.
+	forwardErr(error)
+	// resetForTests resets the routerOutput for a benchmark or test run.
+	resetForTests(context.Context)
 }
 
 // getDefaultRouterOutputBlockedThreshold returns the number of unread values
@@ -78,7 +86,7 @@ type drainCoordinator interface {
 	// encounteredError should be called when a routerOutput encounters an error.
 	// This terminates execution. No locks should be held when calling this
 	// method, since cancellation could occur.
-	encounteredError(context.Context, error)
+	encounteredError(context.Context)
 	// drainMeta should be called exactly once when the routerOutput moves to
 	// draining.
 	drainMeta() []execinfrapb.ProducerMetadata
@@ -100,6 +108,9 @@ type routerOutputOp struct {
 	mu struct {
 		syncutil.Mutex
 		state routerOutputOpState
+		// forwardedErr is an error that was forwarded by the HashRouter. If set,
+		// any subsequent calls to Next will return this error.
+		forwardedErr error
 		// unlimitedAllocator tracks the memory usage of this router output,
 		// providing a signal for when it should spill to disk.
 		// The memory lifecycle is as follows:
@@ -245,7 +256,7 @@ func (o *routerOutputOp) nextErrorLocked(ctx context.Context, err error) {
 	o.maybeUnblockLocked()
 	// Unlock the mutex, since the HashRouter will cancel all outputs.
 	o.mu.Unlock()
-	o.drainCoordinator.encounteredError(ctx, err)
+	o.drainCoordinator.encounteredError(ctx)
 	o.mu.Lock()
 	colexecerror.InternalError(err)
 }
@@ -256,9 +267,12 @@ func (o *routerOutputOp) nextErrorLocked(ctx context.Context, err error) {
 func (o *routerOutputOp) Next(ctx context.Context) coldata.Batch {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	for o.mu.state == routerOutputOpRunning && o.mu.pendingBatch == nil && o.mu.data.empty() {
+	for o.mu.forwardedErr == nil && o.mu.state == routerOutputOpRunning && o.mu.pendingBatch == nil && o.mu.data.empty() {
 		// Wait until there is data to read or the output is canceled.
 		o.mu.cond.Wait()
+	}
+	if o.mu.forwardedErr != nil {
+		colexecerror.ExpectedError(o.mu.forwardedErr)
 	}
 	if o.mu.state == routerOutputOpDraining {
 		return coldata.ZeroBatch
@@ -325,13 +339,27 @@ func (o *routerOutputOp) closeLocked(ctx context.Context) {
 // cancel wakes up a reader in Next if there is one and results in the output
 // returning zero length batches for every Next call after cancel. Note that
 // all accumulated data that hasn't been read will not be returned.
-func (o *routerOutputOp) cancel(ctx context.Context) {
+func (o *routerOutputOp) cancel(ctx context.Context, err error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.closeLocked(ctx)
+	o.forwardErrLocked(err)
 	// Some goroutine might be waiting on the condition variable, so wake it up.
 	// Note that read goroutines check o.mu.done, so won't wait on the condition
 	// variable after we unlock the mutex.
+	o.mu.cond.Signal()
+}
+
+func (o *routerOutputOp) forwardErrLocked(err error) {
+	if err != nil {
+		o.mu.forwardedErr = err
+	}
+}
+
+func (o *routerOutputOp) forwardErr(err error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.forwardErrLocked(err)
 	o.mu.cond.Signal()
 }
 
@@ -449,11 +477,12 @@ func (o *routerOutputOp) maybeUnblockLocked() {
 	}
 }
 
-// resetForBenchmarks resets the routerOutputOp for a benchmark run.
-func (o *routerOutputOp) resetForBenchmarks(ctx context.Context) {
+// resetForTests resets the routerOutputOp for a test or benchmark run.
+func (o *routerOutputOp) resetForTests(ctx context.Context) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.mu.state = routerOutputOpRunning
+	o.mu.forwardedErr = nil
 	o.mu.data.reset(ctx)
 	o.mu.numUnread = 0
 	o.mu.blocked = false
@@ -605,20 +634,22 @@ func newHashRouterWithOutputs(
 	return r
 }
 
-// bufferErr buffers the given error to be returned by one of the router outputs.
-func (r *HashRouter) bufferErr(err error) {
-	if err == nil {
-		return
-	}
-	r.bufferedMeta = append(r.bufferedMeta, execinfrapb.ProducerMetadata{Err: err})
-}
-
-func (r *HashRouter) cancelOutputs(ctx context.Context) {
+// cancelOutputs cancels all outputs and forwards the given error to one output
+// if non-nil. The only case where the error is not forwarded if no output could
+// be canceled due to an error. In this case each output will forward the error
+// returned during cancellation.
+func (r *HashRouter) cancelOutputs(ctx context.Context, errToForward error) {
 	for _, o := range r.outputs {
 		if err := colexecerror.CatchVectorizedRuntimeError(func() {
-			o.cancel(ctx)
+			o.cancel(ctx, errToForward)
 		}); err != nil {
-			r.bufferErr(err)
+			// If there was an error canceling this output, this error can be
+			// forwarded to whoever is calling Next.
+			o.forwardErr(err)
+		} else {
+			// Successful cancellation, which means errToForward was also consumed.
+			// Set it to nil to not forward it to another output.
+			errToForward = nil
 		}
 	}
 }
@@ -641,15 +672,6 @@ func (r *HashRouter) Run(ctx context.Context) {
 	// well for more fine-grained control of error propagation.
 	if err := colexecerror.CatchVectorizedRuntimeError(func() {
 		r.input.Init()
-		// bufferErrAndCancelOutputs buffers non-nil error as metadata, cancels all
-		// of the outputs additionally buffering any error if such occurs during the
-		// outputs' cancellation as metadata as well. Note that it attempts to
-		// cancel every output regardless of whether "previous" output's
-		// cancellation succeeds.
-		bufferErrAndCancelOutputs := func(err error) {
-			r.bufferErr(err)
-			r.cancelOutputs(ctx)
-		}
 		var done bool
 		processNextBatch := func() {
 			done = r.processNextBatch(ctx)
@@ -662,7 +684,7 @@ func (r *HashRouter) Run(ctx context.Context) {
 			// Check for cancellation.
 			select {
 			case <-ctx.Done():
-				bufferErrAndCancelOutputs(ctx.Err())
+				r.cancelOutputs(ctx, ctx.Err())
 				return
 			default:
 			}
@@ -685,13 +707,13 @@ func (r *HashRouter) Run(ctx context.Context) {
 				case <-r.unblockedEventsChan:
 					r.numBlockedOutputs--
 				case <-ctx.Done():
-					bufferErrAndCancelOutputs(ctx.Err())
+					r.cancelOutputs(ctx, ctx.Err())
 					return
 				}
 			}
 
 			if err := colexecerror.CatchVectorizedRuntimeError(processNextBatch); err != nil {
-				bufferErrAndCancelOutputs(err)
+				r.cancelOutputs(ctx, err)
 				return
 			}
 			if done {
@@ -701,7 +723,7 @@ func (r *HashRouter) Run(ctx context.Context) {
 			}
 		}
 	}); err != nil {
-		r.bufferErr(err)
+		r.cancelOutputs(ctx, err)
 	}
 
 	// Non-blocking send of metadata so that one of the outputs can return it
@@ -738,8 +760,8 @@ func (r *HashRouter) processNextBatch(ctx context.Context) bool {
 	return false
 }
 
-// resetForBenchmarks resets the HashRouter for a benchmark run.
-func (r *HashRouter) resetForBenchmarks(ctx context.Context) {
+// resetForTests resets the HashRouter for a test or benchmark run.
+func (r *HashRouter) resetForTests(ctx context.Context) {
 	if i, ok := r.input.(resetter); ok {
 		i.reset(ctx)
 	}
@@ -756,19 +778,17 @@ func (r *HashRouter) resetForBenchmarks(ctx context.Context) {
 		}
 	}
 	for _, o := range r.outputs {
-		if op, ok := o.(*routerOutputOp); ok {
-			op.resetForBenchmarks(ctx)
-		}
+		o.resetForTests(ctx)
 	}
 }
 
-func (r *HashRouter) encounteredError(ctx context.Context, err error) {
+func (r *HashRouter) encounteredError(ctx context.Context) {
 	// Once one output returns an error the hash router needs to stop running
 	// and drain its input.
 	r.setDrainState(hashRouterDrainStateRequested)
 	// cancel all outputs. The Run goroutine will eventually realize that the
 	// HashRouter is done and exit without draining.
-	r.cancelOutputs(ctx)
+	r.cancelOutputs(ctx, nil /* errToForward */)
 }
 
 func (r *HashRouter) drainMeta() []execinfrapb.ProducerMetadata {

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -239,7 +239,7 @@ func TestRouterOutputNext(t *testing.T) {
 			// CancelUnblocksReader verifies that calling cancel on an output unblocks
 			// a reader.
 			unblockEvent: func(_ colexecbase.Operator, o *routerOutputOp) {
-				o.cancel(ctx)
+				o.cancel(ctx, nil /* err */)
 			},
 			expected: tuples{},
 			name:     "CancelUnblocksReader",
@@ -517,7 +517,7 @@ func TestRouterOutputRandom(t *testing.T) {
 						}
 
 						if rng.Float64() < 0.1 {
-							o.cancel(ctx)
+							o.cancel(ctx, nil /* err */)
 							canceled = true
 							errCh <- nil
 							return
@@ -578,15 +578,16 @@ func TestRouterOutputRandom(t *testing.T) {
 
 type callbackRouterOutput struct {
 	colexecbase.ZeroInputNode
-	addBatchCb func(coldata.Batch, []int) bool
-	cancelCb   func()
+	addBatchCb   func(coldata.Batch, []int) bool
+	cancelCb     func()
+	forwardedErr error
 }
 
-var _ routerOutput = callbackRouterOutput{}
+var _ routerOutput = &callbackRouterOutput{}
 
-func (o callbackRouterOutput) initWithHashRouter(*HashRouter) {}
+func (o *callbackRouterOutput) initWithHashRouter(*HashRouter) {}
 
-func (o callbackRouterOutput) addBatch(
+func (o *callbackRouterOutput) addBatch(
 	_ context.Context, batch coldata.Batch, selection []int,
 ) bool {
 	if o.addBatchCb != nil {
@@ -595,10 +596,18 @@ func (o callbackRouterOutput) addBatch(
 	return false
 }
 
-func (o callbackRouterOutput) cancel(context.Context) {
+func (o *callbackRouterOutput) cancel(context.Context, error) {
 	if o.cancelCb != nil {
 		o.cancelCb()
 	}
+}
+
+func (o *callbackRouterOutput) forwardErr(err error) {
+	o.forwardedErr = err
+}
+
+func (o *callbackRouterOutput) resetForTests(context.Context) {
+	o.forwardedErr = nil
 }
 
 func TestHashRouterComputesDestination(t *testing.T) {
@@ -640,7 +649,7 @@ func TestHashRouterComputesDestination(t *testing.T) {
 	for i := range outputs {
 		// Capture the index.
 		outputIdx := i
-		outputs[i] = callbackRouterOutput{
+		outputs[i] = &callbackRouterOutput{
 			addBatchCb: func(batch coldata.Batch, sel []int) bool {
 				for _, j := range sel {
 					key := batch.ColVec(0).Int64()[j]
@@ -679,18 +688,19 @@ func TestHashRouterCancellation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	outputs := make([]routerOutput, 4)
+	outputs := make([]*callbackRouterOutput, 4)
+	routerOutputs := make([]routerOutput, 4)
 	numCancels := int64(0)
 	numAddBatches := int64(0)
 	for i := range outputs {
-		// We'll just be checking canceled.
-		outputs[i] = callbackRouterOutput{
+		outputs[i] = &callbackRouterOutput{
 			addBatchCb: func(_ coldata.Batch, _ []int) bool {
 				atomic.AddInt64(&numAddBatches, 1)
 				return false
 			},
 			cancelCb: func() { atomic.AddInt64(&numCancels, 1) },
 		}
+		routerOutputs[i] = outputs[i]
 	}
 
 	typs := []*types.T{types.Int}
@@ -700,23 +710,11 @@ func TestHashRouterCancellation(t *testing.T) {
 	in := colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 
 	unbufferedCh := make(chan struct{})
-	r := newHashRouterWithOutputs(in, typs, []uint32{0}, unbufferedCh, outputs, nil /* toDrain */, nil /* toClose */)
-	drainMeta := func(t *testing.T) []execinfrapb.ProducerMetadata {
-		var metadata []execinfrapb.ProducerMetadata
-		for range outputs {
-			if routerMeta := r.drainMeta(); routerMeta != nil {
-				if metadata != nil {
-					t.Fatal("HashRouter returned metadata more than once, only the last output to call drainMeta should have received metadata")
-				}
-				metadata = routerMeta
-			}
-		}
-		return metadata
-	}
+	r := newHashRouterWithOutputs(in, typs, []uint32{0}, unbufferedCh, routerOutputs, nil /* toDrain */, nil /* toClose */)
 
 	t.Run("BeforeRun", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		r.resetForBenchmarks(ctx)
+		r.resetForTests(ctx)
 		cancel()
 		r.Run(ctx)
 
@@ -727,10 +725,6 @@ func TestHashRouterCancellation(t *testing.T) {
 		if numAddBatches != 0 {
 			t.Fatalf("detected %d addBatch calls but expected 0", numAddBatches)
 		}
-
-		meta := drainMeta(t)
-		require.Equal(t, 1, len(meta))
-		require.True(t, testutils.IsError(meta[0].Err, "context canceled"), meta[0].Err)
 	})
 
 	testCases := []struct {
@@ -753,7 +747,7 @@ func TestHashRouterCancellation(t *testing.T) {
 			numAddBatches = 0
 
 			ctx, cancel := context.WithCancel(context.Background())
-			r.resetForBenchmarks(ctx)
+			r.resetForTests(ctx)
 
 			if tc.blocked {
 				r.numBlockedOutputs = len(outputs)
@@ -782,9 +776,6 @@ func TestHashRouterCancellation(t *testing.T) {
 			}
 			cancel()
 			<-doneCh
-			meta := drainMeta(t)
-			require.Equal(t, 1, len(meta), "expected one metadata message but got: %v", meta)
-			require.True(t, testutils.IsError(meta[0].Err, "canceled"), meta[0].Err)
 
 			if numCancels != int64(len(outputs)) {
 				t.Fatalf("expected %d canceled outputs, actual %d", len(outputs), numCancels)
@@ -927,13 +918,13 @@ func TestHashRouterRandom(t *testing.T) {
 	)
 
 	testName := fmt.Sprintf(
-		"numOutputs=%d/blockedThreshold=%d/outputSize=%d/totalInputSize=%d/hashCols=%v/terminationScenario=%d",
+		"terminationScenario=%d/numOutputs=%d/blockedThreshold=%d/outputSize=%d/totalInputSize=%d/hashCols=%v",
+		terminationScenario,
 		numOutputs,
 		blockedThreshold,
 		outputSize,
 		len(data),
 		hashCols,
-		terminationScenario,
 	)
 
 	queueCfg, cleanup, memoryTestCases := getDiskQueueCfgAndMemoryTestCases(t, rng)
@@ -1084,7 +1075,7 @@ func TestHashRouterRandom(t *testing.T) {
 				metadata := metadataMu.metadata
 				checkMetadata := func(t *testing.T, expectedErrMsgs []string) {
 					t.Helper()
-					require.Equal(t, 1, len(metadataMu.metadata), "one output (the last to exit) should return metadata")
+					require.Equal(t, 1, len(metadata), "one output (the last to exit) should return metadata")
 
 					require.Equal(t, len(expectedErrMsgs), len(metadata[0]), "unexpected number of metadata messages")
 					var actualErrMsgs []string
@@ -1104,6 +1095,31 @@ func TestHashRouterRandom(t *testing.T) {
 					t.Helper()
 					for i := range resultsByOp {
 						require.NoError(t, resultsByOp[i].err)
+					}
+				}
+				requireOneError := func(t *testing.T, err error) {
+					t.Helper()
+					if err == nil {
+						t.Fatal("use requireNoErrors instead")
+					}
+					for i := range resultsByOp {
+						if err == nil {
+							// A match was already found. Since we only expect one error, this
+							// error must be nil.
+							require.Nil(t, resultsByOp[i].err, "expected error to be nil")
+							continue
+						}
+						if resultsByOp[i].err == nil {
+							// This result has no error but we have not yet found the expected
+							// error, continue to another result.
+							continue
+						}
+						require.True(t, testutils.IsError(resultsByOp[i].err, err.Error()), "unexpected error %v", resultsByOp[i].err)
+						err = nil
+					}
+					if err != nil {
+						// err is set to nil when a match is found.
+						t.Fatal("no matching error found")
 					}
 				}
 
@@ -1140,13 +1156,11 @@ func TestHashRouterRandom(t *testing.T) {
 						}
 					}
 				case hashRouterContextCanceled:
-					// Outputs won't observe an error in this case, the cancellation error
-					// is propagated when/if the outputs are drained.
-					requireNoErrors(t)
-					checkMetadata(t, []string{hashRouterMetadataMsg, context.Canceled.Error()})
+					requireOneError(t, context.Canceled)
+					checkMetadata(t, []string{hashRouterMetadataMsg})
 				case hashRouterOutputErrorOnAddBatch:
-					requireNoErrors(t)
-					checkMetadata(t, []string{hashRouterMetadataMsg, addBatchErrMsg})
+					requireOneError(t, errors.New(addBatchErrMsg))
+					checkMetadata(t, []string{hashRouterMetadataMsg})
 				case hashRouterOutputErrorOnNext:
 					// If an error is encountered in Next, it is returned to the caller,
 					// not as metadata by the HashRouter.
@@ -1236,7 +1250,7 @@ func BenchmarkHashRouter(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					input.ResetBatchesToReturn(numInputBatches)
-					r.resetForBenchmarks(ctx)
+					r.resetForTests(ctx)
 					wg.Add(len(outputs))
 					for j := range outputs {
 						go func(j int) {

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -229,9 +229,7 @@ func TestOutboxInbox(t *testing.T) {
 
 		inboxMemAcc := testMemMonitor.MakeBoundAccount()
 		defer inboxMemAcc.Close(ctx)
-		inbox, err := NewInbox(
-			colmem.NewAllocator(ctx, &inboxMemAcc, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0),
-		)
+		inbox, err := NewInbox(ctx, colmem.NewAllocator(ctx, &inboxMemAcc, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 
 		streamHandlerErrCh := handleStream(serverStream.Context(), inbox, serverStream, func() { close(serverStreamNotification.Donec) })
@@ -505,10 +503,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 
 			inboxMemAcc := testMemMonitor.MakeBoundAccount()
 			defer inboxMemAcc.Close(ctx)
-			inbox, err := NewInbox(
-				colmem.NewAllocator(ctx, &inboxMemAcc, coldata.StandardColumnFactory),
-				typs, execinfrapb.StreamID(0),
-			)
+			inbox, err := NewInbox(ctx, colmem.NewAllocator(ctx, &inboxMemAcc, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0))
 			require.NoError(t, err)
 
 			var (
@@ -578,9 +573,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 
 	inboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer inboxMemAcc.Close(ctx)
-	inbox, err := NewInbox(
-		colmem.NewAllocator(ctx, &inboxMemAcc, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0),
-	)
+	inbox, err := NewInbox(ctx, colmem.NewAllocator(ctx, &inboxMemAcc, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0))
 	require.NoError(b, err)
 
 	var wg sync.WaitGroup
@@ -702,7 +695,7 @@ func TestInboxCtxStreamIDTagging(t *testing.T) {
 
 			typs := []*types.T{types.Int}
 
-			inbox, err := NewInbox(testAllocator, typs, streamID)
+			inbox, err := NewInbox(ctx, testAllocator, typs, streamID)
 			require.NoError(t, err)
 
 			ctxExtract := make(chan struct{})

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -90,6 +90,14 @@ type Inbox struct {
 	// only the Next/DrainMeta goroutine may access it.
 	stream flowStreamServer
 
+	// flowCtx is a temporary field that captures a flow's context during
+	// initialization. This is so that RunWithStream can listen for cancellation
+	// even in the case in which Next is not called (e.g. in cases where the Inbox
+	// is the left side of a HashJoiner). The best solution for this problem would
+	// be to refactor Operator.Init to accept a context since that must be called
+	// regardless of whether or not Next is called.
+	flowCtx context.Context
+
 	scratch struct {
 		data []*array.Data
 		b    coldata.Batch
@@ -100,7 +108,7 @@ var _ colexecbase.Operator = &Inbox{}
 
 // NewInbox creates a new Inbox.
 func NewInbox(
-	allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
+	ctx context.Context, allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
 ) (*Inbox, error) {
 	c, err := colserde.NewArrowBatchConverter(typs)
 	if err != nil {
@@ -119,6 +127,7 @@ func NewInbox(
 		contextCh:  make(chan context.Context, 1),
 		timeoutCh:  make(chan error, 1),
 		errCh:      make(chan error, 1),
+		flowCtx:    ctx,
 	}
 	i.scratch.data = make([]*array.Data, len(typs))
 	i.scratch.b = allocator.NewMemBatch(typs)
@@ -190,6 +199,8 @@ func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer
 		log.VEvent(streamCtx, 2, "Inbox reader arrived")
 	case <-streamCtx.Done():
 		return fmt.Errorf("%s: streamCtx while waiting for reader (remote client canceled)", streamCtx.Err())
+	case <-i.flowCtx.Done():
+		return fmt.Errorf("%s: flowCtx while waiting for reader (local server canceled)", i.flowCtx.Err())
 	}
 
 	// Now wait for one of the events described in the method comment. If a

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -61,7 +61,7 @@ func TestInboxCancellation(t *testing.T) {
 
 	typs := []*types.T{types.Int}
 	t.Run("ReaderWaitingForStreamHandler", func(t *testing.T) {
-		inbox, err := NewInbox(testAllocator, typs, execinfrapb.StreamID(0))
+		inbox, err := NewInbox(context.Background(), testAllocator, typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 		ctx, cancelFn := context.WithCancel(context.Background())
 		// Cancel the context.
@@ -76,7 +76,7 @@ func TestInboxCancellation(t *testing.T) {
 
 	t.Run("DuringRecv", func(t *testing.T) {
 		rpcLayer := makeMockFlowStreamRPCLayer()
-		inbox, err := NewInbox(testAllocator, typs, execinfrapb.StreamID(0))
+		inbox, err := NewInbox(context.Background(), testAllocator, typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 		ctx, cancelFn := context.WithCancel(context.Background())
 
@@ -107,7 +107,7 @@ func TestInboxCancellation(t *testing.T) {
 
 	t.Run("StreamHandlerWaitingForReader", func(t *testing.T) {
 		rpcLayer := makeMockFlowStreamRPCLayer()
-		inbox, err := NewInbox(testAllocator, typs, execinfrapb.StreamID(0))
+		inbox, err := NewInbox(context.Background(), testAllocator, typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 
 		ctx, cancelFn := context.WithCancel(context.Background())
@@ -125,7 +125,7 @@ func TestInboxCancellation(t *testing.T) {
 func TestInboxNextPanicDoesntLeakGoroutines(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	inbox, err := NewInbox(testAllocator, []*types.T{types.Int}, execinfrapb.StreamID(0))
+	inbox, err := NewInbox(context.Background(), testAllocator, []*types.T{types.Int}, execinfrapb.StreamID(0))
 	require.NoError(t, err)
 
 	rpcLayer := makeMockFlowStreamRPCLayer()
@@ -152,7 +152,7 @@ func TestInboxTimeout(t *testing.T) {
 
 	ctx := context.Background()
 
-	inbox, err := NewInbox(testAllocator, []*types.T{types.Int}, execinfrapb.StreamID(0))
+	inbox, err := NewInbox(ctx, testAllocator, []*types.T{types.Int}, execinfrapb.StreamID(0))
 	require.NoError(t, err)
 
 	var (
@@ -255,10 +255,7 @@ func TestInboxShutdown(t *testing.T) {
 					inboxCtx, inboxCancel := context.WithCancel(context.Background())
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(inboxCtx)
-					inbox, err := NewInbox(
-						colmem.NewAllocator(inboxCtx, &inboxMemAccount, coldata.StandardColumnFactory),
-						typs, execinfrapb.StreamID(0),
-					)
+					inbox, err := NewInbox(context.Background(), colmem.NewAllocator(inboxCtx, &inboxMemAccount, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0))
 					require.NoError(t, err)
 					c, err := colserde.NewArrowBatchConverter(typs)
 					require.NoError(t, err)

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -55,9 +55,7 @@ func TestOutboxCatchesPanics(t *testing.T) {
 
 	inboxMemAccount := testMemMonitor.MakeBoundAccount()
 	defer inboxMemAccount.Close(ctx)
-	inbox, err := NewInbox(
-		colmem.NewAllocator(ctx, &inboxMemAccount, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0),
-	)
+	inbox, err := NewInbox(ctx, colmem.NewAllocator(ctx, &inboxMemAccount, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0))
 	require.NoError(t, err)
 
 	streamHandlerErrCh := handleStream(ctx, inbox, rpcLayer.server, func() { close(rpcLayer.server.csChan) })

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -208,7 +208,10 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(ctxLocal)
 					inbox, err := colrpc.NewInbox(
-						colmem.NewAllocator(ctxLocal, &inboxMemAccount, testColumnFactory), typs, execinfrapb.StreamID(streamID),
+						ctxLocal,
+						colmem.NewAllocator(ctxLocal, &inboxMemAccount, testColumnFactory),
+						typs,
+						execinfrapb.StreamID(streamID),
 					)
 					require.NoError(t, err)
 					inboxes = append(inboxes, inbox)
@@ -288,7 +291,15 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 						remoteAllocator := colmem.NewAllocator(ctxRemote, &sourceMemAccount, testColumnFactory)
 						batch := remoteAllocator.NewMemBatch(typs)
 						batch.SetLength(coldata.BatchSize())
-						runOutboxInbox(ctxRemote, cancelRemote, &outboxMemAccount, colexecbase.NewRepeatableBatchSource(remoteAllocator, batch, typs), inboxes[i], streamID, []execinfrapb.MetadataSource{createMetadataSourceForID(streamID)})
+						runOutboxInbox(
+							ctxRemote,
+							cancelRemote,
+							&outboxMemAccount,
+							colexecbase.NewRepeatableBatchSource(remoteAllocator, batch, typs),
+							inboxes[i],
+							streamID,
+							[]execinfrapb.MetadataSource{createMetadataSourceForID(streamID)},
+						)
 					}
 					streamID++
 				}
@@ -300,14 +311,24 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(ctxAnotherRemote)
 					inbox, err := colrpc.NewInbox(
+						ctxAnotherRemote,
 						colmem.NewAllocator(ctxAnotherRemote, &inboxMemAccount, testColumnFactory),
-						typs, execinfrapb.StreamID(streamID),
+						typs,
+						execinfrapb.StreamID(streamID),
 					)
 					require.NoError(t, err)
 					inboxes = append(inboxes, inbox)
 					outboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer outboxMemAccount.Close(ctxAnotherRemote)
-					runOutboxInbox(ctxAnotherRemote, cancelAnotherRemote, &outboxMemAccount, synchronizer, inbox, streamID, []execinfrapb.MetadataSource{materializerMetadataSource, createMetadataSourceForID(streamID)})
+					runOutboxInbox(
+						ctxAnotherRemote,
+						cancelAnotherRemote,
+						&outboxMemAccount,
+						synchronizer,
+						inbox,
+						streamID,
+						[]execinfrapb.MetadataSource{materializerMetadataSource, createMetadataSourceForID(streamID)},
+					)
 					streamID++
 					// There is now only a single Inbox on the "local" node which is the
 					// only metadata source.

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -50,7 +50,7 @@ func (c callbackRemoteComponentCreator) newOutbox(
 }
 
 func (c callbackRemoteComponentCreator) newInbox(
-	allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
+	ctx context.Context, allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
 ) (*colrpc.Inbox, error) {
 	return c.newInboxFn(allocator, typs, streamID)
 }
@@ -202,7 +202,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 			return colrpc.NewOutbox(allocator, op, typs, sources, nil /* toClose */)
 		},
 		newInboxFn: func(allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error) {
-			inbox, err := colrpc.NewInbox(allocator, typs, streamID)
+			inbox, err := colrpc.NewInbox(context.Background(), allocator, typs, streamID)
 			inboxToNumInputTypes[inbox] = typs
 			return inbox, err
 		},


### PR DESCRIPTION
This PR fixes a bunch of instances that would swallow uncertainty errors in the vectorized engine and adds a test for this. This also uncovered a query termination edge case in the vectorized Inbox we weren't handling properly.

Release note (bug fix): fix edge cases where the vectorized execution engine would drop some results under contention