### PR TITLE
colexec: implement Close in Columnarizer

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -470,6 +470,7 @@ func (r opResult) createAndWrapRowSource(
 	// own, so the used memory will be accounted for.
 	r.Op, r.IsStreaming = c, true
 	r.MetadataSources = append(r.MetadataSources, c)
+	r.ToClose = append(r.ToClose, c)
 	return nil
 }
 

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -138,8 +138,11 @@ func (c *Columnarizer) Run(context.Context) {
 	colexecerror.InternalError("Columnarizer should not be Run")
 }
 
-var _ colexecbase.Operator = &Columnarizer{}
-var _ execinfrapb.MetadataSource = &Columnarizer{}
+var (
+	_ colexecbase.Operator       = &Columnarizer{}
+	_ execinfrapb.MetadataSource = &Columnarizer{}
+	_ Closer                     = &Columnarizer{}
+)
 
 // DrainMeta is part of the MetadataSource interface.
 func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
@@ -152,6 +155,12 @@ func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 		c.accumulatedMeta = append(c.accumulatedMeta, *meta)
 	}
 	return c.accumulatedMeta
+}
+
+// Close is part of the Operator interface.
+func (c *Columnarizer) Close(ctx context.Context) error {
+	c.input.ConsumerClosed()
+	return nil
 }
 
 // ChildCount is part of the Operator interface.

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -100,6 +100,10 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 	require.True(t, len(meta) == 1)
 	require.True(t, testutils.IsError(meta[0].Err, errMsg))
 	require.True(t, rb.Done)
+	require.Equal(t, execinfra.DrainRequested, rb.ConsumerStatus, "unexpected consumer status %d", rb.ConsumerStatus)
+	// Closing the Columnarizer should call ConsumerClosed on the processor.
+	require.NoError(t, c.Close(ctx))
+	require.Equal(t, execinfra.ConsumerClosed, rb.ConsumerStatus, "unexpected consumer status %d", rb.ConsumerStatus)
 }
 
 func BenchmarkColumnarize(b *testing.B) {


### PR DESCRIPTION
A Columnarizer needs to call ConsumerClosed on the wrapped input tree since
those inputs may not be drained in some cases.

Release note: None

Fixes #51179 