### PR TITLE
opt, cat: cleaner API for mutation columns

### DIFF
--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -15,6 +15,21 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
+// ColumnKind differentiates between different kinds of table columns.
+type ColumnKind uint8
+
+const (
+	// Ordinary columns are "regular" table columns (including hidden columns
+	// like `rowid`).
+	Ordinary ColumnKind = iota
+	// WriteOnly columns are mutation columns that have to be updated on writes
+	// (inserts, updates, deletes) and cannot be otherwise accessed.
+	WriteOnly
+	// DeleteOnly columns are mutation columns that have to be updated only on
+	// deletes and cannot be otherwise accessed.
+	DeleteOnly
+)
+
 // Column is an interface to a table column, exposing only the information
 // needed by the query optimizer.
 type Column interface {
@@ -85,5 +100,6 @@ type Column interface {
 // IsMutationColumn is a convenience function that returns true if the column at
 // the given ordinal position is a mutation column.
 func IsMutationColumn(table Table, ord int) bool {
-	return ord >= table.ColumnCount()
+	kind := table.ColumnKind(ord)
+	return kind == WriteOnly || kind == DeleteOnly
 }

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -41,21 +41,9 @@ type Table interface {
 	// information_schema tables.
 	IsVirtualTable() bool
 
-	// ColumnCount returns the number of public columns in the table. Public
-	// columns are not currently being added or dropped from the table. This
-	// method should be used when mutation columns can be ignored (the common
-	// case).
-	ColumnCount() int
-
-	// WritableColumnCount returns the number of public and write-only columns in
-	// the table. Although write-only columns are not visible, any inserts and
-	// updates must still set them. WritableColumnCount is always >= ColumnCount.
-	WritableColumnCount() int
-
-	// DeletableColumnCount returns the number of public, write-only, and
-	// delete- only columns in the table. DeletableColumnCount is always >=
-	// WritableColumnCount.
-	DeletableColumnCount() int
+	// AllColumnCount returns the number of columns in the table. This includes
+	// public columns, write-only columns, etc.
+	AllColumnCount() int
 
 	// Column returns a Column interface to the column at the ith ordinal
 	// position within the table, where i < ColumnCount. Note that the Columns
@@ -69,6 +57,12 @@ type Table interface {
 	// Writable columns are always situated after public columns, and are followed
 	// by deletable columns.
 	Column(i int) Column
+
+	// ColumnKind returns the column kind.
+	// Note: this is not a method in Column for the efficiency of the
+	// Column implementation (which can't access this information without using
+	// extra objects).
+	ColumnKind(i int) ColumnKind
 
 	// IndexCount returns the number of public indexes defined on this table.
 	// Public indexes are not currently being added or dropped from the table.

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -121,29 +121,6 @@ func ResolveTableIndex(
 	return found, foundTabName, nil
 }
 
-// ConvertColumnIDsToOrdinals converts a list of ColumnIDs (such as from a
-// tree.TableRef), to a list of ordinal positions of non-mutation columns within
-// the given table. See tree.Table for more information on column ordinals.
-func ConvertColumnIDsToOrdinals(tab Table, columns []tree.ColumnID) (ordinals []int) {
-	ordinals = make([]int, len(columns))
-	for i, c := range columns {
-		ord := 0
-		cnt := tab.AllColumnCount()
-		for ord < cnt {
-			if !IsMutationColumn(tab, ord) && tab.Column(ord).ColID() == StableID(c) {
-				break
-			}
-			ord++
-		}
-		if ord >= cnt {
-			panic(pgerror.Newf(pgcode.UndefinedColumn,
-				"column [%d] does not exist", c))
-		}
-		ordinals[i] = ord
-	}
-	return ordinals
-}
-
 // FindTableColumnByName returns the ordinal of the non-mutation column having
 // the given name, if one exists in the given table. Otherwise, it returns -1.
 func FindTableColumnByName(tab Table, name tree.Name) int {

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -121,17 +121,6 @@ func ResolveTableIndex(
 	return found, foundTabName, nil
 }
 
-// FindTableColumnByName returns the ordinal of the non-mutation column having
-// the given name, if one exists in the given table. Otherwise, it returns -1.
-func FindTableColumnByName(tab Table, name tree.Name) int {
-	for ord, n := 0, tab.AllColumnCount(); ord < n; ord++ {
-		if !IsMutationColumn(tab, ord) && tab.Column(ord).ColName() == name {
-			return ord
-		}
-	}
-	return -1
-}
-
 // FormatTable nicely formats a catalog table using a treeprinter for debugging
 // and testing.
 func FormatTable(cat Catalog, tab Table, tp treeprinter.Node) {

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -699,7 +699,7 @@ func mutationOutputColMap(mutation memo.RelExpr) opt.ColMap {
 
 	var colMap opt.ColMap
 	ord := 0
-	for i, n := 0, tab.DeletableColumnCount(); i < n; i++ {
+	for i, n := 0, tab.AllColumnCount(); i < n; i++ {
 		colID := private.Table.ColumnID(i)
 		if outCols.Contains(colID) {
 			colMap.Set(int(colID), ord)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -411,7 +411,7 @@ func (b *Builder) getColumns(
 	var needed exec.TableColumnOrdinalSet
 	var output opt.ColMap
 
-	columnCount := b.mem.Metadata().Table(tableID).DeletableColumnCount()
+	columnCount := b.mem.Metadata().Table(tableID).AllColumnCount()
 	n := 0
 	for i := 0; i < columnCount; i++ {
 		colID := tableID.ColumnID(i)

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -14,6 +14,7 @@ package memo
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -172,14 +173,14 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 
 	case *InsertExpr:
 		tab := m.Metadata().Table(t.Table)
-		m.checkColListLen(t.InsertCols, tab.DeletableColumnCount(), "InsertCols")
+		m.checkColListLen(t.InsertCols, tab.AllColumnCount(), "InsertCols")
 		m.checkColListLen(t.FetchCols, 0, "FetchCols")
 		m.checkColListLen(t.UpdateCols, 0, "UpdateCols")
 
 		// Ensure that insert columns include all columns except for delete-only
 		// mutation columns (which do not need to be part of INSERT).
-		for i, n := 0, tab.WritableColumnCount(); i < n; i++ {
-			if t.InsertCols[i] == 0 {
+		for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+			if tab.ColumnKind(i) != cat.DeleteOnly && t.InsertCols[i] == 0 {
 				panic(errors.AssertionFailedf("insert values not provided for all table columns"))
 			}
 		}
@@ -189,8 +190,8 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 	case *UpdateExpr:
 		tab := m.Metadata().Table(t.Table)
 		m.checkColListLen(t.InsertCols, 0, "InsertCols")
-		m.checkColListLen(t.FetchCols, tab.DeletableColumnCount(), "FetchCols")
-		m.checkColListLen(t.UpdateCols, tab.DeletableColumnCount(), "UpdateCols")
+		m.checkColListLen(t.FetchCols, tab.AllColumnCount(), "FetchCols")
+		m.checkColListLen(t.UpdateCols, tab.AllColumnCount(), "UpdateCols")
 		m.checkMutationExpr(t, &t.MutationPrivate)
 
 	case *ZigzagJoinExpr:
@@ -249,8 +250,10 @@ func (m *Memo) checkMutationExpr(rel RelExpr, private *MutationPrivate) {
 	// Output columns should never include mutation columns.
 	tab := m.Metadata().Table(private.Table)
 	var mutCols opt.ColSet
-	for i, n := tab.ColumnCount(), tab.DeletableColumnCount(); i < n; i++ {
-		mutCols.Add(private.Table.ColumnID(i))
+	for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+		if cat.IsMutationColumn(tab, i) {
+			mutCols.Add(private.Table.ColumnID(i))
+		}
 	}
 	if rel.Relational().OutputCols.Intersects(mutCols) {
 		panic(errors.AssertionFailedf("output columns cannot include mutation columns"))

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -618,7 +618,7 @@ func (m *MutationPrivate) MapToInputCols(tabCols opt.ColSet) opt.ColSet {
 // AddEquivTableCols adds an FD to the given set that declares an equivalence
 // between each table column and its corresponding input column.
 func (m *MutationPrivate) AddEquivTableCols(md *opt.Metadata, fdset *props.FuncDepSet) {
-	for i, n := 0, md.Table(m.Table).DeletableColumnCount(); i < n; i++ {
+	for i, n := 0, md.Table(m.Table).AllColumnCount(); i < n; i++ {
 		t := m.Table.ColumnID(i)
 		id := m.MapToInputID(t)
 		if id != 0 {

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1268,7 +1268,7 @@ func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Re
 	// Output Columns
 	// --------------
 	// Only non-mutation columns are output columns.
-	for i, n := 0, tab.ColumnCount(); i < n; i++ {
+	for i, n := 0, tab.AllColumnCount(); i < n; i++ {
 		if private.IsColumnOutput(i) {
 			colID := private.Table.ColumnID(i)
 			rel.OutputCols.Add(colID)
@@ -1289,7 +1289,7 @@ func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Re
 	// null or the corresponding insert and fetch/update columns are not null. In
 	// other words, if either the source or destination column is not null, then
 	// the column must be not null.
-	for i, n := 0, tab.ColumnCount(); i < n; i++ {
+	for i, n := 0, tab.AllColumnCount(); i < n; i++ {
 		tabColID := private.Table.ColumnID(i)
 		if !rel.OutputCols.Contains(tabColID) {
 			continue
@@ -1562,7 +1562,7 @@ func MakeTableFuncDep(md *opt.Metadata, tabID opt.TableID) *props.FuncDepSet {
 	// Make now and annotate the metadata table with it for next time.
 	var allCols opt.ColSet
 	tab := md.Table(tabID)
-	for i := 0; i < tab.DeletableColumnCount(); i++ {
+	for i := 0; i < tab.AllColumnCount(); i++ {
 		allCols.Add(tabID.ColumnID(i))
 	}
 
@@ -1812,16 +1812,16 @@ func ensureInputPropsForIndex(
 	}
 }
 
-// tableNotNullCols returns the set of not-NULL columns from the given table.
+// tableNotNullCols returns the set of not-NULL non-mutation columns from the given table.
 func tableNotNullCols(md *opt.Metadata, tabID opt.TableID) opt.ColSet {
 	cs := opt.ColSet{}
 	tab := md.Table(tabID)
 
 	// Only iterate over non-mutation columns, since even non-null mutation
 	// columns can be null during backfill.
-	for i := 0; i < tab.ColumnCount(); i++ {
+	for i := 0; i < tab.AllColumnCount(); i++ {
 		// Non-null mutation columns can be null during backfill.
-		if !tab.Column(i).IsNullable() {
+		if !cat.IsMutationColumn(tab, i) && !tab.Column(i).IsNullable() {
 			cs.Add(tabID.ColumnID(i))
 		}
 	}

--- a/pkg/sql/opt/memo/multiplicity_builder.go
+++ b/pkg/sql/opt/memo/multiplicity_builder.go
@@ -118,7 +118,7 @@ func deriveUnfilteredCols(in RelExpr) opt.ColSet {
 		md := t.Memo().Metadata()
 		baseTable := md.Table(t.Table)
 		if t.IsUnfiltered(md) {
-			for i, cnt := 0, baseTable.ColumnCount(); i < cnt; i++ {
+			for i, cnt := 0, baseTable.AllColumnCount(); i < cnt; i++ {
 				unfilteredCols.Add(t.Table.ColumnID(i))
 			}
 		}

--- a/pkg/sql/opt/memo/multiplicity_builder_test.go
+++ b/pkg/sql/opt/memo/multiplicity_builder_test.go
@@ -321,7 +321,7 @@ func (ob *testOpBuilder) makeScan(tableName tree.Name) (scan RelExpr, vars []*Va
 	tab := ob.cat.Table(tn)
 	tabID := ob.mem.Metadata().AddTable(tab, tn)
 	var cols opt.ColSet
-	for i := 0; i < tab.ColumnCount(); i++ {
+	for i := 0; i < tab.AllColumnCount(); i++ {
 		col := tabID.ColumnID(i)
 		cols.Add(col)
 		newVar := ob.mem.MemoizeVariable(col)

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -99,7 +99,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		t.Helper()
 
 		var cols opt.ColSet
-		for i := 0; i < tab.ColumnCount(); i++ {
+		for i := 0; i < tab.AllColumnCount(); i++ {
 			cols.Add(tabID.ColumnID(i))
 		}
 

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -336,7 +336,7 @@ func (md *Metadata) AddTable(tab cat.Table, alias *tree.TableName) TableID {
 	}
 	md.tables = append(md.tables, TableMeta{MetaID: tabID, Table: tab, Alias: *alias})
 
-	colCount := tab.DeletableColumnCount()
+	colCount := tab.AllColumnCount()
 	if md.cols == nil {
 		md.cols = make([]ColumnMeta, 0, colCount)
 	}

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -904,7 +904,7 @@ func (mb *mutationBuilder) setUpsertCols(insertCols tree.NameList) {
 		for _, name := range insertCols {
 			// Table column must exist, since existence of insertCols has already
 			// been checked previously.
-			ord := cat.FindTableColumnByName(mb.tab, name)
+			ord := findPublicTableColumnByName(mb.tab, name)
 			mb.updateOrds[ord] = mb.insertOrds[ord]
 		}
 	} else {

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -288,7 +288,7 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 		// Wrap the input in one LEFT OUTER JOIN per UNIQUE index, and filter out
 		// rows that have conflicts. See the buildInputForDoNothing comment for
 		// more details.
-		conflictOrds := mb.mapColumnNamesToOrdinals(ins.OnConflict.Columns)
+		conflictOrds := mb.mapPublicColumnNamesToOrdinals(ins.OnConflict.Columns)
 		mb.buildInputForDoNothing(inScope, conflictOrds)
 
 		// Since buildInputForDoNothing filters out rows with conflicts, always
@@ -321,7 +321,7 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 	default:
 		// Left-join each input row to the target table, using the conflict columns
 		// as the join condition.
-		conflictOrds := mb.mapColumnNamesToOrdinals(ins.OnConflict.Columns)
+		conflictOrds := mb.mapPublicColumnNamesToOrdinals(ins.OnConflict.Columns)
 		mb.buildInputForUpsert(inScope, conflictOrds, ins.OnConflict.Where)
 
 		// Derive the columns that will be updated from the SET expressions.
@@ -366,7 +366,7 @@ func (mb *mutationBuilder) needExistingRows() bool {
 	// TODO(andyk): This is not true in the case of composite key encodings. See
 	// issue #34518.
 	keyOrds := getIndexLaxKeyOrdinals(mb.tab.Index(cat.PrimaryIndex))
-	for i, n := 0, mb.tab.DeletableColumnCount(); i < n; i++ {
+	for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
 		if keyOrds.Contains(i) {
 			// #1: Don't consider key columns.
 			continue
@@ -512,9 +512,9 @@ func (mb *mutationBuilder) addTargetTableColsForInsert(maxCols int) {
 	// Only consider non-mutation columns, since mutation columns are hidden from
 	// the SQL user.
 	numCols := 0
-	for i, n := 0, mb.tab.ColumnCount(); i < n && numCols < maxCols; i++ {
-		// Skip hidden columns.
-		if mb.tab.Column(i).IsHidden() {
+	for i, n := 0, mb.tab.AllColumnCount(); i < n && numCols < maxCols; i++ {
+		// Skip mutation or hidden columns.
+		if cat.IsMutationColumn(mb.tab, i) || mb.tab.Column(i).IsHidden() {
 			continue
 		}
 
@@ -559,12 +559,13 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 			desiredTypes[i] = mb.md.ColumnMeta(colID).Type
 		}
 	} else {
-		// Do not target mutation columns.
-		desiredTypes = make([]*types.T, 0, mb.tab.ColumnCount())
-		for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
-			tabCol := mb.tab.Column(i)
-			if !tabCol.IsHidden() {
-				desiredTypes = append(desiredTypes, tabCol.DatumType())
+		desiredTypes = make([]*types.T, 0, mb.tab.AllColumnCount())
+		for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
+			if !cat.IsMutationColumn(mb.tab, i) {
+				tabCol := mb.tab.Column(i)
+				if !tabCol.IsHidden() {
+					desiredTypes = append(desiredTypes, tabCol.DatumType())
+				}
 			}
 		}
 	}
@@ -758,7 +759,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, conflictOrds u
 			conflictCols, mb.outScope, true /* nullsAreDistinct */, "" /* errorOnDup */)
 	}
 
-	mb.targetColList = make(opt.ColList, 0, mb.tab.DeletableColumnCount())
+	mb.targetColList = make(opt.ColList, 0, mb.tab.AllColumnCount())
 	mb.targetColSet = opt.ColSet{}
 }
 
@@ -872,7 +873,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 		mb.b.buildWhere(where, mb.outScope)
 	}
 
-	mb.targetColList = make(opt.ColList, 0, mb.tab.DeletableColumnCount())
+	mb.targetColList = make(opt.ColList, 0, mb.tab.AllColumnCount())
 	mb.targetColSet = opt.ColSet{}
 }
 
@@ -911,8 +912,10 @@ func (mb *mutationBuilder) setUpsertCols(insertCols tree.NameList) {
 	}
 
 	// Never update mutation columns.
-	for i, n := mb.tab.ColumnCount(), mb.tab.DeletableColumnCount(); i < n; i++ {
-		mb.updateOrds[i] = -1
+	for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
+		if cat.IsMutationColumn(mb.tab, i) {
+			mb.updateOrds[i] = -1
+		}
 	}
 
 	// Never update primary key columns.
@@ -968,7 +971,7 @@ func (mb *mutationBuilder) projectUpsertColumns() {
 
 	// Add a new column for each target table column that needs to be upserted.
 	// This can include mutation columns.
-	for i, n := 0, mb.tab.DeletableColumnCount(); i < n; i++ {
+	for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
 		insertScopeOrd := mb.insertOrds[i]
 		updateScopeOrd := mb.updateOrds[i]
 		if updateScopeOrd == -1 {
@@ -1048,15 +1051,16 @@ func (mb *mutationBuilder) ensureUniqueConflictCols(conflictOrds util.FastIntSet
 		"there is no unique or exclusion constraint matching the ON CONFLICT specification"))
 }
 
-// mapColumnNamesToOrdinals returns the set of ordinal positions within the
-// target table that correspond to the given names.
-func (mb *mutationBuilder) mapColumnNamesToOrdinals(names tree.NameList) util.FastIntSet {
+// mapPublicColumnNamesToOrdinals returns the set of ordinal positions within
+// the target table that correspond to the given names. Mutation columns are
+// ignored.
+func (mb *mutationBuilder) mapPublicColumnNamesToOrdinals(names tree.NameList) util.FastIntSet {
 	var ords util.FastIntSet
 	for _, name := range names {
 		found := false
-		for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
+		for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
 			tabCol := mb.tab.Column(i)
-			if tabCol.ColName() == name {
+			if tabCol.ColName() == name && !cat.IsMutationColumn(mb.tab, i) {
 				ords.Add(i)
 				found = true
 				break

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -194,7 +194,7 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 		}
 
 		ins.Columns = make(tree.NameList, len(refColumns))
-		for i, ord := range cat.ConvertColumnIDsToOrdinals(tab, refColumns) {
+		for i, ord := range resolveNumericColumnRefs(tab, refColumns) {
 			ins.Columns[i] = tab.Column(ord).ColName()
 		}
 	}

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -400,7 +400,7 @@ func (mb *mutationBuilder) addTargetColsByName(names tree.NameList) {
 	for _, name := range names {
 		// Determine the ordinal position of the named column in the table and
 		// add it as a target column.
-		if ord := cat.FindTableColumnByName(mb.tab, name); ord != -1 {
+		if ord := findPublicTableColumnByName(mb.tab, name); ord != -1 {
 			mb.addTargetCol(ord)
 			continue
 		}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -442,29 +442,9 @@ func (b *Builder) buildScan(
 		tabMeta.IgnoreForeignKeys = true
 	}
 
-	colCount := len(ordinals)
-	if colCount == 0 {
-		// If scanning mutation columns, then include writable and deletable
-		// columns in the output, in addition to public columns.
-		if scanMutationCols {
-			colCount = tab.DeletableColumnCount()
-		} else {
-			colCount = tab.ColumnCount()
-		}
-	}
-
-	getOrdinal := func(i int) int {
-		if ordinals == nil {
-			return i
-		}
-		return ordinals[i]
-	}
-
-	var tabColIDs opt.ColSet
 	outScope = inScope.push()
-	outScope.cols = make([]scopeColumn, 0, colCount)
-	for i := 0; i < colCount; i++ {
-		ord := getOrdinal(i)
+	var tabColIDs opt.ColSet
+	addCol := func(ord int) {
 		col := tab.Column(ord)
 		colID := tabID.ColumnID(ord)
 		tabColIDs.Add(colID)
@@ -478,6 +458,23 @@ func (b *Builder) buildScan(
 			hidden:   col.IsHidden() || isMutation,
 			mutation: isMutation,
 		})
+	}
+
+	if ordinals == nil {
+		// If no ordinals are requested, then add in all of the table columns
+		// (including mutation columns if scanMutationCols is true).
+		outScope.cols = make([]scopeColumn, 0, tab.AllColumnCount())
+		for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+			if scanMutationCols || !cat.IsMutationColumn(tab, i) {
+				addCol(i)
+			}
+		}
+	} else {
+		// Otherwise, just add the ordinals.
+		outScope.cols = make([]scopeColumn, 0, len(ordinals))
+		for _, ord := range ordinals {
+			addCol(ord)
+		}
 	}
 
 	if tab.IsVirtualTable() {
@@ -536,7 +533,11 @@ func (b *Builder) buildScan(
 			// We will track the ColumnID to Ord mapping so Ords can be added
 			// when a column is referenced.
 			for i, col := range outScope.cols {
-				dep.ColumnIDToOrd[col.id] = getOrdinal(i)
+				if ordinals == nil {
+					dep.ColumnIDToOrd[col.id] = i
+				} else {
+					dep.ColumnIDToOrd[col.id] = ordinals[i]
+				}
 			}
 			if private.Flags.ForceIndex {
 				dep.SpecificIndex = true
@@ -575,10 +576,11 @@ func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
 	tableScope := b.allocScope()
 	tableScope.appendColumnsFromTable(tabMeta, &tabMeta.Alias)
 
-	// Find the non-nullable table columns.
+	// Find the non-nullable table columns. Mutation columns can be NULL during
+	// backfill, so they should be excluded.
 	var notNullCols opt.ColSet
-	for i := 0; i < tab.ColumnCount(); i++ {
-		if !tab.Column(i).IsNullable() {
+	for i := 0; i < tab.AllColumnCount(); i++ {
+		if !tab.Column(i).IsNullable() && !cat.IsMutationColumn(tab, i) {
 			notNullCols.Add(tabMeta.MetaID.ColumnID(i))
 		}
 	}
@@ -626,9 +628,14 @@ func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
 func (b *Builder) addComputedColsForTable(tabMeta *opt.TableMeta) {
 	var tableScope *scope
 	tab := tabMeta.Table
-	for i, n := 0, tab.ColumnCount(); i < n; i++ {
+	for i, n := 0, tab.AllColumnCount(); i < n; i++ {
 		tabCol := tab.Column(i)
 		if !tabCol.IsComputed() {
+			continue
+		}
+		if cat.IsMutationColumn(tab, i) {
+			// Mutation columns can be NULL during backfill, so they won't equal the
+			// computed column expression value (in general).
 			continue
 		}
 		expr, err := parser.ParseExpr(tabCol.ComputedExprStr())

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -393,7 +393,7 @@ func (b *Builder) buildScanFromTableRef(
 			panic(pgerror.Newf(pgcode.Syntax,
 				"an explicit list of column IDs must include at least one column"))
 		}
-		ordinals = cat.ConvertColumnIDsToOrdinals(tab, ref.Columns)
+		ordinals = resolveNumericColumnRefs(tab, ref.Columns)
 	}
 
 	tn := tree.MakeUnqualifiedTableName(tab.Name())

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -17,6 +17,15 @@ exec-ddl
 CREATE TABLE tab55 (a INT PRIMARY KEY, b INT NOT NULL, CONSTRAINT foo CHECK (a+b < 10))
 ----
 
+exec-ddl
+CREATE TABLE tab56 (
+  a INT PRIMARY KEY,
+  b INT,
+  "c:write-only" INT,
+  "d:delete-only" INT
+)
+----
+
 # SELECT with no table.
 
 build
@@ -1094,6 +1103,22 @@ scan t
  ├── columns: a:1!null
  └── check constraint expressions
       └── (a:1 + b:2) < 10
+
+# Test that we error out if we refer to a mutation column,
+build
+SELECT * FROM [56(1,3) AS t(a, b)]
+----
+error (42703): column [3] does not exist
+
+build
+SELECT * FROM [56(1,4) AS t(a, b)]
+----
+error (42703): column [4] does not exist
+
+build
+INSERT INTO [56(1,3) AS t(a,b)] VALUES (1,2)
+----
+error (42703): column [3] does not exist
 
 # Regression test for #28388. Ensure that selecting from a table with no
 # columns does not cause a panic.

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -658,3 +658,15 @@ func resolveNumericColumnRefs(tab cat.Table, columns []tree.ColumnID) (ordinals 
 	}
 	return ordinals
 }
+
+// findPublicTableColumnByName returns the ordinal of the non-mutation column
+// having the given name, if one exists in the given table. Otherwise, it
+// returns -1.
+func findPublicTableColumnByName(tab cat.Table, name tree.Name) int {
+	for ord, n := 0, tab.AllColumnCount(); ord < n; ord++ {
+		if tab.Column(ord).ColName() == name && !cat.IsMutationColumn(tab, ord) {
+			return ord
+		}
+	}
+	return -1
+}

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -94,7 +94,7 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 
 	if !hasPrimaryIndex {
 		rowid := &Column{
-			Ordinal:     tab.ColumnCount(),
+			Ordinal:     tab.AllColumnCount(),
 			Name:        "rowid",
 			Type:        types.Int,
 			Hidden:      true,
@@ -254,7 +254,7 @@ func (tc *Catalog) CreateTableAs(name tree.TableName, columns []*Column) *Table 
 	tab := &Table{TabID: tc.nextStableID(), TabName: name, Catalog: tc, Columns: columns}
 
 	rowid := &Column{
-		Ordinal:     tab.ColumnCount(),
+		Ordinal:     tab.AllColumnCount(),
 		Name:        "rowid",
 		Type:        types.Int,
 		Hidden:      true,
@@ -380,7 +380,7 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 func (tt *Table) addColumn(def *tree.ColumnTableDef) {
 	nullable := !def.PrimaryKey.IsPrimaryKey && def.Nullable.Nullability != tree.NotNull
 	col := &Column{
-		Ordinal:  tt.ColumnCount(),
+		Ordinal:  tt.AllColumnCount(),
 		Name:     string(def.Name),
 		Type:     tree.MustBeStaticallyKnownType(def.Type),
 		Nullable: nullable,
@@ -480,7 +480,7 @@ func (tt *Table) addIndex(def *tree.IndexTableDef, typ indexType) *Index {
 			pkOrdinals.Add(c.Ordinal)
 		}
 		// Add the rest of the columns in the table.
-		for i, n := 0, tt.DeletableColumnCount(); i < n; i++ {
+		for i, n := 0, tt.AllColumnCount(); i < n; i++ {
 			if !pkOrdinals.Contains(i) {
 				idx.addColumnByOrdinal(tt, i, tree.Ascending, nonKeyCol)
 			}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -596,24 +596,28 @@ func (tt *Table) IsVirtualTable() bool {
 	return tt.IsVirtual
 }
 
-// ColumnCount is part of the cat.Table interface.
-func (tt *Table) ColumnCount() int {
-	return len(tt.Columns) - tt.writeOnlyColCount - tt.deleteOnlyColCount
-}
-
-// WritableColumnCount is part of the cat.Table interface.
-func (tt *Table) WritableColumnCount() int {
-	return len(tt.Columns) - tt.deleteOnlyColCount
-}
-
-// DeletableColumnCount is part of the cat.Table interface.
-func (tt *Table) DeletableColumnCount() int {
+// AllColumnCount is part of the cat.Table interface.
+func (tt *Table) AllColumnCount() int {
 	return len(tt.Columns)
 }
 
 // Column is part of the cat.Table interface.
 func (tt *Table) Column(i int) cat.Column {
 	return tt.Columns[i]
+}
+
+// ColumnKind is part of the cat.Table interface.
+func (tt *Table) ColumnKind(i int) cat.ColumnKind {
+	writeOnlyEnd := len(tt.Columns) - tt.deleteOnlyColCount
+	standardEnd := writeOnlyEnd - tt.writeOnlyColCount
+	switch {
+	case i < standardEnd:
+		return cat.Ordinary
+	case i < writeOnlyEnd:
+		return cat.WriteOnly
+	default:
+		return cat.DeleteOnly
+	}
 }
 
 // IndexCount is part of the cat.Table interface.

--- a/pkg/sql/opt/xform/memo_format.go
+++ b/pkg/sql/opt/xform/memo_format.go
@@ -275,7 +275,7 @@ func (mf *memoFormatter) formatPrivate(e opt.Expr, physProps *physical.Required)
 	switch t := e.(type) {
 	case *memo.ScanExpr:
 		tab := m.Metadata().Table(t.Table)
-		if tab.ColumnCount() != t.Cols.Len() {
+		if tab.AllColumnCount() != t.Cols.Len() {
 			fmt.Fprintf(mf.buf, ",cols=%s", t.Cols)
 		}
 		if t.Constraint != nil {

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1782,7 +1782,7 @@ func (rb *renderBuilder) setOutput(exprs tree.TypedExprs, columns sqlbase.Result
 // included if their ordinal position in the table schema is in the cols set.
 func makeColDescList(table cat.Table, cols exec.TableColumnOrdinalSet) []sqlbase.ColumnDescriptor {
 	colDescs := make([]sqlbase.ColumnDescriptor, 0, cols.Len())
-	for i, n := 0, table.DeletableColumnCount(); i < n; i++ {
+	for i, n := 0, table.AllColumnCount(); i < n; i++ {
 		if !cols.Contains(i) {
 			continue
 		}


### PR DESCRIPTION
**NOTE** I used `AllColumnCount` so that the compiler forces me to look at all callsites, and left it like this so they are also apparent in the diff. I intend to rename it to `ColumnCount` before merging.

The catalog currently relies on a particular ordering to separate
different kinds of columns (ordinary, write-only, delete-only). This
is unfortunate because it restricts the underlying implementation; in
particular, it makes it tricky to add a new kind of column (like the
`mvcc_timestamp` system column) without potentially breaking existing
code in subtle ways.

This change reworks the cat API to have a single `ColumnCount` method
and a separate `ColumnKind` method used to figure out the column kind.
This forces all code that cares about the kind to check it explicitly
rather than relying on a potentially faulty column count.

Fixes #51323.

Release note: None