### PR TITLE
sql: propagate vectorize batch size to remote nodes explicitly

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -749,7 +749,7 @@ func registerTPCHVec(r *testRegistry) {
 			// In order to use this test for benchmarking, include the queries
 			// that modify the cluster settings for all configs to benchmark
 			// like in the example below. The example benchmarks three values
-			// of coldata.BatchSize() variable against each other.
+			// of coldata.BatchSize variable against each other.
 			var clusterSetups [][]string
 			var setupNames []string
 			for _, batchSize := range []int{512, 1024, 1536} {

--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -389,7 +389,7 @@ func (b *Bytes) ProportionalSize(n int64) uintptr {
 	return FlatBytesOverhead + uintptr(len(b.data[:b.offsets[n]])) + uintptr(n)*sizeOfInt32
 }
 
-var zeroInt32Slice = make([]int32, BytesInitialAllocationFactor*BatchSize())
+var zeroInt32Slice = make([]int32, BytesInitialAllocationFactor*BatchSize)
 
 // Reset resets the underlying Bytes for reuse. Note that this zeroes out the
 // underlying bytes but doesn't change the length (see #42054 for the

--- a/pkg/col/coldata/nulls_test.go
+++ b/pkg/col/coldata/nulls_test.go
@@ -28,13 +28,13 @@ var nulls5 Nulls
 var nulls10 Nulls
 
 // pos is a collection of interesting boundary indices to use in tests.
-var pos = []int{0, 1, 63, 64, 65, BatchSize() - 1, BatchSize()}
+var pos = []int{0, 1, 63, 64, 65, BatchSize - 1, BatchSize}
 
 func init() {
-	nulls3 = NewNulls(BatchSize())
-	nulls5 = NewNulls(BatchSize())
-	nulls10 = NewNulls(BatchSize() * 2)
-	for i := 0; i < BatchSize(); i++ {
+	nulls3 = NewNulls(BatchSize)
+	nulls5 = NewNulls(BatchSize)
+	nulls10 = NewNulls(BatchSize * 2)
+	for i := 0; i < BatchSize; i++ {
 		if i%3 == 0 {
 			nulls3.SetNull(i)
 		}
@@ -42,7 +42,7 @@ func init() {
 			nulls5.SetNull(i)
 		}
 	}
-	for i := 0; i < BatchSize()*2; i++ {
+	for i := 0; i < BatchSize*2; i++ {
 		if i%10 == 0 {
 			nulls10.SetNull(i)
 		}
@@ -50,7 +50,7 @@ func init() {
 }
 
 func TestNullAt(t *testing.T) {
-	for i := 0; i < BatchSize(); i++ {
+	for i := 0; i < BatchSize; i++ {
 		if i%3 == 0 {
 			require.True(t, nulls3.NullAt(i))
 		} else {
@@ -62,9 +62,9 @@ func TestNullAt(t *testing.T) {
 func TestSetNullRange(t *testing.T) {
 	for _, start := range pos {
 		for _, end := range pos {
-			n := NewNulls(BatchSize())
+			n := NewNulls(BatchSize)
 			n.SetNullRange(start, end)
-			for i := 0; i < BatchSize(); i++ {
+			for i := 0; i < BatchSize; i++ {
 				expected := i >= start && i < end
 				require.Equal(t, expected, n.NullAt(i),
 					"NullAt(%d) should be %t after SetNullRange(%d, %d)", i, expected, start, end)
@@ -76,10 +76,10 @@ func TestSetNullRange(t *testing.T) {
 func TestUnsetNullRange(t *testing.T) {
 	for _, start := range pos {
 		for _, end := range pos {
-			n := NewNulls(BatchSize())
+			n := NewNulls(BatchSize)
 			n.SetNulls()
 			n.UnsetNullRange(start, end)
-			for i := 0; i < BatchSize(); i++ {
+			for i := 0; i < BatchSize; i++ {
 				notExpected := i >= start && i < end
 				require.NotEqual(t, notExpected, n.NullAt(i),
 					"NullAt(%d) saw %t, expected %t, after SetNullRange(%d, %d)", i, n.NullAt(i), !notExpected, start, end)
@@ -89,8 +89,8 @@ func TestUnsetNullRange(t *testing.T) {
 }
 
 func TestSwapNulls(t *testing.T) {
-	n := NewNulls(BatchSize())
-	swapPos := []int{0, 1, 63, 64, 65, BatchSize() - 1}
+	n := NewNulls(BatchSize)
+	swapPos := []int{0, 1, 63, 64, 65, BatchSize - 1}
 	idxInSwapPos := func(idx int) bool {
 		for _, p := range swapPos {
 			if p == idx {
@@ -108,7 +108,7 @@ func TestSwapNulls(t *testing.T) {
 		for _, i := range swapPos {
 			for _, j := range swapPos {
 				n.swap(i, j)
-				for k := 0; k < BatchSize(); k++ {
+				for k := 0; k < BatchSize; k++ {
 					require.Equal(t, idxInSwapPos(k), n.NullAt(k),
 						"after swapping NULLS (%d, %d), NullAt(%d) saw %t, expected %t", i, j, k, n.NullAt(k), idxInSwapPos(k))
 				}
@@ -120,7 +120,7 @@ func TestSwapNulls(t *testing.T) {
 		// Test that swapping null with not null changes things appropriately.
 		n.UnsetNulls()
 		swaps := map[int]int{
-			0:  BatchSize() - 1,
+			0:  BatchSize - 1,
 			1:  62,
 			2:  3,
 			63: 65,
@@ -141,7 +141,7 @@ func TestSwapNulls(t *testing.T) {
 			n.swap(i, j)
 			require.Truef(t, n.NullAt(i), "after swapping not null and null (%d, %d), found null=%t at %d", i, j, n.NullAt(i), i)
 			require.Truef(t, !n.NullAt(j), "after swapping not null and null (%d, %d), found null=%t at %d", i, j, !n.NullAt(j), j)
-			for k := 0; k < BatchSize(); k++ {
+			for k := 0; k < BatchSize; k++ {
 				if idxInSwaps(k) {
 					continue
 				}
@@ -160,7 +160,7 @@ func TestSwapNulls(t *testing.T) {
 		for _, i := range swapPos {
 			for _, j := range swapPos {
 				n.swap(i, j)
-				for k := 0; k < BatchSize(); k++ {
+				for k := 0; k < BatchSize; k++ {
 					require.Equal(t, idxInSwapPos(k), !n.NullAt(k),
 						"after swapping NULLS (%d, %d), NullAt(%d) saw %t, expected %t", i, j, k, !n.NullAt(k), idxInSwapPos(k))
 				}
@@ -171,9 +171,9 @@ func TestSwapNulls(t *testing.T) {
 
 func TestNullsTruncate(t *testing.T) {
 	for _, size := range pos {
-		n := NewNulls(BatchSize())
+		n := NewNulls(BatchSize)
 		n.Truncate(size)
-		for i := 0; i < BatchSize(); i++ {
+		for i := 0; i < BatchSize; i++ {
 			expected := i >= size
 			require.Equal(t, expected, n.NullAt(i),
 				"NullAt(%d) should be %t after Truncate(%d)", i, expected, size)
@@ -183,10 +183,10 @@ func TestNullsTruncate(t *testing.T) {
 
 func TestUnsetNullsAfter(t *testing.T) {
 	for _, size := range pos {
-		n := NewNulls(BatchSize())
+		n := NewNulls(BatchSize)
 		n.SetNulls()
 		n.UnsetNullsAfter(size)
-		for i := 0; i < BatchSize(); i++ {
+		for i := 0; i < BatchSize; i++ {
 			expected := i < size
 			require.Equal(t, expected, n.NullAt(i),
 				"NullAt(%d) should be %t after UnsetNullsAfter(%d)", i, expected, size)
@@ -195,19 +195,19 @@ func TestUnsetNullsAfter(t *testing.T) {
 }
 
 func TestSetAndUnsetNulls(t *testing.T) {
-	n := NewNulls(BatchSize())
-	for i := 0; i < BatchSize(); i++ {
+	n := NewNulls(BatchSize)
+	for i := 0; i < BatchSize; i++ {
 		require.False(t, n.NullAt(i))
 	}
 	n.SetNulls()
-	for i := 0; i < BatchSize(); i++ {
+	for i := 0; i < BatchSize; i++ {
 		require.True(t, n.NullAt(i))
 	}
 
-	for i := 0; i < BatchSize(); i += 3 {
+	for i := 0; i < BatchSize; i += 3 {
 		n.UnsetNull(i)
 	}
-	for i := 0; i < BatchSize(); i++ {
+	for i := 0; i < BatchSize; i++ {
 		if i%3 == 0 {
 			require.False(t, n.NullAt(i))
 		} else {
@@ -216,7 +216,7 @@ func TestSetAndUnsetNulls(t *testing.T) {
 	}
 
 	n.UnsetNulls()
-	for i := 0; i < BatchSize(); i++ {
+	for i := 0; i < BatchSize; i++ {
 		require.False(t, n.NullAt(i))
 	}
 }
@@ -230,7 +230,7 @@ func TestNullsSet(t *testing.T) {
 		t.Run(fmt.Sprintf("WithSel=%t", withSel), func(t *testing.T) {
 			var srcNulls *Nulls
 			if withSel {
-				args.Sel = make([]int, BatchSize())
+				args.Sel = make([]int, BatchSize)
 				// Make a selection vector with every even index. (This turns nulls10 into
 				// nulls5.)
 				for i := range args.Sel {
@@ -264,7 +264,7 @@ func TestNullsSet(t *testing.T) {
 								for i := 0; i < toAppend; i++ {
 									require.Equal(t, nulls5.NullAt(srcStartIdx+i), n.NullAt(destStartIdx+i))
 								}
-								for i := destStartIdx + toAppend; i < BatchSize(); i++ {
+								for i := destStartIdx + toAppend; i < BatchSize; i++ {
 									require.Equal(t, nulls3.NullAt(i), n.NullAt(i))
 								}
 							})
@@ -288,7 +288,7 @@ func TestSlice(t *testing.T) {
 		}
 	}
 	// Ensure we haven't modified the receiver.
-	for i := 0; i < BatchSize(); i++ {
+	for i := 0; i < BatchSize; i++ {
 		expected := i%3 == 0
 		require.Equal(t, expected, nulls3.NullAt(i))
 	}

--- a/pkg/col/coldata/testutils.go
+++ b/pkg/col/coldata/testutils.go
@@ -49,7 +49,7 @@ func AssertEquivalentBatches(t testingT, expected, actual Batch) {
 	require.Equal(t, expected.Width(), actual.Width())
 	for colIdx := 0; colIdx < expected.Width(); colIdx++ {
 		// Verify equality of ColVecs (this includes nulls). Since the coldata.Vec
-		// backing array is always of coldata.BatchSize() due to the scratch batch
+		// backing array is always of coldata.BatchSize due to the scratch batch
 		// that the converter keeps around, the coldata.Vec needs to be sliced to
 		// the first length elements to match on length, otherwise the check will
 		// fail.

--- a/pkg/col/coldata/vec_test.go
+++ b/pkg/col/coldata/vec_test.go
@@ -27,10 +27,10 @@ func TestMemColumnWindow(t *testing.T) {
 
 	rng, _ := randutil.NewPseudoRand()
 
-	c := coldata.NewMemColumn(types.Int, coldata.BatchSize(), coldata.StandardColumnFactory)
+	c := coldata.NewMemColumn(types.Int, coldata.BatchSize, coldata.StandardColumnFactory)
 
 	ints := c.Int64()
-	for i := 0; i < coldata.BatchSize(); i++ {
+	for i := 0; i < coldata.BatchSize; i++ {
 		ints[i] = int64(i)
 		if i%2 == 0 {
 			// Set every other value to null.
@@ -41,8 +41,8 @@ func TestMemColumnWindow(t *testing.T) {
 	startWindow := 1
 	endWindow := 0
 	for startWindow > endWindow {
-		startWindow = rng.Intn(coldata.BatchSize())
-		endWindow = 1 + rng.Intn(coldata.BatchSize())
+		startWindow = rng.Intn(coldata.BatchSize)
+		endWindow = 1 + rng.Intn(coldata.BatchSize)
 	}
 
 	window := c.Window(startWindow, endWindow)
@@ -115,12 +115,12 @@ func TestNullRanges(t *testing.T) {
 		},
 	}
 
-	c := coldata.NewMemColumn(types.Int, coldata.BatchSize(), coldata.StandardColumnFactory)
+	c := coldata.NewMemColumn(types.Int, coldata.BatchSize, coldata.StandardColumnFactory)
 	for _, tc := range tcs {
 		c.Nulls().UnsetNulls()
 		c.Nulls().SetNullRange(tc.start, tc.end)
 
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			if i >= tc.start && i < tc.end {
 				if !c.Nulls().NullAt(i) {
 					t.Fatalf("expected null at %d, start: %d end: %d", i, tc.start, tc.end)
@@ -138,7 +138,7 @@ func TestAppend(t *testing.T) {
 	// TODO(asubiotto): Test nulls.
 	var typ = types.Int
 
-	src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+	src := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 	sel := make([]int, len(src.Int64()))
 	for i := range sel {
 		sel[i] = i
@@ -153,9 +153,9 @@ func TestAppend(t *testing.T) {
 			name: "AppendSimple",
 			args: coldata.SliceArgs{
 				// DestIdx must be specified to append to the end of dest.
-				DestIdx: coldata.BatchSize(),
+				DestIdx: coldata.BatchSize,
 			},
-			expectedLength: coldata.BatchSize() * 2,
+			expectedLength: coldata.BatchSize * 2,
 		},
 		{
 			name: "AppendOverwriteSimple",
@@ -163,7 +163,7 @@ func TestAppend(t *testing.T) {
 				// DestIdx 0, the default value, will start appending at index 0.
 				DestIdx: 0,
 			},
-			expectedLength: coldata.BatchSize(),
+			expectedLength: coldata.BatchSize,
 		},
 		{
 			name: "AppendOverwriteSlice",
@@ -171,7 +171,7 @@ func TestAppend(t *testing.T) {
 				// Start appending at index 10.
 				DestIdx: 10,
 			},
-			expectedLength: coldata.BatchSize() + 10,
+			expectedLength: coldata.BatchSize + 10,
 		},
 		{
 			name: "AppendSlice",
@@ -199,7 +199,7 @@ func TestAppend(t *testing.T) {
 				Sel:       sel[:len(sel)/2],
 				SrcEndIdx: len(sel) / 2,
 			},
-			expectedLength: 5 + (coldata.BatchSize())/2,
+			expectedLength: 5 + (coldata.BatchSize)/2,
 		},
 	}
 
@@ -207,10 +207,10 @@ func TestAppend(t *testing.T) {
 		tc.args.Src = src
 		if tc.args.SrcEndIdx == 0 {
 			// SrcEndIdx is always required.
-			tc.args.SrcEndIdx = coldata.BatchSize()
+			tc.args.SrcEndIdx = coldata.BatchSize
 		}
 		t.Run(tc.name, func(t *testing.T) {
-			dest := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+			dest := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 			dest.Append(tc.args)
 			require.Equal(t, tc.expectedLength, len(dest.Int64()))
 		})
@@ -221,7 +221,7 @@ func TestCopy(t *testing.T) {
 	// TODO(asubiotto): Test nulls.
 	var typ = types.Int
 
-	src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+	src := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 	srcInts := src.Int64()
 	for i := range srcInts {
 		srcInts[i] = int64(i + 1)
@@ -255,11 +255,11 @@ func TestCopy(t *testing.T) {
 				SliceArgs: coldata.SliceArgs{
 					// Use DestIdx 1 to make sure that it is respected.
 					DestIdx:   1,
-					SrcEndIdx: coldata.BatchSize() - 1,
+					SrcEndIdx: coldata.BatchSize - 1,
 				},
 			},
 			// expectedSum uses sum of positive integers formula.
-			expectedSum: (coldata.BatchSize() - 1) * coldata.BatchSize() / 2,
+			expectedSum: (coldata.BatchSize - 1) * coldata.BatchSize / 2,
 		},
 		{
 			name: "CopyWithSel",
@@ -279,7 +279,7 @@ func TestCopy(t *testing.T) {
 	for _, tc := range testCases {
 		tc.args.Src = src
 		t.Run(tc.name, func(t *testing.T) {
-			dest := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+			dest := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 			dest.Copy(tc.args)
 			destInts := dest.Int64()
 			firstNonZero := 0
@@ -300,7 +300,7 @@ func TestCopyNulls(t *testing.T) {
 	var typ = types.Int
 
 	// Set up the destination vector.
-	dst := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+	dst := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 	dstInts := dst.Int64()
 	for i := range dstInts {
 		dstInts[i] = int64(1)
@@ -311,7 +311,7 @@ func TestCopyNulls(t *testing.T) {
 	}
 
 	// Set up the source vector.
-	src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+	src := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 	srcInts := src.Int64()
 	for i := range srcInts {
 		srcInts[i] = 2
@@ -345,7 +345,7 @@ func TestCopyNulls(t *testing.T) {
 	}
 
 	// Verify that the remaining elements in dst have not been touched.
-	for i := 10; i < coldata.BatchSize(); i++ {
+	for i := 10; i < coldata.BatchSize; i++ {
 		require.True(t, dstInts[i] == 1, "data in dst outside copy range has been changed")
 		require.True(t, !dst.Nulls().NullAt(i), "no extra nulls were added")
 	}
@@ -356,7 +356,7 @@ func TestCopySelOnDestDoesNotUnsetOldNulls(t *testing.T) {
 
 	// Set up the destination vector. It is all nulls except for a single
 	// non-null at index 0.
-	dst := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+	dst := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 	dstInts := dst.Int64()
 	for i := range dstInts {
 		dstInts[i] = 1
@@ -365,7 +365,7 @@ func TestCopySelOnDestDoesNotUnsetOldNulls(t *testing.T) {
 	dst.Nulls().UnsetNull(0)
 
 	// Set up the source vector with two nulls.
-	src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+	src := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 	srcInts := src.Int64()
 	for i := range srcInts {
 		srcInts[i] = 2
@@ -401,7 +401,7 @@ func TestCopySelOnDestDoesNotUnsetOldNulls(t *testing.T) {
 
 func BenchmarkAppend(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
-	sel := rng.Perm(coldata.BatchSize())
+	sel := rng.Perm(coldata.BatchSize)
 
 	benchCases := []struct {
 		name string
@@ -421,24 +421,24 @@ func BenchmarkAppend(b *testing.B) {
 
 	for _, typ := range []*types.T{types.Bytes, types.Decimal, types.Int} {
 		for _, nullProbability := range []float64{0, 0.2} {
-			src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+			src := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 			coldatatestutils.RandomVec(coldatatestutils.RandomVecArgs{
 				Rand:             rng,
 				Vec:              src,
-				N:                coldata.BatchSize(),
+				N:                coldata.BatchSize,
 				NullProbability:  nullProbability,
 				BytesFixedLength: 8,
 			})
 			for _, bc := range benchCases {
 				bc.args.Src = src
-				bc.args.SrcEndIdx = coldata.BatchSize()
-				dest := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+				bc.args.SrcEndIdx = coldata.BatchSize
+				dest := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 				b.Run(fmt.Sprintf("%s/%s/NullProbability=%.1f", typ, bc.name, nullProbability), func(b *testing.B) {
-					b.SetBytes(8 * int64(coldata.BatchSize()))
+					b.SetBytes(8 * int64(coldata.BatchSize))
 					bc.args.DestIdx = 0
 					for i := 0; i < b.N; i++ {
 						dest.Append(bc.args)
-						bc.args.DestIdx += coldata.BatchSize()
+						bc.args.DestIdx += coldata.BatchSize
 					}
 				})
 			}
@@ -448,7 +448,7 @@ func BenchmarkAppend(b *testing.B) {
 
 func BenchmarkCopy(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
-	sel := rng.Perm(coldata.BatchSize())
+	sel := rng.Perm(coldata.BatchSize)
 
 	benchCases := []struct {
 		name string
@@ -470,20 +470,20 @@ func BenchmarkCopy(b *testing.B) {
 
 	for _, typ := range []*types.T{types.Bytes, types.Decimal, types.Int} {
 		for _, nullProbability := range []float64{0, 0.2} {
-			src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+			src := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 			coldatatestutils.RandomVec(coldatatestutils.RandomVecArgs{
 				Rand:             rng,
 				Vec:              src,
-				N:                coldata.BatchSize(),
+				N:                coldata.BatchSize,
 				NullProbability:  nullProbability,
 				BytesFixedLength: 8,
 			})
 			for _, bc := range benchCases {
 				bc.args.Src = src
-				bc.args.SrcEndIdx = coldata.BatchSize()
-				dest := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
+				bc.args.SrcEndIdx = coldata.BatchSize
+				dest := coldata.NewMemColumn(typ, coldata.BatchSize, coldata.StandardColumnFactory)
 				b.Run(fmt.Sprintf("%s/%s/NullProbability=%.1f", typ, bc.name, nullProbability), func(b *testing.B) {
-					b.SetBytes(8 * int64(coldata.BatchSize()))
+					b.SetBytes(8 * int64(coldata.BatchSize))
 					for i := 0; i < b.N; i++ {
 						dest.Copy(bc.args)
 						if typ.Identical(types.Bytes) {

--- a/pkg/col/coldatatestutils/random_testutils.go
+++ b/pkg/col/coldatatestutils/random_testutils.go
@@ -278,7 +278,7 @@ type RandomDataOpArgs struct {
 	// MaxSchemaLength is the maximum length of the operator's schema, which will
 	// be at least one type.
 	MaxSchemaLength int
-	// BatchSize() is the size of batches returned.
+	// BatchSize is the size of batches returned.
 	BatchSize int
 	// NumBatches is the number of batches returned before the final, zero batch.
 	NumBatches int
@@ -314,7 +314,7 @@ func NewRandomDataOp(
 ) *RandomDataOp {
 	var (
 		maxSchemaLength = defaultMaxSchemaLength
-		batchSize       = coldata.BatchSize()
+		batchSize       = coldata.BatchSize
 		numBatches      = defaultNumBatches
 	)
 	if args.MaxSchemaLength > 0 {

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -79,7 +79,7 @@ const (
 
 // BatchToArrow converts the first batch.Length elements of the batch into an
 // arrow []*array.Data. It is assumed that the batch is not larger than
-// coldata.BatchSize(). The returned []*array.Data may only be used until the
+// coldata.BatchSize. The returned []*array.Data may only be used until the
 // next call to BatchToArrow.
 func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, error) {
 	if batch.Width() != len(c.typs) {
@@ -236,7 +236,7 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 }
 
 // ArrowToBatch converts []*array.Data to a coldata.Batch. There must not be
-// more than coldata.BatchSize() elements in data. It's safe to call ArrowToBatch
+// more than coldata.BatchSize elements in data. It's safe to call ArrowToBatch
 // concurrently.
 //
 // The passed in batch is overwritten, but after this method returns it stays

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -36,7 +36,7 @@ func randomBatch(allocator *colmem.Allocator) ([]*types.T, coldata.Batch) {
 		typs[i] = rowenc.RandType(rng)
 	}
 
-	capacity := rng.Intn(coldata.BatchSize()) + 1
+	capacity := rng.Intn(coldata.BatchSize) + 1
 	length := rng.Intn(capacity)
 	b := coldatatestutils.RandomBatch(allocator, rng, typs, capacity, length, rng.Float64())
 	return typs, b
@@ -130,15 +130,15 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 	// converting on one iteration of the benchmark for the corresponding type in
 	// typs.
 	numBytes := []int64{
-		int64(coldata.BatchSize()),
-		fixedLen * int64(coldata.BatchSize()),
+		int64(coldata.BatchSize),
+		fixedLen * int64(coldata.BatchSize),
 		0, // The number of bytes for decimals will be set below.
-		8 * int64(coldata.BatchSize()),
-		3 * 8 * int64(coldata.BatchSize()),
+		8 * int64(coldata.BatchSize),
+		3 * 8 * int64(coldata.BatchSize),
 	}
 	// Run a benchmark on every type we care about.
 	for typIdx, typ := range typs {
-		batch := coldatatestutils.RandomBatch(testAllocator, rng, []*types.T{typ}, coldata.BatchSize(), 0 /* length */, 0 /* nullProbability */)
+		batch := coldatatestutils.RandomBatch(testAllocator, rng, []*types.T{typ}, coldata.BatchSize, 0 /* length */, 0 /* nullProbability */)
 		if batch.Width() != 1 {
 			b.Fatalf("unexpected batch width: %d", batch.Width())
 		}
@@ -193,7 +193,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 					if len(data) != 1 {
 						b.Fatal("expected arrow batch of length 1")
 					}
-					if data[0].Len() != coldata.BatchSize() {
+					if data[0].Len() != coldata.BatchSize {
 						b.Fatal("unexpected number of elements")
 					}
 				}
@@ -216,7 +216,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 					if result.Width() != 1 {
 						b.Fatal("expected one column")
 					}
-					if result.Length() != coldata.BatchSize() {
+					if result.Length() != coldata.BatchSize {
 						b.Fatal("unexpected number of elements")
 					}
 				}

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -718,7 +718,7 @@ func (d *diskQueue) Dequeue(ctx context.Context, b coldata.Batch) (bool, error) 
 				// reallocating a new scratchDecompressedReadBytes every time we perform
 				// a read from the file and constrains the downside to allocating a new
 				// null bitmap every couple of batches.
-				nulls := coldata.NewNulls(coldata.BatchSize())
+				nulls := coldata.NewNulls(coldata.BatchSize)
 				vecs[i].SetNulls(&nulls)
 			}
 		}

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -66,7 +66,7 @@ func TestDiskQueue(t *testing.T) {
 					batches := make([]coldata.Batch, 0, numBatches)
 					op := coldatatestutils.NewRandomDataOp(testAllocator, rng, coldatatestutils.RandomDataOpArgs{
 						NumBatches: cap(batches),
-						BatchSize:  1 + rng.Intn(coldata.BatchSize()),
+						BatchSize:  1 + rng.Intn(coldata.BatchSize),
 						Nulls:      true,
 						BatchAccumulator: func(b coldata.Batch, typs []*types.T) {
 							batches = append(batches, coldatatestutils.CopyBatch(b, typs, testColumnFactory))
@@ -191,7 +191,7 @@ func BenchmarkDiskQueue(b *testing.B) {
 	if err != nil {
 		b.Fatalf("could not pase -datasize: %s", err)
 	}
-	numBatches := int(dataSize / (8 * int64(coldata.BatchSize())))
+	numBatches := int(dataSize / (8 * int64(coldata.BatchSize)))
 
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
 	defer cleanup()
@@ -200,7 +200,7 @@ func BenchmarkDiskQueue(b *testing.B) {
 
 	rng, _ := randutil.NewPseudoRand()
 	typs := []*types.T{types.Int}
-	batch := coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), 0, 0)
+	batch := coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize, 0, 0)
 	op := colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {

--- a/pkg/sql/colcontainer/partitionedqueue_test.go
+++ b/pkg/sql/colcontainer/partitionedqueue_test.go
@@ -97,7 +97,7 @@ func TestPartitionedDiskQueue(t *testing.T) {
 		batch = testAllocator.NewMemBatchWithMaxCapacity(typs)
 		sem   = &colexecbase.TestingSemaphore{}
 	)
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
@@ -152,7 +152,7 @@ func TestPartitionedDiskQueueSimulatedExternal(t *testing.T) {
 		// numRepartitions is in [1, 5].
 		numRepartitions = 1 + rng.Intn(5)
 	)
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -825,9 +825,9 @@ func TestAggregatorRandom(t *testing.T) {
 	// This test aggregates random inputs, keeping track of the expected results
 	// to make sure the aggregations are correct.
 	rng, _ := randutil.NewPseudoRand()
-	for _, groupSize := range []int{1, 2, coldata.BatchSize() / 4, coldata.BatchSize() / 2} {
+	for _, groupSize := range []int{1, 2, coldata.BatchSize / 4, coldata.BatchSize / 2} {
 		if groupSize == 0 {
-			// We might be varying coldata.BatchSize() so that when it is divided by
+			// We might be varying coldata.BatchSize so that when it is divided by
 			// 4, groupSize is 0. We want to skip such configuration.
 			continue
 		}
@@ -835,7 +835,7 @@ func TestAggregatorRandom(t *testing.T) {
 			for _, hasNulls := range []bool{true, false} {
 				for _, agg := range aggTypes {
 					log.Infof(context.Background(), "%s/groupSize=%d/numInputBatches=%d/hasNulls=%t", agg.name, groupSize, numInputBatches, hasNulls)
-					nTuples := coldata.BatchSize() * numInputBatches
+					nTuples := coldata.BatchSize * numInputBatches
 					typs := []*types.T{types.Int, types.Float}
 					cols := []coldata.Vec{
 						testAllocator.NewMemColumn(typs[0], nTuples),
@@ -962,7 +962,7 @@ func benchmarkAggregateFunction(
 	evalCtx.SingleDatumAggMemAccount = &aggMemAcc
 	const bytesFixedLength = 8
 	typs := append([]*types.T{types.Int}, aggInputTypes...)
-	nTuples := numInputBatches * coldata.BatchSize()
+	nTuples := numInputBatches * coldata.BatchSize
 	cols := make([]coldata.Vec, len(typs))
 	for i := range typs {
 		cols[i] = testAllocator.NewMemColumn(typs[i], nTuples)
@@ -1076,10 +1076,10 @@ func benchmarkAggregateFunction(
 func BenchmarkAggregator(b *testing.B) {
 	aggFn := execinfrapb.AggregatorSpec_MIN
 	numBatches := []int{4, 64, 1024}
-	groupSizes := []int{1, 2, 32, 128, coldata.BatchSize() / 2, coldata.BatchSize()}
+	groupSizes := []int{1, 2, 32, 128, coldata.BatchSize / 2, coldata.BatchSize}
 	if testing.Short() {
 		numBatches = []int{64}
-		groupSizes = []int{1, coldata.BatchSize()}
+		groupSizes = []int{1, coldata.BatchSize}
 	}
 	for _, agg := range aggTypes {
 		for _, numInputBatches := range numBatches {
@@ -1121,7 +1121,7 @@ func BenchmarkAllOptimizedAggregateFunctions(b *testing.B) {
 			default:
 				aggInputTypes = []*types.T{types.Int}
 			}
-			for _, groupSize := range []int{1, coldata.BatchSize()} {
+			for _, groupSize := range []int{1, coldata.BatchSize} {
 				benchmarkAggregateFunction(
 					b, agg, aggFn, aggInputTypes, groupSize, nullProbability, numInputBatches,
 				)
@@ -1172,7 +1172,7 @@ func BenchmarkDistinctAggregation(b *testing.B) {
 		} else {
 			aggSpec.OrderedGroupCols = aggSpec.GroupCols
 		}
-		for _, groupSize := range []int{1, 2, 32, 128, coldata.BatchSize() / 2, coldata.BatchSize()} {
+		for _, groupSize := range []int{1, 2, 32, 128, coldata.BatchSize / 2, coldata.BatchSize} {
 			for _, distinctProbability := range []float64{0.01, 0.1, 1.0} {
 				distinctModulo := int(1.0 / distinctProbability)
 				if (groupSize == 1 && distinctProbability != 1.0) || float64(groupSize)/float64(distinctModulo) < 0.1 {
@@ -1191,7 +1191,7 @@ func BenchmarkDistinctAggregation(b *testing.B) {
 						b.Run(fmt.Sprintf("%s/%s/groupSize=%d/distinctProb=%.2f/nulls=%t",
 							agg.name, aggFn, groupSize, distinctProbability, hasNulls),
 							func(b *testing.B) {
-								nTuples := numInputBatches * coldata.BatchSize()
+								nTuples := numInputBatches * coldata.BatchSize
 								cols := []coldata.Vec{
 									testAllocator.NewMemColumn(typs[0], nTuples),
 									testAllocator.NewMemColumn(typs[1], nTuples),
@@ -1280,9 +1280,9 @@ func TestHashAggregator(t *testing.T) {
 			input: tuples{
 				{0, 3},
 				{0, 4},
-				{coldata.BatchSize(), 6},
+				{coldata.BatchSize, 6},
 				{0, 5},
-				{coldata.BatchSize(), 7},
+				{coldata.BatchSize, 7},
 			},
 			typs:      []*types.T{types.Int, types.Int},
 			groupCols: []uint32{0},

--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -127,7 +127,7 @@ type aggregatorHelperBase struct {
 
 func newAggregatorHelperBase(spec *execinfrapb.AggregatorSpec) *aggregatorHelperBase {
 	b := &aggregatorHelperBase{spec: spec}
-	b.origSel = make([]int, coldata.BatchSize())
+	b.origSel = make([]int, coldata.BatchSize)
 	return b
 }
 
@@ -295,7 +295,7 @@ func newDistinctAggregatorHelperBase(
 	}
 	b.aggColsConverter = newVecToDatumConverter(len(inputTypes), vecIdxsToConvert)
 	b.scratch.converted = []tree.Datum{nil}
-	b.scratch.sel = make([]int, coldata.BatchSize())
+	b.scratch.sel = make([]int, coldata.BatchSize)
 	return b
 }
 
@@ -506,7 +506,7 @@ var _ colexecbase.Operator = &singleBatchOperator{}
 
 func newSingleBatchOperator(allocator *colmem.Allocator, typs []*types.T) *singleBatchOperator {
 	return &singleBatchOperator{
-		batch: allocator.NewMemBatchNoCols(typs, coldata.BatchSize()),
+		batch: allocator.NewMemBatchNoCols(typs, coldata.BatchSize),
 	}
 }
 

--- a/pkg/sql/colexec/and_or_projection.eg.go
+++ b/pkg/sql/colexec/and_or_projection.eg.go
@@ -144,7 +144,7 @@ func newAndProjOp(
 		leftIdx:          leftIdx,
 		rightIdx:         rightIdx,
 		outputIdx:        outputIdx,
-		origSel:          make([]int, coldata.BatchSize()),
+		origSel:          make([]int, coldata.BatchSize),
 	}
 }
 
@@ -582,7 +582,7 @@ func newAndRightNullProjOp(
 		leftIdx:          leftIdx,
 		rightIdx:         rightIdx,
 		outputIdx:        outputIdx,
-		origSel:          make([]int, coldata.BatchSize()),
+		origSel:          make([]int, coldata.BatchSize),
 	}
 }
 
@@ -987,7 +987,7 @@ func newAndLeftNullProjOp(
 		leftIdx:          leftIdx,
 		rightIdx:         rightIdx,
 		outputIdx:        outputIdx,
-		origSel:          make([]int, coldata.BatchSize()),
+		origSel:          make([]int, coldata.BatchSize),
 	}
 }
 
@@ -1373,7 +1373,7 @@ func newOrProjOp(
 		leftIdx:          leftIdx,
 		rightIdx:         rightIdx,
 		outputIdx:        outputIdx,
-		origSel:          make([]int, coldata.BatchSize()),
+		origSel:          make([]int, coldata.BatchSize),
 	}
 }
 
@@ -1812,7 +1812,7 @@ func newOrRightNullProjOp(
 		leftIdx:          leftIdx,
 		rightIdx:         rightIdx,
 		outputIdx:        outputIdx,
-		origSel:          make([]int, coldata.BatchSize()),
+		origSel:          make([]int, coldata.BatchSize),
 	}
 }
 
@@ -2218,7 +2218,7 @@ func newOrLeftNullProjOp(
 		leftIdx:          leftIdx,
 		rightIdx:         rightIdx,
 		outputIdx:        outputIdx,
-		origSel:          make([]int, coldata.BatchSize()),
+		origSel:          make([]int, coldata.BatchSize),
 	}
 }
 

--- a/pkg/sql/colexec/and_or_projection_test.go
+++ b/pkg/sql/colexec/and_or_projection_test.go
@@ -234,14 +234,14 @@ func benchmarkLogicalProjOp(
 	batch := testAllocator.NewMemBatchWithMaxCapacity([]*types.T{types.Bool, types.Bool})
 	col1 := batch.ColVec(0).Bool()
 	col2 := batch.ColVec(0).Bool()
-	for i := 0; i < coldata.BatchSize(); i++ {
+	for i := 0; i < coldata.BatchSize; i++ {
 		col1[i] = rng.Float64() < 0.5
 		col2[i] = rng.Float64() < 0.5
 	}
 	if hasNulls {
 		nulls1 := batch.ColVec(0).Nulls()
 		nulls2 := batch.ColVec(0).Nulls()
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			if rng.Float64() < nullProbability {
 				nulls1.SetNull(i)
 			}
@@ -250,11 +250,11 @@ func benchmarkLogicalProjOp(
 			}
 		}
 	}
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 	if useSelectionVector {
 		batch.SetSelection(true)
 		sel := batch.Selection()
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			sel[i] = i
 		}
 	}
@@ -267,7 +267,7 @@ func benchmarkLogicalProjOp(
 	require.NoError(b, err)
 	logicalProjOp.Init()
 
-	b.SetBytes(int64(8 * coldata.BatchSize()))
+	b.SetBytes(int64(8 * coldata.BatchSize))
 	for i := 0; i < b.N; i++ {
 		logicalProjOp.Next(ctx)
 	}

--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -119,7 +119,7 @@ func new_OP_TITLEProjOp(
 		leftIdx:          leftIdx,
 		rightIdx:         rightIdx,
 		outputIdx:        outputIdx,
-		origSel:          make([]int, coldata.BatchSize()),
+		origSel:          make([]int, coldata.BatchSize),
 	}
 }
 

--- a/pkg/sql/colexec/buffer_test.go
+++ b/pkg/sql/colexec/buffer_test.go
@@ -27,7 +27,7 @@ func TestBufferOp(t *testing.T) {
 
 	ctx := context.Background()
 	inputTuples := tuples{{int64(1)}, {int64(2)}, {int64(3)}}
-	input := newOpTestInput(coldata.BatchSize(), inputTuples, []*types.T{types.Int})
+	input := newOpTestInput(coldata.BatchSize, inputTuples, []*types.T{types.Int})
 	buffer := NewBufferOp(input).(*bufferOp)
 	buffer.Init()
 

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -98,8 +98,8 @@ func benchmarkBuiltinFunctions(b *testing.B, useSelectionVector bool, hasNulls b
 	batch := testAllocator.NewMemBatchWithMaxCapacity([]*types.T{types.Int})
 	col := batch.ColVec(0).Int64()
 
-	for i := 0; i < coldata.BatchSize(); i++ {
-		if float64(i) < float64(coldata.BatchSize())*selectivity {
+	for i := 0; i < coldata.BatchSize; i++ {
+		if float64(i) < float64(coldata.BatchSize)*selectivity {
 			col[i] = -1
 		} else {
 			col[i] = 1
@@ -107,19 +107,19 @@ func benchmarkBuiltinFunctions(b *testing.B, useSelectionVector bool, hasNulls b
 	}
 
 	if hasNulls {
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			if rand.Float64() < nullProbability {
 				batch.ColVec(0).Nulls().SetNull(i)
 			}
 		}
 	}
 
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 
 	if useSelectionVector {
 		batch.SetSelection(true)
 		sel := batch.Selection()
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			sel[i] = i
 		}
 	}
@@ -133,7 +133,7 @@ func benchmarkBuiltinFunctions(b *testing.B, useSelectionVector bool, hasNulls b
 	require.NoError(b, err)
 	op.Init()
 
-	b.SetBytes(int64(8 * coldata.BatchSize()))
+	b.SetBytes(int64(8 * coldata.BatchSize))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		op.Next(ctx)
@@ -164,12 +164,12 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 	bCol := batch.ColVec(0).Bytes()
 	sCol := batch.ColVec(1).Int64()
 	eCol := batch.ColVec(2).Int64()
-	for i := 0; i < coldata.BatchSize(); i++ {
+	for i := 0; i < coldata.BatchSize; i++ {
 		bCol.Set(i, []byte("hello there"))
 		sCol[i] = 1
 		eCol[i] = 4
 	}
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 	var source colexecbase.Operator
 	source = colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 	source = newVectorTypeEnforcer(testAllocator, source, types.Bytes, outputIdx)
@@ -209,7 +209,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 	specOp.Init()
 
 	b.Run("DefaultBuiltinOperator", func(b *testing.B) {
-		b.SetBytes(int64(len("hello there") * coldata.BatchSize()))
+		b.SetBytes(int64(len("hello there") * coldata.BatchSize))
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			b := defaultOp.Next(ctx)
@@ -220,7 +220,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 	})
 
 	b.Run("SpecializedSubstringOperator", func(b *testing.B) {
-		b.SetBytes(int64(len("hello there") * coldata.BatchSize()))
+		b.SetBytes(int64(len("hello there") * coldata.BatchSize))
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			b := specOp.Next(ctx)

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -97,8 +97,8 @@ func NewCaseOp(
 		thenIdxs:  thenIdxs,
 		outputIdx: outputIdx,
 		typ:       typ,
-		origSel:   make([]int, coldata.BatchSize()),
-		prevSel:   make([]int, coldata.BatchSize()),
+		origSel:   make([]int, coldata.BatchSize),
+		prevSel:   make([]int, coldata.BatchSize),
 	}
 }
 

--- a/pkg/sql/colexec/cast_test.go
+++ b/pkg/sql/colexec/cast_test.go
@@ -190,12 +190,12 @@ func BenchmarkCastOp(b *testing.B) {
 						typs := []*types.T{typePair[0]}
 						batch := coldatatestutils.RandomBatchWithSel(
 							testAllocator, rng, typs,
-							coldata.BatchSize(), nullProbability, selectivity,
+							coldata.BatchSize, nullProbability, selectivity,
 						)
 						source := colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 						op, err := createTestCastOperator(ctx, flowCtx, source, typePair[0], typePair[1])
 						require.NoError(b, err)
-						b.SetBytes(int64(8 * coldata.BatchSize()))
+						b.SetBytes(int64(8 * coldata.BatchSize))
 						b.ResetTimer()
 						op.Init()
 						for i := 0; i < b.N; i++ {

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Columnarizer turns an execinfra.RowSource input into an Operator output, by
-// reading the input in chunks of size coldata.BatchSize() and converting each
+// reading the input in chunks of size coldata.BatchSize and converting each
 // chunk into a coldata.Batch column by column.
 type Columnarizer struct {
 	execinfra.ProcessorBase

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -37,7 +37,7 @@ func TestColumnarizerResetsInternalBatch(t *testing.T) {
 	typs := []*types.T{types.Int}
 	// There will be at least two batches of rows so that we can see whether the
 	// internal batch is reset.
-	nRows := coldata.BatchSize() * 2
+	nRows := coldata.BatchSize * 2
 	nCols := len(typs)
 	rows := rowenc.MakeIntRows(nRows, nCols)
 	input := execinfra.NewRepeatableRowSource(typs, rows)

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -160,7 +160,7 @@ func BenchmarkDefaultAggregateFunction(b *testing.B) {
 	const numInputBatches = 64
 	aggFn := execinfrapb.AggregatorSpec_STRING_AGG
 	for _, agg := range aggTypes {
-		for _, groupSize := range []int{1, 2, 32, 128, coldata.BatchSize() / 2, coldata.BatchSize()} {
+		for _, groupSize := range []int{1, 2, 32, 128, coldata.BatchSize / 2, coldata.BatchSize} {
 			for _, nullProb := range []float64{0.0, nullProbability} {
 				benchmarkAggregateFunction(
 					b, agg, aggFn, []*types.T{types.String, types.String}, groupSize, nullProb, numInputBatches,

--- a/pkg/sql/colexec/deselector_test.go
+++ b/pkg/sql/colexec/deselector_test.go
@@ -92,16 +92,16 @@ func BenchmarkDeselector(b *testing.B) {
 
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		col := batch.ColVec(colIdx).Int64()
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			col[i] = int64(i)
 		}
 	}
 	for _, probOfOmitting := range []float64{0.1, 0.9} {
-		sel := coldatatestutils.RandomSel(rng, coldata.BatchSize(), probOfOmitting)
+		sel := coldatatestutils.RandomSel(rng, coldata.BatchSize, probOfOmitting)
 		batchLen := len(sel)
 
 		for _, nBatches := range []int{1 << 1, 1 << 2, 1 << 4, 1 << 8} {
-			b.Run(fmt.Sprintf("rows=%d/after selection=%d", nBatches*coldata.BatchSize(), nBatches*batchLen), func(b *testing.B) {
+			b.Run(fmt.Sprintf("rows=%d/after selection=%d", nBatches*coldata.BatchSize, nBatches*batchLen), func(b *testing.B) {
 				// We're measuring the amount of data that is not selected out.
 				b.SetBytes(int64(8 * nBatches * batchLen * nCols))
 				batch.SetSelection(true)

--- a/pkg/sql/colexec/distinct.eg.go
+++ b/pkg/sql/colexec/distinct.eg.go
@@ -33,7 +33,7 @@ import (
 func OrderedDistinctColsToOperators(
 	input colexecbase.Operator, distinctCols []uint32, typs []*types.T,
 ) (colexecbase.Operator, []bool, error) {
-	distinctCol := make([]bool, coldata.BatchSize())
+	distinctCol := make([]bool, coldata.BatchSize)
 	// zero the boolean column on every iteration.
 	input = fnOp{
 		OneInputNode: NewOneInputNode(input),

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -242,7 +242,7 @@ func BenchmarkDistinct(b *testing.B) {
 						typs[i] = types.Int
 					}
 					batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
-					batch.SetLength(coldata.BatchSize())
+					batch.SetLength(coldata.BatchSize)
 					distinctCols := []uint32{0, 1, 2, 3}[:nCols]
 					// We have the following equation:
 					//   newTupleProbability = 1 - (1 - newValueProbability) ^ nCols,
@@ -252,7 +252,7 @@ func BenchmarkDistinct(b *testing.B) {
 					for i := range distinctCols {
 						col := batch.ColVec(i).Int64()
 						col[0] = 0
-						for j := 1; j < coldata.BatchSize(); j++ {
+						for j := 1; j < coldata.BatchSize; j++ {
 							col[j] = col[j-1]
 							if rng.Float64() < newValueProbability {
 								col[j]++
@@ -270,10 +270,10 @@ func BenchmarkDistinct(b *testing.B) {
 						b.Run(
 							fmt.Sprintf("%s/hasNulls=%v/newTupleProbability=%.3f/rows=%d/cols=%d/ordCols=%d",
 								distinctNames[distinctIdx], hasNulls, newTupleProbability,
-								nBatches*coldata.BatchSize(), nCols, numOrderedCols,
+								nBatches*coldata.BatchSize, nCols, numOrderedCols,
 							),
 							func(b *testing.B) {
-								b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols))
+								b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols))
 								b.ResetTimer()
 								for n := 0; n < b.N; n++ {
 									// Note that the source will be ordered on all nCols so that the

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -37,7 +37,7 @@ import (
 func OrderedDistinctColsToOperators(
 	input colexecbase.Operator, distinctCols []uint32, typs []*types.T,
 ) (colexecbase.Operator, []bool, error) {
-	distinctCol := make([]bool, coldata.BatchSize())
+	distinctCol := make([]bool, coldata.BatchSize)
 	// zero the boolean column on every iteration.
 	input = fnOp{
 		OneInputNode: NewOneInputNode(input),

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -391,8 +391,8 @@ func NewExternalHashJoiner(
 	if ehj.memState.maxRightPartitionSizeToJoin < externalHJMinimalMaxRightPartitionSize {
 		ehj.memState.maxRightPartitionSizeToJoin = externalHJMinimalMaxRightPartitionSize
 	}
-	ehj.scratch.leftBatch = unlimitedAllocator.NewMemBatchWithFixedCapacity(spec.left.sourceTypes, coldata.BatchSize())
-	ehj.recursiveScratch.leftBatch = unlimitedAllocator.NewMemBatchWithFixedCapacity(spec.left.sourceTypes, coldata.BatchSize())
+	ehj.scratch.leftBatch = unlimitedAllocator.NewMemBatchWithFixedCapacity(spec.left.sourceTypes, coldata.BatchSize)
+	ehj.recursiveScratch.leftBatch = unlimitedAllocator.NewMemBatchWithFixedCapacity(spec.left.sourceTypes, coldata.BatchSize)
 	sameSourcesSchema := len(spec.left.sourceTypes) == len(spec.right.sourceTypes)
 	for i, leftType := range spec.left.sourceTypes {
 		if i < len(spec.right.sourceTypes) && !leftType.Identical(spec.right.sourceTypes[i]) {
@@ -405,8 +405,8 @@ func NewExternalHashJoiner(
 		ehj.scratch.rightBatch = ehj.scratch.leftBatch
 		ehj.recursiveScratch.rightBatch = ehj.recursiveScratch.leftBatch
 	} else {
-		ehj.scratch.rightBatch = unlimitedAllocator.NewMemBatchWithFixedCapacity(spec.right.sourceTypes, coldata.BatchSize())
-		ehj.recursiveScratch.rightBatch = unlimitedAllocator.NewMemBatchWithFixedCapacity(spec.right.sourceTypes, coldata.BatchSize())
+		ehj.scratch.rightBatch = unlimitedAllocator.NewMemBatchWithFixedCapacity(spec.right.sourceTypes, coldata.BatchSize)
+		ehj.recursiveScratch.rightBatch = unlimitedAllocator.NewMemBatchWithFixedCapacity(spec.right.sourceTypes, coldata.BatchSize)
 	}
 	ehj.testingKnobs.numForcedRepartitions = numForcedRepartitions
 	ehj.testingKnobs.delegateFDAcquisitions = delegateFDAcquisitions

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -137,7 +137,7 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 	sourceTypes := []*types.T{types.Int}
 	batch := testAllocator.NewMemBatchWithMaxCapacity(sourceTypes)
 	// We don't need to set the data since zero values in the columns work.
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 	nBatches := 2
 	leftSource := newFiniteBatchSource(batch, sourceTypes, nBatches)
 	rightSource := newFiniteBatchSource(batch, sourceTypes, nBatches)
@@ -176,7 +176,7 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 	hj.Init()
 	// We have a full cross-product, so we should get the number of tuples
 	// squared in the output.
-	expectedTuplesCount := nBatches * nBatches * coldata.BatchSize() * coldata.BatchSize()
+	expectedTuplesCount := nBatches * nBatches * coldata.BatchSize * coldata.BatchSize
 	actualTuplesCount := 0
 	for b := hj.Next(ctx); b.Length() > 0; b = hj.Next(ctx) {
 		actualTuplesCount += b.Length()
@@ -208,11 +208,11 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 	batch := testAllocator.NewMemBatchWithMaxCapacity(sourceTypes)
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		col := batch.ColVec(colIdx).Int64()
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			col[i] = int64(i)
 		}
 	}
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 
 	var (
 		memAccounts []*mon.BoundAccount
@@ -257,9 +257,9 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 					tc.init()
 					spec := createSpecForHashJoiner(tc)
 					b.Run(name, func(b *testing.B) {
-						// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize() (rows /
+						// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
 						// batch) * nCols (number of columns / row) * 2 (number of sources).
-						b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols * 2))
+						b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols * 2))
 						b.ResetTimer()
 						for i := 0; i < b.N; i++ {
 							leftSource.reset(nBatches)

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -195,7 +195,7 @@ func NewExternalSorter(
 	// memoryLimit of the partitions to sort in memory by those cache sizes. To be
 	// safe, we also estimate the size of the output batch and subtract that as
 	// well.
-	batchMemSize := colmem.EstimateBatchSizeBytes(inputTypes, coldata.BatchSize())
+	batchMemSize := colmem.EstimateBatchSizeBytes(inputTypes, coldata.BatchSize)
 	// Reserve a certain amount of memory for the partition caches.
 	memoryLimit -= int64((maxNumberPartitions * diskQueueCfg.BufferSizeBytes) + batchMemSize)
 	if memoryLimit < 1 {

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -138,7 +138,7 @@ func TestExternalSortRandomized(t *testing.T) {
 		},
 	}
 	rng, _ := randutil.NewPseudoRand()
-	nTups := coldata.BatchSize()*4 + 1
+	nTups := coldata.BatchSize*4 + 1
 	maxCols := 2
 	// TODO(yuzefovich): randomize types as well.
 	typs := make([]*types.T, maxCols)
@@ -161,7 +161,7 @@ func TestExternalSortRandomized(t *testing.T) {
 	//    memory limit.
 	// memoryToSort is the total amount of memory that will be sorted in this
 	// test.
-	memoryToSort := (nTups / coldata.BatchSize()) * colmem.EstimateBatchSizeBytes(typs, coldata.BatchSize())
+	memoryToSort := (nTups / coldata.BatchSize) * colmem.EstimateBatchSizeBytes(typs, coldata.BatchSize)
 	// partitionSize will be the memory limit passed in to tests with a memory
 	// limit. With a maximum number of partitions of 2 this will result in
 	// repartitioning twice. To make this a total amount of memory, we also need
@@ -252,23 +252,23 @@ func BenchmarkExternalSort(b *testing.B) {
 		for _, nCols := range []int{1, 2, 4} {
 			for _, spillForced := range []bool{false, true} {
 				flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
-				name := fmt.Sprintf("rows=%d/cols=%d/spilled=%t", nBatches*coldata.BatchSize(), nCols, spillForced)
+				name := fmt.Sprintf("rows=%d/cols=%d/spilled=%t", nBatches*coldata.BatchSize, nCols, spillForced)
 				b.Run(name, func(b *testing.B) {
-					// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize() (rows /
+					// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize (rows /
 					// batch) * nCols (number of columns / row).
-					b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols))
+					b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols))
 					typs := make([]*types.T, nCols)
 					for i := range typs {
 						typs[i] = types.Int
 					}
 					batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
-					batch.SetLength(coldata.BatchSize())
+					batch.SetLength(coldata.BatchSize)
 					ordCols := make([]execinfrapb.Ordering_Column, nCols)
 					for i := range ordCols {
 						ordCols[i].ColIdx = uint32(i)
 						ordCols[i].Direction = execinfrapb.Ordering_Column_Direction(rng.Int() % 2)
 						col := batch.ColVec(i).Int64()
-						for j := 0; j < coldata.BatchSize(); j++ {
+						for j := 0; j < coldata.BatchSize; j++ {
 							col[j] = rng.Int63() % int64((i*1024)+1)
 						}
 					}

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -148,10 +148,10 @@ func (op *hashAggregator) Init() {
 	// simply reallocate the output batch.
 	// TODO(yuzefovich): consider changing aggregateFunc interface to allow for
 	// updating the output vector.
-	op.output = op.allocator.NewMemBatchWithFixedCapacity(op.outputTypes, coldata.BatchSize())
-	op.scratch.eqChains = make([][]int, coldata.BatchSize())
-	op.scratch.intSlice = make([]int, coldata.BatchSize())
-	op.scratch.anotherIntSlice = make([]int, coldata.BatchSize())
+	op.output = op.allocator.NewMemBatchWithFixedCapacity(op.outputTypes, coldata.BatchSize)
+	op.scratch.eqChains = make([][]int, coldata.BatchSize)
+	op.scratch.intSlice = make([]int, coldata.BatchSize)
+	op.scratch.anotherIntSlice = make([]int, coldata.BatchSize)
 	// The hash table only needs to store the grouping columns to be able to
 	// perform the equality check.
 	colsToStore := make([]int, len(op.spec.GroupCols))
@@ -225,7 +225,7 @@ func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 //   {-3}, {-3}, {-2}, {-1}, {-4}, {-1}, {-1}, {-4}.
 // (Note that negative values are chosen in order to visually distinguish them
 // from the IDs that we'll be working with below.)
-// We will use coldata.BatchSize() == 4 and let's assume that we will use a
+// We will use coldata.BatchSize == 4 and let's assume that we will use a
 // simple hash function h(i) = i % 2 with two buckets in the hash table.
 //
 // I. we get a batch [-3, -3, -2, -1].

--- a/pkg/sql/colexec/hash_utils.go
+++ b/pkg/sql/colexec/hash_utils.go
@@ -115,11 +115,11 @@ type tupleHashDistributor struct {
 func newTupleHashDistributor(initHashValue uint64, numOutputs int) *tupleHashDistributor {
 	selections := make([][]int, numOutputs)
 	for i := range selections {
-		selections[i] = make([]int, 0, coldata.BatchSize())
+		selections[i] = make([]int, 0, coldata.BatchSize)
 	}
 	return &tupleHashDistributor{
 		initHashValue: initHashValue,
-		buckets:       make([]uint64, coldata.BatchSize()),
+		buckets:       make([]uint64, coldata.BatchSize),
 		selections:    selections,
 	}
 }
@@ -172,6 +172,6 @@ func (d *tupleHashDistributor) resetNumOutputs(numOutputs int) {
 	}
 	d.selections = d.selections[:cap(d.selections)]
 	for len(d.selections) < numOutputs {
-		d.selections = append(d.selections, make([]int, 0, coldata.BatchSize()))
+		d.selections = append(d.selections, make([]int, 0, coldata.BatchSize))
 	}
 }

--- a/pkg/sql/colexec/hash_utils_test.go
+++ b/pkg/sql/colexec/hash_utils_test.go
@@ -31,11 +31,11 @@ func TestHashFunctionFamily(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	bucketsA, bucketsB := make([]uint64, coldata.BatchSize()), make([]uint64, coldata.BatchSize())
-	nKeys := coldata.BatchSize()
+	bucketsA, bucketsB := make([]uint64, coldata.BatchSize), make([]uint64, coldata.BatchSize)
+	nKeys := coldata.BatchSize
 	keyTypes := []*types.T{types.Int}
-	keys := []coldata.Vec{testAllocator.NewMemColumn(keyTypes[0], coldata.BatchSize())}
-	for i := int64(0); i < int64(coldata.BatchSize()); i++ {
+	keys := []coldata.Vec{testAllocator.NewMemColumn(keyTypes[0], coldata.BatchSize)}
+	for i := int64(0); i < int64(coldata.BatchSize); i++ {
 		keys[0].Int64()[i] = i
 	}
 	numBuckets := uint64(16)

--- a/pkg/sql/colexec/hashjoiner.eg.go
+++ b/pkg/sql/colexec/hashjoiner.eg.go
@@ -24,7 +24,7 @@ func collectProbeOuter_false(
 		currentID := hj.ht.probeScratch.headID[i]
 
 		for {
-			if nResults >= coldata.BatchSize() {
+			if nResults >= coldata.BatchSize {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults
@@ -70,7 +70,7 @@ func collectProbeOuter_true(
 		currentID := hj.ht.probeScratch.headID[i]
 
 		for {
-			if nResults >= coldata.BatchSize() {
+			if nResults >= coldata.BatchSize {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults
@@ -116,7 +116,7 @@ func collectProbeNoOuter_false(
 	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
 		currentID := hj.ht.probeScratch.headID[i]
 		for currentID != 0 {
-			if nResults >= coldata.BatchSize() {
+			if nResults >= coldata.BatchSize {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults
@@ -148,7 +148,7 @@ func collectProbeNoOuter_true(
 	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
 		currentID := hj.ht.probeScratch.headID[i]
 		for currentID != 0 {
-			if nResults >= coldata.BatchSize() {
+			if nResults >= coldata.BatchSize {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults

--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -77,7 +77,7 @@ type hashJoinerSourceSpec struct {
 
 // hashJoiner performs a hash join on the input tables equality columns.
 // It requires that the output for every input batch in the probe phase fits
-// within coldata.BatchSize(), otherwise the behavior is undefined. A join is
+// within coldata.BatchSize, otherwise the behavior is undefined. A join is
 // performed and there is no guarantee on the ordering of the output columns.
 // The hash table will be built on the right side source, and the left side
 // source will be used for probing.
@@ -148,7 +148,7 @@ type hashJoinerSourceSpec struct {
 // 3. Now, head stores the keyID of the first match in the build table for every
 //    probe table key. ht.same is used to select all build key matches for each
 //    probe key, which are added to the resulting batch. Output batching is done
-//    to ensure that each batch is at most coldata.BatchSize().
+//    to ensure that each batch is at most coldata.BatchSize.
 //
 // In the case that an outer join on the probe table side is performed, every
 // single probe row is kept even if its groupID is 0. If a groupID of 0 is
@@ -343,7 +343,7 @@ func (hj *hashJoiner) build(ctx context.Context) {
 // OUTER joins.
 func (hj *hashJoiner) emitUnmatched() {
 	nResults := 0
-	for nResults < coldata.BatchSize() && hj.emittingUnmatchedState.rowIdx < hj.ht.vals.Length() {
+	for nResults < coldata.BatchSize && hj.emittingUnmatchedState.rowIdx < hj.ht.vals.Length() {
 		if !hj.probeState.buildRowMatched[hj.emittingUnmatchedState.rowIdx] {
 			hj.probeState.buildIdx[nResults] = hj.emittingUnmatchedState.rowIdx
 			nResults++
@@ -581,7 +581,7 @@ func (hj *hashJoiner) ExportBuffered(input colexecbase.Operator) coldata.Batch {
 		if hj.exportBufferedState.rightExported == hj.ht.vals.Length() {
 			return coldata.ZeroBatch
 		}
-		newRightExported := hj.exportBufferedState.rightExported + coldata.BatchSize()
+		newRightExported := hj.exportBufferedState.rightExported + coldata.BatchSize
 		if newRightExported > hj.ht.vals.Length() {
 			newRightExported = hj.ht.vals.Length()
 		}
@@ -626,10 +626,10 @@ func (hj *hashJoiner) reset(ctx context.Context) {
 	}
 	hj.state = hjBuilding
 	hj.ht.reset(ctx)
-	copy(hj.probeState.buildIdx[:coldata.BatchSize()], zeroIntColumn)
-	copy(hj.probeState.probeIdx[:coldata.BatchSize()], zeroIntColumn)
+	copy(hj.probeState.buildIdx[:coldata.BatchSize], zeroIntColumn)
+	copy(hj.probeState.probeIdx[:coldata.BatchSize], zeroIntColumn)
 	if hj.spec.left.outer {
-		copy(hj.probeState.probeRowUnmatched[:coldata.BatchSize()], zeroBoolColumn)
+		copy(hj.probeState.probeRowUnmatched[:coldata.BatchSize], zeroBoolColumn)
 	}
 	// hj.probeState.buildRowMatched is reset after building the hash table is
 	// complete in build() method.
@@ -729,10 +729,10 @@ func NewHashJoiner(
 		spec:                     spec,
 		outputTypes:              outputTypes,
 	}
-	hj.probeState.buildIdx = make([]int, coldata.BatchSize())
-	hj.probeState.probeIdx = make([]int, coldata.BatchSize())
+	hj.probeState.buildIdx = make([]int, coldata.BatchSize)
+	hj.probeState.probeIdx = make([]int, coldata.BatchSize)
 	if spec.left.outer {
-		hj.probeState.probeRowUnmatched = make([]bool, coldata.BatchSize())
+		hj.probeState.probeRowUnmatched = make([]bool, coldata.BatchSize)
 	}
 	return hj
 }

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -380,22 +380,22 @@ func init() {
 
 			leftTuples: tuples{
 				{0},
-				{coldata.BatchSize()},
-				{coldata.BatchSize()},
-				{coldata.BatchSize()},
+				{coldata.BatchSize},
+				{coldata.BatchSize},
+				{coldata.BatchSize},
 				{0},
-				{coldata.BatchSize() * 2},
+				{coldata.BatchSize * 2},
 				{1},
 				{1},
-				{coldata.BatchSize() + 1},
+				{coldata.BatchSize + 1},
 			},
 			rightTuples: tuples{
-				{coldata.BatchSize()},
-				{coldata.BatchSize() * 2},
-				{coldata.BatchSize() * 3},
+				{coldata.BatchSize},
+				{coldata.BatchSize * 2},
+				{coldata.BatchSize * 3},
 				{0},
 				{1},
-				{coldata.BatchSize() + 1},
+				{coldata.BatchSize + 1},
 			},
 
 			leftEqCols:   []uint32{0},
@@ -408,15 +408,15 @@ func init() {
 			rightEqColsAreKey: false,
 
 			expected: tuples{
-				{coldata.BatchSize(), coldata.BatchSize()},
-				{coldata.BatchSize(), coldata.BatchSize()},
-				{coldata.BatchSize(), coldata.BatchSize()},
-				{coldata.BatchSize() * 2, coldata.BatchSize() * 2},
+				{coldata.BatchSize, coldata.BatchSize},
+				{coldata.BatchSize, coldata.BatchSize},
+				{coldata.BatchSize, coldata.BatchSize},
+				{coldata.BatchSize * 2, coldata.BatchSize * 2},
 				{0, 0},
 				{0, 0},
 				{1, 1},
 				{1, 1},
-				{coldata.BatchSize() + 1, coldata.BatchSize() + 1},
+				{coldata.BatchSize + 1, coldata.BatchSize + 1},
 			},
 		},
 		{
@@ -501,14 +501,14 @@ func init() {
 			// hash to the same bucket.
 			leftTuples: tuples{
 				{0},
-				{coldata.BatchSize()},
-				{coldata.BatchSize() * 2},
-				{coldata.BatchSize() * 3},
+				{coldata.BatchSize},
+				{coldata.BatchSize * 2},
+				{coldata.BatchSize * 3},
 			},
 			rightTuples: tuples{
 				{0},
-				{coldata.BatchSize()},
-				{coldata.BatchSize() * 3},
+				{coldata.BatchSize},
+				{coldata.BatchSize * 3},
 			},
 
 			leftEqCols:   []uint32{0},
@@ -521,8 +521,8 @@ func init() {
 
 			expected: tuples{
 				{0},
-				{coldata.BatchSize()},
-				{coldata.BatchSize() * 3},
+				{coldata.BatchSize},
+				{coldata.BatchSize * 3},
 			},
 		},
 		{
@@ -607,17 +607,17 @@ func init() {
 			// Test multiple column with values that hash to the same bucket.
 			leftTuples: tuples{
 				{10, 0, 0},
-				{20, 0, coldata.BatchSize()},
-				{40, coldata.BatchSize(), 0},
-				{50, coldata.BatchSize(), coldata.BatchSize()},
-				{60, coldata.BatchSize() * 2, 0},
-				{70, coldata.BatchSize() * 2, coldata.BatchSize()},
+				{20, 0, coldata.BatchSize},
+				{40, coldata.BatchSize, 0},
+				{50, coldata.BatchSize, coldata.BatchSize},
+				{60, coldata.BatchSize * 2, 0},
+				{70, coldata.BatchSize * 2, coldata.BatchSize},
 			},
 			rightTuples: tuples{
-				{0, coldata.BatchSize()},
-				{coldata.BatchSize() * 2, coldata.BatchSize()},
+				{0, coldata.BatchSize},
+				{coldata.BatchSize * 2, coldata.BatchSize},
 				{0, 0},
-				{0, coldata.BatchSize() * 2},
+				{0, coldata.BatchSize * 2},
 			},
 
 			leftEqCols:   []uint32{1, 2},
@@ -629,8 +629,8 @@ func init() {
 			rightEqColsAreKey: true,
 
 			expected: tuples{
-				{20, 0, coldata.BatchSize()},
-				{70, coldata.BatchSize() * 2, coldata.BatchSize()},
+				{20, 0, coldata.BatchSize},
+				{70, coldata.BatchSize * 2, coldata.BatchSize},
 				{10, 0, 0},
 			},
 		},
@@ -1028,12 +1028,12 @@ func BenchmarkHashJoiner(b *testing.B) {
 
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		col := batch.ColVec(colIdx).Int64()
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			col[i] = int64(i)
 		}
 	}
 
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 
 	for _, hasNulls := range []bool{false, true} {
 		b.Run(fmt.Sprintf("nulls=%v", hasNulls), func(b *testing.B) {
@@ -1055,10 +1055,10 @@ func BenchmarkHashJoiner(b *testing.B) {
 					for _, rightDistinct := range []bool{true, false} {
 						b.Run(fmt.Sprintf("distinct=%v", rightDistinct), func(b *testing.B) {
 							for _, nBatches := range []int{1 << 1, 1 << 8, 1 << 12} {
-								b.Run(fmt.Sprintf("rows=%d", nBatches*coldata.BatchSize()), func(b *testing.B) {
-									// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize() (rows /
+								b.Run(fmt.Sprintf("rows=%d", nBatches*coldata.BatchSize), func(b *testing.B) {
+									// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
 									// batch) * nCols (number of columns / row) * 2 (number of sources).
-									b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols * 2))
+									b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols * 2))
 									b.ResetTimer()
 									for i := 0; i < b.N; i++ {
 										leftSource := colexecbase.NewRepeatableBatchSource(testAllocator, batch, sourceTypes)

--- a/pkg/sql/colexec/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/hashjoiner_tmpl.go
@@ -30,7 +30,7 @@ func collectProbeOuter(
 		currentID := hj.ht.probeScratch.headID[i]
 
 		for {
-			if nResults >= coldata.BatchSize() {
+			if nResults >= coldata.BatchSize {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults
@@ -71,7 +71,7 @@ func collectProbeNoOuter(
 	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
 		currentID := hj.ht.probeScratch.headID[i]
 		for currentID != 0 {
-			if nResults >= coldata.BatchSize() {
+			if nResults >= coldata.BatchSize {
 				hj.probeState.prevBatch = batch
 				hj.probeState.prevBatchResumeIdx = i
 				return nResults

--- a/pkg/sql/colexec/like_ops_test.go
+++ b/pkg/sql/colexec/like_ops_test.go
@@ -108,7 +108,7 @@ func BenchmarkLikeOps(b *testing.B) {
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
 	col := batch.ColVec(0).Bytes()
 	width := 64
-	for i := 0; i < coldata.BatchSize(); i++ {
+	for i := 0; i < coldata.BatchSize; i++ {
 		col.Set(i, randutil.RandBytes(rng, width))
 	}
 
@@ -117,13 +117,13 @@ func BenchmarkLikeOps(b *testing.B) {
 	prefix := "abc"
 	suffix := "xyz"
 	contains := "lmn"
-	for i := 0; i < coldata.BatchSize()/2; i++ {
+	for i := 0; i < coldata.BatchSize/2; i++ {
 		copy(col.Get(i)[:3], prefix)
 		copy(col.Get(i)[width-3:], suffix)
 		copy(col.Get(i)[width/2:], contains)
 	}
 
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 	source := colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 	source.Init()
 
@@ -161,7 +161,7 @@ func BenchmarkLikeOps(b *testing.B) {
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			tc.op.Init()
-			b.SetBytes(int64(width * coldata.BatchSize()))
+			b.SetBytes(int64(width * coldata.BatchSize))
 			for i := 0; i < b.N; i++ {
 				tc.op.Next(ctx)
 			}

--- a/pkg/sql/colexec/main_test.go
+++ b/pkg/sql/colexec/main_test.go
@@ -12,15 +12,12 @@ package colexec
 
 import (
 	"context"
-	"flag"
-	"fmt"
 	"os"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -67,17 +64,17 @@ func TestMain(m *testing.M) {
 		testDiskAcc = &diskAcc
 		defer testDiskAcc.Close(ctx)
 
-		flag.Parse()
-		if f := flag.Lookup("test.bench"); f == nil || f.Value.String() == "" {
-			// If we're running benchmarks, don't set a random batch size.
-			// Pick a random batch size in [minBatchSize, coldata.MaxBatchSize]
-			// range. The randomization can be disabled using COCKROACH_RANDOMIZE_BATCH_SIZE=false.
-			randomBatchSize := generateBatchSize()
-			fmt.Printf("coldata.BatchSize() is set to %d\n", randomBatchSize)
-			if err := coldata.SetBatchSizeForTests(randomBatchSize); err != nil {
-				colexecerror.InternalError(err)
-			}
-		}
+		//flag.Parse()
+		//if f := flag.Lookup("test.bench"); f == nil || f.Value.String() == "" {
+		//	// If we're running benchmarks, don't set a random batch size.
+		//	// Pick a random batch size in [minBatchSize, coldata.MaxBatchSize]
+		//	// range. The randomization can be disabled using COCKROACH_RANDOMIZE_BATCH_SIZE=false.
+		//	randomBatchSize := generateBatchSize()
+		//	fmt.Printf("coldata.BatchSize is set to %d\n", randomBatchSize)
+		//	if err := coldata.SetBatchSizeForTests(randomBatchSize); err != nil {
+		//		colexecerror.InternalError(err)
+		//	}
+		//}
 		return m.Run()
 	}())
 }
@@ -101,10 +98,10 @@ func generateBatchSize() int {
 			minBatchSize,
 			minBatchSize + 1,
 			minBatchSize + 2,
-			coldata.BatchSize(),
+			coldata.BatchSize,
 			minBatchSize + rng.Intn(coldata.MaxBatchSize-minBatchSize),
 		}
 		return sizesToChooseFrom[rng.Intn(len(sizesToChooseFrom))]
 	}
-	return coldata.BatchSize()
+	return coldata.BatchSize
 }

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -106,7 +106,7 @@ func BenchmarkMaterializer(b *testing.B) {
 
 	rng, _ := randutil.NewPseudoRand()
 	nBatches := 10
-	nRows := nBatches * coldata.BatchSize()
+	nRows := nBatches * coldata.BatchSize
 	for _, typ := range []*types.T{types.Int, types.Float, types.Bytes} {
 		typs := []*types.T{typ}
 		nCols := len(typs)
@@ -122,16 +122,16 @@ func BenchmarkMaterializer(b *testing.B) {
 						coldatatestutils.RandomVec(coldatatestutils.RandomVecArgs{
 							Rand:             rng,
 							Vec:              colVec,
-							N:                coldata.BatchSize(),
+							N:                coldata.BatchSize,
 							NullProbability:  nullProb,
 							BytesFixedLength: 8,
 						})
 					}
-					batch.SetLength(coldata.BatchSize())
+					batch.SetLength(coldata.BatchSize)
 					if useSelectionVector {
 						batch.SetSelection(true)
 						sel := batch.Selection()
-						for i := 0; i < coldata.BatchSize(); i++ {
+						for i := 0; i < coldata.BatchSize; i++ {
 							sel[i] = i
 						}
 					}

--- a/pkg/sql/colexec/mergejoiner.go
+++ b/pkg/sql/colexec/mergejoiner.go
@@ -527,7 +527,7 @@ func (o *mergeJoinBase) reset(ctx context.Context) {
 
 func (o *mergeJoinBase) InternalMemoryUsage() int {
 	const sizeOfGroup = int(unsafe.Sizeof(group{}))
-	return 8 * coldata.BatchSize() * sizeOfGroup // o.groups
+	return 8 * coldata.BatchSize * sizeOfGroup // o.groups
 }
 
 func (o *mergeJoinBase) Init() {
@@ -555,7 +555,7 @@ func (o *mergeJoinBase) Init() {
 	o.builderState.lGroups = make([]group, 1)
 	o.builderState.rGroups = make([]group, 1)
 
-	o.groups = makeGroupsBuffer(coldata.BatchSize())
+	o.groups = makeGroupsBuffer(coldata.BatchSize)
 	o.resetBuilderCrossProductState()
 }
 

--- a/pkg/sql/colexec/offset_test.go
+++ b/pkg/sql/colexec/offset_test.go
@@ -69,13 +69,13 @@ func BenchmarkOffset(b *testing.B) {
 	ctx := context.Background()
 	typs := []*types.T{types.Int, types.Int, types.Int}
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 	source := colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 	source.Init()
 
 	o := NewOffsetOp(source, 1)
 	// Set throughput proportional to size of the selection vector.
-	b.SetBytes(int64(2 * coldata.BatchSize()))
+	b.SetBytes(int64(2 * coldata.BatchSize))
 	for i := 0; i < b.N; i++ {
 		o.(*offsetOp).Reset()
 		o.Next(ctx)

--- a/pkg/sql/colexec/ordered_synchronizer_test.go
+++ b/pkg/sql/colexec/ordered_synchronizer_test.go
@@ -157,8 +157,8 @@ func TestOrderedSyncRandomInput(t *testing.T) {
 	numInputs := 3
 	inputLen := 1024
 	batchSize := 16
-	if batchSize > coldata.BatchSize() {
-		batchSize = coldata.BatchSize()
+	if batchSize > coldata.BatchSize {
+		batchSize = coldata.BatchSize
 	}
 	typs := []*types.T{types.Int}
 
@@ -204,9 +204,9 @@ func BenchmarkOrderedSynchronizer(b *testing.B) {
 	batches := make([]coldata.Batch, numInputs)
 	for i := range batches {
 		batches[i] = testAllocator.NewMemBatchWithMaxCapacity(typs)
-		batches[i].SetLength(coldata.BatchSize())
+		batches[i].SetLength(coldata.BatchSize)
 	}
-	for i := int64(0); i < int64(coldata.BatchSize())*numInputs; i++ {
+	for i := int64(0); i < int64(coldata.BatchSize)*numInputs; i++ {
 		batch := batches[i%numInputs]
 		batch.ColVec(0).Int64()[i/numInputs] = i
 	}
@@ -221,7 +221,7 @@ func BenchmarkOrderedSynchronizer(b *testing.B) {
 	require.NoError(b, err)
 	op.Init()
 
-	b.SetBytes(8 * int64(coldata.BatchSize()) * numInputs)
+	b.SetBytes(8 * int64(coldata.BatchSize) * numInputs)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		op.Next(ctx)

--- a/pkg/sql/colexec/ordinality_test.go
+++ b/pkg/sql/colexec/ordinality_test.go
@@ -88,13 +88,13 @@ func BenchmarkOrdinality(b *testing.B) {
 
 	typs := []*types.T{types.Int, types.Int, types.Int}
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 	source := colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 	ordinality, err := createTestOrdinalityOperator(ctx, flowCtx, source, []*types.T{types.Int, types.Int, types.Int})
 	require.NoError(b, err)
 	ordinality.Init()
 
-	b.SetBytes(int64(8 * coldata.BatchSize()))
+	b.SetBytes(int64(8 * coldata.BatchSize))
 	for i := 0; i < b.N; i++ {
 		ordinality.Next(ctx)
 	}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -53,7 +53,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 	for i := range inputs {
 		source := colexecbase.NewRepeatableBatchSource(
 			testAllocator,
-			coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), 0 /* length */, rng.Float64()),
+			coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize, 0 /* length */, rng.Float64()),
 			typs,
 		)
 		source.ResetBatchesToReturn(numBatches)
@@ -198,13 +198,13 @@ func BenchmarkParallelUnorderedSynchronizer(b *testing.B) {
 	inputs := make([]SynchronizerInput, numInputs)
 	for i := range inputs {
 		batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
-		batch.SetLength(coldata.BatchSize())
+		batch.SetLength(coldata.BatchSize)
 		inputs[i].Op = colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 	}
 	var wg sync.WaitGroup
 	ctx, cancelFn := context.WithCancel(context.Background())
 	s := NewParallelUnorderedSynchronizer(inputs, &wg)
-	b.SetBytes(8 * int64(coldata.BatchSize()))
+	b.SetBytes(8 * int64(coldata.BatchSize))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		s.Next(ctx)

--- a/pkg/sql/colexec/partially_ordered_distinct.go
+++ b/pkg/sql/colexec/partially_ordered_distinct.go
@@ -117,7 +117,7 @@ func newChunkerOperator(
 	return &chunkerOperator{
 		input:         input,
 		inputTypes:    inputTypes,
-		windowedBatch: allocator.NewMemBatchNoCols(inputTypes, coldata.BatchSize()),
+		windowedBatch: allocator.NewMemBatchNoCols(inputTypes, coldata.BatchSize),
 	}
 }
 
@@ -193,8 +193,8 @@ func (c *chunkerOperator) Next(ctx context.Context) coldata.Batch {
 		// When newChunksCol is nil, then all tuples that are returned via
 		// getValues are equal on the ordered columns, so we simply emit the next
 		// "window" of those tuples.
-		if outputTupleEndIdx-c.outputTupleStartIdx > coldata.BatchSize() {
-			outputTupleEndIdx = c.outputTupleStartIdx + coldata.BatchSize()
+		if outputTupleEndIdx-c.outputTupleStartIdx > coldata.BatchSize {
+			outputTupleEndIdx = c.outputTupleStartIdx + coldata.BatchSize
 		}
 	} else {
 		// newChunksCol is non-nil, so there are multiple chunks within the

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -312,7 +312,7 @@ func benchmarkProjOp(
 		coldatatestutils.RandomVec(coldatatestutils.RandomVecArgs{
 			Rand:            rng,
 			Vec:             colVec,
-			N:               coldata.BatchSize(),
+			N:               coldata.BatchSize,
 			NullProbability: nullProb,
 			// We will limit the range of integers so that we won't get "out of
 			// range" errors.
@@ -321,11 +321,11 @@ func benchmarkProjOp(
 			ZeroProhibited: true,
 		})
 	}
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 	if useSelectionVector {
 		batch.SetSelection(true)
 		sel := batch.Selection()
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			sel[i] = i
 		}
 	}
@@ -335,7 +335,7 @@ func benchmarkProjOp(
 	op.Init()
 
 	b.Run(name, func(b *testing.B) {
-		b.SetBytes(int64(len(inputTypes) * 8 * coldata.BatchSize()))
+		b.SetBytes(int64(len(inputTypes) * 8 * coldata.BatchSize))
 		for i := 0; i < b.N; i++ {
 			op.Next(ctx)
 		}

--- a/pkg/sql/colexec/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/relative_rank_tmpl.go
@@ -144,16 +144,16 @@ func _COMPUTE_PARTITIONS_SIZES() { // */}}
 			// TODO(yuzefovich): do not instantiate a new batch here once
 			// spillingQueues actually copy the batches when those are kept
 			// in-memory.
-			r.partitionsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
+			r.partitionsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize)
 			runningPartitionsSizesCol = r.partitionsState.runningSizes.ColVec(0).Int64()
 		}
 		if r.numTuplesInPartition > 0 {
 			runningPartitionsSizesCol[r.partitionsState.idx] = r.numTuplesInPartition
 			r.numTuplesInPartition = 0
 			r.partitionsState.idx++
-			if r.partitionsState.idx == coldata.BatchSize() {
+			if r.partitionsState.idx == coldata.BatchSize {
 				// We need to flush the vector of partitions sizes.
-				r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
+				r.partitionsState.runningSizes.SetLength(coldata.BatchSize)
 				if err := r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes); err != nil {
 					colexecerror.InternalError(err)
 				}
@@ -182,16 +182,16 @@ func _COMPUTE_PEER_GROUPS_SIZES() { // */}}
 			// TODO(yuzefovich): do not instantiate a new batch here once
 			// spillingQueues actually copy the batches when those are kept
 			// in-memory.
-			r.peerGroupsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
+			r.peerGroupsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize)
 			runningPeerGroupsSizesCol = r.peerGroupsState.runningSizes.ColVec(0).Int64()
 		}
 		if r.numPeers > 0 {
 			runningPeerGroupsSizesCol[r.peerGroupsState.idx] = r.numPeers
 			r.numPeers = 0
 			r.peerGroupsState.idx++
-			if r.peerGroupsState.idx == coldata.BatchSize() {
+			if r.peerGroupsState.idx == coldata.BatchSize {
 				// We need to flush the vector of peer group sizes.
-				r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
+				r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize)
 				if err := r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes); err != nil {
 					colexecerror.InternalError(err)
 				}
@@ -222,7 +222,7 @@ type relativeRankSizesState struct {
 	*spillingQueue
 
 	// runningSizes is a batch consisting of a single int64 vector that stores
-	// sizes while we're computing them. Once all coldata.BatchSize() slots are
+	// sizes while we're computing them. Once all coldata.BatchSize slots are
 	// filled, it will be flushed to the spillingQueue.
 	runningSizes coldata.Batch
 	// dequeuedSizes is a batch of already computed sizes that is dequeued
@@ -300,7 +300,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Init() {
 		int64(float64(r.memoryLimit)*(1.0-usedMemoryLimitFraction)),
 		r.diskQueueCfg, r.fdSemaphore, r.diskAcc,
 	)
-	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())
+	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize)
 	// {{if .IsPercentRank}}
 	// All rank functions start counting from 1. Before we assign the rank to a
 	// tuple in the batch, we first increment r.rank, so setting this
@@ -324,7 +324,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			// partitions. These sizes are stored in r.partitionsState.runningSizes
 			// batch (that consists of a single vector) and r.partitionsState.idx
 			// points at the next slot in that vector to write to. Once it
-			// reaches coldata.BatchSize(), the batch is "flushed" to the
+			// reaches coldata.BatchSize, the batch is "flushed" to the
 			// corresponding spillingQueue. The "running" value of the current
 			// partition size is stored in r.numTuplesInPartition.
 			//
@@ -332,7 +332,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			// of peer groups. These sizes are stored in r.peerGroupsState.runningSizes
 			// batch (that consists of a single vector) and r.peerGroupsState.idx
 			// points at the next slot in that vector to write to. Once it
-			// reaches coldata.BatchSize(), the batch is "flushed" to the
+			// reaches coldata.BatchSize, the batch is "flushed" to the
 			// corresponding spillingQueue. The "running" value of the current
 			// peer group size is stored in r.numPeers.
 			//
@@ -358,7 +358,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 					// TODO(yuzefovich): do not instantiate a new batch here once
 					// spillingQueues actually copy the batches when those are kept
 					// in-memory.
-					r.partitionsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
+					r.partitionsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize)
 				}
 				runningPartitionsSizesCol := r.partitionsState.runningSizes.ColVec(0).Int64()
 				runningPartitionsSizesCol[r.partitionsState.idx] = r.numTuplesInPartition
@@ -378,7 +378,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 					// TODO(yuzefovich): do not instantiate a new batch here once
 					// spillingQueues actually copy the batches when those are kept
 					// in-memory.
-					r.peerGroupsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
+					r.peerGroupsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize)
 				}
 				runningPeerGroupsSizesCol := r.peerGroupsState.runningSizes.ColVec(0).Int64()
 				runningPeerGroupsSizesCol[r.peerGroupsState.idx] = r.numPeers

--- a/pkg/sql/colexec/routers.go
+++ b/pkg/sql/colexec/routers.go
@@ -57,10 +57,10 @@ type routerOutput interface {
 // getDefaultRouterOutputBlockedThreshold returns the number of unread values
 // buffered by the routerOutputOp after which the output is considered blocked.
 // It is a function rather than a variable so that in tests we could modify
-// coldata.BatchSize() (if it were a variable, then its value would be
+// coldata.BatchSize (if it were a variable, then its value would be
 // evaluated before we set the desired batch size).
 func getDefaultRouterOutputBlockedThreshold() int {
-	return coldata.BatchSize() * 2
+	return coldata.BatchSize * 2
 }
 
 type routerOutputOpState int
@@ -412,7 +412,7 @@ func (o *routerOutputOp) addBatch(ctx context.Context, batch coldata.Batch, sele
 
 	for toAppend := len(selection); toAppend > 0; {
 		if o.mu.pendingBatch == nil {
-			o.mu.pendingBatch = o.mu.unlimitedAllocator.NewMemBatchWithFixedCapacity(o.types, coldata.BatchSize())
+			o.mu.pendingBatch = o.mu.unlimitedAllocator.NewMemBatchWithFixedCapacity(o.types, coldata.BatchSize)
 		}
 		available := o.mu.pendingBatch.Capacity() - o.mu.pendingBatch.Length()
 		numAppended := toAppend

--- a/pkg/sql/colexec/select_in_test.go
+++ b/pkg/sql/colexec/select_in_test.go
@@ -103,8 +103,8 @@ func benchmarkSelectInInt64(b *testing.B, useSelectionVector bool, hasNulls bool
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
 	col1 := batch.ColVec(0).Int64()
 
-	for i := 0; i < coldata.BatchSize(); i++ {
-		if float64(i) < float64(coldata.BatchSize())*selectivity {
+	for i := 0; i < coldata.BatchSize; i++ {
+		if float64(i) < float64(coldata.BatchSize)*selectivity {
 			col1[i] = int64(i % 10)
 		} else {
 			col1[i] = -1
@@ -112,19 +112,19 @@ func benchmarkSelectInInt64(b *testing.B, useSelectionVector bool, hasNulls bool
 	}
 
 	if hasNulls {
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			if rand.Float64() < nullProbability {
 				batch.ColVec(0).Nulls().SetNull(i)
 			}
 		}
 	}
 
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 
 	if useSelectionVector {
 		batch.SetSelection(true)
 		sel := batch.Selection()
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			sel[i] = i
 		}
 	}
@@ -138,7 +138,7 @@ func benchmarkSelectInInt64(b *testing.B, useSelectionVector bool, hasNulls bool
 	}
 	inOp.Init()
 
-	b.SetBytes(int64(8 * coldata.BatchSize()))
+	b.SetBytes(int64(8 * coldata.BatchSize))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		inOp.Next(ctx)

--- a/pkg/sql/colexec/selection_ops_test.go
+++ b/pkg/sql/colexec/selection_ops_test.go
@@ -160,25 +160,25 @@ func benchmarkSelLTInt64Int64ConstOp(b *testing.B, useSelectionVector bool, hasN
 	typs := []*types.T{types.Int}
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
 	col := batch.ColVec(0).Int64()
-	for i := 0; i < coldata.BatchSize(); i++ {
-		if float64(i) < float64(coldata.BatchSize())*selectivity {
+	for i := 0; i < coldata.BatchSize; i++ {
+		if float64(i) < float64(coldata.BatchSize)*selectivity {
 			col[i] = -1
 		} else {
 			col[i] = 1
 		}
 	}
 	if hasNulls {
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			if rand.Float64() < nullProbability {
 				batch.ColVec(0).Nulls().SetNull(i)
 			}
 		}
 	}
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 	if useSelectionVector {
 		batch.SetSelection(true)
 		sel := batch.Selection()
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			sel[i] = i
 		}
 	}
@@ -194,7 +194,7 @@ func benchmarkSelLTInt64Int64ConstOp(b *testing.B, useSelectionVector bool, hasN
 	}
 	plusOp.Init()
 
-	b.SetBytes(int64(8 * coldata.BatchSize()))
+	b.SetBytes(int64(8 * coldata.BatchSize))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		plusOp.Next(ctx)
@@ -218,15 +218,15 @@ func benchmarkSelLTInt64Int64Op(b *testing.B, useSelectionVector bool, hasNulls 
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
 	col1 := batch.ColVec(0).Int64()
 	col2 := batch.ColVec(1).Int64()
-	for i := 0; i < coldata.BatchSize(); i++ {
-		if float64(i) < float64(coldata.BatchSize())*selectivity {
+	for i := 0; i < coldata.BatchSize; i++ {
+		if float64(i) < float64(coldata.BatchSize)*selectivity {
 			col1[i], col2[i] = -1, 1
 		} else {
 			col1[i], col2[i] = 1, -1
 		}
 	}
 	if hasNulls {
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			if rand.Float64() < nullProbability {
 				batch.ColVec(0).Nulls().SetNull(i)
 			}
@@ -235,11 +235,11 @@ func benchmarkSelLTInt64Int64Op(b *testing.B, useSelectionVector bool, hasNulls 
 			}
 		}
 	}
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 	if useSelectionVector {
 		batch.SetSelection(true)
 		sel := batch.Selection()
-		for i := 0; i < coldata.BatchSize(); i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			sel[i] = i
 		}
 	}
@@ -255,7 +255,7 @@ func benchmarkSelLTInt64Int64Op(b *testing.B, useSelectionVector bool, hasNulls 
 	}
 	plusOp.Init()
 
-	b.SetBytes(int64(8 * coldata.BatchSize() * 2))
+	b.SetBytes(int64(8 * coldata.BatchSize * 2))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		plusOp.Next(ctx)

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -38,7 +38,7 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 	typs := []*types.T{types.Int}
 	inputs := make([]SynchronizerInput, numInputs)
 	for i := range inputs {
-		batch := coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), 0 /* length */, rng.Float64())
+		batch := coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize, 0 /* length */, rng.Float64())
 		source := colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 		source.ResetBatchesToReturn(numBatches)
 		inputIdx := i

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -269,8 +269,8 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 				p.state = sortDone
 				continue
 			}
-			if toEmit > coldata.BatchSize() {
-				toEmit = coldata.BatchSize()
+			if toEmit > coldata.BatchSize {
+				toEmit = coldata.BatchSize
 			}
 			p.output, _ = p.allocator.ResetMaybeReallocate(p.inputTypes, p.output, toEmit)
 			newEmitted := p.emitted + toEmit
@@ -427,7 +427,7 @@ func (p *sortOp) ExportBuffered(colexecbase.Operator) coldata.Batch {
 	if p.exported == p.input.getNumTuples() {
 		return coldata.ZeroBatch
 	}
-	newExported := p.exported + coldata.BatchSize()
+	newExported := p.exported + coldata.BatchSize
 	if newExported > p.input.getNumTuples() {
 		newExported = p.input.getNumTuples()
 	}

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -87,7 +87,7 @@ func (c *sortChunksOp) Init() {
 	// TODO(yuzefovich): switch to calling this method on allocator. This will
 	// require plumbing unlimited allocator to work correctly in tests with
 	// memory limit of 1.
-	c.windowedBatch = coldata.NewMemBatchNoCols(c.input.inputTypes, coldata.BatchSize())
+	c.windowedBatch = coldata.NewMemBatchNoCols(c.input.inputTypes, coldata.BatchSize)
 }
 
 func (c *sortChunksOp) Next(ctx context.Context) coldata.Batch {
@@ -115,7 +115,7 @@ func (c *sortChunksOp) ExportBuffered(colexecbase.Operator) coldata.Batch {
 	// whether we have exported them all.
 	if c.input.bufferedTuples.Length() > 0 {
 		if c.exportedFromBuffer < c.input.bufferedTuples.Length() {
-			newExportedFromBuffer := c.exportedFromBuffer + coldata.BatchSize()
+			newExportedFromBuffer := c.exportedFromBuffer + coldata.BatchSize
 			if newExportedFromBuffer > c.input.bufferedTuples.Length() {
 				newExportedFromBuffer = c.input.bufferedTuples.Length()
 			}
@@ -232,7 +232,7 @@ type chunker struct {
 	chunksStartIdx int
 
 	// bufferedTuples is a buffer to store tuples when a chunk is bigger than
-	// coldata.BatchSize() or when the chunk is the last in the last read batch
+	// coldata.BatchSize or when the chunk is the last in the last read batch
 	// (we don't know yet where the end of such chunk is).
 	bufferedTuples *appendOnlyBufferedBatch
 
@@ -279,7 +279,7 @@ func newChunker(
 func (s *chunker) init() {
 	s.input.Init()
 	s.bufferedTuples = newAppendOnlyBufferedBatch(s.allocator, s.inputTypes, nil /* colsToStore */)
-	s.partitionCol = make([]bool, coldata.BatchSize())
+	s.partitionCol = make([]bool, coldata.BatchSize)
 	s.chunks = make([]int, 0, 16)
 }
 

--- a/pkg/sql/colexec/sort_chunks_test.go
+++ b/pkg/sql/colexec/sort_chunks_test.go
@@ -257,17 +257,17 @@ func BenchmarkSortChunks(b *testing.B) {
 						}
 						b.Run(
 							fmt.Sprintf("%s/rows=%d/cols=%d/matchLen=%d/avgChunkSize=%d",
-								sorterNames[sorterIdx], nBatches*coldata.BatchSize(), nCols, matchLen, avgChunkSize),
+								sorterNames[sorterIdx], nBatches*coldata.BatchSize, nCols, matchLen, avgChunkSize),
 							func(b *testing.B) {
-								// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize() (rows /
+								// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize (rows /
 								// batch) * nCols (number of columns / row).
-								b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols))
+								b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols))
 								typs := make([]*types.T, nCols)
 								for i := range typs {
 									typs[i] = types.Int
 								}
 								batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
-								batch.SetLength(coldata.BatchSize())
+								batch.SetLength(coldata.BatchSize)
 								ordCols := make([]execinfrapb.Ordering_Column, nCols)
 								for i := range ordCols {
 									ordCols[i].ColIdx = uint32(i)
@@ -279,7 +279,7 @@ func BenchmarkSortChunks(b *testing.B) {
 
 									col := batch.ColVec(i).Int64()
 									col[0] = 0
-									for j := 1; j < coldata.BatchSize(); j++ {
+									for j := 1; j < coldata.BatchSize; j++ {
 										if i < matchLen {
 											col[j] = col[j-1]
 											if rng.Float64() < 1.0/float64(avgChunkSize) {

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -151,7 +151,7 @@ func TestSortRandomized(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	rng, _ := randutil.NewPseudoRand()
-	nTups := coldata.BatchSize()*2 + 1
+	nTups := coldata.BatchSize*2 + 1
 	maxCols := 3
 	// TODO(yuzefovich): randomize types as well.
 	typs := make([]*types.T, maxCols)
@@ -285,24 +285,24 @@ func BenchmarkSort(b *testing.B) {
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
 		for _, nCols := range []int{1, 2, 4} {
 			for _, topK := range []bool{false, true} {
-				name := fmt.Sprintf("rows=%d/cols=%d/topK=%t", nBatches*coldata.BatchSize(), nCols, topK)
+				name := fmt.Sprintf("rows=%d/cols=%d/topK=%t", nBatches*coldata.BatchSize, nCols, topK)
 				b.Run(name, func(b *testing.B) {
-					// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize() (rows /
+					// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize (rows /
 					// batch) * nCols (number of columns / row).
-					b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols))
+					b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols))
 					typs := make([]*types.T, nCols)
 					for i := range typs {
 						typs[i] = types.Int
 					}
 					batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
-					batch.SetLength(coldata.BatchSize())
+					batch.SetLength(coldata.BatchSize)
 					ordCols := make([]execinfrapb.Ordering_Column, nCols)
 					for i := range ordCols {
 						ordCols[i].ColIdx = uint32(i)
 						ordCols[i].Direction = execinfrapb.Ordering_Column_Direction(rng.Int() % 2)
 
 						col := batch.ColVec(i).Int64()
-						for j := 0; j < coldata.BatchSize(); j++ {
+						for j := 0; j < coldata.BatchSize; j++ {
 							col[j] = rng.Int63() % int64((i*1024)+1)
 						}
 					}
@@ -335,19 +335,19 @@ func BenchmarkAllSpooler(b *testing.B) {
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
 		for _, nCols := range []int{1, 2, 4} {
-			b.Run(fmt.Sprintf("rows=%d/cols=%d", nBatches*coldata.BatchSize(), nCols), func(b *testing.B) {
-				// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize() (rows /
+			b.Run(fmt.Sprintf("rows=%d/cols=%d", nBatches*coldata.BatchSize, nCols), func(b *testing.B) {
+				// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
 				// batch) * nCols (number of columns / row).
-				b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols))
+				b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols))
 				typs := make([]*types.T, nCols)
 				for i := range typs {
 					typs[i] = types.Int
 				}
 				batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
-				batch.SetLength(coldata.BatchSize())
+				batch.SetLength(coldata.BatchSize)
 				for i := 0; i < nCols; i++ {
 					col := batch.ColVec(i).Int64()
-					for j := 0; j < coldata.BatchSize(); j++ {
+					for j := 0; j < coldata.BatchSize; j++ {
 						col[j] = rng.Int63() % int64((i*1024)+1)
 					}
 				}

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -106,7 +106,7 @@ func (t *topKSorter) Init() {
 	// TODO(yuzefovich): switch to calling this method on allocator. This will
 	// require plumbing unlimited allocator to work correctly in tests with
 	// memory limit of 1.
-	t.windowedBatch = coldata.NewMemBatchNoCols(t.inputTypes, coldata.BatchSize())
+	t.windowedBatch = coldata.NewMemBatchNoCols(t.inputTypes, coldata.BatchSize)
 }
 
 func (t *topKSorter) Next(ctx context.Context) coldata.Batch {
@@ -213,8 +213,8 @@ func (t *topKSorter) emit() coldata.Batch {
 		// We're done.
 		return coldata.ZeroBatch
 	}
-	if toEmit > coldata.BatchSize() {
-		toEmit = coldata.BatchSize()
+	if toEmit > coldata.BatchSize {
+		toEmit = coldata.BatchSize
 	}
 	t.output, _ = t.allocator.ResetMaybeReallocate(t.inputTypes, t.output, toEmit)
 	for i := range t.inputTypes {
@@ -268,7 +268,7 @@ func (t *topKSorter) ExportBuffered(colexecbase.Operator) coldata.Batch {
 	topKLen := t.topK.Length()
 	// First, we check whether we have exported all tuples from the topK vector.
 	if t.exportedFromTopK < topKLen {
-		newExportedFromTopK := t.exportedFromTopK + coldata.BatchSize()
+		newExportedFromTopK := t.exportedFromTopK + coldata.BatchSize
 		if newExportedFromTopK > topKLen {
 			newExportedFromTopK = topKLen
 		}

--- a/pkg/sql/colexec/spilling_queue.go
+++ b/pkg/sql/colexec/spilling_queue.go
@@ -83,7 +83,7 @@ func newSpillingQueue(
 	if memoryLimit < 0 {
 		memoryLimit = 0
 	}
-	itemsLen := memoryLimit / int64(colmem.EstimateBatchSizeBytes(typs, coldata.BatchSize()))
+	itemsLen := memoryLimit / int64(colmem.EstimateBatchSizeBytes(typs, coldata.BatchSize))
 	if itemsLen == 0 {
 		// Make items at least of length 1. Even though batches will spill to disk
 		// directly (this can only happen with a very low memory limit), it's nice
@@ -98,7 +98,7 @@ func newSpillingQueue(
 		items:              make([]coldata.Batch, itemsLen),
 		diskQueueCfg:       cfg,
 		fdSemaphore:        fdSemaphore,
-		dequeueScratch:     unlimitedAllocator.NewMemBatchWithFixedCapacity(typs, coldata.BatchSize()),
+		dequeueScratch:     unlimitedAllocator.NewMemBatchWithFixedCapacity(typs, coldata.BatchSize),
 		diskAcc:            diskAcc,
 	}
 }

--- a/pkg/sql/colexec/spilling_queue_test.go
+++ b/pkg/sql/colexec/spilling_queue_test.go
@@ -62,7 +62,7 @@ func TestSpillingQueue(t *testing.T) {
 			batches := make([]coldata.Batch, 0, numBatches)
 			op := coldatatestutils.NewRandomDataOp(testAllocator, rng, coldatatestutils.RandomDataOpArgs{
 				NumBatches: cap(batches),
-				BatchSize:  1 + rng.Intn(coldata.BatchSize()),
+				BatchSize:  1 + rng.Intn(coldata.BatchSize),
 				Nulls:      true,
 				BatchAccumulator: func(b coldata.Batch, typs []*types.T) {
 					batches = append(batches, coldatatestutils.CopyBatch(b, typs, testColumnFactory))

--- a/pkg/sql/colexec/stats_test.go
+++ b/pkg/sql/colexec/stats_test.go
@@ -32,7 +32,7 @@ func TestNumBatches(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	nBatches := 10
-	noop := NewNoop(makeFiniteChunksSourceWithBatchSize(nBatches, coldata.BatchSize()))
+	noop := NewNoop(makeFiniteChunksSourceWithBatchSize(nBatches, coldata.BatchSize))
 	vsc := NewVectorizedStatsCollector(
 		noop, 0 /* id */, execinfrapb.ProcessorIDTagKey, true, /* ioTime */
 		timeutil.NewStopWatch(), nil /* memMonitors */, nil, /* diskMonitors */
@@ -84,7 +84,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 		timeSource := timeutil.NewTestTimeSource()
 		mjInputWatch := timeutil.NewTestStopWatch(timeSource.Now)
 		leftSource := &timeAdvancingOperator{
-			OneInputNode: NewOneInputNode(makeFiniteChunksSourceWithBatchSize(nBatches, coldata.BatchSize())),
+			OneInputNode: NewOneInputNode(makeFiniteChunksSourceWithBatchSize(nBatches, coldata.BatchSize)),
 			timeSource:   timeSource,
 		}
 		leftInput := NewVectorizedStatsCollector(
@@ -93,7 +93,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 			nil, /* inputStatsCollectors */
 		)
 		rightSource := &timeAdvancingOperator{
-			OneInputNode: NewOneInputNode(makeFiniteChunksSourceWithBatchSize(nBatches, coldata.BatchSize())),
+			OneInputNode: NewOneInputNode(makeFiniteChunksSourceWithBatchSize(nBatches, coldata.BatchSize)),
 			timeSource:   timeSource,
 		}
 		rightInput := NewVectorizedStatsCollector(
@@ -124,7 +124,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 		)
 
 		// The inputs are identical, so the merge joiner should output
-		// nBatches x coldata.BatchSize() tuples.
+		// nBatches x coldata.BatchSize tuples.
 		mjStatsCollector.Init()
 		batchCount, tupleCount := 0, 0
 		for {
@@ -137,7 +137,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 		}
 		mjStatsCollector.finalizeStats()
 
-		require.Equal(t, nBatches*coldata.BatchSize(), int(mjStatsCollector.NumTuples))
+		require.Equal(t, nBatches*coldata.BatchSize, int(mjStatsCollector.NumTuples))
 		// Two inputs are advancing the time source for a total of 2 * nBatches
 		// advances, but these do not count towards merge joiner execution time.
 		// Merge joiner advances the time on its every non-empty batch totaling

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -64,9 +64,9 @@ func TestSQLTypesIntegration(t *testing.T) {
 		for _, numRows := range []int{
 			// A few interesting sizes.
 			1,
-			coldata.BatchSize() - 1,
-			coldata.BatchSize(),
-			coldata.BatchSize() + 1,
+			coldata.BatchSize - 1,
+			coldata.BatchSize,
+			coldata.BatchSize + 1,
 		} {
 			rows := make(rowenc.EncDatumRows, numRows)
 			for i := 0; i < numRows; i++ {

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -91,7 +91,7 @@ func newPartitionerToOperator(
 	return &partitionerToOperator{
 		partitioner:  partitioner,
 		partitionIdx: partitionIdx,
-		batch:        allocator.NewMemBatchWithFixedCapacity(types, coldata.BatchSize()),
+		batch:        allocator.NewMemBatchWithFixedCapacity(types, coldata.BatchSize),
 	}
 }
 

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -487,14 +487,14 @@ func runTestsWithFn(
 	test func(t *testing.T, inputs []colexecbase.Operator),
 ) {
 	// Run tests over batchSizes of 1, (sometimes) a batch size that is small but
-	// greater than 1, and a full coldata.BatchSize().
+	// greater than 1, and a full coldata.BatchSize.
 	batchSizes := make([]int, 0, 3)
 	batchSizes = append(batchSizes, 1)
-	smallButGreaterThanOne := int(math.Trunc(.002 * float64(coldata.BatchSize())))
+	smallButGreaterThanOne := int(math.Trunc(.002 * float64(coldata.BatchSize)))
 	if smallButGreaterThanOne > 1 {
 		batchSizes = append(batchSizes, smallButGreaterThanOne)
 	}
-	batchSizes = append(batchSizes, coldata.BatchSize())
+	batchSizes = append(batchSizes, coldata.BatchSize)
 
 	for _, batchSize := range batchSizes {
 		for _, useSel := range []bool{false, true} {
@@ -699,7 +699,7 @@ func (s *opTestInput) Init() {
 	}
 	s.batch = testAllocator.NewMemBatchWithMaxCapacity(s.typs)
 
-	s.selection = make([]int, coldata.BatchSize())
+	s.selection = make([]int, coldata.BatchSize)
 	for i := range s.selection {
 		s.selection[i] = i
 	}
@@ -752,7 +752,7 @@ func (s *opTestInput) Next(context.Context) coldata.Batch {
 		// than the max batch size, so the test will panic if this part of the slice
 		// is accidentally accessed.
 		for i := range s.selection[batchSize:] {
-			s.selection[batchSize+i] = coldata.BatchSize() + 1
+			s.selection[batchSize+i] = coldata.BatchSize + 1
 		}
 
 		s.batch.SetSelection(true)
@@ -1294,8 +1294,8 @@ func TestRepeatableBatchSource(t *testing.T) {
 	typs := []*types.T{types.Int}
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
 	batchLen := 10
-	if coldata.BatchSize() < batchLen {
-		batchLen = coldata.BatchSize()
+	if coldata.BatchSize < batchLen {
+		batchLen = coldata.BatchSize
 	}
 	batch.SetLength(batchLen)
 	input := colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
@@ -1320,8 +1320,8 @@ func TestRepeatableBatchSourceWithFixedSel(t *testing.T) {
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
 	rng, _ := randutil.NewPseudoRand()
 	batchSize := 10
-	if batchSize > coldata.BatchSize() {
-		batchSize = coldata.BatchSize()
+	if batchSize > coldata.BatchSize {
+		batchSize = coldata.BatchSize
 	}
 	sel := coldatatestutils.RandomSel(rng, batchSize, 0 /* probOfOmitting */)
 	batchLen := len(sel)
@@ -1408,7 +1408,7 @@ func (c *chunkingBatchSource) Next(context.Context) coldata.Batch {
 	// explicitly set below. ResetInternalBatch cannot be used here because we're
 	// operating on Windows into the vectors.
 	c.batch.SetSelection(false)
-	lastIdx := c.curIdx + coldata.BatchSize()
+	lastIdx := c.curIdx + coldata.BatchSize
 	if lastIdx > c.len {
 		lastIdx = c.len
 	}

--- a/pkg/sql/colexec/vec_to_datum.eg.go
+++ b/pkg/sql/colexec/vec_to_datum.eg.go
@@ -116,9 +116,9 @@ func (c *vecToDatumConverter) convertVecs(vecs []coldata.Vec, inputLen int, sel 
 	requiredLength := inputLen
 	if sel != nil {
 		// When sel is non-nil, it might be something like sel = [1023], so we
-		// need to allocate up to the full coldata.BatchSize(), regardless of
+		// need to allocate up to the full coldata.BatchSize, regardless of
 		// the length of the batch.
-		requiredLength = coldata.BatchSize()
+		requiredLength = coldata.BatchSize
 	}
 	if cap(c.convertedVecs[c.vecIdxsToConvert[0]]) < requiredLength {
 		for _, vecIdx := range c.vecIdxsToConvert {

--- a/pkg/sql/colexec/vec_to_datum_tmpl.go
+++ b/pkg/sql/colexec/vec_to_datum_tmpl.go
@@ -119,9 +119,9 @@ func (c *vecToDatumConverter) convertVecs(vecs []coldata.Vec, inputLen int, sel 
 	requiredLength := inputLen
 	if sel != nil {
 		// When sel is non-nil, it might be something like sel = [1023], so we
-		// need to allocate up to the full coldata.BatchSize(), regardless of
+		// need to allocate up to the full coldata.BatchSize, regardless of
 		// the length of the batch.
-		requiredLength = coldata.BatchSize()
+		requiredLength = coldata.BatchSize
 	}
 	if cap(c.convertedVecs[c.vecIdxsToConvert[0]]) < requiredLength {
 		for _, vecIdx := range c.vecIdxsToConvert {

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -500,7 +500,7 @@ func (rf *cFetcher) Init(
 	rf.table = table
 	// Change the allocation size to be the same as the capacity of the batch
 	// we allocated above.
-	rf.table.da.AllocSize = coldata.BatchSize()
+	rf.table.da.AllocSize = coldata.BatchSize
 
 	return nil
 }
@@ -655,7 +655,7 @@ func (rf *cFetcher) nextAdapter() {
 }
 
 // nextBatch processes keys until we complete one batch of rows,
-// coldata.BatchSize() in length, which are returned in columnar format as a
+// coldata.BatchSize in length, which are returned in columnar format as a
 // coldata.Batch. The batch contains one Vec per table column, regardless of
 // the index used; columns that are not needed (as per neededCols) are empty.
 // The Batch should not be modified and is only valid until the next call.

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -561,7 +561,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 	typs := []*types.T{types.Int}
 
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
-	batch.SetLength(coldata.BatchSize())
+	batch.SetLength(coldata.BatchSize)
 
 	input := colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 
@@ -585,7 +585,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 
 	streamHandlerErrCh := handleStream(serverStream.Context(), inbox, serverStream, func() { close(serverStreamNotification.Donec) })
 
-	b.SetBytes(8 * int64(coldata.BatchSize()))
+	b.SetBytes(8 * int64(coldata.BatchSize))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		inbox.Next(ctx)

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -202,7 +202,7 @@ func TestInboxShutdown(t *testing.T) {
 		nextSleep          = time.Millisecond * time.Duration(rng.Intn(10))
 		runWithStreamSleep = time.Millisecond * time.Duration(rng.Intn(10))
 		typs               = []*types.T{types.Int}
-		batch              = coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), 0 /* length */, rng.Float64())
+		batch              = coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize, 0 /* length */, rng.Float64())
 	)
 
 	// drainMetaScenario specifies when DrainMeta should be called in the Next

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -183,17 +183,17 @@ func (f *vectorizedFlow) Setup(
 	}
 	helper := &vectorizedFlowCreatorHelper{f: f.FlowBase}
 
-	testingBatchSize := int64(0)
-	if f.FlowCtx.Cfg.Settings != nil {
-		testingBatchSize = VectorizeTestingBatchSize.Get(&f.FlowCtx.Cfg.Settings.SV)
-	}
-	if testingBatchSize != 0 {
-		if err := coldata.SetBatchSizeForTests(int(testingBatchSize)); err != nil {
-			return ctx, err
-		}
-	} else {
-		coldata.ResetBatchSizeForTests()
-	}
+	//testingBatchSize := int64(0)
+	//if f.FlowCtx.Cfg.Settings != nil {
+	//	testingBatchSize = VectorizeTestingBatchSize.Get(&f.FlowCtx.Cfg.Settings.SV)
+	//}
+	//if testingBatchSize != 0 {
+	//	if err := coldata.SetBatchSizeForTests(int(testingBatchSize)); err != nil {
+	//		return ctx, err
+	//	}
+	//} else {
+	//	coldata.ResetBatchSizeForTests()
+	//}
 
 	// Create a name for this flow's temporary directory. Note that this directory
 	// is lazily created when necessary and cleaned up in Cleanup(). The directory

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -298,7 +298,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 						defer sourceMemAccount.Close(ctxRemote)
 						remoteAllocator := colmem.NewAllocator(ctxRemote, &sourceMemAccount, testColumnFactory)
 						batch := remoteAllocator.NewMemBatchWithMaxCapacity(typs)
-						batch.SetLength(coldata.BatchSize())
+						batch.SetLength(coldata.BatchSize)
 						runOutboxInbox(
 							ctxRemote,
 							cancelRemote,

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -102,10 +102,10 @@ func (a *Allocator) NewMemBatchWithFixedCapacity(typs []*types.T, capacity int) 
 }
 
 // NewMemBatchWithMaxCapacity is a convenience shortcut of
-// NewMemBatchWithFixedCapacity with capacity=coldata.BatchSize() and should
+// NewMemBatchWithFixedCapacity with capacity=coldata.BatchSize and should
 // only be used in tests (this is enforced by a linter).
 func (a *Allocator) NewMemBatchWithMaxCapacity(typs []*types.T) coldata.Batch {
-	return a.NewMemBatchWithFixedCapacity(typs, coldata.BatchSize())
+	return a.NewMemBatchWithFixedCapacity(typs, coldata.BatchSize)
 }
 
 // NewMemBatchNoCols creates a "skeleton" of new in-memory coldata.Batch. It
@@ -123,32 +123,32 @@ func (a *Allocator) NewMemBatchNoCols(typs []*types.T, capacity int) coldata.Bat
 // state (meaning it is ready to be used) and to have the capacity of at least
 // minCapacity. The method will grow the allocated capacity of the batch
 // exponentially (possibly incurring a reallocation), until the batch reaches
-// coldata.BatchSize().
+// coldata.BatchSize.
 // NOTE: if the reallocation occurs, then the memory under the old batch is
 // released, so it is expected that the caller will lose the references to the
 // old batch.
 // Note: the method assumes that minCapacity is at least 1 and will "truncate"
-// minCapacity if it is larger than coldata.BatchSize().
+// minCapacity if it is larger than coldata.BatchSize.
 func (a *Allocator) ResetMaybeReallocate(
 	typs []*types.T, oldBatch coldata.Batch, minCapacity int,
 ) (newBatch coldata.Batch, reallocated bool) {
 	if minCapacity < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid minCapacity %d", minCapacity))
 	}
-	if minCapacity > coldata.BatchSize() {
-		minCapacity = coldata.BatchSize()
+	if minCapacity > coldata.BatchSize {
+		minCapacity = coldata.BatchSize
 	}
 	reallocated = true
 	if oldBatch == nil {
 		newBatch = a.NewMemBatchWithFixedCapacity(typs, minCapacity)
-	} else if oldBatch.Capacity() < coldata.BatchSize() {
+	} else if oldBatch.Capacity() < coldata.BatchSize {
 		a.ReleaseBatch(oldBatch)
 		newCapacity := oldBatch.Capacity() * 2
 		if newCapacity < minCapacity {
 			newCapacity = minCapacity
 		}
-		if newCapacity > coldata.BatchSize() {
-			newCapacity = coldata.BatchSize()
+		if newCapacity > coldata.BatchSize {
+			newCapacity = coldata.BatchSize
 		}
 		newBatch = a.NewMemBatchWithFixedCapacity(typs, newCapacity)
 	} else {
@@ -326,8 +326,8 @@ const (
 )
 
 // SizeOfBatchSizeSelVector is the size (in bytes) of a selection vector of
-// coldata.BatchSize() length.
-var SizeOfBatchSizeSelVector = coldata.BatchSize() * sizeOfInt
+// coldata.BatchSize length.
+var SizeOfBatchSizeSelVector = coldata.BatchSize * sizeOfInt
 
 // EstimateBatchSizeBytes returns an estimated amount of bytes needed to
 // store a batch in memory that has column types vecTypes.

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -413,7 +413,7 @@ func TestSorterAgainstProcessor(t *testing.T) {
 
 	rng, seed := randutil.NewPseudoRand()
 	nRuns := 5
-	nRows := 8 * coldata.BatchSize()
+	nRows := 8 * coldata.BatchSize
 	maxCols := 5
 	maxNum := 10
 	intTyps := make([]*types.T, maxCols)
@@ -487,7 +487,7 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 
 	rng, seed := randutil.NewPseudoRand()
 	nRuns := 5
-	nRows := 5 * coldata.BatchSize() / 4
+	nRows := 5 * coldata.BatchSize / 4
 	maxCols := 3
 	maxNum := 10
 	intTyps := make([]*types.T, maxCols)
@@ -1027,7 +1027,7 @@ func TestWindowFunctionsAgainstProcessor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	rng, seed := randutil.NewPseudoRand()
-	nRows := 2 * coldata.BatchSize()
+	nRows := 2 * coldata.BatchSize
 	maxCols := 4
 	maxNum := 10
 	typs := make([]*types.T, maxCols)

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -18,7 +18,6 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
@@ -74,12 +73,12 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 	if rng == nil {
 		rng, _ = randutil.NewPseudoRand()
 	}
-	if rng.Float64() < 0.5 {
-		randomBatchSize := 1 + rng.Intn(3)
-		if err := coldata.SetBatchSizeForTests(randomBatchSize); err != nil {
-			return err
-		}
-	}
+	//if rng.Float64() < 0.5 {
+	//	randomBatchSize := 1 + rng.Intn(3)
+	//	if err := coldata.SetBatchSizeForTests(randomBatchSize); err != nil {
+	//		return err
+	//	}
+	//}
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2798,7 +2798,7 @@ func RunLogicTestWithDefaultConfig(
 	// Determining whether or not to randomize vectorized batch size.
 	rng, _ := randutil.NewPseudoRand()
 	randVal := rng.Float64()
-	randomizedVectorizedBatchSize := coldata.BatchSize()
+	randomizedVectorizedBatchSize := coldata.BatchSize
 	if randVal < 0.25 {
 		randomizedVectorizedBatchSize = 1
 	} else if randVal < 0.375 {
@@ -2806,7 +2806,7 @@ func RunLogicTestWithDefaultConfig(
 	} else if randVal < 0.5 {
 		randomizedVectorizedBatchSize = 3
 	}
-	if randomizedVectorizedBatchSize != coldata.BatchSize() {
+	if randomizedVectorizedBatchSize != coldata.BatchSize {
 		t.Log(fmt.Sprintf("randomize batchSize to %d", randomizedVectorizedBatchSize))
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -971,7 +971,7 @@ NULL  1     1
 1     1     2
 
 # Regression test for #42816 - top K sort when K is greater than
-# coldata.BatchSize().
+# coldata.BatchSize.
 statement ok
 RESET vectorize;
 CREATE TABLE t_42816 (a int); INSERT INTO t_42816 SELECT * FROM generate_series(0, 1025);


### PR DESCRIPTION
We have a cluster setting `sql.testing.vectorize.batch_size` which
determines the size of `coldata.Batch`es that are used in the vectorized
engine. By default, this setting is unset, but it can be changed in
tests to exercise multiple-batches scenarios. Cluster settings are
propagated through gossip. Previously, it was possible to run into
a race between that propagation through gossip and executing actual
queries. Consider the following example: we have a 3 node cluster, node
1 is the gateway, and we set the batch size cluster setting to 1. Then,
we issue a query that touches all 3 nodes, but the remote nodes still
don't know that the batch size has been changed, so they emit batches of
the old batch size, yet the gateway is already operating with the new
batch size. This situation could result in an internal error in some
cases.

This is now fixed by serializing the batch size that the flow should run
with. Additionally, we now have `vectorize_batch_size` session variable
and the cluster setting has been renamed to
`sql.defaults.vectorize_batch_size`.

Fixes: #51156.

Release note: None