### PR TITLE
catalog: start generifying desc.Collection for types

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -100,7 +100,7 @@ func (p *planner) AlterPrimaryKey(
 			if i != 0 {
 				sb.WriteString(comma)
 			}
-			childTable, err := p.Tables().GetTableVersionByID(
+			childTable, err := p.Descriptors().GetTableVersionByID(
 				ctx,
 				p.Txn(),
 				interleave.Table,

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1096,7 +1096,7 @@ func (p *planner) updateFKBackReferenceName(
 	if tableDesc.ID == ref.ReferencedTableID {
 		referencedTableDesc = tableDesc
 	} else {
-		lookup, err := p.Tables().GetMutableTableVersionByID(ctx, ref.ReferencedTableID, p.txn)
+		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.ReferencedTableID, p.txn)
 		if err != nil {
 			return errors.Errorf("error resolving referenced table ID %d: %v", ref.ReferencedTableID, err)
 		}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1390,7 +1390,7 @@ func runSchemaChangesInTxn(
 				if doneColumnBackfill || !sqlbase.ColumnNeedsBackfill(m.GetColumn()) {
 					break
 				}
-				if err := columnBackfillInTxn(ctx, planner.Txn(), planner.Tables(), planner.EvalContext(), immutDesc, traceKV); err != nil {
+				if err := columnBackfillInTxn(ctx, planner.Txn(), planner.Descriptors(), planner.EvalContext(), immutDesc, traceKV); err != nil {
 					return err
 				}
 				doneColumnBackfill = true
@@ -1412,7 +1412,7 @@ func runSchemaChangesInTxn(
 					if selfReference {
 						referencedTableDesc = tableDesc
 					} else {
-						lookup, err := planner.Tables().GetMutableTableVersionByID(ctx, fk.ReferencedTableID, planner.Txn())
+						lookup, err := planner.Descriptors().GetMutableTableVersionByID(ctx, fk.ReferencedTableID, planner.Txn())
 						if err != nil {
 							return errors.Errorf("error resolving referenced table ID %d: %v", fk.ReferencedTableID, err)
 						}
@@ -1451,7 +1451,7 @@ func runSchemaChangesInTxn(
 					break
 				}
 				if err := columnBackfillInTxn(
-					ctx, planner.Txn(), planner.Tables(), planner.EvalContext(), immutDesc, traceKV,
+					ctx, planner.Txn(), planner.Descriptors(), planner.EvalContext(), immutDesc, traceKV,
 				); err != nil {
 					return err
 				}
@@ -1520,7 +1520,7 @@ func runSchemaChangesInTxn(
 				}
 				if len(oldIndex.Interleave.Ancestors) != 0 {
 					ancestorInfo := oldIndex.Interleave.Ancestors[len(oldIndex.Interleave.Ancestors)-1]
-					ancestor, err := planner.Tables().GetMutableTableVersionByID(ctx, ancestorInfo.TableID, planner.txn)
+					ancestor, err := planner.Descriptors().GetMutableTableVersionByID(ctx, ancestorInfo.TableID, planner.txn)
 					if err != nil {
 						return err
 					}
@@ -1560,7 +1560,7 @@ func runSchemaChangesInTxn(
 		switch c.ConstraintType {
 		case sqlbase.ConstraintToUpdate_CHECK, sqlbase.ConstraintToUpdate_NOT_NULL:
 			if err := validateCheckInTxn(
-				ctx, planner.Tables().LeaseManager(), &planner.semaCtx, planner.EvalContext(), tableDesc, planner.txn, c.Check.Name,
+				ctx, planner.Descriptors().LeaseManager(), &planner.semaCtx, planner.EvalContext(), tableDesc, planner.txn, c.Check.Name,
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1208,7 +1208,7 @@ func (sc *SchemaChanger) validateForwardIndexes(
 			}
 			tc := descs.NewCollection(sc.leaseMgr, sc.settings)
 			// pretend that the schema has been modified.
-			if err := tc.AddUncommittedTable(*desc); err != nil {
+			if err := tc.AddUncommittedDescriptor(desc); err != nil {
 				return err
 			}
 
@@ -1617,7 +1617,7 @@ func validateCheckInTxn(
 	if tableDesc.Version > tableDesc.ClusterVersion.Version {
 		newTc := descs.NewCollection(leaseMgr, evalCtx.Settings)
 		// pretend that the schema has been modified.
-		if err := newTc.AddUncommittedTable(*tableDesc); err != nil {
+		if err := newTc.AddUncommittedDescriptor(tableDesc); err != nil {
 			return err
 		}
 
@@ -1658,7 +1658,7 @@ func validateFkInTxn(
 	if tableDesc.Version > tableDesc.ClusterVersion.Version {
 		newTc := descs.NewCollection(leaseMgr, evalCtx.Settings)
 		// pretend that the schema has been modified.
-		if err := newTc.AddUncommittedTable(*tableDesc); err != nil {
+		if err := newTc.AddUncommittedDescriptor(tableDesc); err != nil {
 			return err
 		}
 

--- a/pkg/sql/catalog/catalog.go
+++ b/pkg/sql/catalog/catalog.go
@@ -23,7 +23,7 @@ type Descriptor = sqlbase.DescriptorInterface
 type MutableDescriptor interface {
 	Descriptor
 	// MaybeIncrementVersion sets the version of the descriptor to
-	// ClusterVersion.Version + 1.
+	// OriginalVersion()+1.
 	// TODO (lucy): It's not a good idea to have callers handle incrementing the
 	// version manually. Find a better API for this. Maybe creating a new mutable
 	// descriptor should increment the version on the mutable copy from the
@@ -31,6 +31,11 @@ type MutableDescriptor interface {
 	MaybeIncrementVersion()
 	// SetDrainingNames sets the draining names for the descriptor.
 	SetDrainingNames([]sqlbase.NameInfo)
+
+	// Accessors for the original state of the descriptor prior to the mutations.
+	OriginalName() string
+	OriginalID() sqlbase.ID
+	OriginalVersion() sqlbase.DescriptorVersion
 	// Immutable returns an immutable copy of this descriptor.
 	Immutable() Descriptor
 	// IsNew returns whether the descriptor was created in this transaction.

--- a/pkg/sql/catalog/catalog.go
+++ b/pkg/sql/catalog/catalog.go
@@ -33,6 +33,8 @@ type MutableDescriptor interface {
 	SetDrainingNames([]sqlbase.NameInfo)
 	// Immutable returns an immutable copy of this descriptor.
 	Immutable() Descriptor
+	// IsNew returns whether the descriptor was created in this transaction.
+	IsNew() bool
 }
 
 // VirtualSchemas is a collection of VirtualSchemas.

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -160,7 +160,7 @@ func unwrapDescriptorMutable(
 		if err := table.MaybeFillInDescriptor(ctx, txn, codec); err != nil {
 			return nil, err
 		}
-		if err := table.Validate(ctx, txn, codec); err != nil {
+		if err := table.ValidateTable(); err != nil {
 			return nil, err
 		}
 		return sqlbase.NewMutableExistingTableDescriptor(*table), nil

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -1,0 +1,68 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package catalog
+
+import "github.com/cockroachdb/errors"
+
+type inactiveDescriptorError struct {
+	cause error
+}
+
+// errTableAdding is returned when the descriptor is being added.
+//
+// Only tables can be in the adding state, and this will be true for the
+// foreseeable future, so the error message remains a table-specific version.
+var errTableAdding = errors.New("table is being added")
+
+// ErrDescriptorDropped is returned when the descriptor is being dropped.
+// TODO (lucy): Make the error message specific to each descriptor type (e.g.,
+// "table is being dropped") and add the pgcodes (UndefinedTable, etc.).
+var ErrDescriptorDropped = errors.New("descriptor is being dropped")
+
+func (i *inactiveDescriptorError) Error() string { return i.cause.Error() }
+
+func (i *inactiveDescriptorError) Unwrap() error { return i.cause }
+
+// HasAddingTableError returns true if the error contains errTableAdding.
+func HasAddingTableError(err error) bool {
+	return errors.Is(err, errTableAdding)
+}
+
+// HasInactiveDescriptorError returns true if the error contains an
+// inactiveDescriptorError.
+func HasInactiveDescriptorError(err error) bool {
+	return errors.HasType(err, (*inactiveDescriptorError)(nil))
+}
+
+// NewInactiveDescriptorError wraps an error in a new inactiveDescriptorError.
+func NewInactiveDescriptorError(err error) error {
+	return &inactiveDescriptorError{err}
+}
+
+// FilterDescriptorState inspects the state of a given descriptor and returns an
+// error if the state is anything but public. The error describes the state of
+// the descriptor.
+func FilterDescriptorState(desc Descriptor) error {
+	switch {
+	case desc.Dropped():
+		return NewInactiveDescriptorError(ErrDescriptorDropped)
+	case desc.Offline():
+		err := errors.Errorf("%s %q is offline", desc.TypeName(), desc.GetName())
+		if desc.GetOfflineReason() != "" {
+			err = errors.Errorf("%s %q is offline: %s", desc.TypeName(), desc.GetName(), desc.GetOfflineReason())
+		}
+		return NewInactiveDescriptorError(err)
+	case desc.Adding():
+		return errTableAdding
+	default:
+		return nil
+	}
+}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -14,7 +14,6 @@ package descs
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -42,11 +41,11 @@ type UncommittedDatabase struct {
 	dropped bool
 }
 
-// UncommittedTable is a table that has been created/dropped within the
-// current transaction.
-type UncommittedTable struct {
-	*sqlbase.MutableTableDescriptor
-	*sqlbase.ImmutableTableDescriptor
+// uncommittedDescriptor is a descriptor that has been modified in the current
+// transaction.
+type uncommittedDescriptor struct {
+	mutable   catalog.MutableDescriptor
+	immutable catalog.Descriptor
 }
 
 // MakeCollection constructs a Collection.
@@ -83,15 +82,13 @@ type Collection struct {
 	// the timestamp changes, the descriptors are released.
 	// TODO (lucy): Use something other than an unsorted slice for faster lookups.
 	leasedDescriptors []catalog.Descriptor
-	// Tables modified by the uncommitted transaction affiliated
-	// with this Collection. This allows a transaction to see
-	// its own modifications while bypassing the table lease mechanism.
-	// The table lease mechanism will have its own transaction to read
-	// the table and will hang waiting for the uncommitted changes to
-	// the table. These table descriptors are local to this
-	// Collection and invisible to other transactions. A dropped
-	// table is marked dropped.
-	uncommittedTables []UncommittedTable
+	// Descriptors modified by the uncommitted transaction affiliated with this
+	// Collection. This allows a transaction to see its own modifications while
+	// bypassing the descriptor lease mechanism. The lease mechanism will have its
+	// own transaction to read the descriptor and will hang waiting for the
+	// uncommitted changes to the descriptor. These descriptors are local to this
+	// Collection and invisible to other transactions.
+	uncommittedDescriptors []uncommittedDescriptor
 
 	// databaseCache is used as a cache for database names.
 	// This field is nil when the field is initialized for an internalPlanner.
@@ -110,7 +107,7 @@ type Collection struct {
 	// updated when ReleaseAll is called.
 	dbCacheSubscriber DatabaseCacheSubscriber
 
-	// Same as uncommittedTables applying to databases modified within
+	// Same as uncommittedDescriptors applying to databases modified within
 	// an uncommitted transaction.
 	uncommittedDatabases []UncommittedDatabase
 
@@ -157,15 +154,29 @@ func isSupportedSchemaName(n tree.Name) bool {
 func (tc *Collection) GetMutableTableDescriptor(
 	ctx context.Context, txn *kv.Txn, tn *tree.TableName, flags tree.ObjectLookupFlags,
 ) (*sqlbase.MutableTableDescriptor, error) {
+	desc, err := tc.getMutableObjectDescriptor(ctx, txn, tn, flags)
+	if err != nil {
+		return nil, err
+	}
+	mutDesc, ok := desc.(*sqlbase.MutableTableDescriptor)
+	if !ok {
+		return nil, nil
+	}
+	return mutDesc, nil
+}
+
+func (tc *Collection) getMutableObjectDescriptor(
+	ctx context.Context, txn *kv.Txn, name tree.ObjectName, flags tree.ObjectLookupFlags,
+) (catalog.MutableDescriptor, error) {
 	if log.V(2) {
-		log.Infof(ctx, "reading mutable descriptor on table '%s'", tn)
+		log.Infof(ctx, "reading mutable descriptor on '%s'", name)
 	}
 
-	if !isSupportedSchemaName(tn.SchemaName) {
+	if !isSupportedSchemaName(tree.Name(name.Schema())) {
 		return nil, nil
 	}
 
-	refuseFurtherLookup, dbID, err := tc.GetUncommittedDatabaseID(tn.Catalog(), flags.Required)
+	refuseFurtherLookup, dbID, err := tc.GetUncommittedDatabaseID(name.Catalog(), flags.Required)
 	if refuseFurtherLookup || err != nil {
 		return nil, err
 	}
@@ -173,7 +184,7 @@ func (tc *Collection) GetMutableTableDescriptor(
 	if dbID == sqlbase.InvalidID && tc.DatabaseCache() != nil {
 		// Resolve the database from the database cache when the transaction
 		// hasn't modified the database.
-		dbID, err = tc.DatabaseCache().GetDatabaseID(ctx, tc.leaseMgr.DB().Txn, tn.Catalog(), flags.Required)
+		dbID, err = tc.DatabaseCache().GetDatabaseID(ctx, tc.leaseMgr.DB().Txn, name.Catalog(), flags.Required)
 		if err != nil || dbID == sqlbase.InvalidID {
 			// dbID can still be invalid if required is false and the database is not found.
 			return nil, err
@@ -183,20 +194,20 @@ func (tc *Collection) GetMutableTableDescriptor(
 	// The following checks only work if the dbID is not invalid.
 	if dbID != sqlbase.InvalidID {
 		// Resolve the schema to the ID of the schema.
-		foundSchema, schemaID, err := tc.ResolveSchemaID(ctx, txn, dbID, tn.Schema())
+		foundSchema, schemaID, err := tc.ResolveSchemaID(ctx, txn, dbID, name.Schema())
 		if err != nil || !foundSchema {
 			return nil, err
 		}
 
-		if refuseFurtherLookup, table, err := tc.getUncommittedTable(
+		if refuseFurtherLookup, desc, err := tc.getUncommittedDescriptor(
 			dbID,
 			schemaID,
-			tn,
+			name.Object(),
 			flags.Required,
 		); refuseFurtherLookup || err != nil {
 			return nil, err
-		} else if mut := table.MutableTableDescriptor; mut != nil {
-			log.VEventf(ctx, 2, "found uncommitted table %d", mut.ID)
+		} else if mut := desc.mutable; mut != nil {
+			log.VEventf(ctx, 2, "found uncommitted descriptor %d", mut.GetID())
 			return mut, nil
 		}
 	}
@@ -207,17 +218,17 @@ func (tc *Collection) GetMutableTableDescriptor(
 		txn,
 		tc.settings,
 		tc.codec(),
-		tn.Catalog(),
-		tn.Schema(),
-		tn.Table(),
+		name.Catalog(),
+		name.Schema(),
+		name.Object(),
 		flags,
 	)
-	if obj == nil {
+	if err != nil || obj == nil {
 		return nil, err
 	}
-	mutDesc, ok := obj.(*sqlbase.MutableTableDescriptor)
+	mutDesc, ok := obj.(catalog.MutableDescriptor)
 	if !ok {
-		return nil, err
+		return nil, nil
 	}
 	return mutDesc, nil
 }
@@ -266,37 +277,46 @@ func (tc *Collection) ResolveSchemaID(
 func (tc *Collection) GetTableVersion(
 	ctx context.Context, txn *kv.Txn, tn *tree.TableName, flags tree.ObjectLookupFlags,
 ) (*sqlbase.ImmutableTableDescriptor, error) {
+	desc, err := tc.getObjectVersion(ctx, txn, tn, flags)
+	if err != nil {
+		return nil, err
+	}
+	table, ok := desc.(*sqlbase.ImmutableTableDescriptor)
+	if !ok {
+		if flags.Required {
+			return nil, sqlbase.NewUndefinedRelationError(tn)
+		}
+		return nil, nil
+	}
+	return table, nil
+}
+
+func (tc *Collection) getObjectVersion(
+	ctx context.Context, txn *kv.Txn, name tree.ObjectName, flags tree.ObjectLookupFlags,
+) (catalog.Descriptor, error) {
 	if log.V(2) {
-		log.Infof(ctx, "planner acquiring lease on table '%s'", tn)
+		log.Infof(ctx, "planner acquiring lease on descriptor '%s'", name)
 	}
 
-	if !isSupportedSchemaName(tn.SchemaName) {
+	if !isSupportedSchemaName(tree.Name(name.Schema())) {
 		return nil, nil
 	}
 
-	readTableFromStore := func() (*sqlbase.ImmutableTableDescriptor, error) {
+	readObjectFromStore := func() (catalog.Descriptor, error) {
 		phyAccessor := catalogkv.UncachedPhysicalAccessor{}
-		obj, err := phyAccessor.GetObjectDesc(
+		return phyAccessor.GetObjectDesc(
 			ctx,
 			txn,
 			tc.settings,
 			tc.codec(),
-			tn.Catalog(),
-			tn.Schema(),
-			tn.Table(),
+			name.Catalog(),
+			name.Schema(),
+			name.Object(),
 			flags,
 		)
-		if obj == nil {
-			return nil, err
-		}
-		tbl, ok := obj.(*sqlbase.ImmutableTableDescriptor)
-		if !ok {
-			return nil, err
-		}
-		return tbl, err
 	}
 
-	refuseFurtherLookup, dbID, err := tc.GetUncommittedDatabaseID(tn.Catalog(), flags.Required)
+	refuseFurtherLookup, dbID, err := tc.GetUncommittedDatabaseID(name.Catalog(), flags.Required)
 	if refuseFurtherLookup || err != nil {
 		return nil, err
 	}
@@ -304,7 +324,7 @@ func (tc *Collection) GetTableVersion(
 	if dbID == sqlbase.InvalidID && tc.DatabaseCache() != nil {
 		// Resolve the database from the database cache when the transaction
 		// hasn't modified the database.
-		dbID, err = tc.DatabaseCache().GetDatabaseID(ctx, tc.leaseMgr.DB().Txn, tn.Catalog(), flags.Required)
+		dbID, err = tc.DatabaseCache().GetDatabaseID(ctx, tc.leaseMgr.DB().Txn, name.Catalog(), flags.Required)
 		if err != nil || dbID == sqlbase.InvalidID {
 			// dbID can still be invalid if required is false and the database is not found.
 			return nil, err
@@ -313,11 +333,11 @@ func (tc *Collection) GetTableVersion(
 
 	// If at this point we have an InvalidID, we should immediately try read from store.
 	if dbID == sqlbase.InvalidID {
-		return readTableFromStore()
+		return readObjectFromStore()
 	}
 
 	// Resolve the schema to the ID of the schema.
-	foundSchema, schemaID, err := tc.ResolveSchemaID(ctx, txn, dbID, tn.Schema())
+	foundSchema, schemaID, err := tc.ResolveSchemaID(ctx, txn, dbID, name.Schema())
 	if err != nil || !foundSchema {
 		return nil, err
 	}
@@ -328,18 +348,18 @@ func (tc *Collection) GetTableVersion(
 	// But doing so turned problematic and the tests pass only by also
 	// disabling caching of system.eventlog, system.rangelog, and
 	// system.users. For now we're sticking to disabling caching of
-	// all system descriptors except the role-members-table.
+	// all system descriptors except the role-members-desc.
 	avoidCache := flags.AvoidCached || lease.TestingTableLeasesAreDisabled() ||
-		(tn.Catalog() == sqlbase.SystemDatabaseName && tn.ObjectName.String() != sqlbase.RoleMembersTable.Name)
+		(name.Catalog() == sqlbase.SystemDatabaseName && name.Object() != sqlbase.RoleMembersTable.Name)
 
-	if refuseFurtherLookup, table, err := tc.getUncommittedTable(
+	if refuseFurtherLookup, desc, err := tc.getUncommittedDescriptor(
 		dbID,
 		schemaID,
-		tn,
+		name.Object(),
 		flags.Required,
 	); refuseFurtherLookup || err != nil {
 		return nil, err
-	} else if immut := table.ImmutableTableDescriptor; immut != nil {
+	} else if immut := desc.immutable; immut != nil {
 		// If not forcing to resolve using KV, tables being added aren't visible.
 		if immut.Adding() && !avoidCache {
 			if !flags.Required {
@@ -348,132 +368,133 @@ func (tc *Collection) GetTableVersion(
 			return nil, catalog.FilterDescriptorState(immut)
 		}
 
-		log.VEventf(ctx, 2, "found uncommitted table %d", immut.ID)
+		log.VEventf(ctx, 2, "found uncommitted descriptor %d", immut.GetID())
 		return immut, nil
 	}
 
 	if avoidCache {
-		return readTableFromStore()
+		return readObjectFromStore()
 	}
 
-	// First, look to see if we already have the table.
+	// First, look to see if we already have the descriptor.
 	// This ensures that, once a SQL transaction resolved name N to id X, it will
 	// continue to use N to refer to X even if N is renamed during the
 	// transaction.
 	for _, table := range tc.leasedDescriptors {
-		if lease.NameMatchesDescriptor(table, dbID, schemaID, tn.Table()) {
-			log.VEventf(ctx, 2, "found table in table collection for table '%s'", tn)
-			return table.(*sqlbase.ImmutableTableDescriptor), nil
+		if lease.NameMatchesDescriptor(table, dbID, schemaID, name.Object()) {
+			log.VEventf(ctx, 2, "found descriptor in collection for '%s'", name)
+			return table, nil
 		}
 	}
 
 	readTimestamp := txn.ReadTimestamp()
-	desc, expiration, err := tc.leaseMgr.AcquireByName(ctx, readTimestamp, dbID, schemaID, tn.Table())
+	desc, expiration, err := tc.leaseMgr.AcquireByName(ctx, readTimestamp, dbID, schemaID, name.Object())
 	if err != nil {
 		// Read the descriptor from the store in the face of some specific errors
 		// because of a known limitation of AcquireByName. See the known
 		// limitations of AcquireByName for details.
 		if catalog.HasInactiveDescriptorError(err) ||
 			errors.Is(err, sqlbase.ErrDescriptorNotFound) {
-			return readTableFromStore()
+			return readObjectFromStore()
 		}
 		// Lease acquisition failed with some other error. This we don't
 		// know how to deal with, so propagate the error.
 		return nil, err
 	}
-	table, ok := desc.(*sqlbase.ImmutableTableDescriptor)
-	if !ok {
-		if flags.Required {
-			return nil, sqlbase.NewUndefinedRelationError(tn)
-		}
-		return nil, nil
-	}
 
 	if expiration.LessEq(readTimestamp) {
-		log.Fatalf(ctx, "bad table for T=%s, expiration=%s", readTimestamp, expiration)
+		log.Fatalf(ctx, "bad descriptor for T=%s, expiration=%s", readTimestamp, expiration)
 	}
 
-	tc.leasedDescriptors = append(tc.leasedDescriptors, table)
-	log.VEventf(ctx, 2, "added table '%s' to table collection", tn)
+	tc.leasedDescriptors = append(tc.leasedDescriptors, desc)
+	log.VEventf(ctx, 2, "added descriptor '%s' to collection", name)
 
-	// If the table we just acquired expires before the txn's deadline, reduce
-	// the deadline. We use ReadTimestamp() that doesn't return the commit timestamp,
-	// so we need to set a deadline on the transaction to prevent it from committing
-	// beyond the table version expiration time.
+	// If the descriptor we just acquired expires before the txn's deadline,
+	// reduce the deadline. We use ReadTimestamp() that doesn't return the commit
+	// timestamp, so we need to set a deadline on the transaction to prevent it
+	// from committing beyond the version's expiration time.
 	txn.UpdateDeadlineMaybe(ctx, expiration)
-	return table, nil
+	return desc, nil
 }
 
 // GetTableVersionByID is a by-ID variant of GetTableVersion (i.e. uses same cache).
 func (tc *Collection) GetTableVersionByID(
 	ctx context.Context, txn *kv.Txn, tableID sqlbase.ID, flags tree.ObjectLookupFlags,
 ) (*sqlbase.ImmutableTableDescriptor, error) {
-	log.VEventf(ctx, 2, "planner getting table on table ID %d", tableID)
-
-	if flags.AvoidCached || lease.TestingTableLeasesAreDisabled() {
-		table, err := sqlbase.GetTableDescFromID(ctx, txn, tc.codec(), tableID)
-		if err != nil {
-			return nil, err
-		}
-		immutDesc := sqlbase.NewImmutableTableDescriptor(*table)
-		if err := catalog.FilterDescriptorState(immutDesc); err != nil {
-			return nil, err
-		}
-		return immutDesc, nil
-	}
-
-	for _, table := range tc.uncommittedTables {
-		if immut := table.ImmutableTableDescriptor; immut.ID == tableID {
-			log.VEventf(ctx, 2, "found uncommitted table %d", tableID)
-			if immut.Dropped() {
-				return nil, sqlbase.NewUndefinedRelationError(
-					tree.NewUnqualifiedTableName(tree.Name(fmt.Sprintf("<id=%d>", tableID))),
-				)
-			}
-			return immut, nil
-		}
-	}
-
-	// First, look to see if we already have the table -- including those
-	// via `GetTableVersion`.
-	for _, table := range tc.leasedDescriptors {
-		if table.GetID() == tableID {
-			log.VEventf(ctx, 2, "found table %d in table cache", tableID)
-			return table.(*sqlbase.ImmutableTableDescriptor), nil
-		}
-	}
-
-	readTimestamp := txn.ReadTimestamp()
-	desc, expiration, err := tc.leaseMgr.Acquire(ctx, readTimestamp, tableID)
+	desc, err := tc.getDescriptorVersionByID(ctx, txn, tableID, flags)
 	if err != nil {
 		if errors.Is(err, sqlbase.ErrDescriptorNotFound) {
-			// Transform the descriptor error into an error that references the
-			// table's ID.
 			return nil, sqlbase.NewUndefinedRelationError(
 				&tree.TableRef{TableID: int64(tableID)})
 		}
 		return nil, err
 	}
-	// Also return an error if the descriptor isn't a table.
 	table, ok := desc.(*sqlbase.ImmutableTableDescriptor)
 	if !ok {
 		return nil, sqlbase.NewUndefinedRelationError(
 			&tree.TableRef{TableID: int64(tableID)})
 	}
+	return table, nil
+}
 
-	if expiration.LessEq(readTimestamp) {
-		log.Fatalf(ctx, "bad table for T=%s, expiration=%s", readTimestamp, expiration)
+func (tc *Collection) getDescriptorVersionByID(
+	ctx context.Context, txn *kv.Txn, id sqlbase.ID, flags tree.ObjectLookupFlags,
+) (catalog.Descriptor, error) {
+	if flags.AvoidCached || lease.TestingTableLeasesAreDisabled() {
+		desc, err := catalogkv.GetDescriptorByID(ctx, txn, tc.codec(), id)
+		if err != nil {
+			return nil, err
+		}
+		if desc == nil {
+			return nil, sqlbase.ErrDescriptorNotFound
+		}
+		if err := catalog.FilterDescriptorState(desc); err != nil {
+			return nil, err
+		}
+		return desc, nil
 	}
 
-	tc.leasedDescriptors = append(tc.leasedDescriptors, table)
-	log.VEventf(ctx, 2, "added table '%s' to table collection", table.Name)
+	for _, ud := range tc.uncommittedDescriptors {
+		if immut := ud.immutable; immut.GetID() == id {
+			log.VEventf(ctx, 2, "found uncommitted descriptor %d", id)
+			if immut.Dropped() {
+				// TODO (lucy): This error is meant to be parallel to the error returned
+				// from FilterDescriptorState, but it may be too low-level for getting
+				// descriptors from the descriptor collection. In general the errors
+				// being returned from this method aren't that consistent.
+				return nil, catalog.NewInactiveDescriptorError(catalog.ErrDescriptorDropped)
+			}
+			return immut, nil
+		}
+	}
 
-	// If the table we just acquired expires before the txn's deadline, reduce
-	// the deadline. We use ReadTimestamp() that doesn't return the commit timestamp,
-	// so we need to set a deadline on the transaction to prevent it from committing
-	// beyond the table version expiration time.
+	// First, look to see if we already have the table in the shared cache.
+	for _, desc := range tc.leasedDescriptors {
+		if desc.GetID() == id {
+			log.VEventf(ctx, 2, "found descriptor %d in cache", id)
+			return desc, nil
+		}
+	}
+
+	readTimestamp := txn.ReadTimestamp()
+	desc, expiration, err := tc.leaseMgr.Acquire(ctx, readTimestamp, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if expiration.LessEq(readTimestamp) {
+		log.Fatalf(ctx, "bad descriptor for T=%s, expiration=%s", readTimestamp, expiration)
+	}
+
+	tc.leasedDescriptors = append(tc.leasedDescriptors, desc)
+	log.VEventf(ctx, 2, "added descriptor %q to collection", desc.GetName())
+
+	// If the descriptor we just acquired expires before the txn's deadline,
+	// reduce the deadline. We use ReadTimestamp() that doesn't return the commit
+	// timestamp, so we need to set a deadline on the transaction to prevent it
+	// from committing beyond the version's expiration time.
 	txn.UpdateDeadlineMaybe(ctx, expiration)
-	return table, nil
+	return desc, nil
 }
 
 // GetMutableTableVersionByID is a variant of sqlbase.GetTableDescFromID which returns a mutable
@@ -481,36 +502,53 @@ func (tc *Collection) GetTableVersionByID(
 func (tc *Collection) GetMutableTableVersionByID(
 	ctx context.Context, tableID sqlbase.ID, txn *kv.Txn,
 ) (*sqlbase.MutableTableDescriptor, error) {
-	log.VEventf(ctx, 2, "planner getting mutable table on table ID %d", tableID)
-
-	if table := tc.GetUncommittedTableByID(tableID).MutableTableDescriptor; table != nil {
-		log.VEventf(ctx, 2, "found uncommitted table %d", tableID)
-		return table, nil
+	desc, err := tc.getMutableDescriptorByID(ctx, tableID, txn)
+	if err != nil {
+		return nil, err
 	}
-	return sqlbase.GetMutableTableDescFromID(ctx, txn, tc.codec(), tableID)
+	return desc.(*sqlbase.MutableTableDescriptor), nil
 }
 
-// ReleaseTableLeases releases the leases for the tables with ids in
+func (tc *Collection) getMutableDescriptorByID(
+	ctx context.Context, id sqlbase.ID, txn *kv.Txn,
+) (catalog.MutableDescriptor, error) {
+	log.VEventf(ctx, 2, "planner getting mutable descriptor for id %d", id)
+
+	if desc := tc.getUncommittedDescriptorByID(id); desc != nil {
+		log.VEventf(ctx, 2, "found uncommitted descriptor %d", id)
+		return desc, nil
+	}
+	desc, err := catalogkv.GetMutableDescriptorByID(ctx, txn, tc.codec(), id)
+	if err != nil {
+		return nil, err
+	}
+	if desc == nil {
+		return nil, sqlbase.ErrDescriptorNotFound
+	}
+	return desc, nil
+}
+
+// ReleaseSpecifiedLeases releases the leases for the descriptors with ids in
 // the passed slice. Errors are logged but ignored.
-func (tc *Collection) ReleaseTableLeases(ctx context.Context, tables []lease.IDVersion) {
-	// Sort the tables and leases to make it easy to find the leases to release.
-	leasedTables := tc.leasedDescriptors
-	sort.Slice(tables, func(i, j int) bool {
-		return tables[i].ID < tables[j].ID
+func (tc *Collection) ReleaseSpecifiedLeases(ctx context.Context, descs []lease.IDVersion) {
+	// Sort the descriptors and leases to make it easy to find the leases to release.
+	leasedDescs := tc.leasedDescriptors
+	sort.Slice(descs, func(i, j int) bool {
+		return descs[i].ID < descs[j].ID
 	})
-	sort.Slice(leasedTables, func(i, j int) bool {
-		return leasedTables[i].GetID() < leasedTables[j].GetID()
+	sort.Slice(leasedDescs, func(i, j int) bool {
+		return leasedDescs[i].GetID() < leasedDescs[j].GetID()
 	})
 
-	filteredLeases := leasedTables[:0] // will store the remaining leases
-	tablesToConsider := tables
+	filteredLeases := leasedDescs[:0] // will store the remaining leases
+	tablesToConsider := descs
 	shouldRelease := func(id sqlbase.ID) (found bool) {
 		for len(tablesToConsider) > 0 && tablesToConsider[0].ID < id {
 			tablesToConsider = tablesToConsider[1:]
 		}
 		return len(tablesToConsider) > 0 && tablesToConsider[0].ID == id
 	}
-	for _, l := range leasedTables {
+	for _, l := range leasedDescs {
 		if !shouldRelease(l.GetID()) {
 			filteredLeases = append(filteredLeases, l)
 		} else if err := tc.leaseMgr.Release(l); err != nil {
@@ -520,13 +558,12 @@ func (tc *Collection) ReleaseTableLeases(ctx context.Context, tables []lease.IDV
 	tc.leasedDescriptors = filteredLeases
 }
 
-// ReleaseLeases releases the leases for the tables with ids in
-// the passed slice. Errors are logged but ignored.
+// ReleaseLeases releases all leases. Errors are logged but ignored.
 func (tc *Collection) ReleaseLeases(ctx context.Context) {
 	if len(tc.leasedDescriptors) > 0 {
-		log.VEventf(ctx, 2, "releasing %d tables", len(tc.leasedDescriptors))
-		for _, table := range tc.leasedDescriptors {
-			if err := tc.leaseMgr.Release(table); err != nil {
+		log.VEventf(ctx, 2, "releasing %d descriptors", len(tc.leasedDescriptors))
+		for _, desc := range tc.leasedDescriptors {
+			if err := tc.leaseMgr.Release(desc); err != nil {
 				log.Warningf(ctx, "%v", err)
 			}
 		}
@@ -538,7 +575,7 @@ func (tc *Collection) ReleaseLeases(ctx context.Context) {
 // ReleaseAll calls ReleaseLeases.
 func (tc *Collection) ReleaseAll(ctx context.Context) {
 	tc.ReleaseLeases(ctx)
-	tc.uncommittedTables = nil
+	tc.uncommittedDescriptors = nil
 	tc.uncommittedDatabases = nil
 	tc.releaseAllDescriptors()
 }
@@ -579,57 +616,74 @@ func (tc *Collection) WaitForCacheToDropDatabases(ctx context.Context) {
 // HasUncommittedTables returns true if the Collection contains uncommitted
 // tables.
 func (tc *Collection) HasUncommittedTables() bool {
-	return len(tc.uncommittedTables) > 0
+	for _, desc := range tc.uncommittedDescriptors {
+		if desc.immutable.TableDesc() != nil {
+			return true
+		}
+	}
+	return false
 }
 
-// AddUncommittedTable adds desc to the Collection.
-func (tc *Collection) AddUncommittedTable(desc sqlbase.MutableTableDescriptor) error {
-	if desc.Version != desc.ClusterVersion.Version+1 {
-		return errors.Errorf(
+// HasUncommittedTypes returns true if the Collection contains uncommitted
+// types.
+func (tc *Collection) HasUncommittedTypes() bool {
+	for _, desc := range tc.uncommittedDescriptors {
+		if desc.immutable.TypeDesc() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// Satisfy the linter.
+var _ = (*Collection).HasUncommittedTypes
+
+// AddUncommittedDescriptor adds an uncommitted descriptor modified in the
+// transaction to the Collection.
+func (tc *Collection) AddUncommittedDescriptor(desc catalog.MutableDescriptor) error {
+	if desc.GetVersion() != desc.OriginalVersion()+1 {
+		return errors.AssertionFailedf(
 			"descriptor version %d not incremented from cluster version %d",
-			desc.Version, desc.ClusterVersion.Version)
+			desc.GetVersion(), desc.OriginalVersion())
 	}
-	tbl := UncommittedTable{
-		MutableTableDescriptor:   &desc,
-		ImmutableTableDescriptor: sqlbase.NewImmutableTableDescriptor(desc.TableDescriptor),
+	tbl := uncommittedDescriptor{
+		mutable:   desc,
+		immutable: desc.Immutable(),
 	}
-	for i, table := range tc.uncommittedTables {
-		if table.MutableTableDescriptor.ID == desc.ID {
-			tc.uncommittedTables[i] = tbl
+	for i, d := range tc.uncommittedDescriptors {
+		if d.mutable.GetID() == desc.GetID() {
+			tc.uncommittedDescriptors[i] = tbl
 			return nil
 		}
 	}
-	tc.uncommittedTables = append(tc.uncommittedTables, tbl)
+	tc.uncommittedDescriptors = append(tc.uncommittedDescriptors, tbl)
 	tc.releaseAllDescriptors()
 	return nil
 }
 
-// GetTablesWithNewVersion returns all the idVersion pairs that have undergone a
-// schema change. Returns nil for no schema changes. The version returned for
-// each schema change is ClusterVersion - 1, because that's the one that will be
-// used when checking for table descriptor two version invariance.
-// Also returns strings representing the new <name, version> pairs
-func (tc *Collection) GetTablesWithNewVersion() []lease.IDVersion {
-	var tables []lease.IDVersion
-	for _, table := range tc.uncommittedTables {
-		if mut := table.MutableTableDescriptor; !mut.IsNew() {
-			clusterVer := &mut.ClusterVersion
-			tables = append(tables, lease.NewIDVersionPrev(clusterVer.Name, clusterVer.ID, clusterVer.Version))
+// GetDescriptorsWithNewVersion returns all the IDVersion pairs that have
+// undergone a schema change. Returns nil for no schema changes. The version
+// returned for each schema change is ClusterVersion - 1, because that's the one
+// that will be used when checking for table descriptor two version invariance.
+func (tc *Collection) GetDescriptorsWithNewVersion() []lease.IDVersion {
+	var descs []lease.IDVersion
+	for _, desc := range tc.uncommittedDescriptors {
+		if mut := desc.mutable; !mut.IsNew() {
+			descs = append(descs, lease.NewIDVersionPrev(mut.OriginalName(), mut.OriginalID(), mut.OriginalVersion()))
+		}
+	}
+	return descs
+}
+
+// GetUncommittedTables returns all the tables updated or created in the
+// transaction.
+func (tc *Collection) GetUncommittedTables() (tables []*sqlbase.ImmutableTableDescriptor) {
+	for _, desc := range tc.uncommittedDescriptors {
+		if desc.immutable.TableDesc() != nil {
+			tables = append(tables, desc.immutable.(*sqlbase.ImmutableTableDescriptor))
 		}
 	}
 	return tables
-}
-
-// GetTableDescsWithNewVersion is like GetTablesWithNewVersion but returns descriptors.
-func (tc *Collection) GetTableDescsWithNewVersion() (
-	newTables []*sqlbase.ImmutableTableDescriptor,
-) {
-	for _, table := range tc.uncommittedTables {
-		if mut := table.MutableTableDescriptor; mut.IsNew() {
-			newTables = append(newTables, table.ImmutableTableDescriptor)
-		}
-	}
-	return newTables
 }
 
 // DBAction is an operation to an uncommitted database.
@@ -673,85 +727,86 @@ func (tc *Collection) GetUncommittedDatabaseID(
 	return false, sqlbase.InvalidID, nil
 }
 
-// getUncommittedTable returns a table for the requested tablename
-// if the requested tablename is for a table modified within the transaction
+// getUncommittedDescriptor returns a descriptor for the requested name
+// if the requested name is for a descriptor modified within the transaction
 // affiliated with the LeaseCollection.
 //
 // The first return value "refuseFurtherLookup" is true when there is
-// a known deletion of that table, so it would be invalid to miss the
+// a known deletion of that descriptor, so it would be invalid to miss the
 // cache and go to KV (where the descriptor prior to the DROP may
 // still exist).
-func (tc *Collection) getUncommittedTable(
-	dbID sqlbase.ID, schemaID sqlbase.ID, tn *tree.TableName, required bool,
-) (refuseFurtherLookup bool, table UncommittedTable, err error) {
-	// Walk latest to earliest so that a DROP TABLE followed by a CREATE TABLE
-	// with the same name will result in the CREATE TABLE being seen.
-	for i := len(tc.uncommittedTables) - 1; i >= 0; i-- {
-		table := tc.uncommittedTables[i]
-		mutTbl := table.MutableTableDescriptor
-		// If a table has gotten renamed we'd like to disallow using the old names.
-		// The renames could have happened in another transaction but it's still okay
-		// to disallow the use of the old name in this transaction because the other
-		// transaction has already committed and this transaction is seeing the
-		// effect of it.
-		for _, drain := range mutTbl.DrainingNames {
-			if drain.Name == string(tn.ObjectName) &&
+func (tc *Collection) getUncommittedDescriptor(
+	dbID sqlbase.ID, schemaID sqlbase.ID, name string, required bool,
+) (refuseFurtherLookup bool, desc uncommittedDescriptor, err error) {
+	// Walk latest to earliest so that a DROP followed by a CREATE with the same
+	// name will result in the CREATE being seen.
+	for i := len(tc.uncommittedDescriptors) - 1; i >= 0; i-- {
+		desc := tc.uncommittedDescriptors[i]
+		mutDesc := desc.mutable
+		// If a descriptor has gotten renamed we'd like to disallow using the old
+		// names. The renames could have happened in another transaction but it's
+		// still okay to disallow the use of the old name in this transaction
+		// because the other transaction has already committed and this transaction
+		// is seeing the effect of it.
+		for _, drain := range mutDesc.GetDrainingNames() {
+			if drain.Name == name &&
 				drain.ParentID == dbID &&
 				drain.ParentSchemaID == schemaID {
-				// Table name has gone away.
+				// Name has gone away.
 				if required {
 					// If it's required here, say it doesn't exist.
-					err = sqlbase.NewUndefinedRelationError(tn)
+					err = sqlbase.NewUndefinedRelationError(tree.NewUnqualifiedTableName(tree.Name(name)))
 				}
-				// The table collection knows better; the caller has to avoid
+				// The desc collection knows better; the caller has to avoid
 				// going to KV in any case: refuseFurtherLookup = true
-				return true, UncommittedTable{}, err
+				return true, uncommittedDescriptor{}, err
 			}
 		}
 
-		// Do we know about a table with this name?
-		if lease.NameMatchesDescriptor(
-			mutTbl,
-			dbID,
-			schemaID,
-			tn.Table(),
-		) {
+		// Do we know about a descriptor with this name?
+		if lease.NameMatchesDescriptor(mutDesc, dbID, schemaID, name) {
 			// Right state?
-			if err = catalog.FilterDescriptorState(mutTbl); err != nil && !catalog.HasAddingTableError(err) {
+			if err = catalog.FilterDescriptorState(mutDesc); err != nil && !catalog.HasAddingTableError(err) {
 				if !required {
 					// If it's not required here, we simply say we don't have it.
 					err = nil
 				}
-				// The table collection knows better; the caller has to avoid
+				// The desc collection knows better; the caller has to avoid
 				// going to KV in any case: refuseFurtherLookup = true
-				return true, UncommittedTable{}, err
+				return true, uncommittedDescriptor{}, err
 			}
 
-			// Got a table.
-			return false, table, nil
+			// Got a descriptor.
+			return false, desc, nil
 		}
 	}
-	return false, UncommittedTable{}, nil
+	return false, uncommittedDescriptor{}, nil
 }
 
 // GetUncommittedTableByID returns an uncommitted table by its ID.
-func (tc *Collection) GetUncommittedTableByID(id sqlbase.ID) UncommittedTable {
-	// Walk latest to earliest so that a DROP TABLE followed by a CREATE TABLE
-	// with the same name will result in the CREATE TABLE being seen.
-	for i := len(tc.uncommittedTables) - 1; i >= 0; i-- {
-		table := tc.uncommittedTables[i]
-		if table.MutableTableDescriptor.ID == id {
+func (tc *Collection) GetUncommittedTableByID(id sqlbase.ID) *sqlbase.MutableTableDescriptor {
+	desc := tc.getUncommittedDescriptorByID(id)
+	if desc != nil {
+		if table, ok := desc.(*sqlbase.MutableTableDescriptor); ok {
 			return table
 		}
 	}
-	return UncommittedTable{}
+	return nil
+}
+
+func (tc *Collection) getUncommittedDescriptorByID(id sqlbase.ID) catalog.MutableDescriptor {
+	for i := range tc.uncommittedDescriptors {
+		desc := &tc.uncommittedDescriptors[i]
+		if desc.mutable.GetID() == id {
+			return desc.mutable
+		}
+	}
+	return nil
 }
 
 // GetAllDescriptors returns all descriptors visible by the transaction,
 // first checking the Collection's cached descriptors for validity
 // before defaulting to a key-value scan, if necessary.
-//
-// TODO(ajwerner): Have this return []sqlbase.DescriptorInterface.
 func (tc *Collection) GetAllDescriptors(
 	ctx context.Context, txn *kv.Txn,
 ) ([]sqlbase.DescriptorInterface, error) {
@@ -873,7 +928,7 @@ func (tc *Collection) CopyModifiedObjects(to *Collection) {
 	if tc == nil {
 		return
 	}
-	to.uncommittedTables = tc.uncommittedTables
+	to.uncommittedDescriptors = tc.uncommittedDescriptors
 	to.uncommittedDatabases = tc.uncommittedDatabases
 	// Do not copy the leased descriptors because we do not want
 	// the leased descriptors to be released by the "to" Collection.

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -575,7 +575,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 	// try to acquire at a bogus version to make sure we don't get back a lease we
 	// already had.
 	_, _, err = t.acquireMinVersion(1, tableDesc.ID, tableDesc.Version+1)
-	if !testutils.IsError(err, "table is being dropped") {
+	if !testutils.IsError(err, "descriptor is being dropped") {
 		t.Fatalf("got a different error than expected: %v", err)
 	}
 }
@@ -682,7 +682,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 	}
 	// Now we shouldn't be able to acquire any more.
 	_, _, err = acquire(ctx, s.(*server.TestServer), tableDesc.ID)
-	if !testutils.IsError(err, "table is being dropped") {
+	if !testutils.IsError(err, "descriptor is being dropped") {
 		t.Fatalf("got a different error than expected: %v", err)
 	}
 }

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1592,7 +1592,7 @@ INSERT INTO t.kv VALUES ('a', 'b');
 		// This can hang waiting for one version before tx.Commit() is
 		// called below, so it is executed in another goroutine
 		if err := txRetry.Commit(); !testutils.IsError(err,
-			`TransactionRetryWithProtoRefreshError: cannot publish new versions for tables: \[\{kv1 53 1\}\], old versions still in use`,
+			`TransactionRetryWithProtoRefreshError: cannot publish new versions for descriptors: \[\{kv1 53 1\}\], old versions still in use`,
 		) {
 			t.Errorf("err = %v", err)
 		}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2374,10 +2374,10 @@ func (ex *connExecutor) sessionEventf(ctx context.Context, format string, args .
 // the stats refresher that new tables exist and should have their stats
 // collected now.
 func (ex *connExecutor) notifyStatsRefresherOfNewTables(ctx context.Context) {
-	for _, desc := range ex.extraTxnState.descCollection.GetTableDescsWithNewVersion() {
+	for _, desc := range ex.extraTxnState.descCollection.GetUncommittedTables() {
 		// The CREATE STATISTICS run for an async CTAS query is initiated by the
 		// SchemaChanger, so we don't do it here.
-		if desc.IsTable() && !desc.IsAs() {
+		if desc.IsTable() && !desc.IsAs() && desc.GetVersion() == 1 {
 			// Initiate a run of CREATE STATISTICS. We use a large number
 			// for rowsAffected because we want to make sure that stats always get
 			// created/refreshed here.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -551,7 +551,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	return nil, nil, nil
 }
 
-// checkTableTwoVersionInvariant checks whether any new table schema being
+// checkDescriptorTwoVersionInvariant checks whether any new schema being
 // modified written at a version V has only valid leases at version = V - 1.
 // A transaction retry error is returned whenever the invariant is violated.
 // Before returning the retry error the current transaction is
@@ -560,8 +560,8 @@ func (ex *connExecutor) execStmtInOpenState(
 // event that there are no other schema changes simultaneously contending with
 // this txn.
 //
-// checkTableTwoVersionInvariant blocks until it's legal for the modified
-// table descriptors (if any) to be committed.
+// checkDescriptorTwoVersionInvariant blocks until it's legal for the modified
+// descriptors (if any) to be committed.
 // Reminder: a descriptor version v can only be written at a timestamp
 // that's not covered by a lease on version v-2. So, if the current
 // txn wants to write some updated descriptors, it needs
@@ -574,11 +574,11 @@ func (ex *connExecutor) execStmtInOpenState(
 // v-1 exists.
 //
 // If this method succeeds it is the caller's responsibility to release the
-// executor's table leases after the txn commits so that schema changes can
+// executor's leases after the txn commits so that schema changes can
 // proceed.
-func (ex *connExecutor) checkTableTwoVersionInvariant(ctx context.Context) error {
-	tables := ex.extraTxnState.descCollection.GetTablesWithNewVersion()
-	if tables == nil {
+func (ex *connExecutor) checkDescriptorTwoVersionInvariant(ctx context.Context) error {
+	descs := ex.extraTxnState.descCollection.GetDescriptorsWithNewVersion()
+	if descs == nil {
 		return nil
 	}
 	txn := ex.state.mu.txn
@@ -586,28 +586,28 @@ func (ex *connExecutor) checkTableTwoVersionInvariant(ctx context.Context) error
 		panic("transaction has already committed")
 	}
 
-	// We potentially hold leases for tables which we've modified which
-	// we need to drop. Say we're updating tables at version V. All leases
+	// We potentially hold leases for descriptors which we've modified which
+	// we need to drop. Say we're updating descriptors at version V. All leases
 	// for version V-2 need to be dropped immediately, otherwise the check
 	// below that nobody holds leases for version V-2 will fail. Worse yet,
 	// the code below loops waiting for nobody to hold leases on V-2. We also
-	// may hold leases for version V-1 of modified tables that are good to drop
+	// may hold leases for version V-1 of modified descriptors that are good to drop
 	// but not as vital for correctness. It's good to drop them because as soon
 	// as this transaction commits jobs may start and will need to wait until
 	// the lease expires. It is safe because V-1 must remain valid until this
 	// transaction commits; if we commit then nobody else could have written
 	// a new V beneath us because we've already laid down an intent.
 	//
-	// All this being said, we must retain our leases on tables which we have
-	// not modified to ensure that our writes to those other tables in this
+	// All this being said, we must retain our leases on descriptors which we have
+	// not modified to ensure that our writes to those other descriptors in this
 	// transaction remain valid.
-	ex.extraTxnState.descCollection.ReleaseTableLeases(ctx, tables)
+	ex.extraTxnState.descCollection.ReleaseSpecifiedLeases(ctx, descs)
 
-	// We know that so long as there are no leases on the updated tables as of
+	// We know that so long as there are no leases on the updated descriptors as of
 	// the current provisional commit timestamp for this transaction then if this
 	// transaction ends up committing then there won't have been any created
 	// in the meantime.
-	count, err := lease.CountLeases(ctx, ex.server.cfg.InternalExecutor, tables, txn.ProvisionalCommitTimestamp())
+	count, err := lease.CountLeases(ctx, ex.server.cfg.InternalExecutor, descs, txn.ProvisionalCommitTimestamp())
 	if err != nil {
 		return err
 	}
@@ -620,21 +620,21 @@ func (ex *connExecutor) checkTableTwoVersionInvariant(ctx context.Context) error
 	// version.
 	retryErr := txn.PrepareRetryableError(ctx,
 		fmt.Sprintf(
-			`cannot publish new versions for tables: %v, old versions still in use`,
-			tables))
+			`cannot publish new versions for descriptors: %v, old versions still in use`,
+			descs))
 	// We cleanup the transaction and create a new transaction after
 	// waiting for the invariant to be satisfied because the wait time
 	// might be extensive and intents can block out leases being created
 	// on a descriptor.
 	//
 	// TODO(vivek): Change this to restart a txn while fixing #20526 . All the
-	// table descriptor intents can be laid down here after the invariant
+	// descriptor intents can be laid down here after the invariant
 	// has been checked.
 	userPriority := txn.UserPriority()
 	// We cleanup the transaction and create a new transaction wait time
 	// might be extensive and so we'd better get rid of all the intents.
 	txn.CleanupOnError(ctx, retryErr)
-	// Release the rest of our leases on unmodified tables so we don't hold up
+	// Release the rest of our leases on unmodified descriptors so we don't hold up
 	// schema changes there and potentially create a deadlock.
 	ex.extraTxnState.descCollection.ReleaseLeases(ctx)
 
@@ -642,7 +642,7 @@ func (ex *connExecutor) checkTableTwoVersionInvariant(ctx context.Context) error
 	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
 		// Use the current clock time.
 		now := ex.server.cfg.Clock.Now()
-		count, err := lease.CountLeases(ctx, ex.server.cfg.InternalExecutor, tables, now)
+		count, err := lease.CountLeases(ctx, ex.server.cfg.InternalExecutor, descs, now)
 		if err != nil {
 			return err
 		}
@@ -684,7 +684,7 @@ func (ex *connExecutor) commitSQLTransactionInternal(
 		return err
 	}
 
-	if err := ex.checkTableTwoVersionInvariant(ctx); err != nil {
+	if err := ex.checkDescriptorTwoVersionInvariant(ctx); err != nil {
 		return err
 	}
 
@@ -692,10 +692,10 @@ func (ex *connExecutor) commitSQLTransactionInternal(
 		return err
 	}
 
-	// Now that we've committed, if we modified any table we need to make sure
+	// Now that we've committed, if we modified any descriptor we need to make sure
 	// to release the leases for them so that the schema change can proceed and
 	// we don't block the client.
-	if tables := ex.extraTxnState.descCollection.GetTablesWithNewVersion(); tables != nil {
+	if descs := ex.extraTxnState.descCollection.GetDescriptorsWithNewVersion(); descs != nil {
 		ex.extraTxnState.descCollection.ReleaseLeases(ctx)
 	}
 	return nil
@@ -705,9 +705,8 @@ func (ex *connExecutor) commitSQLTransactionInternal(
 // an enabled primary key after potentially undergoing DROP PRIMARY KEY, which
 // is required to be followed by ADD PRIMARY KEY.
 func validatePrimaryKeys(tc *descs.Collection) error {
-	modifiedTables := tc.GetTablesWithNewVersion()
-	for i := range modifiedTables {
-		table := tc.GetUncommittedTableByID(modifiedTables[i].ID).MutableTableDescriptor
+	tables := tc.GetUncommittedTables()
+	for _, table := range tables {
 		if !table.HasPrimaryKey() {
 			return unimplemented.NewWithIssuef(48026,
 				"primary key of table %s dropped without subsequent addition of new primary key",

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -245,7 +245,7 @@ CREATE TABLE crdb_internal.tables (
 	generator: func(ctx context.Context, p *planner, dbDesc *sqlbase.ImmutableDatabaseDescriptor) (virtualTableGenerator, cleanupFunc, error) {
 		row := make(tree.Datums, 14)
 		worker := func(pusher rowPusher) error {
-			descs, err := p.Tables().GetAllDescriptors(ctx, p.txn)
+			descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 			if err != nil {
 				return err
 			}
@@ -352,7 +352,7 @@ CREATE TABLE crdb_internal.schema_changes (
   direction     STRING NOT NULL
 )`,
 	populate: func(ctx context.Context, p *planner, _ *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		descs, err := p.Tables().GetAllDescriptors(ctx, p.txn)
+		descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 		if err != nil {
 			return err
 		}
@@ -2188,7 +2188,7 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.ranges_no_leases"); err != nil {
 			return nil, nil, err
 		}
-		descs, err := p.Tables().GetAllDescriptors(ctx, p.txn)
+		descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -164,7 +164,7 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 		flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{
 			AvoidCached: n.p.avoidCachedDescriptors,
 		}}
-		tableDesc, err = n.p.Tables().GetTableVersionByID(ctx, n.p.txn, sqlbase.ID(t.TableID), flags)
+		tableDesc, err = n.p.Descriptors().GetTableVersionByID(ctx, n.p.txn, sqlbase.ID(t.TableID), flags)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -320,7 +320,7 @@ func (n *createTableNode) startExec(params runParams) error {
 			}
 			var foundExternalReference bool
 			for id := range refs {
-				if t := params.p.Tables().GetUncommittedTableByID(id).MutableTableDescriptor; t == nil || !t.IsNew() {
+				if t := params.p.Tables().GetUncommittedTableByID(id); t == nil || !t.IsNew() {
 					foundExternalReference = true
 					break
 				}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -320,7 +320,7 @@ func (n *createTableNode) startExec(params runParams) error {
 			}
 			var foundExternalReference bool
 			for id := range refs {
-				if t := params.p.Tables().GetUncommittedTableByID(id); t == nil || !t.IsNew() {
+				if t := params.p.Descriptors().GetUncommittedTableByID(id); t == nil || !t.IsNew() {
 					foundExternalReference = true
 					break
 				}
@@ -1012,7 +1012,7 @@ func (p *planner) finalizeInterleave(
 		ancestorTable = desc
 	} else {
 		var err error
-		ancestorTable, err = p.Tables().GetMutableTableVersionByID(ctx, ancestor.TableID, p.txn)
+		ancestorTable, err = p.Descriptors().GetMutableTableVersionByID(ctx, ancestor.TableID, p.txn)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -320,7 +320,7 @@ func (n *createTableNode) startExec(params runParams) error {
 			}
 			var foundExternalReference bool
 			for id := range refs {
-				if t := params.p.Tables().GetUncommittedTableByID(id).MutableTableDescriptor; t == nil || !t.IsNewTable() {
+				if t := params.p.Tables().GetUncommittedTableByID(id).MutableTableDescriptor; t == nil || !t.IsNew() {
 					foundExternalReference = true
 					break
 				}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -61,7 +61,7 @@ func (n *createViewNode) startExec(params runParams) error {
 	// If so, promote this view to temporary.
 	backRefMutables := make(map[sqlbase.ID]*sqlbase.MutableTableDescriptor, len(n.planDeps))
 	for id, updated := range n.planDeps {
-		backRefMutable := params.p.Tables().GetUncommittedTableByID(id).MutableTableDescriptor
+		backRefMutable := params.p.Tables().GetUncommittedTableByID(id)
 		if backRefMutable == nil {
 			backRefMutable = sqlbase.NewMutableExistingTableDescriptor(*updated.desc.TableDesc())
 		}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -61,7 +61,7 @@ func (n *createViewNode) startExec(params runParams) error {
 	// If so, promote this view to temporary.
 	backRefMutables := make(map[sqlbase.ID]*sqlbase.MutableTableDescriptor, len(n.planDeps))
 	for id, updated := range n.planDeps {
-		backRefMutable := params.p.Tables().GetUncommittedTableByID(id)
+		backRefMutable := params.p.Descriptors().GetUncommittedTableByID(id)
 		if backRefMutable == nil {
 			backRefMutable = sqlbase.NewMutableExistingTableDescriptor(*updated.desc.TableDesc())
 		}
@@ -92,7 +92,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			if err != nil {
 				return err
 			}
-			desc, err := params.p.Tables().GetMutableTableVersionByID(params.ctx, id, params.p.txn)
+			desc, err := params.p.Descriptors().GetMutableTableVersionByID(params.ctx, id, params.p.txn)
 			if err != nil {
 				return err
 			}
@@ -304,7 +304,7 @@ func (p *planner) replaceViewDesc(
 		desc, ok := backRefMutables[id]
 		if !ok {
 			var err error
-			desc, err = p.Tables().GetMutableTableVersionByID(ctx, id, p.txn)
+			desc, err = p.Descriptors().GetMutableTableVersionByID(ctx, id, p.txn)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -68,8 +68,8 @@ func (p *planner) renameDatabase(
 		return err
 	}
 
-	p.Tables().AddUncommittedDatabase(oldName, descID, descs.DBDropped)
-	p.Tables().AddUncommittedDatabase(newName, descID, descs.DBCreated)
+	p.Descriptors().AddUncommittedDatabase(oldName, descID, descs.DBDropped)
+	p.Descriptors().AddUncommittedDatabase(newName, descID, descs.DBCreated)
 
 	return p.txn.Run(ctx, b)
 }

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -152,7 +152,7 @@ func (p *planner) createDescriptorWithID(
 		if err := mutDesc.ValidateTable(); err != nil {
 			return err
 		}
-		if err := p.Tables().AddUncommittedDescriptor(mutDesc); err != nil {
+		if err := p.Descriptors().AddUncommittedDescriptor(mutDesc); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -152,7 +152,7 @@ func (p *planner) createDescriptorWithID(
 		if err := mutDesc.ValidateTable(); err != nil {
 			return err
 		}
-		if err := p.Tables().AddUncommittedTable(*mutDesc); err != nil {
+		if err := p.Tables().AddUncommittedDescriptor(mutDesc); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -69,7 +69,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 		return nil, err
 	}
 
-	schemas, err := p.Tables().GetSchemasForDatabase(ctx, p.txn, dbDesc.GetID())
+	schemas, err := p.Descriptors().GetSchemasForDatabase(ctx, p.txn, dbDesc.GetID())
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		b.DelRange(zoneKeyPrefix, zoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
 	}
 
-	p.Tables().AddUncommittedDatabase(n.dbDesc.GetName(), n.dbDesc.GetID(), descs.DBDropped)
+	p.Descriptors().AddUncommittedDatabase(n.dbDesc.GetName(), n.dbDesc.GetID(), descs.DBDropped)
 
 	if err := p.txn.Run(ctx, b); err != nil {
 		return err
@@ -298,7 +298,7 @@ func (p *planner) accumulateDependentTables(
 ) error {
 	for _, ref := range desc.DependedOnBy {
 		dependentTables[ref.ID] = true
-		dependentDesc, err := p.Tables().GetMutableTableVersionByID(ctx, ref.ID, p.txn)
+		dependentDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.ID, p.txn)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -111,7 +111,7 @@ func (n *DropRoleNode) startExec(params runParams) error {
 	// the predefined forEachTableAll() function because we need to look
 	// at all _visible_ descriptors, not just those on which the current
 	// user has permission.
-	descs, err := params.p.Tables().GetAllDescriptors(params.ctx, params.p.txn)
+	descs, err := params.p.Descriptors().GetAllDescriptors(params.ctx, params.p.txn)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -163,7 +164,7 @@ func (p *planner) canRemoveOwnedSequencesImpl(
 		if err != nil {
 			// Special case error swallowing for #50711 and #50781, which can cause a
 			// column to own sequences that have been dropped/do not exist.
-			if errors.Is(err, sqlbase.ErrTableDropped) ||
+			if errors.Is(err, catalog.ErrDescriptorDropped) ||
 				pgerror.GetPGCode(err) == pgcode.UndefinedTable {
 				log.Eventf(ctx, "swallowing error ensuring owned sequences can be removed: %s", err.Error())
 				continue

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -186,7 +186,7 @@ func (p *planner) prepareDropWithTableDesc(
 func (p *planner) canRemoveFKBackreference(
 	ctx context.Context, from string, ref *sqlbase.ForeignKeyConstraint, behavior tree.DropBehavior,
 ) error {
-	table, err := p.Tables().GetMutableTableVersionByID(ctx, ref.OriginTableID, p.txn)
+	table, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.OriginTableID, p.txn)
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func (p *planner) canRemoveFKBackreference(
 func (p *planner) canRemoveInterleave(
 	ctx context.Context, from string, ref sqlbase.ForeignKeyReference, behavior tree.DropBehavior,
 ) error {
-	table, err := p.Tables().GetMutableTableVersionByID(ctx, ref.Table, p.txn)
+	table, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.Table, p.txn)
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func (p *planner) canRemoveInterleave(
 }
 
 func (p *planner) removeInterleave(ctx context.Context, ref sqlbase.ForeignKeyReference) error {
-	table, err := p.Tables().GetMutableTableVersionByID(ctx, ref.Table, p.txn)
+	table, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.Table, p.txn)
 	if err != nil {
 		return err
 	}
@@ -418,7 +418,7 @@ func (p *planner) removeFKForBackReference(
 	if tableDesc.ID == ref.OriginTableID {
 		originTableDesc = tableDesc
 	} else {
-		lookup, err := p.Tables().GetMutableTableVersionByID(ctx, ref.OriginTableID, p.txn)
+		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.OriginTableID, p.txn)
 		if err != nil {
 			return errors.Errorf("error resolving origin table ID %d: %v", ref.OriginTableID, err)
 		}
@@ -476,7 +476,7 @@ func (p *planner) removeFKBackReference(
 	if tableDesc.ID == ref.ReferencedTableID {
 		referencedTableDesc = tableDesc
 	} else {
-		lookup, err := p.Tables().GetMutableTableVersionByID(ctx, ref.ReferencedTableID, p.txn)
+		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ref.ReferencedTableID, p.txn)
 		if err != nil {
 			return errors.Errorf("error resolving referenced table ID %d: %v", ref.ReferencedTableID, err)
 		}
@@ -533,7 +533,7 @@ func (p *planner) removeInterleaveBackReference(
 	if ancestor.TableID == tableDesc.ID {
 		t = tableDesc
 	} else {
-		lookup, err := p.Tables().GetMutableTableVersionByID(ctx, ancestor.TableID, p.txn)
+		lookup, err := p.Descriptors().GetMutableTableVersionByID(ctx, ancestor.TableID, p.txn)
 		if err != nil {
 			return errors.Errorf("error resolving referenced table ID %d: %v", ancestor.TableID, err)
 		}

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -984,7 +984,7 @@ func TestDropTableWhileUpgradingFormat(t *testing.T) {
 	// Simulate a migration upgrading the table descriptor's format version after
 	// the table has been dropped but before the truncation has occurred.
 	var err error
-	tableDesc, err = sqlbase.GetMutableTableDescFromID(ctx, kvDB.NewTxn(ctx, ""), keys.SystemSQLCodec, tableDesc.ID)
+	tableDesc, err = sqlbase.TestingGetMutableTableDescFromID(ctx, kvDB.NewTxn(ctx, ""), keys.SystemSQLCodec, tableDesc.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -187,7 +187,7 @@ func (p *planner) dropViewImpl(
 
 	// Remove back-references from the tables/views this view depends on.
 	for _, depID := range viewDesc.DependsOn {
-		dependencyDesc, err := p.Tables().GetMutableTableVersionByID(ctx, depID, p.txn)
+		dependencyDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, depID, p.txn)
 		if err != nil {
 			return cascadeDroppedViews,
 				errors.Errorf("error resolving dependency relation ID %d: %v", depID, err)
@@ -239,7 +239,7 @@ func (p *planner) getViewDescForCascade(
 	parentID, viewID sqlbase.ID,
 	behavior tree.DropBehavior,
 ) (*sqlbase.MutableTableDescriptor, error) {
-	viewDesc, err := p.Tables().GetMutableTableVersionByID(ctx, viewID, p.txn)
+	viewDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, viewID, p.txn)
 	if err != nil {
 		log.Warningf(ctx, "unable to retrieve descriptor for view %d: %v", viewID, err)
 		return nil, errors.Wrapf(err, "error resolving dependent view ID %d", viewID)

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -81,11 +81,11 @@ func TestSchemaChangeGCJob(t *testing.T) {
 			var myOtherTableDesc *sqlbase.MutableTableDescriptor
 			if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 				var err error
-				myTableDesc, err = sqlbase.GetMutableTableDescFromID(ctx, txn, keys.SystemSQLCodec, myTableID)
+				myTableDesc, err = sqlbase.TestingGetMutableTableDescFromID(ctx, txn, keys.SystemSQLCodec, myTableID)
 				if err != nil {
 					return err
 				}
-				myOtherTableDesc, err = sqlbase.GetMutableTableDescFromID(ctx, txn, keys.SystemSQLCodec, myOtherTableID)
+				myOtherTableDesc, err = sqlbase.TestingGetMutableTableDescFromID(ctx, txn, keys.SystemSQLCodec, myOtherTableID)
 				return err
 			}); err != nil {
 				t.Fatal(err)
@@ -196,13 +196,13 @@ func TestSchemaChangeGCJob(t *testing.T) {
 
 			if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 				var err error
-				myTableDesc, err = sqlbase.GetMutableTableDescFromID(ctx, txn, keys.SystemSQLCodec, myTableID)
+				myTableDesc, err = sqlbase.TestingGetMutableTableDescFromID(ctx, txn, keys.SystemSQLCodec, myTableID)
 				if ttlTime != FUTURE && (dropItem == TABLE || dropItem == DATABASE) {
 					// We dropped the table, so expect it to not be found.
 					require.EqualError(t, err, "descriptor not found")
 					return nil
 				}
-				myOtherTableDesc, err = sqlbase.GetMutableTableDescFromID(ctx, txn, keys.SystemSQLCodec, myOtherTableID)
+				myOtherTableDesc, err = sqlbase.TestingGetMutableTableDescFromID(ctx, txn, keys.SystemSQLCodec, myOtherTableID)
 				if ttlTime != FUTURE && dropItem == DATABASE {
 					// We dropped the entire database, so expect none of the tables to be found.
 					require.EqualError(t, err, "descriptor not found")

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1523,7 +1523,7 @@ func forEachDatabaseDesc(
 ) error {
 	var dbDescs []*sqlbase.ImmutableDatabaseDescriptor
 	if dbContext == nil {
-		allDbDescs, err := p.Tables().GetAllDatabaseDescriptors(ctx, p.txn)
+		allDbDescs, err := p.Descriptors().GetAllDatabaseDescriptors(ctx, p.txn)
 		if err != nil {
 			return err
 		}
@@ -1559,7 +1559,7 @@ func forEachTypeDesc(
 	dbContext *sqlbase.ImmutableDatabaseDescriptor,
 	fn func(db *sqlbase.ImmutableDatabaseDescriptor, sc string, typ *sqlbase.ImmutableTypeDescriptor) error,
 ) error {
-	descs, err := p.Tables().GetAllDescriptors(ctx, p.txn)
+	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	if err != nil {
 		return err
 	}
@@ -1683,15 +1683,15 @@ func getSchemaNames(
 	ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor,
 ) (map[sqlbase.ID]string, error) {
 	if dbContext != nil {
-		return p.Tables().GetSchemasForDatabase(ctx, p.txn, dbContext.GetID())
+		return p.Descriptors().GetSchemasForDatabase(ctx, p.txn, dbContext.GetID())
 	}
 	ret := make(map[sqlbase.ID]string)
-	dbs, err := p.Tables().GetAllDatabaseDescriptors(ctx, p.txn)
+	dbs, err := p.Descriptors().GetAllDatabaseDescriptors(ctx, p.txn)
 	if err != nil {
 		return nil, err
 	}
 	for _, db := range dbs {
-		schemas, err := p.Tables().GetSchemasForDatabase(ctx, p.txn, db.GetID())
+		schemas, err := p.Descriptors().GetSchemasForDatabase(ctx, p.txn, db.GetID())
 		if err != nil {
 			return nil, err
 		}
@@ -1715,7 +1715,7 @@ func forEachTableDescWithTableLookupInternal(
 	allowAdding bool,
 	fn func(*sqlbase.ImmutableDatabaseDescriptor, string, *ImmutableTableDescriptor, tableLookupFn) error,
 ) error {
-	descs, err := p.Tables().GetAllDescriptors(ctx, p.txn)
+	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -43,7 +43,7 @@ public  b  table
 statement error pgcode 42P01 relation "a" does not exist
 SELECT * FROM a
 
-statement error pq: \[53 AS a\]: table is being dropped
+statement error pq: \[53 AS a\]: descriptor is being dropped
 SELECT * FROM [53 AS a]
 
 statement error pgcode 42P01 relation "a" does not exist

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -262,7 +262,7 @@ EXPLAIN (VERBOSE) SELECT 1 FROM [53() as num_ref_alias]
 statement ok
 DROP TABLE num_ref
 
-query error pq: \[53\(1\) AS num_ref_alias\]: table is being dropped
+query error pq: \[53\(1\) AS num_ref_alias\]: descriptor is being dropped
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -995,7 +995,7 @@ type oneAtATimeSchemaResolver struct {
 func (r oneAtATimeSchemaResolver) getDatabaseByID(
 	id sqlbase.ID,
 ) (*sqlbase.ImmutableDatabaseDescriptor, error) {
-	return r.p.Tables().DatabaseCache().GetDatabaseDescByID(r.ctx, r.p.txn, id)
+	return r.p.Descriptors().DatabaseCache().GetDatabaseDescByID(r.ctx, r.p.txn, id)
 }
 
 func (r oneAtATimeSchemaResolver) getTableByID(id sqlbase.ID) (*TableDescriptor, error) {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -313,7 +313,7 @@ func (opc *optPlanningCtx) reset() {
 		// are multiple DDL operations; and transactions can be aborted leading to
 		// potential reuse of versions. To avoid these issues, we prevent saving a
 		// memo (for prepare) or reusing a saved memo (for execute).
-		opc.allowMemoReuse = !p.Tables().HasUncommittedTables()
+		opc.allowMemoReuse = !p.Descriptors().HasUncommittedTables()
 		opc.useCache = opc.allowMemoReuse && queryCacheEnabled.Get(&p.execCfg.Settings.SV)
 
 		if _, isCanned := p.stmt.AST.(*tree.CannedOptPlan); isCanned {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -412,7 +412,7 @@ func (p *planner) EvalContext() *tree.EvalContext {
 	return &p.extendedEvalCtx.EvalContext
 }
 
-func (p *planner) Tables() *descs.Collection {
+func (p *planner) Descriptors() *descs.Collection {
 	return p.extendedEvalCtx.Descs
 }
 
@@ -422,7 +422,7 @@ func (p *planner) ExecCfg() *ExecutorConfig {
 }
 
 func (p *planner) LeaseMgr() *lease.Manager {
-	return p.Tables().LeaseManager()
+	return p.Descriptors().LeaseManager()
 }
 
 func (p *planner) Txn() *kv.Txn {
@@ -483,7 +483,7 @@ func (p *planner) LookupTableByID(
 		return catalog.TableEntry{Desc: sqlbase.NewImmutableTableDescriptor(*entry.desc)}, nil
 	}
 	flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{AvoidCached: p.avoidCachedDescriptors}}
-	table, err := p.Tables().GetTableVersionByID(ctx, p.txn, tableID, flags)
+	table, err := p.Descriptors().GetTableVersionByID(ctx, p.txn, tableID, flags)
 	if err != nil {
 		if catalog.HasAddingTableError(err) {
 			return catalog.TableEntry{IsAdding: true}, nil

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -485,7 +485,7 @@ func (p *planner) LookupTableByID(
 	flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{AvoidCached: p.avoidCachedDescriptors}}
 	table, err := p.Tables().GetTableVersionByID(ctx, p.txn, tableID, flags)
 	if err != nil {
-		if sqlbase.HasAddingTableError(err) {
+		if catalog.HasAddingTableError(err) {
 			return catalog.TableEntry{IsAdding: true}, nil
 		}
 		return catalog.TableEntry{}, err

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -87,7 +87,7 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 	lookupFlags := p.CommonLookupFlags(true /*required*/)
 	// DDL statements bypass the cache.
 	lookupFlags.AvoidCached = true
-	schemas, err := p.Tables().GetSchemasForDatabase(ctx, p.txn, dbDesc.GetID())
+	schemas, err := p.Descriptors().GetSchemasForDatabase(ctx, p.txn, dbDesc.GetID())
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -717,7 +717,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	wg.Add(1)
 	go func() {
 		// Start schema change that eventually runs a partial backfill.
-		if _, err := sqlDB.Exec("CREATE UNIQUE INDEX bar ON t.test (v)"); err != nil && !testutils.IsError(err, "table is being dropped") {
+		if _, err := sqlDB.Exec("CREATE UNIQUE INDEX bar ON t.test (v)"); err != nil && !testutils.IsError(err, "descriptor is being dropped") {
 			t.Error(err)
 		}
 		wg.Done()

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -160,7 +160,7 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 		return err
 	}
 
-	schemas, err := p.Tables().GetSchemasForDatabase(ctx, p.txn, dbDesc.GetID())
+	schemas, err := p.Descriptors().GetSchemasForDatabase(ctx, p.txn, dbDesc.GetID())
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -335,7 +335,7 @@ func removeSequenceOwnerIfExists(
 	if !opts.HasOwner() {
 		return nil
 	}
-	tableDesc, err := p.Tables().GetMutableTableVersionByID(ctx, opts.SequenceOwner.OwnerTableID, p.txn)
+	tableDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, opts.SequenceOwner.OwnerTableID, p.txn)
 	if err != nil {
 		// Special case error swallowing for #50711 and #50781, which can cause a
 		// column to own sequences that have been dropped/do not exist.
@@ -491,7 +491,7 @@ func (p *planner) dropSequencesOwnedByCol(
 	ctx context.Context, col *sqlbase.ColumnDescriptor, queueJob bool,
 ) error {
 	for _, sequenceID := range col.OwnsSequenceIds {
-		seqDesc, err := p.Tables().GetMutableTableVersionByID(ctx, sequenceID, p.txn)
+		seqDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, sequenceID, p.txn)
 		// Special case error swallowing for #50781, which can cause a
 		// column to own sequences that do not exist.
 		if err != nil {
@@ -526,7 +526,7 @@ func (p *planner) removeSequenceDependencies(
 ) error {
 	for _, sequenceID := range col.UsesSequenceIds {
 		// Get the sequence descriptor so we can remove the reference from it.
-		seqDesc, err := p.Tables().GetMutableTableVersionByID(ctx, sequenceID, p.txn)
+		seqDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, sequenceID, p.txn)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/sqlbase/database_desc.go
+++ b/pkg/sql/sqlbase/database_desc.go
@@ -130,6 +130,26 @@ func (desc *ImmutableDatabaseDescriptor) GetAuditMode() TableDescriptor_AuditMod
 	return TableDescriptor_DISABLED
 }
 
+// Adding implements the BaseDescriptorInterface interface.
+func (desc *ImmutableDatabaseDescriptor) Adding() bool {
+	return false
+}
+
+// Dropped implements the BaseDescriptorInterface interface.
+func (desc *ImmutableDatabaseDescriptor) Dropped() bool {
+	return false
+}
+
+// Offline implements the BaseDescriptorInterface interface.
+func (desc *ImmutableDatabaseDescriptor) Offline() bool {
+	return false
+}
+
+// GetOfflineReason implements the BaseDescriptorInterface interface.
+func (desc *ImmutableDatabaseDescriptor) GetOfflineReason() string {
+	return ""
+}
+
 // DescriptorProto wraps a DatabaseDescriptor in a Descriptor.
 func (desc *ImmutableDatabaseDescriptor) DescriptorProto() *Descriptor {
 	return &Descriptor{
@@ -179,4 +199,9 @@ func (desc *MutableDatabaseDescriptor) Immutable() DescriptorInterface {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
 	return NewImmutableDatabaseDescriptor(*protoutil.Clone(desc.DatabaseDesc()).(*DatabaseDescriptor))
+}
+
+// IsNew implements the MutableDescriptor interface.
+func (desc *MutableDatabaseDescriptor) IsNew() bool {
+	return desc.ClusterVersion.ID == InvalidID
 }

--- a/pkg/sql/sqlbase/database_desc.go
+++ b/pkg/sql/sqlbase/database_desc.go
@@ -187,11 +187,35 @@ func (desc *ImmutableDatabaseDescriptor) Validate() error {
 // MaybeIncrementVersion implements the MutableDescriptor interface.
 func (desc *MutableDatabaseDescriptor) MaybeIncrementVersion() {
 	// Already incremented, no-op.
-	if desc.Version == desc.ClusterVersion.Version+1 {
+	if desc.ClusterVersion == nil || desc.Version == desc.ClusterVersion.Version+1 {
 		return
 	}
 	desc.Version++
 	desc.ModificationTime = hlc.Timestamp{}
+}
+
+// OriginalName implements the MutableDescriptor interface.
+func (desc *MutableDatabaseDescriptor) OriginalName() string {
+	if desc.ClusterVersion == nil {
+		return ""
+	}
+	return desc.ClusterVersion.Name
+}
+
+// OriginalID implements the MutableDescriptor interface.
+func (desc *MutableDatabaseDescriptor) OriginalID() ID {
+	if desc.ClusterVersion == nil {
+		return InvalidID
+	}
+	return desc.ClusterVersion.ID
+}
+
+// OriginalVersion implements the MutableDescriptor interface.
+func (desc *MutableDatabaseDescriptor) OriginalVersion() DescriptorVersion {
+	if desc.ClusterVersion == nil {
+		return 0
+	}
+	return desc.ClusterVersion.Version
 }
 
 // Immutable implements the MutableDescriptor interface.
@@ -203,5 +227,5 @@ func (desc *MutableDatabaseDescriptor) Immutable() DescriptorInterface {
 
 // IsNew implements the MutableDescriptor interface.
 func (desc *MutableDatabaseDescriptor) IsNew() bool {
-	return desc.ClusterVersion.ID == InvalidID
+	return desc.ClusterVersion == nil
 }

--- a/pkg/sql/sqlbase/descriptor.go
+++ b/pkg/sql/sqlbase/descriptor.go
@@ -61,6 +61,11 @@ type BaseDescriptorInterface interface {
 	TypeName() string
 	GetAuditMode() TableDescriptor_AuditMode
 
+	Adding() bool
+	Dropped() bool
+	Offline() bool
+	GetOfflineReason() string
+
 	// DescriptorProto prepares this descriptor for serialization.
 	DescriptorProto() *Descriptor
 }

--- a/pkg/sql/sqlbase/schema_desc.go
+++ b/pkg/sql/sqlbase/schema_desc.go
@@ -120,6 +120,26 @@ func (desc *ImmutableSchemaDescriptor) TypeDesc() *TypeDescriptor {
 	return nil
 }
 
+// Adding implements the BaseDescriptorInterface interface.
+func (desc *ImmutableSchemaDescriptor) Adding() bool {
+	return false
+}
+
+// Dropped implements the BaseDescriptorInterface interface.
+func (desc *ImmutableSchemaDescriptor) Dropped() bool {
+	return false
+}
+
+// Offline implements the BaseDescriptorInterface interface.
+func (desc *ImmutableSchemaDescriptor) Offline() bool {
+	return false
+}
+
+// GetOfflineReason implements the BaseDescriptorInterface interface.
+func (desc *ImmutableSchemaDescriptor) GetOfflineReason() string {
+	return ""
+}
+
 // DescriptorProto wraps a SchemaDescriptor in a Descriptor.
 func (desc *ImmutableSchemaDescriptor) DescriptorProto() *Descriptor {
 	return &Descriptor{
@@ -147,4 +167,9 @@ func (desc *MutableSchemaDescriptor) Immutable() DescriptorInterface {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
 	return NewImmutableSchemaDescriptor(*protoutil.Clone(desc.SchemaDesc()).(*SchemaDescriptor))
+}
+
+// IsNew implements the MutableDescriptor interface.
+func (desc *MutableSchemaDescriptor) IsNew() bool {
+	return desc.ClusterVersion.ID == InvalidID
 }

--- a/pkg/sql/sqlbase/schema_desc.go
+++ b/pkg/sql/sqlbase/schema_desc.go
@@ -155,11 +155,35 @@ func (desc *ImmutableSchemaDescriptor) NameResolutionResult() {}
 // MaybeIncrementVersion implements the MutableDescriptor interface.
 func (desc *MutableSchemaDescriptor) MaybeIncrementVersion() {
 	// Already incremented, no-op.
-	if desc.Version == desc.ClusterVersion.Version+1 {
+	if desc.ClusterVersion == nil || desc.Version == desc.ClusterVersion.Version+1 {
 		return
 	}
 	desc.Version++
 	desc.ModificationTime = hlc.Timestamp{}
+}
+
+// OriginalName implements the MutableDescriptor interface.
+func (desc *MutableSchemaDescriptor) OriginalName() string {
+	if desc.ClusterVersion == nil {
+		return ""
+	}
+	return desc.ClusterVersion.Name
+}
+
+// OriginalID implements the MutableDescriptor interface.
+func (desc *MutableSchemaDescriptor) OriginalID() ID {
+	if desc.ClusterVersion == nil {
+		return InvalidID
+	}
+	return desc.ClusterVersion.ID
+}
+
+// OriginalVersion implements the MutableDescriptor interface.
+func (desc *MutableSchemaDescriptor) OriginalVersion() DescriptorVersion {
+	if desc.ClusterVersion == nil {
+		return 0
+	}
+	return desc.ClusterVersion.Version
 }
 
 // Immutable implements the MutableDescriptor interface.
@@ -171,5 +195,5 @@ func (desc *MutableSchemaDescriptor) Immutable() DescriptorInterface {
 
 // IsNew implements the MutableDescriptor interface.
 func (desc *MutableSchemaDescriptor) IsNew() bool {
-	return desc.ClusterVersion.ID == InvalidID
+	return desc.ClusterVersion == nil
 }

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1736,6 +1736,21 @@ func (desc *MutableTableDescriptor) MaybeIncrementVersion() {
 	desc.ModificationTime = hlc.Timestamp{}
 }
 
+// OriginalName implements the MutableDescriptor interface.
+func (desc *MutableTableDescriptor) OriginalName() string {
+	return desc.ClusterVersion.Name
+}
+
+// OriginalID implements the MutableDescriptor interface.
+func (desc *MutableTableDescriptor) OriginalID() ID {
+	return desc.ClusterVersion.ID
+}
+
+// OriginalVersion implements the MutableDescriptor interface.
+func (desc *MutableTableDescriptor) OriginalVersion() DescriptorVersion {
+	return desc.ClusterVersion.Version
+}
+
 // Validate validates that the table descriptor is well formed. Checks include
 // both single table and cross table invariants.
 func (desc *TableDescriptor) Validate(ctx context.Context, txn *kv.Txn, codec keys.SQLCodec) error {

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -457,11 +457,12 @@ func getTableDescFromIDRaw(
 	return table, nil
 }
 
-// GetMutableTableDescFromID retrieves the table descriptor for the table
+// TestingGetMutableTableDescFromID retrieves the table descriptor for the table
 // ID passed in using an existing proto getter. Returns an error if the
 // descriptor doesn't exist or if it exists and is not a table.
 // Otherwise a mutable copy of the table is returned.
-func GetMutableTableDescFromID(
+// TODO (lucy): Probably replace this with catalogkv.GetMutableDescriptorByID().
+func TestingGetMutableTableDescFromID(
 	ctx context.Context, protoGetter protoGetter, codec keys.SQLCodec, id ID,
 ) (*MutableTableDescriptor, error) {
 	table, err := GetTableDescFromID(ctx, protoGetter, codec, id)

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -3737,9 +3737,9 @@ func (desc *TableDescriptor) HasColumnBackfillMutation() bool {
 	return false
 }
 
-// GoingOffline returns true if the table is being dropped or is importing.
-func (desc *TableDescriptor) GoingOffline() bool {
-	return desc.Dropped() || desc.State == TableDescriptor_OFFLINE
+// Offline returns true if the table is importing.
+func (desc *TableDescriptor) Offline() bool {
+	return desc.State == TableDescriptor_OFFLINE
 }
 
 // Dropped returns true if the table is being dropped.
@@ -3752,9 +3752,9 @@ func (desc *TableDescriptor) Adding() bool {
 	return desc.State == TableDescriptor_ADD
 }
 
-// IsNewTable returns true if the table was created in the current
+// IsNew returns true if the table was created in the current
 // transaction.
-func (desc *MutableTableDescriptor) IsNewTable() bool {
+func (desc *MutableTableDescriptor) IsNew() bool {
 	return desc.ClusterVersion.ID == InvalidID
 }
 
@@ -3879,6 +3879,38 @@ func (desc *Descriptor) GetModificationTime() hlc.Timestamp {
 	default:
 		debug.PrintStack()
 		panic(errors.AssertionFailedf("GetModificationTime: unknown Descriptor type %T", t))
+	}
+}
+
+// Dropped returns whether the descriptor is dropped.
+// TODO (lucy): Does this method belong on Descriptor? This state does matter
+// for descriptor leasing, but arguably we should be upwrapping the descriptor
+// to get it.
+func (desc *Descriptor) Dropped() bool {
+	switch t := desc.Union.(type) {
+	case *Descriptor_Table:
+		return t.Table.Dropped()
+	case *Descriptor_Database, *Descriptor_Type, *Descriptor_Schema:
+		return false
+	default:
+		debug.PrintStack()
+		panic(errors.AssertionFailedf("Dropped: unknown Descriptor type %T", t))
+	}
+}
+
+// Offline returns whether the descriptor is offline.
+// TODO (lucy): Does this method belong on Descriptor? This state does matter
+// for descriptor leasing, but arguably we should be upwrapping the descriptor
+// to get it.
+func (desc *Descriptor) Offline() bool {
+	switch t := desc.Union.(type) {
+	case *Descriptor_Table:
+		return t.Table.Offline()
+	case *Descriptor_Database, *Descriptor_Type, *Descriptor_Schema:
+		return false
+	default:
+		debug.PrintStack()
+		panic(errors.AssertionFailedf("Offline: unknown Descriptor type %T", t))
 	}
 }
 

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -621,52 +621,6 @@ func ConditionalGetTableDescFromTxn(
 	return existingKV.Value.TagAndDataBytes(), nil
 }
 
-// FilterTableState inspects the state of a given table and returns an error if
-// the state is anything but PUBLIC. The error describes the state of the table.
-func FilterTableState(tableDesc *TableDescriptor) error {
-	switch tableDesc.State {
-	case TableDescriptor_DROP:
-		return &inactiveTableError{ErrTableDropped}
-	case TableDescriptor_OFFLINE:
-		err := errors.Errorf("table %q is offline", tableDesc.Name)
-		if tableDesc.OfflineReason != "" {
-			err = errors.Errorf("table %q is offline: %s", tableDesc.Name, tableDesc.OfflineReason)
-		}
-		return &inactiveTableError{err}
-	case TableDescriptor_ADD:
-		return errTableAdding
-	case TableDescriptor_PUBLIC:
-		return nil
-	default:
-		return errors.Errorf("table in unknown state: %s", tableDesc.State.String())
-	}
-}
-
-var errTableAdding = errors.New("table is being added")
-
-// ErrTableDropped is returned when the state of the table is
-// TableDescriptor_DROP.
-var ErrTableDropped = errors.New("table is being dropped")
-
-type inactiveTableError struct {
-	cause error
-}
-
-func (i *inactiveTableError) Error() string { return i.cause.Error() }
-
-func (i *inactiveTableError) Unwrap() error { return i.cause }
-
-// HasAddingTableError returns true if the error contains an addingTableError.
-func HasAddingTableError(err error) bool {
-	return errors.Is(err, errTableAdding)
-}
-
-// HasInactiveTableError returns true if the error contains an
-// inactiveTableError.
-func HasInactiveTableError(err error) bool {
-	return errors.HasType(err, (*inactiveTableError)(nil))
-}
-
 // InitTableDescriptor returns a blank TableDescriptor.
 func InitTableDescriptor(
 	id, parentID, parentSchemaID ID,

--- a/pkg/sql/sqlbase/type_desc.go
+++ b/pkg/sql/sqlbase/type_desc.go
@@ -201,11 +201,35 @@ func (desc *TypeDescriptor) TypeName() string {
 // MaybeIncrementVersion implements the MutableDescriptor interface.
 func (desc *MutableTypeDescriptor) MaybeIncrementVersion() {
 	// Already incremented, no-op.
-	if desc.Version == desc.ClusterVersion.Version+1 {
+	if desc.ClusterVersion == nil || desc.Version == desc.ClusterVersion.Version+1 {
 		return
 	}
 	desc.Version++
 	desc.ModificationTime = hlc.Timestamp{}
+}
+
+// OriginalName implements the MutableDescriptor interface.
+func (desc *MutableTypeDescriptor) OriginalName() string {
+	if desc.ClusterVersion == nil {
+		return ""
+	}
+	return desc.ClusterVersion.Name
+}
+
+// OriginalID implements the MutableDescriptor interface.
+func (desc *MutableTypeDescriptor) OriginalID() ID {
+	if desc.ClusterVersion == nil {
+		return InvalidID
+	}
+	return desc.ClusterVersion.ID
+}
+
+// OriginalVersion implements the MutableDescriptor interface.
+func (desc *MutableTypeDescriptor) OriginalVersion() DescriptorVersion {
+	if desc.ClusterVersion == nil {
+		return 0
+	}
+	return desc.ClusterVersion.Version
 }
 
 // Immutable implements the MutableDescriptor interface.
@@ -217,7 +241,7 @@ func (desc *MutableTypeDescriptor) Immutable() DescriptorInterface {
 
 // IsNew implements the MutableDescriptor interface.
 func (desc *MutableTypeDescriptor) IsNew() bool {
-	return desc.ClusterVersion.ID == InvalidID
+	return desc.ClusterVersion == nil
 }
 
 // EnumMembers is a sortable list of TypeDescriptor_EnumMember, sorted by the

--- a/pkg/sql/sqlbase/type_desc.go
+++ b/pkg/sql/sqlbase/type_desc.go
@@ -147,6 +147,26 @@ func (desc *ImmutableTypeDescriptor) TypeDesc() *TypeDescriptor {
 	return &desc.TypeDescriptor
 }
 
+// Adding implements the BaseDescriptorInterface interface.
+func (desc *TypeDescriptor) Adding() bool {
+	return false
+}
+
+// Dropped implements the BaseDescriptorInterface interface.
+func (desc *TypeDescriptor) Dropped() bool {
+	return false
+}
+
+// Offline implements the BaseDescriptorInterface interface.
+func (desc *TypeDescriptor) Offline() bool {
+	return false
+}
+
+// GetOfflineReason implements the BaseDescriptorInterface interface.
+func (desc *TypeDescriptor) GetOfflineReason() string {
+	return ""
+}
+
 // DescriptorProto returns a Descriptor for serialization.
 func (desc *TypeDescriptor) DescriptorProto() *Descriptor {
 	return &Descriptor{
@@ -193,6 +213,11 @@ func (desc *MutableTypeDescriptor) Immutable() DescriptorInterface {
 	// TODO (lucy): Should the immutable descriptor constructors always make a
 	// copy, so we don't have to do it here?
 	return NewImmutableTypeDescriptor(*protoutil.Clone(desc.TypeDesc()).(*TypeDescriptor))
+}
+
+// IsNew implements the MutableDescriptor interface.
+func (desc *MutableTypeDescriptor) IsNew() bool {
+	return desc.ClusterVersion.ID == InvalidID
 }
 
 // EnumMembers is a sortable list of TypeDescriptor_EnumMember, sorted by the

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -248,7 +248,7 @@ func (p *planner) writeTableDescToBatch(
 		return errors.AssertionFailedf("virtual descriptors cannot be stored, found: %v", tableDesc)
 	}
 
-	if tableDesc.IsNewTable() {
+	if tableDesc.IsNew() {
 		if err := runSchemaChangesInTxn(
 			ctx, p, tableDesc, p.ExtendedEvalContext().Tracing.KVTracingEnabled(),
 		); err != nil {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -263,7 +263,7 @@ func (p *planner) writeTableDescToBatch(
 		return errors.AssertionFailedf("table descriptor is not valid: %s\n%v", err, tableDesc)
 	}
 
-	if err := p.Tables().AddUncommittedTable(*tableDesc); err != nil {
+	if err := p.Tables().AddUncommittedDescriptor(tableDesc); err != nil {
 		return err
 	}
 

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -263,7 +263,7 @@ func (p *planner) writeTableDescToBatch(
 		return errors.AssertionFailedf("table descriptor is not valid: %s\n%v", err, tableDesc)
 	}
 
-	if err := p.Tables().AddUncommittedDescriptor(tableDesc); err != nil {
+	if err := p.Descriptors().AddUncommittedDescriptor(tableDesc); err != nil {
 		return err
 	}
 

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -86,7 +86,7 @@ func (t *truncateNode) startExec(params runParams) error {
 			if _, ok := toTruncate[tableID]; ok {
 				return nil
 			}
-			other, err := p.Tables().GetMutableTableVersionByID(ctx, tableID, p.txn)
+			other, err := p.Descriptors().GetMutableTableVersionByID(ctx, tableID, p.txn)
 			if err != nil {
 				return err
 			}
@@ -164,7 +164,7 @@ func (p *planner) truncateTable(
 ) error {
 	// Read the table descriptor because it might have changed
 	// while another table in the truncation list was truncated.
-	tableDesc, err := p.Tables().GetMutableTableVersionByID(ctx, id, p.txn)
+	tableDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, id, p.txn)
 	if err != nil {
 		return err
 	}
@@ -303,7 +303,7 @@ func (p *planner) findAllReferences(
 		if id == table.ID {
 			continue
 		}
-		t, err := p.Tables().GetMutableTableVersionByID(ctx, id, p.txn)
+		t, err := p.Descriptors().GetMutableTableVersionByID(ctx, id, p.txn)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -66,11 +66,13 @@ func (p *planner) writeTypeChange(
 		log.Infof(ctx, "queued new type change job %d for type %d", *newJob.ID(), typeDesc.ID)
 	}
 
-	// TODO (rohany): Once the desc.Collection has a hook to register a modified
-	//  type, call into that hook here.
-
 	// Maybe increment the type's version.
 	typeDesc.MaybeIncrementVersion()
+
+	// Add the modified descriptor to the descriptor collection.
+	if err := p.Descriptors().AddUncommittedDescriptor(typeDesc); err != nil {
+		return err
+	}
 
 	// Write the type out to a batch.
 	b := p.txn.NewBatch()


### PR DESCRIPTION
This PR primarily extracts shared logic for accessing descriptors from `desc.Collection` previously used only for tables, to prepare for being able to access types. See individual commits for more details.