### PR TITLE
build/deploy: add GEOS libraries to CRDB Docker builds

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -44,6 +44,7 @@ usual fashion. To be more specific, the steps to do this are:
 ```
 go/src/github.com/cockroachdb/cockroach $ ./build/builder.sh mkrelease linux-gnu
 go/src/github.com/cockroachdb/cockroach $ cp ./cockroach-linux-2.6.32-gnu-amd64 build/deploy/cockroach
+go/src/github.com/cockroachdb/cockroach $ cp ./lib.docker_amd64/libgeos_c.so ./lib.docker_amd64/libgeos.so build/deploy/
 go/src/github.com/cockroachdb/cockroach $ cd build/deploy && docker build -t cockroachdb/cockroach .
 ```
 

--- a/build/deploy/.gitignore
+++ b/build/deploy/.gitignore
@@ -1,3 +1,4 @@
 # Do not add environment-specific entries here (see the top-level .gitignore
 # for reasoning and alternatives).
 cockroach
+libgeos*.so*

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -10,6 +10,10 @@ RUN apt-get update && \
 	apt-get install -y libc6 ca-certificates tzdata && \
 	rm -rf /var/lib/apt/lists/*
 
+# Install GEOS libraries.
+RUN mkdir /usr/local/lib/cockroach
+COPY libgeos.so libgeos_c.so /usr/local/lib/cockroach/
+
 RUN mkdir -p /cockroach
 COPY cockroach.sh cockroach /cockroach/
 # Set working directory so that relative paths

--- a/build/teamcity-bless-provisional-artifacts.sh
+++ b/build/teamcity-bless-provisional-artifacts.sh
@@ -30,7 +30,7 @@ if [[ "$release_version" != *-* && -z "$FORCE_PUSH_TO_COCKROACH_UNSTABLE" ]]; th
   image=docker.io/cockroachdb/cockroach
 fi
 
-cp cockroach build/deploy/cockroach
+cp cockroach lib/libgeos.so lib/libgeos_c.so build/deploy
 docker build --no-cache --tag=$image:{latest,"$release_version"} build/deploy
 
 # Only push the "latest" tag for our most recent release branch.


### PR DESCRIPTION
Now that we have the GEOS libraries being built, it's time we copy them
into the right place in the Docker container such that users can import
geospatial features out of the box.

The bless release script will also copy these files over.

Release note (general change): The Docker container that ships with
CockroachDB now includes the GEOS library needed for geospatial
functionality in `/usr/local/lib/cockroach` (which is the default
location of where the cockroach binary looks for the GEOS libraries).