### PR TITLE
vendor: Bump pebble to 36c1b9c7a833, and set FlushSplitBytes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200701140535-d845c8c2d870
+	github.com/cockroachdb/pebble v0.0.0-20200713154309-36c1b9c7a833
 	github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200701140535-d845c8c2d870 h1:i3u72LNTDBSV49gRfJkfv/wjQHOnb9zknH+DXs3+zEI=
-github.com/cockroachdb/pebble v0.0.0-20200701140535-d845c8c2d870/go.mod h1:crLnbSFbwAcQNs9FPfI1avHb5BqVgqZcr4r+IzpJ5FM=
+github.com/cockroachdb/pebble v0.0.0-20200713154309-36c1b9c7a833 h1:JHkdOh1KafUgHyNoTYHDcv3kE5Gp5C1LbNLSQwm5uYU=
+github.com/cockroachdb/pebble v0.0.0-20200713154309-36c1b9c7a833/go.mod h1:TipC4T/j2WXDHhGHuPue5m00pjk21v7qPMYIVj4Ay+I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd h1:KFOt5I9nEKZgCnOSmy8r4Oykh8BYQO8bFOTgHDS8YZA=


### PR DESCRIPTION
Pulls in these changes:
 - 36c1b9c7a833bce8d1ab6f2013780d2d6f3a97f6 db: relax deletion-only compaction conditions
 - a383f2cde93937d8decb8a802f7377163d8bcb7c db: implement delete-only compactions
 - b6a03ca6a613247a86eb62b73ded803fe1c7f5fa internal/manifest: add LevelIterator struct
 - 9f08cf3d3dc69568de3b72b87abe3cee83df5299 *: Always pick base compactions with minCompactionDepth = 1
 - 3a9adc12d6c366ef0f876b773639ed4a98136fcd internal/metamorphic: generate deterministically from prng seed
 - c9a380a7f499f2844aca2990fd012a4068f4c775 tool: Only encode sublevel changes in lsm json object
 - 58d55986b0c37aaf06301ebba4d50bfa95a9cacf docs: fix mouse position calculation on zoom/pan
 - 6cdafa7b75584e1e886ebe19dcdae3e25b6ba9ee docs: use flexbox for layout of nightly benchmarks page
 - 884334184862059f43737420479a4caecdcdb33f docs: display annotation in chart title when hovered
 - 9c8d7390339278b65647bb849f36759747fad606 docs: allow hovering over the detail line
 - 709c5f7d9380b01b2f71b321cd540d2f7df6bb89 docs: add last updated text to nightly benchmarks
 - 0f71f3c8a72a1ce454576a825cad3d44c88c3424 db: clarify Batch.Reset docs
 - deb60d0bf8b53f975884090cc639780de7fefe80 internal/mkbench: walk through symlinks
 - 3b1143d859ffaee68d7f3060a1bf346c008d7de9 docs: indicate data for missing days
 - 999b9646a584ba354a87b9ba60b57b8018b99e93 internal/mkbench: be more permissive in data.js parsing
 - 3cd66bb123c09088a450092363765ad6e2bccace cmd: Address TODO on measuring scan read-amp
 - 8446ccc4c58c02515dbe66e4f9e4818645e0d5c9 internal/manifest: Have flush split bytes account for # of sublevels
 - f8d8b9654d3ed5a66e0d80c2cce65cbefe1926cf internal/mkbench: don't require bzip compression of raw data
 - f32ddecd06a3e06f53ace9d3451d9ef5d68c8440 internal/mkbench: utility for processing nightly benchmark data
 - 5a444e1b29fa1a96da37557315e5133d78bb4c86 docs: serve benchmark data out of S3
 - c1d4e3ce262e0be2849740a9f8b3924abf47858d compaction: Create pickedCompaction struct for use in compaction_picker
 - f02d55b076e0fa277482e43017dd030b7e764fe1 internal/manifest: Don't create new sublevel if overlap is on sentinel key
 - 7fce6da1eb8c0c34238becc1c0885f4acd600bf8 Add panning and zooming
 - 5bf72881988e9d33a48ad0ca522c3fbc9eb1eebc docs: add nightly benchmarks
 - a452ae2c916a74a035d264e42c9b761061a988b5 db: log events unredacted where possible
 - 9dcb6e30ee67f8b5e8ce200e755e6663c0ee81c1 db: truncate tombstones to file bounds when calculating table stats

Based on discussion and benchmarks done as part of
cockroachdb/pebble#781, it's
more idiomatic to tie FlushSplitBytes to the L0 TargetFileSize.
The 2x factor helps to reduce cases of excessive flush splitting.

Release note: None.