### PR TITLE
leaktest: print non-closed stoppers

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -156,8 +156,7 @@ func TestOracleFactory(t *testing.T) {
 	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
 	c := kv.NewDB(log.AmbientContext{
 		Tracer: tracing.NewTracer(),
-	}, kv.MockTxnSenderFactory{},
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond))
+	}, kv.MockTxnSenderFactory{}, hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper)
 	txn := kv.NewTxn(context.Background(), c, 0)
 	of := replicaoracle.NewOracleFactory(followerReadAwareChoice, replicaoracle.Config{
 		Settings:   st,

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -183,13 +183,13 @@ type DBContext struct {
 
 // DefaultDBContext returns (a copy of) the default options for
 // NewDBWithContext.
-func DefaultDBContext() DBContext {
+func DefaultDBContext(stopper *stop.Stopper) DBContext {
 	var c base.NodeIDContainer
 	return DBContext{
 		UserPriority: roachpb.NormalUserPriority,
 		// TODO(tbg): this is ugly. Force callers to pass in an SQLIDContainer.
 		NodeID:  base.NewSQLIDContainer(0, &c, true /* exposed */),
-		Stopper: stop.NewStopper(),
+		Stopper: stopper,
 	}
 }
 
@@ -278,8 +278,10 @@ func (db *DB) Clock() *hlc.Clock {
 }
 
 // NewDB returns a new DB.
-func NewDB(actx log.AmbientContext, factory TxnSenderFactory, clock *hlc.Clock) *DB {
-	return NewDBWithContext(actx, factory, clock, DefaultDBContext())
+func NewDB(
+	actx log.AmbientContext, factory TxnSenderFactory, clock *hlc.Clock, stopper *stop.Stopper,
+) *DB {
+	return NewDBWithContext(actx, factory, clock, DefaultDBContext(stopper))
 }
 
 // NewDBWithContext returns a new DB with the given parameters.

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -101,7 +101,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 		},
 		ds,
 	)
-	db := kv.NewDB(ambient, tsf, s.Clock())
+	db := kv.NewDB(ambient, tsf, s.Clock(), s.Stopper())
 
 	// Now, with an intent pending, attempt (asynchronously) to read
 	// from an arbitrary key. This will cause the distributed sender to

--- a/pkg/kv/kvclient/kvcoord/split_test.go
+++ b/pkg/kv/kvclient/kvcoord/split_test.go
@@ -193,7 +193,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	s.Start(t, testutils.NewNodeTestBaseContext(), InitFactoryForLocalTestCluster)
 
 	// This is purely to silence log spam.
-	config.TestingSetupZoneConfigHook(s.Stopper)
+	config.TestingSetupZoneConfigHook(s.Stopper())
 	defer s.Stop()
 
 	// Start test writer write about a 32K/key so there aren't too many
@@ -240,7 +240,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s := createTestDBWithContextAndKnobs(t, kv.DefaultDBContext(), &kvserver.StoreTestingKnobs{
+	s := createTestDBWithKnobs(t, &kvserver.StoreTestingKnobs{
 		DisableScanner:    true,
 		DisableSplitQueue: true,
 		DisableMergeQueue: true,
@@ -268,7 +268,7 @@ func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 func TestRangeSplitsStickyBit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s := createTestDBWithContextAndKnobs(t, kv.DefaultDBContext(), &kvserver.StoreTestingKnobs{
+	s := createTestDBWithKnobs(t, &kvserver.StoreTestingKnobs{
 		DisableScanner:    true,
 		DisableSplitQueue: true,
 		DisableMergeQueue: true,

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
@@ -98,7 +98,7 @@ func TestHeartbeatFindsOutAboutAbortedTransaction(t *testing.T) {
 		},
 		s.DistSenderI().(*kvcoord.DistSender),
 	)
-	db := kv.NewDB(ambient, tsf, s.Clock())
+	db := kv.NewDB(ambient, tsf, s.Clock(), s.Stopper())
 	txn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
 	if err := txn.Put(ctx, key, "val"); err != nil {
 		t.Fatal(err)

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -43,15 +43,13 @@ import (
 // createTestDB creates a local test server and starts it. The caller
 // is responsible for stopping the test server.
 func createTestDB(t testing.TB) *localtestcluster.LocalTestCluster {
-	return createTestDBWithContextAndKnobs(t, kv.DefaultDBContext(), nil)
+	return createTestDBWithKnobs(t, nil)
 }
 
-func createTestDBWithContextAndKnobs(
-	t testing.TB, dbCtx kv.DBContext, knobs *kvserver.StoreTestingKnobs,
+func createTestDBWithKnobs(
+	t testing.TB, knobs *kvserver.StoreTestingKnobs,
 ) *localtestcluster.LocalTestCluster {
 	s := &localtestcluster.LocalTestCluster{
-		DBContext:         &dbCtx,
-		Stopper:           dbCtx.Stopper,
 		StoreTestingKnobs: knobs,
 	}
 	s.Start(t, testutils.NewNodeTestBaseContext(), InitFactoryForLocalTestCluster)
@@ -237,11 +235,11 @@ func TestTxnCoordSenderCondenseLockSpans(t *testing.T) {
 			AmbientCtx: ambient,
 			Settings:   st,
 			Clock:      s.Clock,
-			Stopper:    s.Stopper,
+			Stopper:    s.Stopper(),
 		},
 		ds,
 	)
-	db := kv.NewDB(ambient, tsf, s.Clock)
+	db := kv.NewDB(ambient, tsf, s.Clock, s.Stopper())
 	ctx := context.Background()
 
 	txn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
@@ -282,7 +280,7 @@ func TestTxnCoordSenderCondenseLockSpans(t *testing.T) {
 func TestTxnCoordSenderHeartbeat(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s := createTestDBWithContextAndKnobs(t, kv.DefaultDBContext(), &kvserver.StoreTestingKnobs{
+	s := createTestDBWithKnobs(t, &kvserver.StoreTestingKnobs{
 		DisableScanner:    true,
 		DisableSplitQueue: true,
 		DisableMergeQueue: true,
@@ -306,14 +304,14 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 			HeartbeatInterval: time.Millisecond,
 			Settings:          s.Cfg.Settings,
 			Clock:             s.Clock,
-			Stopper:           s.Stopper,
+			Stopper:           s.Stopper(),
 		},
 		NewDistSenderForLocalTestCluster(
 			s.Cfg.Settings, &roachpb.NodeDescriptor{NodeID: 1},
-			ambient.Tracer, s.Clock, s.Latency, s.Stores, s.Stopper, s.Gossip,
+			ambient.Tracer, s.Clock, s.Latency, s.Stores, s.Stopper(), s.Gossip,
 		),
 	)
-	quickHeartbeatDB := kv.NewDB(ambient, tsf, s.Clock)
+	quickHeartbeatDB := kv.NewDB(ambient, tsf, s.Clock, s.Stopper())
 
 	// We're going to test twice. In both cases the heartbeat is supposed to
 	// notice that its transaction is aborted, but:
@@ -660,7 +658,7 @@ func TestTxnCoordSenderGCWithAmbiguousResultErr(t *testing.T) {
 			},
 		}
 
-		s := createTestDBWithContextAndKnobs(t, kv.DefaultDBContext(), knobs)
+		s := createTestDBWithKnobs(t, knobs)
 		defer s.Stop()
 
 		ctx := context.Background()
@@ -818,7 +816,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 				},
 				senderFn,
 			)
-			db := kv.NewDB(ambient, tsf, clock)
+			db := kv.NewDB(ambient, tsf, clock, stopper)
 			key := roachpb.Key("test-key")
 			now := clock.Now()
 			origTxnProto := roachpb.MakeTransaction(
@@ -962,7 +960,7 @@ func TestTxnCoordSenderNoDuplicateLockSpans(t *testing.T) {
 	)
 	defer stopper.Stop(ctx)
 
-	db := kv.NewDB(ambient, factory, clock)
+	db := kv.NewDB(ambient, factory, clock, stopper)
 	txn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
 
 	// Acquire locks on a-b, c, u-w before the final batch.
@@ -1053,9 +1051,7 @@ func checkTxnMetricsOnce(
 // have a faster sample interval and returns a cleanup function to be
 // executed by callers.
 func setupMetricsTest(t *testing.T) (*localtestcluster.LocalTestCluster, TxnMetrics, func()) {
-	dbCtx := kv.DefaultDBContext()
 	s := &localtestcluster.LocalTestCluster{
-		DBContext: &dbCtx,
 		// Liveness heartbeat txns mess up the metrics.
 		DisableLivenessHeartbeat: true,
 		DontCreateSystemRanges:   true,
@@ -1336,7 +1332,7 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 				senderFn,
 			)
 
-			db := kv.NewDB(ambient, factory, clock)
+			db := kv.NewDB(ambient, factory, clock, stopper)
 			txn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
 			if pErr := txn.Put(ctx, "a", "b"); pErr != nil {
 				t.Fatalf("put failed: %s", pErr)
@@ -1416,7 +1412,7 @@ func TestRollbackErrorStopsHeartbeat(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(ambient, factory, clock)
+	db := kv.NewDB(ambient, factory, clock, stopper)
 
 	sender.match(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 		if _, ok := ba.GetArg(roachpb.EndTxn); !ok {
@@ -1484,7 +1480,7 @@ func TestOnePCErrorTracking(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(ambient, factory, clock)
+	db := kv.NewDB(ambient, factory, clock, stopper)
 	keyA, keyB, keyC := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c")
 
 	// Register a matcher catching the commit attempt.
@@ -1578,7 +1574,7 @@ func TestCommitReadOnlyTransaction(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "explicit txn", func(t *testing.T, explicitTxn bool) {
 		testutils.RunTrueAndFalse(t, "with get", func(t *testing.T, withGet bool) {
 			calls = nil
-			db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock)
+			db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock, stopper)
 			if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 				b := txn.NewBatch()
 				if withGet {
@@ -1684,7 +1680,7 @@ func TestCommitMutatingTransaction(t *testing.T) {
 	for i, test := range testArgs {
 		t.Run(test.expMethod.String(), func(t *testing.T) {
 			calls = nil
-			db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock)
+			db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock, stopper)
 			if err := db.Txn(ctx, test.f); err != nil {
 				t.Fatalf("%d: unexpected error on commit: %s", i, err)
 			}
@@ -1727,7 +1723,7 @@ func TestAbortReadOnlyTransaction(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock)
+	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock, stopper)
 	if err := db.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
 		return errors.New("foo")
 	}); err == nil {
@@ -1784,7 +1780,7 @@ func TestEndWriteRestartReadOnlyTransaction(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock)
+	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock, stopper)
 
 	testutils.RunTrueAndFalse(t, "write", func(t *testing.T, write bool) {
 		testutils.RunTrueAndFalse(t, "success", func(t *testing.T, success bool) {
@@ -1876,7 +1872,7 @@ func TestTransactionKeyNotChangedInRestart(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock)
+	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock, stopper)
 
 	if err := db.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
 		defer func() { attempt++ }()
@@ -1932,7 +1928,7 @@ func TestSequenceNumbers(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock)
+	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock, stopper)
 	txn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
 
 	for i := 0; i < 5; i++ {
@@ -1982,7 +1978,7 @@ func TestConcurrentTxnRequestsProhibited(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(ambient, factory, clock)
+	db := kv.NewDB(ambient, factory, clock, stopper)
 
 	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		g, gCtx := errgroup.WithContext(ctx)
@@ -2024,7 +2020,7 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock)
+	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock, stopper)
 
 	curReq := 0
 	requests := []struct {
@@ -2100,7 +2096,7 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock)
+	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock, stopper)
 
 	// We're going to run two tests: one where the EndTxn is by itself in a
 	// batch, one where it is not. As of June 2018, the EndTxn is elided in
@@ -2164,9 +2160,9 @@ func TestTxnCoordSenderPipelining(t *testing.T) {
 		AmbientCtx: ambientCtx,
 		Settings:   s.Cfg.Settings,
 		Clock:      s.Clock,
-		Stopper:    s.Stopper,
+		Stopper:    s.Stopper(),
 	}, senderFn)
-	db := kv.NewDB(ambientCtx, tsf, s.Clock)
+	db := kv.NewDB(ambientCtx, tsf, s.Clock, s.Stopper())
 
 	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		return txn.Put(ctx, "key", "val")
@@ -2245,7 +2241,7 @@ func TestAnchorKey(t *testing.T) {
 		},
 		senderFn,
 	)
-	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock)
+	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock, stopper)
 
 	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		ba := txn.NewBatch()
@@ -2283,7 +2279,7 @@ func TestLeafTxnClientRejectError(t *testing.T) {
 		},
 	}
 
-	s := createTestDBWithContextAndKnobs(t, kv.DefaultDBContext(), knobs)
+	s := createTestDBWithKnobs(t, knobs)
 	defer s.Stop()
 
 	ctx := context.Background()
@@ -2314,7 +2310,7 @@ func TestLeafTxnClientRejectError(t *testing.T) {
 func TestUpdateRoootWithLeafFinalStateInAbortedTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s := createTestDBWithContextAndKnobs(t, kv.DefaultDBContext(), nil /* knobs */)
+	s := createTestDBWithKnobs(t, nil /* knobs */)
 	defer s.Stop()
 	ctx := context.Background()
 

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -51,6 +51,7 @@ func createTestDBWithContextAndKnobs(
 ) *localtestcluster.LocalTestCluster {
 	s := &localtestcluster.LocalTestCluster{
 		DBContext:         &dbCtx,
+		Stopper:           dbCtx.Stopper,
 		StoreTestingKnobs: knobs,
 	}
 	s.Start(t, testutils.NewNodeTestBaseContext(), InitFactoryForLocalTestCluster)

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -378,7 +378,7 @@ func TestTxnLongDelayBetweenWritesWithConcurrentRead(t *testing.T) {
 func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	s := createTestDBWithContextAndKnobs(t, kv.DefaultDBContext(), &kvserver.StoreTestingKnobs{
+	s := createTestDBWithKnobs(t, &kvserver.StoreTestingKnobs{
 		DisableScanner:    true,
 		DisableSplitQueue: true,
 		DisableMergeQueue: true,
@@ -620,7 +620,7 @@ func TestTxnCommitTimestampAdvancedByRefresh(t *testing.T) {
 	injected := false
 	var refreshTS hlc.Timestamp
 	errKey := roachpb.Key("inject_err")
-	s := createTestDBWithContextAndKnobs(t, kv.DefaultDBContext(), &kvserver.StoreTestingKnobs{
+	s := createTestDBWithKnobs(t, &kvserver.StoreTestingKnobs{
 		TestingRequestFilter: func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
 			if g, ok := ba.GetArg(roachpb.Get); ok && g.(*roachpb.GetRequest).Key.Equal(errKey) {
 				if injected {

--- a/pkg/kv/kvserver/addressing_test.go
+++ b/pkg/kv/kvserver/addressing_test.go
@@ -145,7 +145,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 			},
 			store.TestSender(),
 		)
-		db := kv.NewDB(actx, tcsf, store.cfg.Clock)
+		db := kv.NewDB(actx, tcsf, store.cfg.Clock, stopper)
 		ctx := context.Background()
 		txn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
 		if err := txn.Run(ctx, b); err != nil {

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -177,7 +177,7 @@ func createTestStoreWithOpts(
 		},
 		distSender,
 	)
-	storeCfg.DB = kv.NewDB(ac, tcsFactory, storeCfg.Clock)
+	storeCfg.DB = kv.NewDB(ac, tcsFactory, storeCfg.Clock, stopper)
 	storeCfg.StorePool = kvserver.NewTestStorePool(storeCfg)
 	storeCfg.Transport = kvserver.NewDummyRaftTransport(storeCfg.Settings)
 	// TODO(bdarnell): arrange to have the transport closed.
@@ -823,7 +823,7 @@ func (m *multiTestContext) populateDB(idx int, st *cluster.Settings, stopper *st
 		},
 		m.distSenders[idx],
 	)
-	m.dbs[idx] = kv.NewDB(ambient, tcsFactory, m.clocks[idx])
+	m.dbs[idx] = kv.NewDB(ambient, tcsFactory, m.clocks[idx], stopper)
 }
 
 func (m *multiTestContext) populateStorePool(

--- a/pkg/kv/kvserver/closedts/container/noop.go
+++ b/pkg/kv/kvserver/closedts/container/noop.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 )
 
@@ -35,7 +34,7 @@ func NoopContainer() *Container {
 	return &Container{
 		Config: Config{
 			Settings: cluster.MakeTestingClusterSettings(),
-			Stopper:  stop.NewStopper(),
+			Stopper:  nil,
 			Clock: func(roachpb.NodeID) (hlc.Timestamp, ctpb.Epoch, error) {
 				return hlc.Timestamp{}, 0, errors.New("closed timestamps disabled for testing")
 			},

--- a/pkg/kv/kvserver/idalloc/id_alloc_test.go
+++ b/pkg/kv/kvserver/idalloc/id_alloc_test.go
@@ -46,7 +46,7 @@ func newTestAllocator(t testing.TB) (*localtestcluster.LocalTestCluster, *idallo
 		Key:         keys.RangeIDGenerator,
 		Incrementer: idalloc.DBIncrementer(s.DB),
 		BlockSize:   10, /* blockSize */
-		Stopper:     s.Stopper,
+		Stopper:     s.Stopper(),
 	})
 	if err != nil {
 		s.Stop()

--- a/pkg/kv/kvserver/protectedts/ptverifier/verifier_test.go
+++ b/pkg/kv/kvserver/protectedts/ptverifier/verifier_test.go
@@ -65,7 +65,7 @@ func TestVerifier(t *testing.T) {
 
 	pts := ptstorage.New(s.ClusterSettings(), s.InternalExecutor().(sqlutil.InternalExecutor))
 	withDB := ptstorage.WithDatabase(pts, s.DB())
-	db := kv.NewDB(s.DB().AmbientContext, tsf, s.Clock())
+	db := kv.NewDB(s.DB().AmbientContext, tsf, s.Clock(), s.Stopper())
 	ptv := ptverifier.New(db, pts)
 	makeTableSpan := func(tableID uint32) roachpb.Span {
 		k := keys.SystemSQLCodec.TablePrefix(tableID)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -244,7 +244,7 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 		// circular dependency between the test sender and the store. The actual
 		// store will be passed to the sender after it is created and bootstrapped.
 		factory := &testSenderFactory{}
-		cfg.DB = kv.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
+		cfg.DB = kv.NewDB(cfg.AmbientCtx, factory, cfg.Clock, stopper)
 
 		require.NoError(t, WriteClusterVersion(ctx, tc.engine, cv))
 		if err := InitEngine(ctx, tc.engine, roachpb.StoreIdent{

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -231,7 +231,7 @@ func createTestStoreWithoutStart(
 	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
 	factory := &testSenderFactory{}
-	cfg.DB = kv.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
+	cfg.DB = kv.NewDB(cfg.AmbientCtx, factory, cfg.Clock, stopper)
 	store := NewStore(context.Background(), *cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 	factory.setStore(store)
 
@@ -436,7 +436,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
 	factory := &testSenderFactory{}
-	cfg.DB = kv.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
+	cfg.DB = kv.NewDB(cfg.AmbientCtx, factory, cfg.Clock, stopper)
 	{
 		store := NewStore(ctx, cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 		// Can't start as haven't bootstrapped.

--- a/pkg/kv/kvserver/txnrecovery/manager_test.go
+++ b/pkg/kv/kvserver/txnrecovery/manager_test.go
@@ -34,7 +34,7 @@ func makeManager(s *kv.Sender) (Manager, *hlc.Clock, *stop.Stopper) {
 		ctx context.Context, ba roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, *roachpb.Error) {
 		return (*s).Send(ctx, ba)
-	}), clock)
+	}), clock, stopper)
 	return NewManager(ac, clock, db, stopper), clock, stopper
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -404,7 +404,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 	tcsFactory := kvcoord.NewTxnCoordSenderFactory(txnCoordSenderFactoryCfg, distSender)
 
-	dbCtx := kv.DefaultDBContext()
+	dbCtx := kv.DefaultDBContext(stopper)
 	dbCtx.NodeID = idContainer
 	dbCtx.Stopper = stopper
 	db := kv.NewDBWithContext(cfg.AmbientCtx, tcsFactory, clock, dbCtx)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -543,11 +543,7 @@ func makeSQLServerArgs(
 		},
 		ds,
 	)
-	db := kv.NewDB(
-		baseCfg.AmbientCtx,
-		tcsFactory,
-		clock,
-	)
+	db := kv.NewDB(baseCfg.AmbientCtx, tcsFactory, clock, stopper)
 
 	circularInternalExecutor := &sql.InternalExecutor{}
 	// Protected timestamps won't be available (at first) in multi-tenant

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -246,7 +246,7 @@ func startConnExecutor(
 		) (*roachpb.BatchResponse, *roachpb.Error) {
 			return nil, nil
 		})
-	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock)
+	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock, stopper)
 	st := cluster.MakeTestingClusterSettings()
 	nodeID := base.TestingIDContainer
 	distSQLMetrics := execinfra.MakeDistSQLMetrics(time.Hour /* histogramWindow */)

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -102,7 +102,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		},
 		s.DistSenderI().(*kvcoord.DistSender),
 	)
-	shortDB := kv.NewDB(ambient, tsf, s.Clock())
+	shortDB := kv.NewDB(ambient, tsf, s.Clock(), s.Stopper())
 
 	iter := 0
 	// We'll trace to make sure the test isn't fooling itself.

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -112,7 +112,9 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	}
 
 	ltc.tester = t
-	ltc.Stopper = stop.NewStopper()
+	if ltc.Stopper == nil {
+		ltc.Stopper = stop.NewStopper()
+	}
 	cfg.RPCContext = rpc.NewContext(rpc.ContextOptions{
 		AmbientCtx: ambient,
 		Config:     baseCtx,

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -56,10 +56,10 @@ type LocalTestCluster struct {
 	Eng               storage.Engine
 	Store             *kvserver.Store
 	StoreTestingKnobs *kvserver.StoreTestingKnobs
-	DBContext         *kv.DBContext
+	dbContext         *kv.DBContext
 	DB                *kv.DB
 	Stores            *kvserver.Stores
-	Stopper           *stop.Stopper
+	stopper           *stop.Stopper
 	Latency           time.Duration // sleep for each RPC sent
 	tester            testing.TB
 
@@ -92,12 +92,19 @@ type InitFactoryFn func(
 	gossip *gossip.Gossip,
 ) kv.TxnSenderFactory
 
+// Stopper returns the Stopper.
+func (ltc *LocalTestCluster) Stopper() *stop.Stopper {
+	return ltc.stopper
+}
+
 // Start starts the test cluster by bootstrapping an in-memory store
 // (defaults to maximum of 50M). The server is started, launching the
 // node RPC server and all HTTP endpoints. Use the value of
 // TestServer.Addr after Start() for client connections. Use Stop()
 // to shutdown the server after the test completes.
 func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFactory InitFactoryFn) {
+	ltc.stopper = stop.NewStopper()
+
 	ltc.Manual = hlc.NewManualClock(123)
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano, 50*time.Millisecond)
 	cfg := kvserver.TestStoreConfig(ltc.Clock)
@@ -112,38 +119,34 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	}
 
 	ltc.tester = t
-	if ltc.Stopper == nil {
-		ltc.Stopper = stop.NewStopper()
-	}
 	cfg.RPCContext = rpc.NewContext(rpc.ContextOptions{
 		AmbientCtx: ambient,
 		Config:     baseCtx,
 		Clock:      ltc.Clock,
-		Stopper:    ltc.Stopper,
+		Stopper:    ltc.stopper,
 		Settings:   cfg.Settings,
 	})
 	cfg.RPCContext.NodeID.Set(ambient.AnnotateCtx(context.Background()), nodeID)
-	c := &cfg.RPCContext.ClusterID
+	clusterID := &cfg.RPCContext.ClusterID
 	server := rpc.NewServer(cfg.RPCContext) // never started
-	ltc.Gossip = gossip.New(ambient, c, nc, cfg.RPCContext, server, ltc.Stopper, metric.NewRegistry(), roachpb.Locality{}, zonepb.DefaultZoneConfigRef())
+	ltc.Gossip = gossip.New(ambient, clusterID, nc, cfg.RPCContext, server, ltc.stopper, metric.NewRegistry(), roachpb.Locality{}, zonepb.DefaultZoneConfigRef())
 	ltc.Eng = storage.NewInMem(ambient.AnnotateCtx(context.Background()),
 		storage.DefaultStorageEngine, roachpb.Attributes{}, 50<<20)
-	ltc.Stopper.AddCloser(ltc.Eng)
+	ltc.stopper.AddCloser(ltc.Eng)
 
 	ltc.Stores = kvserver.NewStores(ambient, ltc.Clock)
 
-	factory := initFactory(cfg.Settings, nodeDesc, ambient.Tracer, ltc.Clock, ltc.Latency, ltc.Stores, ltc.Stopper, ltc.Gossip)
-	if ltc.DBContext == nil {
-		dbCtx := kv.DefaultDBContext()
-		dbCtx.Stopper = ltc.Stopper
-		ltc.DBContext = &dbCtx
+	factory := initFactory(cfg.Settings, nodeDesc, ambient.Tracer, ltc.Clock, ltc.Latency, ltc.Stores, ltc.stopper, ltc.Gossip)
+
+	var nodeIDContainer base.NodeIDContainer
+	nodeIDContainer.Set(context.Background(), nodeID)
+
+	ltc.dbContext = &kv.DBContext{
+		UserPriority: roachpb.NormalUserPriority,
+		Stopper:      ltc.stopper,
+		NodeID:       base.NewSQLIDContainer(0, &nodeIDContainer, true /* exposed */),
 	}
-	{
-		var c base.NodeIDContainer
-		c.Set(context.Background(), nodeID)
-		ltc.DBContext.NodeID = base.NewSQLIDContainer(0, &c, true /* exposed */)
-	}
-	ltc.DB = kv.NewDBWithContext(cfg.AmbientCtx, factory, ltc.Clock, *ltc.DBContext)
+	ltc.DB = kv.NewDBWithContext(cfg.AmbientCtx, factory, ltc.Clock, *ltc.dbContext)
 	transport := kvserver.NewDummyRaftTransport(cfg.Settings)
 	// By default, disable the replica scanner and split queue, which
 	// confuse tests using LocalTestCluster.
@@ -218,10 +221,10 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	}
 
 	if !ltc.DisableLivenessHeartbeat {
-		cfg.NodeLiveness.StartHeartbeat(ctx, ltc.Stopper, []storage.Engine{ltc.Eng}, nil /* alive */)
+		cfg.NodeLiveness.StartHeartbeat(ctx, ltc.stopper, []storage.Engine{ltc.Eng}, nil /* alive */)
 	}
 
-	if err := ltc.Store.Start(ctx, ltc.Stopper); err != nil {
+	if err := ltc.Store.Start(ctx, ltc.stopper); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
 
@@ -244,5 +247,5 @@ func (ltc *LocalTestCluster) Stop() {
 	if r := recover(); r != nil {
 		panic(r)
 	}
-	ltc.Stopper.Stop(context.TODO())
+	ltc.stopper.Stop(context.TODO())
 }

--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/petermattis/goid"
@@ -86,6 +85,10 @@ func interestingGoroutines() map[int64]string {
 // mis-attributed as leaked by the currently-running test.
 var leakDetectorDisabled uint32
 
+// PrintLeakedStoppers is injected from `pkg/util/stop` to avoid a dependency
+// cycle.
+var PrintLeakedStoppers = func(t testing.TB) {}
+
 // AfterTest snapshots the currently-running goroutines and returns a
 // function to be run at the end of tests to see whether any
 // goroutines leaked.
@@ -111,7 +114,7 @@ func AfterTest(t testing.TB) func() {
 
 		// TODO(tbg): make this call 't.Error' instead of 't.Logf' once there is
 		// enough Stopper discipline.
-		stop.PrintLeakedStoppers(t)
+		PrintLeakedStoppers(t)
 
 		// Loop, waiting for goroutines to shut down.
 		// Wait up to 5 seconds, but finish as quickly as possible.

--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/petermattis/goid"
@@ -107,6 +108,10 @@ func AfterTest(t testing.TB) func() {
 			}
 			return
 		}
+
+		// TODO(tbg): make this call 't.Error' instead of 't.Logf' once there is
+		// enough Stopper discipline.
+		stop.PrintLeakedStoppers(t)
 
 		// Loop, waiting for goroutines to shut down.
 		// Wait up to 5 seconds, but finish as quickly as possible.


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/issues/51363 we saw
use-after-close of an engine, which I tracked down to `LocalTestCluster`
using more than one stopper (only one of which was actually stopped).

This is likely a larger class of problem, so I added a facility to
ensure that no stoppers are currently active, which is invoked from
leaktest. However, due to the large amount of work that is necessary
to sanitize the whole testing codebase, this is for now only advisory
(i.e. logs, does not error). Nevertheless, this will be useful in tests
in which a use-after-stop actually causes problems.

For the LocalTestCluster, I made sure that the warning is no longer
printed, which mainly entailed not handing a different stopper to the kv
DB than that used for the main server. This explains the failures we
have been seeing, which always involved a KV client request.

Closes #51363.

Release note: None