### PR TITLE
storage: remove delete-range table property collector

### DIFF
--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -133,10 +133,6 @@ func NewPebbleTempEngine(
 	return newPebbleTempEngine(ctx, tempStorage, storeSpec)
 }
 
-var pebbleTempEngineTablePropertyCollectors = []func() pebble.TablePropertyCollector{
-	func() pebble.TablePropertyCollector { return &pebbleDeleteRangeCollector{} },
-}
-
 func newPebbleTempEngine(
 	ctx context.Context, tempStorage base.TempStorageConfig, storeSpec base.StoreSpec,
 ) (*pebbleTempEngine, fs.FS, error) {
@@ -153,7 +149,7 @@ func newPebbleTempEngine(
 	// Use the default bytes.Compare-like comparer.
 	opts.Comparer = pebble.DefaultComparer
 	opts.DisableWAL = true
-	opts.TablePropertyCollectors = pebbleTempEngineTablePropertyCollectors
+	opts.TablePropertyCollectors = nil
 
 	storageConfig := storageConfigFromTempStorageConfigAndStoreSpec(tempStorage, storeSpec)
 	if tempStorage.InMemory {


### PR DESCRIPTION
Pebble handles prioritization of compacting delete-range tombstones, so
the table property collector introduced in #47944 is no longer
necessary.

Release note: None