### PR TITLE
roachtest: upload GEOS libs for sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -63,7 +63,7 @@ func main() {
 			}
 			switch cmd.Name() {
 			case "run", "bench", "store-gen":
-				initBinaries()
+				initBinariesAndLibraries()
 			}
 			return nil
 		},

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -81,6 +81,9 @@ func registerSQLSmith(r *testRegistry) {
 		c.l.Printf("seed: %d", seed)
 
 		c.Put(ctx, cockroach, "./cockroach")
+		if err := c.PutLibraries(ctx, "./lib"); err != nil {
+			t.Fatalf("could not initialize libraries: %v", err)
+		}
 		c.Start(ctx, t)
 
 		setupFunc, ok := setups[setupName]


### PR DESCRIPTION
* Add code to recognise GEOS code locations.
* Upload GEOS related files into any roachtest cluster.
* Configured builds to save lib*/libgeos* artifacts in
  [MergeToMaster](https://teamcity.cockroachdb.com/admin/editBuild.html?id=buildType:Cockroach_MergeToMaster)
  and take them from
  [Nightlies](https://teamcity.cockroachdb.com/admin/editDependencies.html?id=buildType:Cockroach_Nightlies_WorkloadNightly).
* Make sqlsmith explicitly upload geospatial related directories.

Release note: None