### PR TITLE
sql: ensure SQLSTATE 42710 on secondary errors

### DIFF
--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -133,7 +133,7 @@ func NewDatabaseAlreadyExistsError(name string) error {
 // when an error occurs while trying to get the colliding object for an
 // ObjectAlreadyExistsErr.
 func WrapErrorWhileConstructingObjectAlreadyExistsErr(err error) error {
-	return errors.Wrap(err, "object already exists")
+	return pgerror.WithCandidateCode(errors.Wrap(err, "object already exists"), pgcode.DuplicateObject)
 }
 
 // MakeObjectAlreadyExistsError creates an error for a namespace collision


### PR DESCRIPTION
Amends #51260

When creating an object that collides with another, we have to perform
another lookup to get the kind of object that it collided with.

If an error occurs during this second stage, we want the error to
propose SQLSTATE "Duplicate object" (42710) to the client if there is
no pgcode in the error object already.

Release note: None