### PR TITLE
roachprod: stage GEOS libraries to clusters

### DIFF
--- a/pkg/cmd/roachprod/install/staging.go
+++ b/pkg/cmd/roachprod/install/staging.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 )
@@ -24,21 +25,21 @@ const (
 	releaseBinaryServer = "https://s3.amazonaws.com/binaries.cockroachdb.com/"
 )
 
-func getEdgeBinaryURL(binaryName, SHA, arch string) (*url.URL, error) {
+func getEdgeURL(urlPathBase, SHA, arch string, ext string) (*url.URL, error) {
 	edgeBinaryLocation, err := url.Parse(edgeBinaryServer)
 	if err != nil {
 		return nil, err
 	}
-	edgeBinaryLocation.Path = binaryName
+	edgeBinaryLocation.Path = urlPathBase
 	// If a target architecture is provided, attach that.
 	if len(arch) > 0 {
 		edgeBinaryLocation.Path += "." + arch
 	}
 	// If a specific SHA is provided, just attach that.
 	if len(SHA) > 0 {
-		edgeBinaryLocation.Path += "." + SHA
+		edgeBinaryLocation.Path += "." + SHA + ext
 	} else {
-		edgeBinaryLocation.Path += ".LATEST"
+		edgeBinaryLocation.Path += ext + ".LATEST"
 		// Otherwise, find the latest SHA binary available. This works because
 		// "[executable].LATEST" redirects to the latest SHA.
 		resp, err := httputil.Head(context.TODO(), edgeBinaryLocation.String())
@@ -54,17 +55,45 @@ func getEdgeBinaryURL(binaryName, SHA, arch string) (*url.URL, error) {
 // StageRemoteBinary downloads a cockroach edge binary with the provided
 // application path to each specified by the cluster. If no SHA is specified,
 // the latest build of the binary is used instead.
-func StageRemoteBinary(c *SyncedCluster, applicationName, binaryPath, SHA, arch string) error {
-	binURL, err := getEdgeBinaryURL(binaryPath, SHA, arch)
+// Returns the SHA of the resolve binary.
+func StageRemoteBinary(
+	c *SyncedCluster, applicationName, urlPathBase, SHA, arch string,
+) (string, error) {
+	binURL, err := getEdgeURL(urlPathBase, SHA, arch, "")
 	if err != nil {
-		return err
+		return "", err
 	}
 	fmt.Printf("Resolved binary url for %s: %s\n", applicationName, binURL)
+	urlSplit := strings.Split(binURL.Path, ".")
 	cmdStr := fmt.Sprintf(
 		`curl -sfSL -o %s "%s" && chmod 755 ./%s`, applicationName, binURL, applicationName,
 	)
-	return c.Run(
+	return urlSplit[len(urlSplit)-1], c.Run(
 		os.Stdout, os.Stderr, c.Nodes, fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
+	)
+}
+
+// StageOptionalRemoteLibrary downloads a library from the cockroach edge with the provided
+// application path to each specified by the cluster.
+// If no SHA is specified, the latest build of the library is used instead.
+// It will not error if the library does not exist on the edge.
+func StageOptionalRemoteLibrary(
+	c *SyncedCluster, libraryName, urlPathBase, SHA, arch, ext string,
+) error {
+	url, err := getEdgeURL(urlPathBase, SHA, arch, ext)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Resolved library url for %s: %s\n", libraryName, url)
+	cmdStr := fmt.Sprintf(
+		`mkdir -p ./lib && \
+sudo curl -sfSL -o "./lib/%s" "%s" 2>/dev/null || echo 'optional library %s not found; continuing...'`,
+		libraryName+ext,
+		url,
+		libraryName+ext,
+	)
+	return c.Run(
+		os.Stdout, os.Stderr, c.Nodes, fmt.Sprintf("staging library (%s)", libraryName), cmdStr,
 	)
 }
 
@@ -92,6 +121,8 @@ func StageCockroachRelease(c *SyncedCluster, version, arch string) error {
 tmpdir="$(mktemp -d /tmp/cockroach-release.XXX)" && \
 curl -f -s -S -o- %s | tar xfz - -C "${tmpdir}" --strip-components 1 && \
 mv ${tmpdir}/cockroach ./cockroach && \
+sudo mkdir -p ./lib && \
+if [ -d ${tmpdir}/lib ]; then sudo mv ${tmpdir}/lib/* ./lib; fi && \
 chmod 755 ./cockroach
 `, binURL)
 	return c.Run(

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1284,14 +1284,14 @@ Some examples of usage:
 		} else if c.IsLocal() {
 			os = runtime.GOOS
 		}
-		var debugArch, releaseArch string
+		var debugArch, releaseArch, libExt string
 		switch os {
 		case "linux":
-			debugArch, releaseArch = "linux-gnu-amd64", "linux-amd64"
+			debugArch, releaseArch, libExt = "linux-gnu-amd64", "linux-amd64", ".so"
 		case "darwin":
-			debugArch, releaseArch = "darwin-amd64", "darwin-10.9-amd64"
+			debugArch, releaseArch, libExt = "darwin-amd64", "darwin-10.9-amd64", ".dylib"
 		case "windows":
-			debugArch, releaseArch = "windows-amd64", "windows-6.2-amd64"
+			debugArch, releaseArch, libExt = "windows-amd64", "windows-6.2-amd64", ".dll"
 		default:
 			return errors.Errorf("cannot stage binary on %s", os)
 		}
@@ -1303,13 +1303,32 @@ Some examples of usage:
 		}
 		switch applicationName {
 		case "cockroach":
-			return install.StageRemoteBinary(
+			sha, err := install.StageRemoteBinary(
 				c, applicationName, "cockroach/cockroach", versionArg, debugArch,
 			)
+			if err != nil {
+				return err
+			}
+			// NOTE: libraries may not be present in older versions.
+			// Use the sha for the binary to download the same remote library.
+			for _, library := range []string{"libgeos", "libgeos_c"} {
+				if err := install.StageOptionalRemoteLibrary(
+					c,
+					library,
+					fmt.Sprintf("cockroach/lib/%s", library),
+					sha,
+					debugArch,
+					libExt,
+				); err != nil {
+					return err
+				}
+			}
+			return nil
 		case "workload":
-			return install.StageRemoteBinary(
+			_, err := install.StageRemoteBinary(
 				c, applicationName, "cockroach/workload", versionArg, "", /* arch */
 			)
+			return err
 		case "release":
 			return install.StageCockroachRelease(c, versionArg, releaseArch)
 		default:


### PR DESCRIPTION
This commit adds the libgeos* and libgeos_c* files to be staged on
roachprod. If the files could not be found, they are gracefully handled
in both the library and release cases.

Release note: None