### PR TITLE
kvclient: handle speculative descriptors in the range cache better

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -271,12 +271,12 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 	n4Cache := tc.Server(3).DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
 	entry := n4Cache.GetCached(tablePrefix, false /* inverted */)
 	require.NotNil(t, entry)
-	require.False(t, entry.Lease.Empty())
-	require.Equal(t, roachpb.StoreID(1), entry.Lease.Replica.StoreID)
+	require.False(t, entry.Lease().Empty())
+	require.Equal(t, roachpb.StoreID(1), entry.Lease().Replica.StoreID)
 	require.Equal(t, []roachpb.ReplicaDescriptor{
 		{NodeID: 1, StoreID: 1, ReplicaID: 1},
 		{NodeID: 2, StoreID: 2, ReplicaID: 2},
-	}, entry.Desc.Replicas().All())
+	}, entry.Desc().Replicas().All())
 
 	// Relocate the follower. n2 will no longer have a replica.
 	n1.Exec(t, `ALTER TABLE test EXPERIMENTAL_RELOCATE VALUES (ARRAY[1,3], 1)`)
@@ -292,12 +292,12 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 	// Check that the cache was properly updated.
 	entry = n4Cache.GetCached(tablePrefix, false /* inverted */)
 	require.NotNil(t, entry)
-	require.False(t, entry.Lease.Empty())
-	require.Equal(t, roachpb.StoreID(1), entry.Lease.Replica.StoreID)
+	require.False(t, entry.Lease().Empty())
+	require.Equal(t, roachpb.StoreID(1), entry.Lease().Replica.StoreID)
 	require.Equal(t, []roachpb.ReplicaDescriptor{
 		{NodeID: 1, StoreID: 1, ReplicaID: 1},
 		{NodeID: 3, StoreID: 3, ReplicaID: 3},
-	}, entry.Desc.Replicas().All())
+	}, entry.Desc().Replicas().All())
 
 	// Make a note of the follower reads metric on n3. We'll check that it was
 	// incremented.

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -215,7 +215,7 @@ func (b *SSTBatcher) flushIfNeeded(ctx context.Context, nextKey roachpb.Key) err
 		} else {
 			r := b.rc.GetCached(k, false /* inverted */)
 			if r != nil {
-				b.flushKey = r.Desc.EndKey.AsRawKey()
+				b.flushKey = r.Desc().EndKey.AsRawKey()
 				log.VEventf(ctx, 3, "building sstable that will flush before %v", b.flushKey)
 			} else {
 				log.VEventf(ctx, 3, "no cached range desc available to determine sst flush key")

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -176,9 +176,6 @@ func runTestImport(t *testing.T, batchSizeValue int64) {
 			r := roachpb.RangeInfo{
 				Desc: *tok.Desc(),
 			}
-			if l := tok.Lease(); l != nil {
-				r.Lease = *l
-			}
 			mockCache.Insert(ctx, r)
 
 			ts := hlc.Timestamp{WallTime: 100}

--- a/pkg/kv/kvbase/range_cache.go
+++ b/pkg/kv/kvbase/range_cache.go
@@ -13,116 +13,40 @@ package kvbase
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // RangeDescriptorCache is a simplified interface to the kv.RangeDescriptorCache
 // for use at lower levels of the stack like storage.
 type RangeDescriptorCache interface {
 	// Lookup looks up range information for the range containing key.
-	Lookup(ctx context.Context, key roachpb.RKey) (*RangeCacheEntry, error)
+	Lookup(ctx context.Context, key roachpb.RKey) (RangeCacheEntry, error)
 }
 
-// RangeCacheEntry represents one cache entry.
-//
-// The cache stores *RangeCacheEntry. Entries are immutable: cache lookups
-// returns the same *RangeCacheEntry to multiple queriers for efficiency, but
-// nobody should modify the lookup result.
-type RangeCacheEntry struct {
-	// Desc is always populated.
-	Desc roachpb.RangeDescriptor
-	// Lease has info on the range's lease. It can be Empty() if no lease
-	// information is known. When a lease is known, it is guaranteed that the
-	// lease comes from Desc's range id (i.e. we'll never put a lease from another
-	// range in here). This allows UpdateLease() to use Lease.Sequence to compare
-	// leases. Moreover, the lease will correspond to one of the replicas in Desc.
-	Lease roachpb.Lease
-}
-
-func (e RangeCacheEntry) String() string {
-	return fmt.Sprintf("desc:%s, lease:%s", e.Desc, e.Lease)
-}
-
-// UpdateLease returns a new RangeCacheEntry with the receiver's descriptor and
-// a new lease. The updated retval indicates whether the passed-in lease appears
-// to be newer than the lease the entry had before. If updated is returned true,
-// the caller should evict the existing entry (the receiver) and replace it with
-// newEntry. (true, nil) can be returned meaning that the existing entry should
-// be evicted, but there's no replacement that this function can provide; this
-// happens when the passed-in lease indicates a leaseholder that's not part of
-// the entry's descriptor. The descriptor must be really stale, and the caller
-// should read a new version.
-//
-// If updated=false is returned, then newEntry will be the same as the receiver.
-// This means that the passed-in lease is older than the lease already in the
-// entry.
-//
-// If the new leaseholder is not a replica in the descriptor, we assume the
-// lease information to be more recent than the entry's descriptor, and we
-// return true, nil. The caller should evict the receiver from the cache, but
-// it'll have to do extra work to figure out what to insert instead.
-func (e *RangeCacheEntry) UpdateLease(l *roachpb.Lease) (updated bool, newEntry *RangeCacheEntry) {
-	// If l is older than what the entry has (or the same), return early.
-	// A new lease with a sequence of 0 is presumed to be newer than anything, and
-	// an existing lease with a sequence of 0 is presumed to be older than
-	// anything.
+// RangeCacheEntry represents the information returned by RangeDescriptorCache.Lookup().
+type RangeCacheEntry interface {
+	// Desc returns the cached descriptor. Note that, besides being possibly
+	// stale, this descriptor also might not represent a descriptor that was ever
+	// committed. See DescSpeculative().
+	Desc() *roachpb.RangeDescriptor
+	// DescSpeculative returns true if the descriptor in the entry is "speculative"
+	// - i.e. it doesn't correspond to a committed value. Such descriptors have been
+	// inserted in the cache with Generation=0.
 	//
-	// We handle the case of a lease with the sequence equal to the existing
-	// entry, but otherwise different. This results in the new lease updating the
-	// entry, because the existing lease might correspond to a proposed lease that
-	// a replica returned speculatively while a lease acquisition was in progress.
-	if l.Sequence != 0 && e.Lease.Sequence != 0 && l.Sequence < e.Lease.Sequence {
-		return false, e
-	}
+	// Speculative descriptors come from (not-yet-committed) intents.
+	DescSpeculative() bool
 
-	if l.Equal(e.Lease) {
-		return false, e
-	}
+	// Leaseholder returns the cached leaseholder replica, if known. Returns nil
+	// if the leaseholder is not known.
+	Leaseholder() *roachpb.ReplicaDescriptor
 
-	// Check whether the lease we were given is compatible with the replicas in
-	// the descriptor. If it's not, the descriptor must be really stale, and the
-	// RangeCacheEntry needs to be evicted.
-	_, ok := e.Desc.GetReplicaDescriptorByID(l.Replica.ReplicaID)
-	if !ok {
-		return true, nil
-	}
-
-	// TODO(andrei): If the leaseholder is present, but the descriptor lists the
-	// replica as a learner, this is a sign of a stale descriptor. I'm not sure
-	// what to do about it, though.
-
-	return true, &RangeCacheEntry{
-		Desc:  e.Desc,
-		Lease: *l,
-	}
-}
-
-// NewerThan returns true if the receiver represents newer information about the
-// range than o. The descriptors are assumed to be overlapping.
-//
-// When comparing two overlapping entries for deciding which one is stale, the
-// descriptor's generation is checked first. For equal descriptor generations,
-// the lease sequence number is checked second. For equal lease sequences,
-// returns false. Note that this means that an Empty() e.Lease is considered
-// older than any lease in o.
-func (e *RangeCacheEntry) NewerThan(o *RangeCacheEntry) bool {
-	if util.RaceEnabled {
-		if _, err := e.Desc.RSpan().Intersect(&o.Desc); err != nil {
-			panic(fmt.Sprintf("descriptors don't intersect: %s vs %s", e.Desc, o.Desc))
-		}
-	}
-	if e.Desc.Generation == o.Desc.Generation {
-		// If two RangeDescriptors overlap and have the same Generation, they must
-		// be referencing the same range, in which case their lease sequences are
-		// comparable.
-		if e.Desc.RangeID != o.Desc.RangeID {
-			panic(fmt.Sprintf("overlapping descriptors with same gen but different IDs: %s vs %s",
-				e.Desc, o.Desc))
-		}
-		return e.Lease.Sequence > o.Lease.Sequence
-	}
-	return e.Desc.Generation > o.Desc.Generation
+	// Lease returns the cached lease, if known. Returns nil if no lease is known.
+	// It's possible for a leaseholder to be known, but not a full lease, in which
+	// case Leaseholder() returns non-nil but Lease() returns nil.
+	Lease() *roachpb.Lease
+	// LeaseSpeculative returns true if the lease in the entry is "speculative"
+	// - i.e. it doesn't correspond to a committed lease. Such leases have been
+	// inserted in the cache with Sequence=0.
+	LeaseSpeculative() bool
 }

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1118,7 +1118,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 	// turning single-range queries into multi-range queries for no good
 	// reason.
 	if ba.IsUnsplittable() {
-		mismatch := roachpb.NewRangeKeyMismatchError(ctx, rs.Key.AsRawKey(), rs.EndKey.AsRawKey(), ri.Desc(), ri.Lease())
+		mismatch := roachpb.NewRangeKeyMismatchError(ctx, rs.Key.AsRawKey(), rs.EndKey.AsRawKey(), ri.Desc(), nil /* lease */)
 		return nil, roachpb.NewError(mismatch)
 	}
 	// If there's no transaction and ba spans ranges, possibly re-run as part of

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1727,10 +1727,7 @@ func (ds *DistSender) sendToReplicas(
 ) (*roachpb.BatchResponse, error) {
 	desc := routing.Desc()
 	ba.RangeID = desc.RangeID
-	var leaseholder *roachpb.ReplicaDescriptor
-	if routing.Lease() != nil {
-		leaseholder = &routing.Lease().Replica
-	}
+	leaseholder := routing.Leaseholder()
 	replicas, err := NewReplicaSlice(ctx, ds.nodeDescs, desc, leaseholder)
 	if err != nil {
 		return nil, err
@@ -1743,13 +1740,15 @@ func (ds *DistSender) sendToReplicas(
 	// Try the leaseholder first, if the request wants it.
 	{
 		canFollowerRead := (ds.clusterID != nil) && CanSendToFollower(ds.clusterID.Get(), ds.st, ba)
-		sendToLeaseholder := (routing.Lease() != nil) && !canFollowerRead && ba.RequiresLeaseHolder()
+		sendToLeaseholder := (leaseholder != nil) && !canFollowerRead && ba.RequiresLeaseHolder()
 		if sendToLeaseholder {
-			idx := replicas.Find(routing.Lease().Replica.ReplicaID)
+			idx := replicas.Find(leaseholder.ReplicaID)
 			if idx != -1 {
 				replicas.MoveToFront(idx)
 			} else {
-				log.Eventf(ctx, "leaseholder missing from replicas; lease: %s", routing.Lease())
+				// The leaseholder node's info must have been missing from gossip when
+				// we created replicas.
+				log.Eventf(ctx, "leaseholder %s missing from replicas", leaseholder)
 			}
 		}
 	}
@@ -1803,9 +1802,18 @@ func (ds *DistSender) sendToReplicas(
 		} else {
 			log.VEventf(ctx, 2, "trying next peer %s", curReplica.String())
 		}
+		// Communicate to the server the information our cache has about the range.
+		// If it's stale, the serve will return an update.
 		ba.ClientRangeInfo = &roachpb.ClientRangeInfo{
-			DescriptorGeneration: routing.entry.Desc.Generation,
-			LeaseSequence:        routing.entry.Lease.Sequence,
+			// Note that DescriptorGeneration will be 0 if the cached descriptor is
+			// "speculative" (see DescSpeculative()). Even if the speculation is
+			// correct, we want the serve to return an update, at which point the
+			// cached entry will no longer be "speculative".
+			DescriptorGeneration: routing.Desc().Generation,
+			// The LeaseSequence will be 0 if the cache doen't have lease info, or has
+			// a speculative lease. Like above, this asks the server to return an
+			// update.
+			LeaseSequence: routing.LeaseSeq(),
 		}
 		br, err = transport.SendNext(ctx, ba)
 
@@ -1873,7 +1881,7 @@ func (ds *DistSender) sendToReplicas(
 			// account that the local node can't be down) it won't take long until we
 			// talk to a replica that tells us who the leaseholder is.
 			if ctx.Err() == nil {
-				if routing.Lease() != nil && routing.Lease().Replica == curReplica {
+				if lh := routing.Leaseholder(); lh != nil && *lh == curReplica {
 					routing = routing.ClearLease(ctx)
 				}
 			}
@@ -1912,25 +1920,24 @@ func (ds *DistSender) sendToReplicas(
 				// leaseholder in the range cache.
 			case *roachpb.NotLeaseHolderError:
 				ds.metrics.NotLeaseHolderErrCount.Inc(1)
-				if tErr.LeaseHolder != nil {
+				// If we got some lease information, we use it. If not, we loop around
+				// and try the next replica.
+				if tErr.Lease != nil || tErr.LeaseHolder != nil {
 					// Update the leaseholder in the range cache. Naively this would also
 					// happen when the next RPC comes back, but we don't want to wait out
 					// the additional RPC latency.
 
-					// Figure out the lease we want to put in the cache.
-					l := tErr.Lease
-					// tErr.LeaseHolder might be set when tErr.Lease isn't.
-					if l == nil {
-						l = &roachpb.Lease{
-							Replica: *tErr.LeaseHolder,
-						}
-					}
-
 					var ok bool
-					routing, ok = routing.UpdateLease(ctx, l)
+					if tErr.Lease != nil {
+						routing, ok = routing.UpdateLease(ctx, tErr.Lease)
+					} else if tErr.LeaseHolder != nil {
+						// tErr.LeaseHolder might be set when tErr.Lease isn't.
+						routing = routing.UpdateLeaseholder(ctx, *tErr.LeaseHolder)
+						ok = true
+					}
 					// Move the new lease holder to the head of the queue for the next retry.
-					if !routing.Empty() && routing.Lease() != nil {
-						transport.MoveToFront(routing.Lease().Replica)
+					if lh := routing.Leaseholder(); lh != nil {
+						transport.MoveToFront(*lh)
 					}
 					// See if we want to backoff a little before the next attempt. If the lease info
 					// we got is stale, we backoff because it might be the case that there's a
@@ -1975,8 +1982,12 @@ func (ds *DistSender) sendToReplicas(
 }
 
 // skipStaleReplicas advances the transport until it's positioned on a replica
-// that's part of routing. The routing might be updated as the DistSender tries
-// replicas one by one, and so the transport can get out of date.
+// that's part of routing. This is called as the DistSender tries replicas one
+// by one, as the routing can be updated in the process and so the transport can
+// get out of date.
+//
+// It's valid to pass in an empty routing, in which case the transport will be
+// considered to be exhausted.
 //
 // Returns an error if the transport is exhausted.
 func skipStaleReplicas(
@@ -1998,7 +2009,7 @@ func skipStaleReplicas(
 			return noMoreReplicasErr(ambiguousError, lastErr)
 		}
 
-		if _, ok := routing.entry.Desc.GetReplicaDescriptorByID(transport.NextReplica().ReplicaID); ok {
+		if _, ok := routing.Desc().GetReplicaDescriptorByID(transport.NextReplica().ReplicaID); ok {
 			return nil
 		}
 		transport.SkipReplica()

--- a/pkg/kv/kvclient/kvcoord/range_cache.go
+++ b/pkg/kv/kvclient/kvcoord/range_cache.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -212,26 +213,44 @@ type EvictionToken struct {
 
 	// entry is the cache entry that this EvictionToken refers to - the entry that
 	// Evict() will evict from rdc.
-	entry *kvbase.RangeCacheEntry
-	// nextDesc, if not nil, is the descriptor that should replace desc if desc
-	// proves to be stale - i.e. nextDesc is inserted in the cache automatically
-	// by Evict(). This is used when the range descriptor lookup that populated
-	// the cache returned an intent in addition to the current descriptor value.
+	entry *rangeCacheEntry
+	// speculativeDesc, if not nil, is the descriptor that should replace desc if
+	// desc proves to be stale - i.e. speculativeDesc is inserted in the cache
+	// automatically by Evict(). This is used when the range descriptor lookup
+	// that populated the cache returned an intent in addition to the current
+	// descriptor value. The idea is that, if the range lookup was performed in
+	// the middle of a split or a merge and it's seen an intent, it's likely that
+	// the intent will get committed soon and so the client should use it if the
+	// previous version proves stale. This mechanism also has a role for resolving
+	// intents for the split transactions itself where, immediately after the
+	// split's txn record is committed, an intent is the only correct copy of the
+	// LHS' descriptor.
 	//
-	// TODO(andrei): It's weird that nextDesc hangs from an EvictionToken, instead
-	// of from a cache entry. Hanging from a particular token, only one actor has
-	// the opportunity to use this nextDesc; if another actor races to evict the
-	// respective cache entry and wins, nextDesc becomes useless.
-	nextDesc *roachpb.RangeDescriptor
+	// TODO(andrei): It's weird that speculativeDesc hangs from an EvictionToken,
+	// instead of from a cache entry. Hanging from a particular token, only one
+	// actor has the opportunity to use this speculativeDesc; if another actor
+	// races to evict the respective cache entry and wins, speculativeDesc becomes
+	// useless.
+	speculativeDesc *roachpb.RangeDescriptor
 }
 
 func (rdc *RangeDescriptorCache) makeEvictionToken(
-	entry *kvbase.RangeCacheEntry, nextDesc *roachpb.RangeDescriptor,
+	entry *rangeCacheEntry, speculativeDesc *roachpb.RangeDescriptor,
 ) EvictionToken {
+	if speculativeDesc != nil {
+		// speculativeDesc comes from intents. Being uncommitted, it is speculative.
+		// We reset its generation to indicate this fact and allow it to be easily
+		// overwritten. Putting a speculative descriptor in the cache with a
+		// generation might make it hard for the real descriptor with the same
+		// generation to overwrite it, in case the speculation fails.
+		nextCpy := *speculativeDesc
+		nextCpy.Generation = 0
+		speculativeDesc = &nextCpy
+	}
 	return EvictionToken{
-		rdc:      rdc,
-		entry:    entry,
-		nextDesc: nextDesc,
+		rdc:             rdc,
+		entry:           entry,
+		speculativeDesc: speculativeDesc,
 	}
 }
 
@@ -242,29 +261,44 @@ func (et EvictionToken) Empty() bool {
 
 // Desc returns the RangeDescriptor that was retrieved from the cache. The
 // result is to be considered immutable.
+//
+// Note that the returned descriptor might have Generation = 0. This means that
+// the descriptor is speculative; it is not know to have committed.
 func (et EvictionToken) Desc() *roachpb.RangeDescriptor {
-	if et.entry == nil {
+	if et.Empty() {
 		return nil
 	}
-	return &et.entry.Desc
+	return et.entry.Desc()
 }
 
-// Lease returns the lease that was retrieved from the cache. If the cache
-// didn't have any lease information, returns nil. The result is to be
-// considered immutable.
+// Leaseholder returns the cached leaseholder. If the cache didn't have any
+// lease information, returns nil. The result is to be considered immutable.
 //
-// If a non-nil lease is returned, it will correspond to one of the replicas in
+// If a leaseholder is returned, it will correspond to one of the replicas in
 // et.Desc().
-func (et EvictionToken) Lease() *roachpb.Lease {
-	if et.entry.Lease.Empty() {
+func (et EvictionToken) Leaseholder() *roachpb.ReplicaDescriptor {
+	if et.Empty() {
 		return nil
 	}
-	return &et.entry.Lease
+	return et.entry.Leaseholder()
+}
+
+// LeaseSeq returns the sequence of the cached lease. If no lease is cached, or
+// the cached lease is speculative, 0 is returned.
+func (et EvictionToken) LeaseSeq() roachpb.LeaseSequence {
+	if et.Empty() {
+		panic("invalid LeaseSeq() call on empty EvictionToken")
+	}
+	return et.entry.lease.Sequence
 }
 
 // UpdateLease updates the leaseholder for the token's cache entry to the
 // specified lease, and returns an updated EvictionToken, tied to the new cache
 // entry.
+//
+// The bool retval is true if the requested update was performed (i.e. the
+// passed-in lease was compatible with the descriptor and more recent than the
+// cached lease).
 //
 // UpdateLease also acts as a synchronization point between the caller and the
 // RangeDescriptorCache. In the spirit of a Compare-And-Swap operation (but
@@ -284,21 +318,26 @@ func (et EvictionToken) Lease() *roachpb.Lease {
 // stale to be useful, and it should use a range iterator again to get an
 // updated cache entry.
 //
-// The bool retval is true if the requested update was performed (i.e. the
-// passed-in lease was compatible with the descriptor and more recent than the
-// cached lease).
+// It's legal to pass in a lease with a zero Sequence; it will be treated as a
+// speculative lease and considered newer than any existing lease (and then in
+// turn will be overridden by any subsequent update).
 func (et EvictionToken) UpdateLease(
 	ctx context.Context, lease *roachpb.Lease,
 ) (EvictionToken, bool) {
 	// If the lease we've been given is older than what the cache entry already has,
 	// then short-circuit and don't evict the current entry.
 	{
-		shouldUpdate, _ := et.entry.UpdateLease(lease)
+		shouldUpdate, _ := et.entry.updateLease(lease)
 		if !shouldUpdate {
 			return et, false
 		}
 	}
+	return et.updateLeaseInternal(ctx, lease)
+}
 
+func (et EvictionToken) updateLeaseInternal(
+	ctx context.Context, lease *roachpb.Lease,
+) (EvictionToken, bool) {
 	// Notes for what follows: We can't simply update the cache
 	// entry in place since entries are immutable. So, we're going to evict the
 	// old cache entry and insert a new one, and then change this eviction token
@@ -322,7 +361,7 @@ func (et EvictionToken) UpdateLease(
 		et.entry = curEntry
 	}
 
-	shouldUpdate, updatedEntry := et.entry.UpdateLease(lease)
+	shouldUpdate, updatedEntry := et.entry.updateLease(lease)
 	if !shouldUpdate {
 		return et, false
 	}
@@ -339,7 +378,19 @@ func (et EvictionToken) UpdateLease(
 	et.entry = updatedEntry
 	et.rdc.mustInsertLocked(ctx, updatedEntry)
 	return et, true
+}
 
+// UpdateLeaseholder is like UpdateLease(), but it only takes a leaseholder, not
+// a full lease. This is called when a likely leaseholder is known, but not a
+// full lease. The lease we'll insert into the cache will be considered
+// "speculative".
+func (et EvictionToken) UpdateLeaseholder(
+	ctx context.Context, lh roachpb.ReplicaDescriptor,
+) EvictionToken {
+	// Notice that we don't initialize Lease.Sequence, which will make
+	// entry.LeaseSpeculative() return true.
+	et, _ /* ok */ = et.updateLeaseInternal(ctx, &roachpb.Lease{Replica: lh})
+	return et
 }
 
 // ClearLease evicts information about the current lease from the cache, if the
@@ -360,19 +411,19 @@ func (et EvictionToken) ClearLease(ctx context.Context) EvictionToken {
 	et.rdc.rangeCache.Lock()
 	defer et.rdc.rangeCache.Unlock()
 
-	if et.entry.Lease.Empty() {
+	if et.entry.lease.Empty() {
 		log.Fatalf(ctx, "attempting to clear lease from cache entry without lease")
 	}
 
-	var replacementEntry *kvbase.RangeCacheEntry
+	var replacementEntry *rangeCacheEntry
 	ok, newerEntry := et.rdc.evictLocked(ctx, et.entry)
 	if ok {
 		// This is the happy case: our entry was in the cache and we just evicted
 		// it. We'll now insert a replacement without a lease.
-		replacementEntry = &kvbase.RangeCacheEntry{
-			Desc: et.entry.Desc,
+		replacementEntry = &rangeCacheEntry{
+			desc: et.entry.desc,
 			// No lease.
-			Lease: roachpb.Lease{},
+			lease: roachpb.Lease{},
 		}
 	} else if newerEntry != nil {
 		// We're trying to clear a lease, but we find out that the cache might have
@@ -382,16 +433,16 @@ func (et EvictionToken) ClearLease(ctx context.Context) EvictionToken {
 		// trying the known leaseholder and failing - so it's a particular node that
 		// we have a problem with, not a particular lease (i.e. we want to evict
 		// even a newer lease, but with the same leaseholder).
-		if newerEntry.Lease.Replica != et.entry.Lease.Replica {
+		if newerEntry.lease.Replica != et.entry.lease.Replica {
 			et.entry = newerEntry
 			return et
 		}
 		// The newer entry has the same lease, so we still want to clear it. We
 		// replace the entry, but keep the possibly newer descriptor.
 		et.rdc.mustEvictLocked(ctx, newerEntry)
-		replacementEntry = &kvbase.RangeCacheEntry{
-			Desc:  newerEntry.Desc,
-			Lease: roachpb.Lease{},
+		replacementEntry = &rangeCacheEntry{
+			desc:  *newerEntry.Desc(),
+			lease: roachpb.Lease{},
 		}
 	} else {
 		// The cache doesn't have info about this range any more, or the range keys
@@ -428,10 +479,10 @@ func (et EvictionToken) EvictAndReplace(ctx context.Context, newDescs ...roachpb
 	if len(newDescs) > 0 {
 		log.Eventf(ctx, "evicting cached range descriptor with %d replacements", len(newDescs))
 		et.rdc.insertLocked(ctx, newDescs...)
-	} else if et.nextDesc != nil {
+	} else if et.speculativeDesc != nil {
 		log.Eventf(ctx, "evicting cached range descriptor with replacement from token")
 		et.rdc.insertLocked(ctx, roachpb.RangeInfo{
-			Desc: *et.nextDesc,
+			Desc: *et.speculativeDesc,
 			// We don't know anything about the new lease.
 			Lease: roachpb.Lease{},
 		})
@@ -473,7 +524,7 @@ func (rdc *RangeDescriptorCache) LookupWithEvictionToken(
 // to lower level clients through the kvbase.RangeDescriptorCache interface.
 func (rdc *RangeDescriptorCache) Lookup(
 	ctx context.Context, key roachpb.RKey,
-) (*kvbase.RangeCacheEntry, error) {
+) (kvbase.RangeCacheEntry, error) {
 	tok, err := rdc.lookupInternal(
 		ctx, key, EvictionToken{}, false /* useReverseScan */)
 	if err != nil {
@@ -486,11 +537,11 @@ func (rdc *RangeDescriptorCache) Lookup(
 // span.
 func (rdc *RangeDescriptorCache) GetCachedOverlapping(
 	ctx context.Context, span roachpb.RSpan,
-) []*kvbase.RangeCacheEntry {
+) []kvbase.RangeCacheEntry {
 	rdc.rangeCache.RLock()
 	defer rdc.rangeCache.RUnlock()
 	rawEntries := rdc.getCachedOverlappingRLocked(ctx, span)
-	entries := make([]*kvbase.RangeCacheEntry, len(rawEntries))
+	entries := make([]kvbase.RangeCacheEntry, len(rawEntries))
 	for i, e := range rawEntries {
 		entries[i] = rdc.getValue(e)
 	}
@@ -511,7 +562,7 @@ func (rdc *RangeDescriptorCache) getCachedOverlappingRLocked(
 		cached := rdc.getValue(e)
 		// Stop when we hit a descriptor to the right of span. The end key is
 		// exclusive, so if span is [a,b) and we hit [b,c), we stop.
-		if span.EndKey.Compare(cached.Desc.StartKey) <= 0 {
+		if span.EndKey.Compare(cached.Desc().StartKey) <= 0 {
 			return true
 		}
 		res = append(res, e)
@@ -627,14 +678,14 @@ func (rdc *RangeDescriptorCache) tryLookup(
 			// rs[0]'s eviction token. Note that ranges for which the cache has more
 			// up-to-date information will not be clobbered - for example ranges for
 			// which the cache has the prefetched descriptor already plus a lease.
-			newEntries := make([]*kvbase.RangeCacheEntry, len(preRs)+1)
-			newEntries[0] = &kvbase.RangeCacheEntry{
-				Desc: rs[0],
+			newEntries := make([]*rangeCacheEntry, len(preRs)+1)
+			newEntries[0] = &rangeCacheEntry{
+				desc: rs[0],
 				// We don't have any lease information.
-				Lease: roachpb.Lease{},
+				lease: roachpb.Lease{},
 			}
 			for i, preR := range preRs {
-				newEntries[i+1] = &kvbase.RangeCacheEntry{Desc: preR}
+				newEntries[i+1] = &rangeCacheEntry{desc: preR}
 			}
 			insertedEntries := rdc.insertLockedInner(ctx, newEntries)
 			// entry corresponds to rs[0], which is the descriptor covering the key
@@ -656,9 +707,9 @@ func (rdc *RangeDescriptorCache) tryLookup(
 			// didn't insert anything).
 			// TODO(andrei): It'd be better to retry the cache/database lookup in case 3.
 			if entry == nil {
-				entry = &kvbase.RangeCacheEntry{
-					Desc:  rs[0],
-					Lease: roachpb.Lease{},
+				entry = &rangeCacheEntry{
+					desc:  rs[0],
+					lease: roachpb.Lease{},
 				}
 			}
 			if len(rs) == 1 {
@@ -718,7 +769,7 @@ func (rdc *RangeDescriptorCache) tryLookup(
 	// the descriptor it's looking for in the cache if it was pre-fetched by the
 	// original lookup.
 	lookupRes := res.Val.(EvictionToken)
-	desc := &lookupRes.entry.Desc
+	desc := lookupRes.Desc()
 	containsFn := (*roachpb.RangeDescriptor).ContainsKey
 	if useReverseScan {
 		containsFn = (*roachpb.RangeDescriptor).ContainsKeyInverted
@@ -785,17 +836,11 @@ func (rdc *RangeDescriptorCache) EvictByKey(ctx context.Context, descKey roachpb
 // and newer, that entry is returned. The caller can use this returned entry as
 // more recent data than the version it was trying to evict.
 func (rdc *RangeDescriptorCache) evictLocked(
-	ctx context.Context, entry *kvbase.RangeCacheEntry,
-) (ok bool, updatedEntry *kvbase.RangeCacheEntry) {
-	cachedEntry, rawEntry := rdc.getCachedLocked(entry.Desc.StartKey, false /* inverted */)
+	ctx context.Context, entry *rangeCacheEntry,
+) (ok bool, updatedEntry *rangeCacheEntry) {
+	cachedEntry, rawEntry := rdc.getCachedLocked(entry.desc.StartKey, false /* inverted */)
 	if cachedEntry != entry {
-		if cachedEntry != nil &&
-			descsCompatible(&cachedEntry.Desc, &entry.Desc) &&
-			// cachedEntry is almost certainly newer than entry, but we still check
-			// explicitly. I think it's theoretically possible for cachedEntry to be
-			// older in case entry was evicted due to memory pressure, and an old
-			// entry somehow was inserted afterwards.
-			cachedEntry.NewerThan(entry) {
+		if cachedEntry != nil && descsCompatible(cachedEntry.Desc(), entry.Desc()) {
 			return false, cachedEntry
 		}
 		return false, nil
@@ -809,9 +854,7 @@ func (rdc *RangeDescriptorCache) evictLocked(
 // mustEvictLocked is like evictLocked, except it asserts that the eviction was
 // successful (i.e. that entry is present in the cache). This is used when we're
 // evicting an entry that we just looked up, under the lock.
-func (rdc *RangeDescriptorCache) mustEvictLocked(
-	ctx context.Context, entry *kvbase.RangeCacheEntry,
-) {
+func (rdc *RangeDescriptorCache) mustEvictLocked(ctx context.Context, entry *rangeCacheEntry) {
 	ok, newer := rdc.evictLocked(ctx, entry)
 	if !ok {
 		log.Fatalf(ctx, "failed to evict %s. newer: %v", entry, newer)
@@ -824,13 +867,15 @@ func (rdc *RangeDescriptorCache) mustEvictLocked(
 // `inverted` determines the behavior at the range boundary: If set to true
 // and `key` is the EndKey and StartKey of two adjacent ranges, the first range
 // is returned instead of the second (which technically contains the given key).
-func (rdc *RangeDescriptorCache) GetCached(
-	key roachpb.RKey, inverted bool,
-) *kvbase.RangeCacheEntry {
+func (rdc *RangeDescriptorCache) GetCached(key roachpb.RKey, inverted bool) kvbase.RangeCacheEntry {
 	rdc.rangeCache.RLock()
 	defer rdc.rangeCache.RUnlock()
 	entry, _ := rdc.getCachedLocked(key, inverted)
-	return entry
+	if entry == nil {
+		// This return avoids boxing a nil into a non-nil iface.
+		return nil
+	}
+	return kvbase.RangeCacheEntry(entry)
 }
 
 // getCachedLocked is like GetCached, but it assumes that the caller holds a
@@ -840,7 +885,7 @@ func (rdc *RangeDescriptorCache) GetCached(
 // used for descriptor eviction.
 func (rdc *RangeDescriptorCache) getCachedLocked(
 	key roachpb.RKey, inverted bool,
-) (*kvbase.RangeCacheEntry, *cache.Entry) {
+) (*rangeCacheEntry, *cache.Entry) {
 	// The cache is indexed using the end-key of the range, but the
 	// end-key is non-inverted by default.
 	var metaKey roachpb.RKey
@@ -855,7 +900,7 @@ func (rdc *RangeDescriptorCache) getCachedLocked(
 		return nil, nil
 	}
 	entry := rdc.getValue(rawEntry)
-	desc := &entry.Desc
+	desc := &entry.desc
 
 	containsFn := (*roachpb.RangeDescriptor).ContainsKey
 	if inverted {
@@ -883,10 +928,8 @@ func (rdc *RangeDescriptorCache) Insert(ctx context.Context, rs ...roachpb.Range
 // fatals if the entry fails to be inserted. It's used when it's known that
 // there's nothing in the cache conflicting with the ent because we've just
 // successfully evicted a similar entry.
-func (rdc *RangeDescriptorCache) mustInsertLocked(
-	ctx context.Context, ent *kvbase.RangeCacheEntry,
-) {
-	entry := rdc.insertLockedInner(ctx, []*kvbase.RangeCacheEntry{ent})[0]
+func (rdc *RangeDescriptorCache) mustInsertLocked(ctx context.Context, ent *rangeCacheEntry) {
+	entry := rdc.insertLockedInner(ctx, []*rangeCacheEntry{ent})[0]
 	if entry == nil {
 		log.Fatalf(ctx, "unexpected failure to insert desc: %s", ent)
 	}
@@ -899,33 +942,33 @@ func (rdc *RangeDescriptorCache) mustInsertLocked(
 // stale.
 func (rdc *RangeDescriptorCache) insertLocked(
 	ctx context.Context, rs ...roachpb.RangeInfo,
-) []*kvbase.RangeCacheEntry {
-	entries := make([]*kvbase.RangeCacheEntry, len(rs))
+) []*rangeCacheEntry {
+	entries := make([]*rangeCacheEntry, len(rs))
 	for i, r := range rs {
-		entries[i] = &kvbase.RangeCacheEntry{
-			Desc:  r.Desc,
-			Lease: r.Lease,
+		entries[i] = &rangeCacheEntry{
+			desc:  r.Desc,
+			lease: r.Lease,
 		}
 	}
 	return rdc.insertLockedInner(ctx, entries)
 }
 
 func (rdc *RangeDescriptorCache) insertLockedInner(
-	ctx context.Context, rs []*kvbase.RangeCacheEntry,
-) []*kvbase.RangeCacheEntry {
+	ctx context.Context, rs []*rangeCacheEntry,
+) []*rangeCacheEntry {
 	// entries will have the same element as rs, except the ones that couldn't be
 	// inserted for which the slots will remain nil.
-	entries := make([]*kvbase.RangeCacheEntry, len(rs))
+	entries := make([]*rangeCacheEntry, len(rs))
 	for i, ent := range rs {
-		if !ent.Desc.IsInitialized() {
+		if !ent.desc.IsInitialized() {
 			log.Fatalf(ctx, "inserting uninitialized desc: %s", ent)
 		}
-		if !ent.Lease.Empty() {
-			replID := ent.Lease.Replica.ReplicaID
-			_, ok := ent.Desc.GetReplicaDescriptorByID(replID)
+		if !ent.lease.Empty() {
+			replID := ent.lease.Replica.ReplicaID
+			_, ok := ent.desc.GetReplicaDescriptorByID(replID)
 			if !ok {
 				log.Fatalf(ctx, "leaseholder replicaID: %d not part of descriptor: %s. lease: %s",
-					replID, ent.Desc, ent.Lease)
+					replID, ent.Desc(), ent.Lease())
 			}
 		}
 		// Note: we append the end key of each range to meta records
@@ -944,7 +987,7 @@ func (rdc *RangeDescriptorCache) insertLockedInner(
 			entries[i] = newerEntry
 			continue
 		}
-		rangeKey := keys.RangeMetaKey(ent.Desc.EndKey)
+		rangeKey := keys.RangeMetaKey(ent.Desc().EndKey)
 		if log.V(2) {
 			log.Infof(ctx, "adding cache entry: key=%s value=%s", rangeKey, ent)
 		}
@@ -954,13 +997,13 @@ func (rdc *RangeDescriptorCache) insertLockedInner(
 	return entries
 }
 
-func (rdc *RangeDescriptorCache) getValue(entry *cache.Entry) *kvbase.RangeCacheEntry {
-	return entry.Value.(*kvbase.RangeCacheEntry)
+func (rdc *RangeDescriptorCache) getValue(entry *cache.Entry) *rangeCacheEntry {
+	return entry.Value.(*rangeCacheEntry)
 }
 
 func (rdc *RangeDescriptorCache) clearOlderOverlapping(
-	ctx context.Context, newEntry *kvbase.RangeCacheEntry,
-) (ok bool, newerEntry *kvbase.RangeCacheEntry) {
+	ctx context.Context, newEntry *rangeCacheEntry,
+) (ok bool, newerEntry *rangeCacheEntry) {
 	rdc.rangeCache.Lock()
 	defer rdc.rangeCache.Unlock()
 	return rdc.clearOlderOverlappingLocked(ctx, newEntry)
@@ -977,22 +1020,22 @@ func (rdc *RangeDescriptorCache) clearOlderOverlapping(
 // Note that even if false is returned, older descriptors are still cleared from
 // the cache.
 func (rdc *RangeDescriptorCache) clearOlderOverlappingLocked(
-	ctx context.Context, newEntry *kvbase.RangeCacheEntry,
-) (ok bool, newerEntry *kvbase.RangeCacheEntry) {
-	log.VEventf(ctx, 2, "clearing entries overlapping %s", newEntry.Desc)
+	ctx context.Context, newEntry *rangeCacheEntry,
+) (ok bool, newerEntry *rangeCacheEntry) {
+	log.VEventf(ctx, 2, "clearing entries overlapping %s", newEntry.Desc())
 	newest := true
-	var newerFound *kvbase.RangeCacheEntry
-	overlapping := rdc.getCachedOverlappingRLocked(ctx, newEntry.Desc.RSpan())
+	var newerFound *rangeCacheEntry
+	overlapping := rdc.getCachedOverlappingRLocked(ctx, newEntry.Desc().RSpan())
 	for _, e := range overlapping {
 		entry := rdc.getValue(e)
-		if newEntry.NewerThan(entry) {
+		if newEntry.overrides(entry) {
 			if log.V(2) {
 				log.Infof(ctx, "clearing overlapping descriptor: key=%s entry=%s", e.Key, rdc.getValue(e))
 			}
 			rdc.rangeCache.cache.DelEntry(e)
 		} else {
 			newest = false
-			if descsCompatible(&entry.Desc, &newEntry.Desc) {
+			if descsCompatible(entry.Desc(), newEntry.Desc()) {
 				newerFound = entry
 				// We've found a similar descriptor in the cache; there can't be any
 				// other overlapping ones so let's stop the iteration.
@@ -1005,4 +1048,216 @@ func (rdc *RangeDescriptorCache) clearOlderOverlappingLocked(
 		}
 	}
 	return newest, newerFound
+}
+
+// rangeCacheEntry represents one cache entry.
+//
+// The cache stores *rangeCacheEntry. Entries are immutable: cache lookups
+// returns the same *rangeCacheEntry to multiple queriers for efficiency, but
+// nobody should modify the lookup result.
+type rangeCacheEntry struct {
+	// desc is always populated.
+	desc roachpb.RangeDescriptor
+	// Lease has info on the range's lease. It can be Empty() if no lease
+	// information is known. When a lease is known, it is guaranteed that the
+	// lease comes from Desc's range id (i.e. we'll never put a lease from another
+	// range in here). This allows UpdateLease() to use Lease.Sequence to compare
+	// leases. Moreover, the lease will correspond to one of the replicas in Desc.
+	lease roachpb.Lease
+}
+
+func (e rangeCacheEntry) String() string {
+	return fmt.Sprintf("desc:%s, lease:%s", e.Desc(), e.Lease())
+}
+
+func (e *rangeCacheEntry) Desc() *roachpb.RangeDescriptor {
+	return &e.desc
+}
+
+func (e *rangeCacheEntry) Leaseholder() *roachpb.ReplicaDescriptor {
+	if e.lease.Empty() {
+		return nil
+	}
+	return &e.lease.Replica
+}
+
+func (e *rangeCacheEntry) Lease() *roachpb.Lease {
+	if e.lease.Empty() {
+		return nil
+	}
+	if e.LeaseSpeculative() {
+		return nil
+	}
+	return &e.lease
+}
+
+// DescSpeculative returns true if the descriptor in the entry is "speculative"
+// - i.e. it doesn't correspond to a committed value. Such descriptors have been
+// inserted in the cache with Generation=0.
+func (e *rangeCacheEntry) DescSpeculative() bool {
+	return e.desc.Generation == 0
+}
+
+// LeaseSpeculative returns true if the lease in the entry is "speculative"
+// - i.e. it doesn't correspond to a committed lease. Such leases have been
+// inserted in the cache with Sequence=0.
+func (e *rangeCacheEntry) LeaseSpeculative() bool {
+	if e.lease.Empty() {
+		panic(fmt.Sprintf("LeaseSpeculative called on entry with empty lease: %s", e))
+	}
+	return e.lease.Speculative()
+}
+
+// overrides returns true if o should replace e in the cache. It is assumed that
+// e's and o'd descriptors overlap (and so they can't co-exist in the cache). A
+// newer entry overrides an older entry. What entry is newer is decided based
+// the descriptor's generation and, for equal generations, by the lease's
+// sequence.
+//
+// In situations where it can't be determined which entry represents newer
+// information, e wins - the assumption is that o is already in the cache and we
+// have some reason to believe e should get in the cache instead (generally
+// because a server gave us this information recently). Situations where it
+// can't be determined what information is newer is when at least one of the
+// descriptors is "speculative" (generation=0), or when the lease information is
+// "speculative" (sequence=0).
+func (e *rangeCacheEntry) overrides(o *rangeCacheEntry) bool {
+	if util.RaceEnabled {
+		if _, err := e.Desc().RSpan().Intersect(o.Desc()); err != nil {
+			panic(fmt.Sprintf("descriptors don't intersect: %s vs %s", e.Desc(), o.Desc()))
+		}
+	}
+
+	if res := compareEntryDescs(o, e); res != 0 {
+		return res < 0
+	}
+
+	// Equal descriptor generations. Let's look at the lease sequence.
+
+	// If two RangeDescriptors overlap and have the same Generation, they must
+	// be referencing the same range, in which case their lease sequences are
+	// comparable.
+	if e.Desc().RangeID != o.Desc().RangeID {
+		panic(fmt.Sprintf("overlapping descriptors with same gen but different IDs: %s vs %s",
+			e.Desc(), o.Desc()))
+	}
+
+	return compareEntryLeases(o, e) < 0
+}
+
+// compareEntryDescs returns -1, 0 or 1 depending on whether a's descriptor is
+// considered older, equal to, or newer than b's.
+//
+// In case at least one of the descriptors is "speculative", a is considered
+// older; this matches the semantics of b.overrides(a).
+func compareEntryDescs(a, b *rangeCacheEntry) int {
+	if util.RaceEnabled {
+		if _, err := a.Desc().RSpan().Intersect(b.Desc()); err != nil {
+			panic(fmt.Sprintf("descriptors don't intersect: %s vs %s", a.Desc(), b.Desc()))
+		}
+	}
+
+	if a.desc.Equal(b.desc) {
+		return 0
+	}
+
+	if a.DescSpeculative() || b.DescSpeculative() {
+		return -1
+	}
+
+	if a.Desc().Generation < b.Desc().Generation {
+		return -1
+	}
+	if a.Desc().Generation > b.Desc().Generation {
+		return 1
+	}
+	return 0
+}
+
+// compareEntryLeases returns -1, 0 or 1 depending on whether a's lease is
+// considered older, equal to, or newer than b's. The descriptors in a and b are
+// assumed to be the same.
+//
+// An empty lease is considered older than any other. In case at least one of
+// the leases is "speculative", a is considered older; this matches the
+// semantics of b.overrides(a).
+func compareEntryLeases(a, b *rangeCacheEntry) int {
+	if aEmpty, bEmpty := a.lease.Empty(), b.lease.Empty(); aEmpty || bEmpty {
+		if aEmpty && !bEmpty {
+			return -1
+		}
+		if !aEmpty && bEmpty {
+			return 1
+		}
+		return 0
+	}
+
+	// A speculative lease always loses; we don't know the sequence number of a
+	// speculative lease.
+	if a.LeaseSpeculative() || b.LeaseSpeculative() {
+		return -1
+	}
+
+	if a.Lease().Sequence < b.Lease().Sequence {
+		return -1
+	}
+	if a.Lease().Sequence > b.Lease().Sequence {
+		return 1
+	}
+	return 0
+}
+
+// updateLease returns a new rangeCacheEntry with the receiver's descriptor and
+// a new lease. The updated retval indicates whether the passed-in lease appears
+// to be newer than the lease the entry had before. If updated is returned true,
+// the caller should evict the existing entry (the receiver) and replace it with
+// newEntry. (true, nil) can be returned meaning that the existing entry should
+// be evicted, but there's no replacement that this function can provide; this
+// happens when the passed-in lease indicates a leaseholder that's not part of
+// the entry's descriptor. The descriptor must be really stale, and the caller
+// should read a new version.
+//
+// If updated=false is returned, then newEntry will be the same as the receiver.
+// This means that the passed-in lease is older than the lease already in the
+// entry.
+//
+// If the new leaseholder is not a replica in the descriptor, we assume the
+// lease information to be more recent than the entry's descriptor, and we
+// return true, nil. The caller should evict the receiver from the cache, but
+// it'll have to do extra work to figure out what to insert instead.
+func (e *rangeCacheEntry) updateLease(l *roachpb.Lease) (updated bool, newEntry *rangeCacheEntry) {
+	// If l is older than what the entry has (or the same), return early.
+	//
+	// This method handles speculative leases: a new lease with a sequence of 0 is
+	// presumed to be newer than anything, and an existing lease with a sequence
+	// of 0 is presumed to be older than anything.
+	//
+	// We handle the case of a lease with the sequence equal to the existing
+	// entry, but otherwise different. This results in the new lease updating the
+	// entry, because the existing lease might correspond to a proposed lease that
+	// a replica returned speculatively while a lease acquisition was in progress.
+	if l.Sequence != 0 && e.lease.Sequence != 0 && l.Sequence < e.lease.Sequence {
+		return false, e
+	}
+
+	if l.Equal(e.Lease()) {
+		return false, e
+	}
+
+	// Check whether the lease we were given is compatible with the replicas in
+	// the descriptor. If it's not, the descriptor must be really stale, and the
+	// RangeCacheEntry needs to be evicted.
+	_, ok := e.desc.GetReplicaDescriptorByID(l.Replica.ReplicaID)
+	if !ok {
+		return true, nil
+	}
+
+	// TODO(andrei): If the leaseholder is present, but the descriptor lists the
+	// replica as a learner, this is a sign of a stale descriptor. I'm not sure
+	// what to do about it, though.
+
+	return true, &rangeCacheEntry{
+		desc:  e.desc,
+		lease: *l,
+	}
 }

--- a/pkg/kv/kvclient/kvcoord/range_cache_test.go
+++ b/pkg/kv/kvclient/kvcoord/range_cache_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/biogo/store/llrb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -256,6 +255,7 @@ func initTestDescriptorDB(t *testing.T) *testDescriptorDB {
 			db.splitRange(t, keys.RangeMetaKey(roachpb.RKey(string(char))))
 		}
 	}
+	// TODO(andrei): don't leak this Stopper. Someone needs to Stop() it.
 	db.cache = NewRangeDescriptorCache(st, db, staticSize(2<<10), stop.NewStopper())
 	return db
 }
@@ -284,7 +284,7 @@ func doLookup(
 	return doLookupWithToken(ctx, rc, key, EvictionToken{}, false)
 }
 
-func evict(ctx context.Context, rc *RangeDescriptorCache, entry *kvbase.RangeCacheEntry) bool {
+func evict(ctx context.Context, rc *RangeDescriptorCache, entry *rangeCacheEntry) bool {
 	rc.rangeCache.Lock()
 	defer rc.rangeCache.Unlock()
 	ok, _ /* updatedEntry */ := rc.evictLocked(ctx, entry)
@@ -294,7 +294,7 @@ func evict(ctx context.Context, rc *RangeDescriptorCache, entry *kvbase.RangeCac
 func clearOlderOverlapping(
 	ctx context.Context, rc *RangeDescriptorCache, desc *roachpb.RangeDescriptor,
 ) bool {
-	ent := &kvbase.RangeCacheEntry{Desc: *desc}
+	ent := &rangeCacheEntry{desc: *desc}
 	ok, _ /* newerEntry */ := rc.clearOlderOverlapping(ctx, ent)
 	return ok
 }
@@ -314,7 +314,7 @@ func doLookupWithToken(
 	if err != nil {
 		panic(fmt.Sprintf("unexpected error from Lookup: %s", err))
 	}
-	desc := &returnToken.entry.Desc
+	desc := returnToken.Desc()
 	keyAddr, err := keys.Addr(roachpb.Key(key))
 	if err != nil {
 		panic(err)
@@ -457,7 +457,7 @@ func TestRangeCache(t *testing.T) {
 	// Attempt to compare-and-evict with a cache entry that is not equal to the
 	// cached one; it should not alter the cache.
 	desc, _ := doLookup(ctx, db.cache, "cz")
-	require.False(t, evict(ctx, db.cache, &kvbase.RangeCacheEntry{Desc: *desc}))
+	require.False(t, evict(ctx, db.cache, &rangeCacheEntry{desc: *desc}))
 
 	_, evictToken := doLookup(ctx, db.cache, "cz")
 	db.assertLookupCountEq(t, 0, "cz")
@@ -861,7 +861,7 @@ func TestRangeCacheHandleDoubleSplit(t *testing.T) {
 						ctx, key, evictToken,
 						tc.reverseScan)
 					require.NoError(t, err)
-					desc = &tok.entry.Desc
+					desc = tok.Desc()
 					if tc.reverseScan {
 						if !desc.ContainsKeyInverted(key) {
 							t.Errorf("desc %s does not contain exclusive end key %s", desc, key)
@@ -950,6 +950,10 @@ func TestRangeCacheUseIntents(t *testing.T) {
 	if reflect.DeepEqual(abDesc, abDescIntent) {
 		t.Errorf("expected initial range descriptor to be different from the one from intents, found %v", abDesc)
 	}
+
+	// Check that the intent had been inserted into the cache with Generation=0,
+	// signifying a speculative descriptor.
+	require.Equal(t, roachpb.RangeGeneration(0), abDescIntent.Generation)
 }
 
 // TestRangeCacheClearOverlapping verifies that existing, overlapping
@@ -967,8 +971,10 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	}
 
 	st := cluster.MakeTestingClusterSettings()
-	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stop.NewStopper())
-	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKeyMax)), &kvbase.RangeCacheEntry{Desc: *defDesc})
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stopper)
+	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKeyMax)), &rangeCacheEntry{desc: *defDesc})
 
 	// Now, add a new, overlapping set of descriptors.
 	minToBDesc := &roachpb.RangeDescriptor{
@@ -983,25 +989,25 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	}
 	curGeneration := roachpb.RangeGeneration(1)
 	require.True(t, clearOlderOverlapping(ctx, cache, minToBDesc))
-	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKey("b"))), &kvbase.RangeCacheEntry{Desc: *minToBDesc})
+	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKey("b"))), &rangeCacheEntry{desc: *minToBDesc})
 	if desc := cache.GetCached(roachpb.RKey("b"), false); desc != nil {
 		t.Errorf("descriptor unexpectedly non-nil: %s", desc)
 	}
 
 	require.True(t, clearOlderOverlapping(ctx, cache, bToMaxDesc))
-	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKeyMax)), &kvbase.RangeCacheEntry{Desc: *bToMaxDesc})
+	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKeyMax)), &rangeCacheEntry{desc: *bToMaxDesc})
 	ri := cache.GetCached(roachpb.RKey("b"), false)
-	require.Equal(t, *bToMaxDesc, ri.Desc)
+	require.Equal(t, bToMaxDesc, ri.Desc())
 
 	// Add default descriptor back which should remove two split descriptors.
 	defDescCpy := *defDesc
 	curGeneration++
 	defDescCpy.Generation = curGeneration
 	require.True(t, clearOlderOverlapping(ctx, cache, &defDescCpy))
-	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKeyMax)), &kvbase.RangeCacheEntry{Desc: defDescCpy})
+	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKeyMax)), &rangeCacheEntry{desc: defDescCpy})
 	for _, key := range []roachpb.RKey{roachpb.RKey("a"), roachpb.RKey("b")} {
 		ri = cache.GetCached(key, false)
-		require.Equal(t, defDescCpy, ri.Desc)
+		require.Equal(t, &defDescCpy, ri.Desc())
 	}
 
 	// Insert ["b", "c") and then insert ["a", b"). Verify that the former is not evicted by the latter.
@@ -1012,9 +1018,9 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 		Generation: curGeneration,
 	}
 	require.True(t, clearOlderOverlapping(ctx, cache, bToCDesc))
-	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKey("c"))), &kvbase.RangeCacheEntry{Desc: *bToCDesc})
+	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKey("c"))), &rangeCacheEntry{desc: *bToCDesc})
 	ri = cache.GetCached(roachpb.RKey("c"), true)
-	require.Equal(t, *bToCDesc, ri.Desc)
+	require.Equal(t, bToCDesc, ri.Desc())
 
 	curGeneration++
 	aToBDesc := &roachpb.RangeDescriptor{
@@ -1025,7 +1031,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	require.True(t, clearOlderOverlapping(ctx, cache, aToBDesc))
 	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKey("b"))), ri)
 	ri = cache.GetCached(roachpb.RKey("c"), true)
-	require.Equal(t, *bToCDesc, ri.Desc)
+	require.Equal(t, bToCDesc, ri.Desc())
 }
 
 // Test The ClearOlderOverlapping. There's also the older
@@ -1141,23 +1147,25 @@ func TestRangeCacheClearOlderOverlapping(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
 			st := cluster.MakeTestingClusterSettings()
-			cache := NewRangeDescriptorCache(st, nil /* db */, staticSize(2<<10), stop.NewStopper())
+			stopper := stop.NewStopper()
+			defer stopper.Stop(ctx)
+			cache := NewRangeDescriptorCache(st, nil /* db */, staticSize(2<<10), stopper)
 			for _, d := range tc.cachedDescs {
 				cache.Insert(ctx, roachpb.RangeInfo{Desc: d})
 			}
-			newEntry := &kvbase.RangeCacheEntry{Desc: tc.clearDesc}
+			newEntry := &rangeCacheEntry{desc: tc.clearDesc}
 			newest, newer := cache.clearOlderOverlapping(ctx, newEntry)
 			all := cache.GetCachedOverlapping(ctx, roachpb.RSpan{Key: roachpb.RKeyMin, EndKey: roachpb.RKeyMax})
 			var allDescs []roachpb.RangeDescriptor
 			if len(all) != 0 {
 				allDescs = make([]roachpb.RangeDescriptor, len(all))
 				for i, e := range all {
-					allDescs[i] = e.Desc
+					allDescs[i] = *e.Desc()
 				}
 			}
 			var newerDesc *roachpb.RangeDescriptor
 			if newer != nil {
-				newerDesc = &newer.Desc
+				newerDesc = newer.Desc()
 			}
 
 			assert.Equal(t, tc.expCache, allDescs)
@@ -1191,7 +1199,9 @@ func TestRangeCacheClearOverlappingMeta(t *testing.T) {
 	}
 
 	st := cluster.MakeTestingClusterSettings()
-	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stop.NewStopper())
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stopper)
 	cache.Insert(ctx,
 		roachpb.RangeInfo{Desc: firstDesc},
 		roachpb.RangeInfo{Desc: restDesc})
@@ -1207,7 +1217,7 @@ func TestRangeCacheClearOverlappingMeta(t *testing.T) {
 				t.Fatalf("invocation of clearOlderOverlapping panicked: %v", r)
 			}
 		}()
-		cache.clearOlderOverlapping(ctx, &kvbase.RangeCacheEntry{Desc: metaSplitDesc})
+		cache.clearOlderOverlapping(ctx, &rangeCacheEntry{desc: metaSplitDesc})
 	}()
 }
 
@@ -1224,10 +1234,12 @@ func TestGetCachedRangeDescriptorInverted(t *testing.T) {
 	}
 
 	st := cluster.MakeTestingClusterSettings()
-	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stop.NewStopper())
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stopper)
 	for _, rd := range testData {
 		cache.rangeCache.cache.Add(
-			rangeCacheKey(keys.RangeMetaKey(rd.EndKey)), &kvbase.RangeCacheEntry{Desc: rd})
+			rangeCacheKey(keys.RangeMetaKey(rd.EndKey)), &rangeCacheEntry{desc: rd})
 	}
 
 	testCases := []struct {
@@ -1276,7 +1288,7 @@ func TestGetCachedRangeDescriptorInverted(t *testing.T) {
 			require.Nil(t, targetRange)
 		} else {
 			require.NotNil(t, targetRange)
-			require.Equal(t, *test.rng, targetRange.Desc)
+			require.Equal(t, test.rng, targetRange.Desc())
 		}
 		var cacheKey rangeCacheKey
 		if entry != nil {
@@ -1293,31 +1305,36 @@ func TestRangeCacheGeneration(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	descAM1 := &roachpb.RangeDescriptor{
+	descAM2 := &roachpb.RangeDescriptor{
+		RangeID:    1,
 		StartKey:   roachpb.RKey("a"),
 		EndKey:     roachpb.RKey("m"),
-		Generation: 1,
-	}
-	descMZ3 := &roachpb.RangeDescriptor{
-		StartKey:   roachpb.RKey("m"),
-		EndKey:     roachpb.RKey("z"),
-		Generation: 3,
-	}
-
-	descBY0 := &roachpb.RangeDescriptor{
-		StartKey:   roachpb.RKey("b"),
-		EndKey:     roachpb.RKey("y"),
-		Generation: 0,
-	}
-	descBY2 := &roachpb.RangeDescriptor{
-		StartKey:   roachpb.RKey("b"),
-		EndKey:     roachpb.RKey("y"),
 		Generation: 2,
 	}
-	descBY4 := &roachpb.RangeDescriptor{
+	descMZ4 := &roachpb.RangeDescriptor{
+		RangeID:    2,
+		StartKey:   roachpb.RKey("m"),
+		EndKey:     roachpb.RKey("z"),
+		Generation: 4,
+	}
+
+	descBY1 := &roachpb.RangeDescriptor{
+		RangeID:    3,
 		StartKey:   roachpb.RKey("b"),
 		EndKey:     roachpb.RKey("y"),
-		Generation: 4,
+		Generation: 1,
+	}
+	descBY3 := &roachpb.RangeDescriptor{
+		RangeID:    3,
+		StartKey:   roachpb.RKey("b"),
+		EndKey:     roachpb.RKey("y"),
+		Generation: 3,
+	}
+	descBY5 := &roachpb.RangeDescriptor{
+		RangeID:    3,
+		StartKey:   roachpb.RKey("b"),
+		EndKey:     roachpb.RKey("y"),
+		Generation: 5,
 	}
 
 	testCases := []struct {
@@ -1327,39 +1344,39 @@ func TestRangeCacheGeneration(t *testing.T) {
 		expectedDesc []*roachpb.RangeDescriptor
 	}{
 		{
-			// descBY0 is ignored since the existing keyspace is covered by
-			// descriptors of generations 1 and 3, respectively.
-			name:         "evict 0",
-			insertDesc:   descBY0,
+			// descBY1 is ignored since the existing keyspace is covered by
+			// descriptors of generations 2 and 3, respectively.
+			name:         "insert old",
+			insertDesc:   descBY1,
 			queryKeys:    []roachpb.RKey{roachpb.RKey("b"), roachpb.RKey("y")},
-			expectedDesc: []*roachpb.RangeDescriptor{descAM1, descMZ3},
+			expectedDesc: []*roachpb.RangeDescriptor{descAM2, descMZ4},
 		},
 		{
-			// descBY2 evicts descAM1, but not descMZ3 based on Generation. Since
-			// there is an overlapping descriptor with higher Generation (descMZ3),
+			// descBY3 evicts descAM2, but not descMZ4 based on Generation. Since
+			// there is an overlapping descriptor with higher Generation (descMZ4),
 			// it is not inserted.
-			name:         "evict 1",
-			insertDesc:   descBY2,
+			name:         "evict some",
+			insertDesc:   descBY3,
 			queryKeys:    []roachpb.RKey{roachpb.RKey("b"), roachpb.RKey("y")},
-			expectedDesc: []*roachpb.RangeDescriptor{nil, descMZ3},
+			expectedDesc: []*roachpb.RangeDescriptor{nil, descMZ4},
 		},
 		{
-			// descBY4 replaces both existing descriptors and it is inserted.
-			name:         "evict 2",
-			insertDesc:   descBY4,
+			// descBY5 replaces both existing descriptors and it is inserted.
+			name:         "evict all",
+			insertDesc:   descBY5,
 			queryKeys:    []roachpb.RKey{roachpb.RKey("b"), roachpb.RKey("y")},
-			expectedDesc: []*roachpb.RangeDescriptor{descBY4, nil},
+			expectedDesc: []*roachpb.RangeDescriptor{descBY5, nil},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			st := cluster.MakeTestingClusterSettings()
-			cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stop.NewStopper())
-			cache.Insert(ctx,
-				roachpb.RangeInfo{Desc: *descAM1},
-				roachpb.RangeInfo{Desc: *descMZ3},
-				roachpb.RangeInfo{Desc: *tc.insertDesc})
+			stopper := stop.NewStopper()
+			defer stopper.Stop(ctx)
+			cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stopper)
+			cache.Insert(ctx, roachpb.RangeInfo{Desc: *descAM2}, roachpb.RangeInfo{Desc: *descMZ4})
+			cache.Insert(ctx, roachpb.RangeInfo{Desc: *tc.insertDesc})
 
 			for index, queryKey := range tc.queryKeys {
 				ri := cache.GetCached(queryKey, false)
@@ -1368,7 +1385,7 @@ func TestRangeCacheGeneration(t *testing.T) {
 					require.Nil(t, ri)
 				} else {
 					require.NotNil(t, ri)
-					require.NotNil(t, *exp, ri.Desc)
+					require.NotNil(t, *exp, ri.Desc())
 				}
 			}
 		})
@@ -1426,7 +1443,9 @@ func TestRangeCacheUpdateLease(t *testing.T) {
 	startKey := desc1.StartKey
 
 	st := cluster.MakeTestingClusterSettings()
-	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stop.NewStopper())
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stopper)
 
 	cache.Insert(ctx, roachpb.RangeInfo{
 		Desc:  desc1,
@@ -1437,10 +1456,11 @@ func TestRangeCacheUpdateLease(t *testing.T) {
 	tok, err := cache.LookupWithEvictionToken(
 		ctx, desc1.StartKey, EvictionToken{}, false /* useReverseScan */)
 	require.NoError(t, err)
-	require.Nil(t, tok.Lease())
+	require.Nil(t, tok.Leaseholder())
 
 	l := &roachpb.Lease{
-		Replica: rep1,
+		Replica:  rep1,
+		Sequence: 1,
 	}
 	oldTok := tok
 	tok, ok := tok.UpdateLease(ctx, l)
@@ -1448,18 +1468,19 @@ func TestRangeCacheUpdateLease(t *testing.T) {
 	require.Equal(t, oldTok.Desc(), tok.Desc())
 	ri := cache.GetCached(startKey, false /* inverted */)
 	require.NotNil(t, ri)
-	require.Equal(t, rep1, ri.Lease.Replica)
+	require.Equal(t, rep1, ri.Lease().Replica)
 
 	tok = tok.ClearLease(ctx)
 	ri = cache.GetCached(startKey, false /* inverted */)
 	require.NotNil(t, ri)
-	require.True(t, ri.Lease.Empty())
+	require.True(t, ri.(*rangeCacheEntry).lease.Empty())
 	require.NotNil(t, tok)
 
 	// Check that trying to update the lease to a non-member replica results
 	// in a nil return and the entry's eviction.
 	l = &roachpb.Lease{
-		Replica: repNonMember,
+		Replica:  repNonMember,
+		Sequence: 2,
 	}
 	tok, ok = tok.UpdateLease(ctx, l)
 	require.False(t, ok)
@@ -1485,12 +1506,12 @@ func TestRangeCacheUpdateLease(t *testing.T) {
 	})
 	tok, ok = tok.UpdateLease(ctx,
 		// Specify a lease compatible with desc2.
-		&roachpb.Lease{Replica: rep2},
+		&roachpb.Lease{Replica: rep2, Sequence: 3},
 	)
 	require.True(t, ok)
 	require.NotNil(t, tok)
 	require.Equal(t, tok.Desc(), &desc2)
-	require.Equal(t, tok.Lease().Replica, rep2)
+	require.Equal(t, tok.entry.lease.Replica, rep2)
 
 	// Update the cache again.
 	cache.Insert(ctx, roachpb.RangeInfo{
@@ -1499,7 +1520,7 @@ func TestRangeCacheUpdateLease(t *testing.T) {
 	})
 	// This time try to specify a lease that's not compatible with the desc. The
 	// entry should end up evicted from the cache.
-	tok, ok = tok.UpdateLease(ctx, &roachpb.Lease{Replica: rep3})
+	tok, ok = tok.UpdateLease(ctx, &roachpb.Lease{Replica: rep3, Sequence: 4})
 	require.False(t, ok)
 	require.True(t, tok.Empty())
 	ri = cache.GetCached(startKey, false /* inverted */)
@@ -1533,9 +1554,9 @@ func TestRangeCacheEntryUpdateLease(t *testing.T) {
 		Generation: 0,
 	}
 
-	e := &kvbase.RangeCacheEntry{
-		Desc:  desc,
-		Lease: roachpb.Lease{},
+	e := &rangeCacheEntry{
+		desc:  desc,
+		lease: roachpb.Lease{},
 	}
 
 	// Check that some lease overwrites an empty lease.
@@ -1543,63 +1564,79 @@ func TestRangeCacheEntryUpdateLease(t *testing.T) {
 		Replica:  rep1,
 		Sequence: 1,
 	}
-	ok, e := e.UpdateLease(l)
+	ok, e := e.updateLease(l)
 	require.True(t, ok)
-	require.True(t, l.Equal(&e.Lease))
+	require.True(t, l.Equal(e.Lease()))
 
 	// Check that a lease with no sequence number overwrites any other lease.
 	l = &roachpb.Lease{
 		Replica:  rep1,
 		Sequence: 0,
 	}
-	ok, e = e.UpdateLease(l)
+	ok, e = e.updateLease(l)
 	require.True(t, ok)
-	require.True(t, l.Equal(e.Lease))
+	require.NotNil(t, e.Leaseholder())
+	require.True(t, l.Replica.Equal(*e.Leaseholder()))
+	// Check that Seq=0 leases are not returned by Lease().
+	require.Nil(t, e.Lease())
 
 	// Check that another lease with no seq num overwrites a lease with no seq num.
 	l = &roachpb.Lease{
 		Replica:  rep2,
 		Sequence: 0,
 	}
-	ok, e = e.UpdateLease(l)
+	ok, e = e.updateLease(l)
 	require.True(t, ok)
-	require.True(t, l.Equal(e.Lease))
+	require.NotNil(t, e.Leaseholder())
+	require.True(t, l.Replica.Equal(*e.Leaseholder()))
 
 	// Check that another lease with no seq num overwrites a lease with no seq num.
 	l = &roachpb.Lease{
 		Replica:  rep1,
 		Sequence: 0,
 	}
-	ok, e = e.UpdateLease(l)
+	ok, e = e.updateLease(l)
 	require.True(t, ok)
-	require.True(t, l.Equal(e.Lease))
+	require.NotNil(t, e.Leaseholder())
+	require.True(t, l.Replica.Equal(*e.Leaseholder()))
 
 	// Set a lease
 	l = &roachpb.Lease{
 		Replica:  rep1,
 		Sequence: 2,
 	}
-	ok, e = e.UpdateLease(l)
+	ok, e = e.updateLease(l)
 	require.True(t, ok)
-	require.True(t, l.Equal(e.Lease))
+	require.NotNil(t, e.Leaseholder())
+	require.True(t, l.Equal(*e.Lease()))
 
 	// Check that updating to an older lease doesn't work.
 	l = &roachpb.Lease{
 		Replica:  rep2,
 		Sequence: 1,
 	}
-	ok, e = e.UpdateLease(l)
+	ok, e = e.updateLease(l)
 	require.False(t, ok)
-	require.False(t, l.Equal(e.Lease))
+	require.False(t, l.Equal(*e.Lease()))
 
 	// Check that updating to a lease at the same sequence as the existing one works.
 	l = &roachpb.Lease{
 		Replica:  rep2,
 		Sequence: 2,
 	}
-	ok, e = e.UpdateLease(l)
+	ok, e = e.updateLease(l)
 	require.True(t, ok)
-	require.True(t, l.Equal(e.Lease))
+	require.True(t, l.Equal(e.Lease()))
+
+	// Check that updating to the same lease returns false.
+	l = &roachpb.Lease{
+		Replica:  rep2,
+		Sequence: 2,
+	}
+	require.True(t, l.Equal(e.Lease()))
+	ok, e = e.updateLease(l)
+	require.False(t, ok)
+	require.True(t, l.Equal(e.Lease()))
 
 	// Check that updating the lease to a non-member replica returns a nil
 	// entry.
@@ -1607,7 +1644,152 @@ func TestRangeCacheEntryUpdateLease(t *testing.T) {
 		Replica:  repNonMember,
 		Sequence: 0,
 	}
-	ok, e = e.UpdateLease(l)
+	ok, e = e.updateLease(l)
 	require.True(t, ok)
 	require.Nil(t, e)
+}
+
+func TestRangeCacheEntryOverrides(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	desc := func(gen roachpb.RangeGeneration) roachpb.RangeDescriptor {
+		return roachpb.RangeDescriptor{
+			StartKey:   roachpb.RKey("a"),
+			EndKey:     roachpb.RKey("b"),
+			Generation: gen,
+		}
+	}
+
+	tests := []struct {
+		name string
+		// We'll test b.overrides(a).
+		a, b rangeCacheEntry
+		exp  bool
+	}{
+		{
+			name: "b newer gen",
+			exp:  true,
+			a: rangeCacheEntry{
+				desc:  desc(5),
+				lease: roachpb.Lease{},
+			},
+			b: rangeCacheEntry{
+				desc:  desc(6),
+				lease: roachpb.Lease{},
+			},
+		},
+		{
+			name: "a newer gen",
+			exp:  false,
+			a: rangeCacheEntry{
+				desc:  desc(7),
+				lease: roachpb.Lease{},
+			},
+			b: rangeCacheEntry{
+				desc:  desc(6),
+				lease: roachpb.Lease{},
+			},
+		},
+		{
+			name: "b newer lease",
+			exp:  true,
+			a: rangeCacheEntry{
+				desc:  desc(5),
+				lease: roachpb.Lease{Sequence: 1},
+			},
+			b: rangeCacheEntry{
+				desc:  desc(5),
+				lease: roachpb.Lease{Sequence: 2},
+			},
+		},
+		{
+			name: "a newer lease",
+			exp:  false,
+			a: rangeCacheEntry{
+				desc:  desc(5),
+				lease: roachpb.Lease{Sequence: 2},
+			},
+			b: rangeCacheEntry{
+				desc:  desc(5),
+				lease: roachpb.Lease{Sequence: 1},
+			},
+		},
+		{
+			name: "equal",
+			exp:  false,
+			a: rangeCacheEntry{
+				desc:  desc(5),
+				lease: roachpb.Lease{Sequence: 1},
+			},
+			b: rangeCacheEntry{
+				desc:  desc(5),
+				lease: roachpb.Lease{Sequence: 1},
+			},
+		},
+		{
+			name: "a speculative desc",
+			exp:  true,
+			a: rangeCacheEntry{
+				desc:  desc(0),
+				lease: roachpb.Lease{Sequence: 1},
+			},
+			b: rangeCacheEntry{
+				desc:  desc(5),
+				lease: roachpb.Lease{Sequence: 2},
+			},
+		},
+		{
+			name: "b speculative desc",
+			exp:  true,
+			a: rangeCacheEntry{
+				desc:  desc(1),
+				lease: roachpb.Lease{Sequence: 1},
+			},
+			b: rangeCacheEntry{
+				desc:  desc(0),
+				lease: roachpb.Lease{Sequence: 2},
+			},
+		},
+		{
+			name: "both speculative descs",
+			exp:  true,
+			a: rangeCacheEntry{
+				desc:  desc(0),
+				lease: roachpb.Lease{Sequence: 1},
+			},
+			b: rangeCacheEntry{
+				desc:  desc(0),
+				lease: roachpb.Lease{Sequence: 2},
+			},
+		},
+		{
+			name: "a speculative lease",
+			exp:  true,
+			a: rangeCacheEntry{
+				desc:  desc(1),
+				lease: roachpb.Lease{Sequence: 0},
+			},
+			b: rangeCacheEntry{
+				desc:  desc(1),
+				lease: roachpb.Lease{Sequence: 1},
+			},
+		},
+		{
+			name: "both speculative leases",
+			exp:  true,
+			a: rangeCacheEntry{
+				desc:  desc(1),
+				lease: roachpb.Lease{Replica: roachpb.ReplicaDescriptor{ReplicaID: 1}, Sequence: 0},
+			},
+			b: rangeCacheEntry{
+				desc:  desc(1),
+				lease: roachpb.Lease{Replica: roachpb.ReplicaDescriptor{ReplicaID: 2}, Sequence: 0},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.exp, tc.b.overrides(&tc.a))
+		})
+	}
 }

--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -82,11 +82,7 @@ func (ri *RangeIterator) Leaseholder() *roachpb.ReplicaDescriptor {
 	if !ri.Valid() {
 		panic(ri.Error())
 	}
-	l := ri.token.Lease()
-	if l == nil {
-		return nil
-	}
-	return &l.Replica
+	return ri.token.Leaseholder()
 }
 
 // Token returns the eviction token corresponding to the range

--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -85,6 +85,18 @@ func (ri *RangeIterator) Lease() *roachpb.Lease {
 	return ri.token.Lease()
 }
 
+// Leaseholder returns the current leaseholder, if one is known. Nil otherwise.
+func (ri *RangeIterator) Leaseholder() *roachpb.ReplicaDescriptor {
+	if !ri.Valid() {
+		panic(ri.Error())
+	}
+	l := ri.token.Lease()
+	if l == nil {
+		return nil
+	}
+	return &l.Replica
+}
+
 // Token returns the eviction token corresponding to the range
 // descriptor for the current iteration. The iterator must be valid.
 func (ri *RangeIterator) Token() EvictionToken {

--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -71,21 +71,13 @@ func (ri *RangeIterator) Desc() *roachpb.RangeDescriptor {
 	return ri.token.Desc()
 }
 
-// Lease returns information about the lease of the range at which the iterator
-// is currently positioned. The iterator must be valid.
+// Leaseholder returns information about the leaseholder of the range at which
+// the iterator is currently positioned. The iterator must be valid.
 //
 // The lease information comes from a cache, and so it can be stale. Returns nil
 // if no lease information is known.
 //
 // The returned lease is immutable.
-func (ri *RangeIterator) Lease() *roachpb.Lease {
-	if !ri.Valid() {
-		panic(ri.Error())
-	}
-	return ri.token.Lease()
-}
-
-// Leaseholder returns the current leaseholder, if one is known. Nil otherwise.
 func (ri *RangeIterator) Leaseholder() *roachpb.ReplicaDescriptor {
 	if !ri.Valid() {
 		panic(ri.Error())

--- a/pkg/kv/kvserver/intentresolver/intent_resolver.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver.go
@@ -163,12 +163,34 @@ func setConfigDefaults(c *Config) {
 
 type nopRangeDescriptorCache struct{}
 
-var zeroCacheEntry = kvbase.RangeCacheEntry{}
+type zeroCacheEntry struct{}
+
+func (z zeroCacheEntry) Desc() *roachpb.RangeDescriptor {
+	return &roachpb.RangeDescriptor{}
+}
+
+func (z zeroCacheEntry) DescSpeculative() bool {
+	return false
+}
+
+func (z zeroCacheEntry) Leaseholder() *roachpb.ReplicaDescriptor {
+	return nil
+}
+
+func (z zeroCacheEntry) Lease() *roachpb.Lease {
+	return nil
+}
+
+func (z zeroCacheEntry) LeaseSpeculative() bool {
+	return false
+}
+
+var _ kvbase.RangeCacheEntry = zeroCacheEntry{}
 
 func (nrdc nopRangeDescriptorCache) Lookup(
 	ctx context.Context, key roachpb.RKey,
-) (*kvbase.RangeCacheEntry, error) {
-	return &zeroCacheEntry, nil
+) (kvbase.RangeCacheEntry, error) {
+	return zeroCacheEntry{}, nil
 }
 
 // New creates an new IntentResolver.
@@ -774,7 +796,7 @@ func (ir *IntentResolver) lookupRangeID(ctx context.Context, key roachpb.Key) ro
 		}
 		return 0
 	}
-	return rInfo.Desc.RangeID
+	return rInfo.Desc().RangeID
 }
 
 // ResolveIntent synchronously resolves an intent according to opts.

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1780,6 +1780,15 @@ func (l Lease) Type() LeaseType {
 	return LeaseEpoch
 }
 
+// Speculative returns true if this lease instance doesn't correspond to a
+// committed lease (or at least to a lease that's *known* to have committed).
+// For example, nodes sometimes guess who a leaseholder might be and synthesize
+// a more or less complete lease struct. Such cases are identified by an empty
+// Sequence.
+func (l Lease) Speculative() bool {
+	return l.Sequence == 0
+}
+
 // Equivalent determines whether ol is considered the same lease
 // for the purposes of matching leases when executing a command.
 // For expiration-based leases, extensions are allowed.

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1885,7 +1885,7 @@ func (l *Lease) Equal(that interface{}) bool {
 		if ok {
 			that1 = &that2
 		} else {
-			return false
+			panic(fmt.Sprintf("attempting to compare lease to %T", that))
 		}
 	}
 	if that1 == nil {

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -421,7 +421,7 @@ func (e *RangeKeyMismatchError) Ranges() []RangeInfo {
 	if len(e.rangesInternal) != 0 {
 		return e.rangesInternal
 	}
-	// Fallback for 20.1 errors. Remove in 20.3.
+	// Fallback for 20.1 errors. Remove in 21.1.
 	ranges := []RangeInfo{{Desc: e.DeprecatedMismatchedRange}}
 	if e.DeprecatedSuggestedRange != nil {
 		ranges = append(ranges, RangeInfo{Desc: *e.DeprecatedSuggestedRange})

--- a/pkg/roachpb/errors.pb.go
+++ b/pkg/roachpb/errors.pb.go
@@ -123,7 +123,7 @@ func (x *TransactionAbortedReason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionAbortedReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{0}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{0}
 }
 
 // TransactionRetryReason specifies what caused a transaction retry.
@@ -174,7 +174,7 @@ func (x *TransactionRetryReason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionRetryReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{1}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{1}
 }
 
 // TransactionRestart indicates how an error should be handled in a
@@ -225,7 +225,7 @@ func (x *TransactionRestart) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionRestart) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{2}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{2}
 }
 
 // Reason specifies what caused the error.
@@ -264,7 +264,7 @@ func (x *TransactionStatusError_Reason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionStatusError_Reason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{9, 0}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{9, 0}
 }
 
 // Reason specifies what caused the error.
@@ -320,7 +320,7 @@ func (x *RangeFeedRetryError_Reason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (RangeFeedRetryError_Reason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{27, 0}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{27, 0}
 }
 
 // A NotLeaseHolderError indicates that the current range is not the lease
@@ -334,6 +334,10 @@ type NotLeaseHolderError struct {
 	// The current lease, if known. This might be nil even when lease_holder is
 	// set, as sometimes one can create this error without actually knowing the
 	// current lease, but having a guess about who the leader is.
+	//
+	// It's possible for leases returned here to represent speculative leases, not
+	// actual committed leases. In this case, the lease will not have its Sequence
+	// set.
 	Lease   *Lease  `protobuf:"bytes,4,opt,name=lease" json:"lease,omitempty"`
 	RangeID RangeID `protobuf:"varint,3,opt,name=range_id,json=rangeId,casttype=RangeID" json:"range_id"`
 	// If set, the Error() method will return this instead of composing its
@@ -347,7 +351,7 @@ func (m *NotLeaseHolderError) Reset()         { *m = NotLeaseHolderError{} }
 func (m *NotLeaseHolderError) String() string { return proto.CompactTextString(m) }
 func (*NotLeaseHolderError) ProtoMessage()    {}
 func (*NotLeaseHolderError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{0}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{0}
 }
 func (m *NotLeaseHolderError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -382,7 +386,7 @@ func (m *NodeUnavailableError) Reset()         { *m = NodeUnavailableError{} }
 func (m *NodeUnavailableError) String() string { return proto.CompactTextString(m) }
 func (*NodeUnavailableError) ProtoMessage()    {}
 func (*NodeUnavailableError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{1}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{1}
 }
 func (m *NodeUnavailableError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -416,7 +420,7 @@ func (m *UnsupportedRequestError) Reset()         { *m = UnsupportedRequestError
 func (m *UnsupportedRequestError) String() string { return proto.CompactTextString(m) }
 func (*UnsupportedRequestError) ProtoMessage()    {}
 func (*UnsupportedRequestError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{2}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{2}
 }
 func (m *UnsupportedRequestError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -453,7 +457,7 @@ func (m *RangeNotFoundError) Reset()         { *m = RangeNotFoundError{} }
 func (m *RangeNotFoundError) String() string { return proto.CompactTextString(m) }
 func (*RangeNotFoundError) ProtoMessage()    {}
 func (*RangeNotFoundError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{3}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{3}
 }
 func (m *RangeNotFoundError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -504,7 +508,7 @@ func (m *RangeKeyMismatchError) Reset()         { *m = RangeKeyMismatchError{} }
 func (m *RangeKeyMismatchError) String() string { return proto.CompactTextString(m) }
 func (*RangeKeyMismatchError) ProtoMessage()    {}
 func (*RangeKeyMismatchError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{4}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{4}
 }
 func (m *RangeKeyMismatchError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -550,7 +554,7 @@ func (m *ReadWithinUncertaintyIntervalError) Reset()         { *m = ReadWithinUn
 func (m *ReadWithinUncertaintyIntervalError) String() string { return proto.CompactTextString(m) }
 func (*ReadWithinUncertaintyIntervalError) ProtoMessage()    {}
 func (*ReadWithinUncertaintyIntervalError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{5}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{5}
 }
 func (m *ReadWithinUncertaintyIntervalError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -593,7 +597,7 @@ func (m *TransactionAbortedError) Reset()         { *m = TransactionAbortedError
 func (m *TransactionAbortedError) String() string { return proto.CompactTextString(m) }
 func (*TransactionAbortedError) ProtoMessage()    {}
 func (*TransactionAbortedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{6}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{6}
 }
 func (m *TransactionAbortedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -629,7 +633,7 @@ func (m *TransactionPushError) Reset()         { *m = TransactionPushError{} }
 func (m *TransactionPushError) String() string { return proto.CompactTextString(m) }
 func (*TransactionPushError) ProtoMessage()    {}
 func (*TransactionPushError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{7}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{7}
 }
 func (m *TransactionPushError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -665,7 +669,7 @@ func (m *TransactionRetryError) Reset()         { *m = TransactionRetryError{} }
 func (m *TransactionRetryError) String() string { return proto.CompactTextString(m) }
 func (*TransactionRetryError) ProtoMessage()    {}
 func (*TransactionRetryError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{8}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{8}
 }
 func (m *TransactionRetryError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -705,7 +709,7 @@ func (m *TransactionStatusError) Reset()         { *m = TransactionStatusError{}
 func (m *TransactionStatusError) String() string { return proto.CompactTextString(m) }
 func (*TransactionStatusError) ProtoMessage()    {}
 func (*TransactionStatusError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{9}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{9}
 }
 func (m *TransactionStatusError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -743,7 +747,7 @@ func (m *WriteIntentError) Reset()         { *m = WriteIntentError{} }
 func (m *WriteIntentError) String() string { return proto.CompactTextString(m) }
 func (*WriteIntentError) ProtoMessage()    {}
 func (*WriteIntentError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{10}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{10}
 }
 func (m *WriteIntentError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -781,7 +785,7 @@ func (m *WriteTooOldError) Reset()         { *m = WriteTooOldError{} }
 func (m *WriteTooOldError) String() string { return proto.CompactTextString(m) }
 func (*WriteTooOldError) ProtoMessage()    {}
 func (*WriteTooOldError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{11}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{11}
 }
 func (m *WriteTooOldError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -817,7 +821,7 @@ func (m *OpRequiresTxnError) Reset()         { *m = OpRequiresTxnError{} }
 func (m *OpRequiresTxnError) String() string { return proto.CompactTextString(m) }
 func (*OpRequiresTxnError) ProtoMessage()    {}
 func (*OpRequiresTxnError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{12}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{12}
 }
 func (m *OpRequiresTxnError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -854,7 +858,7 @@ func (m *ConditionFailedError) Reset()         { *m = ConditionFailedError{} }
 func (m *ConditionFailedError) String() string { return proto.CompactTextString(m) }
 func (*ConditionFailedError) ProtoMessage()    {}
 func (*ConditionFailedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{13}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{13}
 }
 func (m *ConditionFailedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -891,7 +895,7 @@ func (m *LeaseRejectedError) Reset()         { *m = LeaseRejectedError{} }
 func (m *LeaseRejectedError) String() string { return proto.CompactTextString(m) }
 func (*LeaseRejectedError) ProtoMessage()    {}
 func (*LeaseRejectedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{14}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{14}
 }
 func (m *LeaseRejectedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -929,7 +933,7 @@ func (m *AmbiguousResultError) Reset()         { *m = AmbiguousResultError{} }
 func (m *AmbiguousResultError) String() string { return proto.CompactTextString(m) }
 func (*AmbiguousResultError) ProtoMessage()    {}
 func (*AmbiguousResultError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{15}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{15}
 }
 func (m *AmbiguousResultError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -963,7 +967,7 @@ func (m *RaftGroupDeletedError) Reset()         { *m = RaftGroupDeletedError{} }
 func (m *RaftGroupDeletedError) String() string { return proto.CompactTextString(m) }
 func (*RaftGroupDeletedError) ProtoMessage()    {}
 func (*RaftGroupDeletedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{16}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{16}
 }
 func (m *RaftGroupDeletedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1001,7 +1005,7 @@ func (m *ReplicaCorruptionError) Reset()         { *m = ReplicaCorruptionError{}
 func (m *ReplicaCorruptionError) String() string { return proto.CompactTextString(m) }
 func (*ReplicaCorruptionError) ProtoMessage()    {}
 func (*ReplicaCorruptionError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{17}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{17}
 }
 func (m *ReplicaCorruptionError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1038,7 +1042,7 @@ func (m *ReplicaTooOldError) Reset()         { *m = ReplicaTooOldError{} }
 func (m *ReplicaTooOldError) String() string { return proto.CompactTextString(m) }
 func (*ReplicaTooOldError) ProtoMessage()    {}
 func (*ReplicaTooOldError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{18}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{18}
 }
 func (m *ReplicaTooOldError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1073,7 +1077,7 @@ func (m *StoreNotFoundError) Reset()         { *m = StoreNotFoundError{} }
 func (m *StoreNotFoundError) String() string { return proto.CompactTextString(m) }
 func (*StoreNotFoundError) ProtoMessage()    {}
 func (*StoreNotFoundError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{19}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{19}
 }
 func (m *StoreNotFoundError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1119,7 +1123,7 @@ func (m *UnhandledRetryableError) Reset()         { *m = UnhandledRetryableError
 func (m *UnhandledRetryableError) String() string { return proto.CompactTextString(m) }
 func (*UnhandledRetryableError) ProtoMessage()    {}
 func (*UnhandledRetryableError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{20}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{20}
 }
 func (m *UnhandledRetryableError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1171,7 +1175,7 @@ func (m *TransactionRetryWithProtoRefreshError) Reset()         { *m = Transacti
 func (m *TransactionRetryWithProtoRefreshError) String() string { return proto.CompactTextString(m) }
 func (*TransactionRetryWithProtoRefreshError) ProtoMessage()    {}
 func (*TransactionRetryWithProtoRefreshError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{21}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{21}
 }
 func (m *TransactionRetryWithProtoRefreshError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1209,7 +1213,7 @@ func (m *TxnAlreadyEncounteredErrorError) Reset()         { *m = TxnAlreadyEncou
 func (m *TxnAlreadyEncounteredErrorError) String() string { return proto.CompactTextString(m) }
 func (*TxnAlreadyEncounteredErrorError) ProtoMessage()    {}
 func (*TxnAlreadyEncounteredErrorError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{22}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{22}
 }
 func (m *TxnAlreadyEncounteredErrorError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1246,7 +1250,7 @@ func (m *IntegerOverflowError) Reset()         { *m = IntegerOverflowError{} }
 func (m *IntegerOverflowError) String() string { return proto.CompactTextString(m) }
 func (*IntegerOverflowError) ProtoMessage()    {}
 func (*IntegerOverflowError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{23}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{23}
 }
 func (m *IntegerOverflowError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1282,7 +1286,7 @@ func (m *BatchTimestampBeforeGCError) Reset()         { *m = BatchTimestampBefor
 func (m *BatchTimestampBeforeGCError) String() string { return proto.CompactTextString(m) }
 func (*BatchTimestampBeforeGCError) ProtoMessage()    {}
 func (*BatchTimestampBeforeGCError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{24}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{24}
 }
 func (m *BatchTimestampBeforeGCError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1321,7 +1325,7 @@ func (m *IntentMissingError) Reset()         { *m = IntentMissingError{} }
 func (m *IntentMissingError) String() string { return proto.CompactTextString(m) }
 func (*IntentMissingError) ProtoMessage()    {}
 func (*IntentMissingError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{25}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{25}
 }
 func (m *IntentMissingError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1358,7 +1362,7 @@ func (m *MergeInProgressError) Reset()         { *m = MergeInProgressError{} }
 func (m *MergeInProgressError) String() string { return proto.CompactTextString(m) }
 func (*MergeInProgressError) ProtoMessage()    {}
 func (*MergeInProgressError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{26}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{26}
 }
 func (m *MergeInProgressError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1393,7 +1397,7 @@ func (m *RangeFeedRetryError) Reset()         { *m = RangeFeedRetryError{} }
 func (m *RangeFeedRetryError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRetryError) ProtoMessage()    {}
 func (*RangeFeedRetryError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{27}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{27}
 }
 func (m *RangeFeedRetryError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1432,7 +1436,7 @@ func (m *IndeterminateCommitError) Reset()         { *m = IndeterminateCommitErr
 func (m *IndeterminateCommitError) String() string { return proto.CompactTextString(m) }
 func (*IndeterminateCommitError) ProtoMessage()    {}
 func (*IndeterminateCommitError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{28}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{28}
 }
 func (m *IndeterminateCommitError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1495,7 +1499,7 @@ func (m *ErrorDetail) Reset()         { *m = ErrorDetail{} }
 func (m *ErrorDetail) String() string { return proto.CompactTextString(m) }
 func (*ErrorDetail) ProtoMessage()    {}
 func (*ErrorDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{29}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{29}
 }
 func (m *ErrorDetail) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2423,7 +2427,7 @@ func (m *ErrPosition) Reset()         { *m = ErrPosition{} }
 func (m *ErrPosition) String() string { return proto.CompactTextString(m) }
 func (*ErrPosition) ProtoMessage()    {}
 func (*ErrPosition) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{30}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{30}
 }
 func (m *ErrPosition) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2477,7 +2481,7 @@ type Error struct {
 func (m *Error) Reset()      { *m = Error{} }
 func (*Error) ProtoMessage() {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_5086ddc4376fe80b, []int{31}
+	return fileDescriptor_errors_c35902ecbd7b91af, []int{31}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -10389,9 +10393,9 @@ var (
 	ErrIntOverflowErrors   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/errors.proto", fileDescriptor_errors_5086ddc4376fe80b) }
+func init() { proto.RegisterFile("roachpb/errors.proto", fileDescriptor_errors_c35902ecbd7b91af) }
 
-var fileDescriptor_errors_5086ddc4376fe80b = []byte{
+var fileDescriptor_errors_c35902ecbd7b91af = []byte{
 	// 2889 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x59, 0xcf, 0x6f, 0x1b, 0xc7,
 	0xf5, 0xe7, 0x92, 0x94, 0x44, 0x3d, 0x4a, 0xf2, 0x7a, 0xac, 0xc8, 0x6b, 0x39, 0xa6, 0x14, 0x3a,

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -36,6 +36,10 @@ message NotLeaseHolderError {
   // The current lease, if known. This might be nil even when lease_holder is
   // set, as sometimes one can create this error without actually knowing the
   // current lease, but having a guess about who the leader is.
+  //
+  // It's possible for leases returned here to represent speculative leases, not
+  // actual committed leases. In this case, the lease will not have its Sequence
+  // set.
   optional Lease lease = 4;
   optional int64 range_id = 3 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "RangeID", (gogoproto.casttype) = "RangeID"];

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -278,15 +278,17 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 			{
 				Desc: descs[0],
 				Lease: roachpb.Lease{
-					Replica: roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 1, ReplicaID: 1},
-					Start:   hlc.MinTimestamp,
+					Replica:  roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 1, ReplicaID: 1},
+					Start:    hlc.MinTimestamp,
+					Sequence: 1,
 				},
 			},
 			{
 				Desc: descs[1],
 				Lease: roachpb.Lease{
-					Replica: roachpb.ReplicaDescriptor{NodeID: 2, StoreID: 2, ReplicaID: 2},
-					Start:   hlc.MinTimestamp,
+					Replica:  roachpb.ReplicaDescriptor{NodeID: 2, StoreID: 2, ReplicaID: 2},
+					Start:    hlc.MinTimestamp,
+					Sequence: 1,
 				},
 			},
 		}})
@@ -298,8 +300,9 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 			{
 				Desc: descs[2],
 				Lease: roachpb.Lease{
-					Replica: roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3, ReplicaID: 3},
-					Start:   hlc.MinTimestamp,
+					Replica:  roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3, ReplicaID: 3},
+					Start:    hlc.MinTimestamp,
+					Sequence: 1,
 				},
 			},
 		}})
@@ -310,8 +313,8 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	for i := range descs {
 		ri := rangeCache.GetCached(descs[i].StartKey, false /* inclusive */)
 		require.NotNilf(t, ri, "failed to find range for key: %s", descs[i].StartKey)
-		require.Equal(t, descs[i], ri.Desc)
-		require.False(t, ri.Lease.Empty())
+		require.Equal(t, &descs[i], ri.Desc())
+		require.NotNil(t, ri.Lease())
 	}
 }
 

--- a/pkg/sql/execinfra/readerbase.go
+++ b/pkg/sql/execinfra/readerbase.go
@@ -85,16 +85,17 @@ func MisplannedRanges(
 		overlapping := rdc.GetCachedOverlapping(ctx, rsp)
 
 		for _, ri := range overlapping {
-			if _, ok := misplanned[ri.Desc.RangeID]; ok {
+			if _, ok := misplanned[ri.Desc().RangeID]; ok {
 				// We're already returning info about this range.
 				continue
 			}
 			// Ranges with unknown leases are not returned, as the current node might
 			// actually have the lease without the local cache knowing about it.
-			if !ri.Lease.Empty() && ri.Lease.Replica.NodeID != nodeID {
+			l := ri.Lease()
+			if l != nil && l.Replica.NodeID != nodeID {
 				misplannedRanges = append(misplannedRanges, roachpb.RangeInfo{
-					Desc:  ri.Desc,
-					Lease: ri.Lease,
+					Desc:  *ri.Desc(),
+					Lease: *l,
 				})
 			}
 		}

--- a/pkg/sql/physicalplan/replicaoracle/oracle.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle.go
@@ -58,7 +58,7 @@ type Oracle interface {
 	// already handled by each node for the current SQL query. The state is not
 	// updated with the result of this method; the caller is in charge of that.
 	//
-	// When the range's leaseholder is known, lease info is passed in; the lease
+	// When the range's leaseholder is known, leaseHolder is passed in; leaseHolder
 	// is nil otherwise. Implementors are free to use it, or ignore it if they
 	// don't care about the leaseholder (e.g. when we're planning for follower
 	// reads).
@@ -66,7 +66,7 @@ type Oracle interface {
 	// A RangeUnavailableError can be returned if there's no information in gossip
 	// about any of the nodes that might be tried.
 	ChoosePreferredReplica(
-		context.Context, *roachpb.RangeDescriptor, *roachpb.Lease, QueryState,
+		ctx context.Context, rng *roachpb.RangeDescriptor, leaseholder *roachpb.ReplicaDescriptor, qState QueryState,
 	) (roachpb.ReplicaDescriptor, error)
 }
 
@@ -133,7 +133,7 @@ func (o *randomOracle) Oracle(_ *kv.Txn) Oracle {
 }
 
 func (o *randomOracle) ChoosePreferredReplica(
-	ctx context.Context, desc *roachpb.RangeDescriptor, _ *roachpb.Lease, _ QueryState,
+	ctx context.Context, desc *roachpb.RangeDescriptor, _ *roachpb.ReplicaDescriptor, _ QueryState,
 ) (roachpb.ReplicaDescriptor, error) {
 	replicas, err := replicaSliceOrErr(ctx, o.nodeDescs, desc)
 	if err != nil {
@@ -163,7 +163,7 @@ func (o *closestOracle) Oracle(_ *kv.Txn) Oracle {
 }
 
 func (o *closestOracle) ChoosePreferredReplica(
-	ctx context.Context, desc *roachpb.RangeDescriptor, _ *roachpb.Lease, _ QueryState,
+	ctx context.Context, desc *roachpb.RangeDescriptor, _ *roachpb.ReplicaDescriptor, _ QueryState,
 ) (roachpb.ReplicaDescriptor, error) {
 	replicas, err := replicaSliceOrErr(ctx, o.nodeDescs, desc)
 	if err != nil {
@@ -213,11 +213,14 @@ func (o *binPackingOracle) Oracle(_ *kv.Txn) Oracle {
 }
 
 func (o *binPackingOracle) ChoosePreferredReplica(
-	ctx context.Context, desc *roachpb.RangeDescriptor, lease *roachpb.Lease, queryState QueryState,
+	ctx context.Context,
+	desc *roachpb.RangeDescriptor,
+	leaseholder *roachpb.ReplicaDescriptor,
+	queryState QueryState,
 ) (roachpb.ReplicaDescriptor, error) {
 	// If we know the leaseholder, we choose it.
-	if lease != nil {
-		return lease.Replica, nil
+	if leaseholder != nil {
+		return *leaseholder, nil
 	}
 
 	replicas, err := replicaSliceOrErr(ctx, o.nodeDescs, desc)

--- a/pkg/sql/physicalplan/replicaoracle/oracle_test.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle_test.go
@@ -57,7 +57,7 @@ func TestClosest(t *testing.T) {
 			{NodeID: 2, StoreID: 2},
 			{NodeID: 3, StoreID: 3},
 		},
-	}, nil /* lease */, QueryState{})
+	}, nil /* leaseHolder */, QueryState{})
 	if err != nil {
 		t.Fatalf("Failed to choose closest replica: %v", err)
 	}

--- a/pkg/sql/physicalplan/span_resolver.go
+++ b/pkg/sql/physicalplan/span_resolver.go
@@ -267,7 +267,7 @@ func (it *spanResolverIterator) ReplicaInfo(
 	}
 
 	repl, err := it.oracle.ChoosePreferredReplica(
-		ctx, it.it.Desc(), it.it.Lease(), it.queryState)
+		ctx, it.it.Desc(), it.it.Leaseholder(), it.queryState)
 	if err != nil {
 		return roachpb.ReplicaDescriptor{}, err
 	}


### PR DESCRIPTION
kvclient: handle speculative descriptors in the range cache better …

This patch fixes an assertion in the range cache that would sometimes
trigger, thinking that it has found inconsistent descriptors - two
overlapping descriptors with the same generation, but otherwise
different. This shouldn't happen, at least in the opinion of the
assertion. But it can happen in case one of the two descriptors is
"speculative": an eviction token for the range cache can contain a
replacement descriptor which comes from an intent. That intent might
never commit, in which case the respective generation might eventually
be assigned to some other, different descriptor.

This patch improves the cache's handling of speculative descriptors, and
also speculative leases, by handling them more explicitly. Such
descriptors are now inserted into the cache with Generation=0, and our
descriptor comparison code learns to deal explicitly with them.

Fixes #50995

Release note: None