### PR TITLE
sql: disable table renames across schemas

### DIFF
--- a/pkg/cli/testdata/dump/reference_self
+++ b/pkg/cli/testdata/dump/reference_self
@@ -70,7 +70,7 @@ ALTER TABLE t VALIDATE CONSTRAINT fk_next_id_ref_t;
 
 sql
 ALTER TABLE d.t RENAME COLUMN next_id TO "'";
-ALTER TABLE d.t RENAME TO d."table";
+ALTER TABLE d.t RENAME TO "table";
 ----
 RENAME TABLE
 

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -12,6 +12,7 @@ package resolver
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -211,7 +212,7 @@ func ResolveTargetObject(
 		err = errors.WithHint(err, "verify that the current database and search_path are valid and/or the target database exists")
 		return nil, prefix, err
 	}
-	if prefix.Schema() != tree.PublicSchema {
+	if prefix.Schema() != tree.PublicSchema && !strings.HasPrefix(prefix.Schema(), sessiondata.PgTempSchemaName) {
 		return nil, prefix, pgerror.Newf(pgcode.InvalidName,
 			"schema cannot be modified: %q", tree.ErrString(&prefix))
 	}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -168,10 +168,11 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 		if err != nil {
 			return nil, err
 		}
-		fqTableName, err = n.p.getQualifiedTableName(ctx, &tableDesc.TableDescriptor)
+		fqName, err := n.p.getQualifiedTableName(ctx, &tableDesc.TableDescriptor)
 		if err != nil {
 			return nil, err
 		}
+		fqTableName = fqName.FQString()
 	}
 
 	if tableDesc.IsVirtualTable() {

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -248,12 +248,13 @@ func (p *planner) getViewDescForCascade(
 		viewName := viewDesc.Name
 		if viewDesc.ParentID != parentID {
 			var err error
-			viewName, err = p.getQualifiedTableName(ctx, viewDesc.TableDesc())
+			viewFQName, err := p.getQualifiedTableName(ctx, viewDesc.TableDesc())
 			if err != nil {
 				log.Warningf(ctx, "unable to retrieve qualified name of view %d: %v", viewID, err)
 				return nil, sqlbase.NewDependentObjectErrorf(
 					"cannot drop %s %q because a view depends on it", typeName, objName)
 			}
+			viewName = viewFQName.FQString()
 		}
 		return nil, errors.WithHintf(
 			sqlbase.NewDependentObjectErrorf("cannot drop %s %q because view %q depends on it",

--- a/pkg/sql/logictest/testdata/logic_test/notice
+++ b/pkg/sql/logictest/testdata/logic_test/notice
@@ -23,3 +23,13 @@ SELECT crdb_internal.notice('debug1', 'now you see this'), crdb_internal.notice(
 ----
 DEBUG1: now you see this
 WARNING: and you see this
+
+statement ok
+CREATE DATABASE d;
+CREATE TABLE d.t (x int)
+
+query T noticetrace
+ALTER TABLE d.t RENAME TO d.t2
+----
+NOTICE: renaming tables with a qualification is deprecated
+HINT: use ALTER TABLE d.t RENAME TO t2 instead

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -242,7 +242,7 @@ SELECT * FROM regression_47030
 ----
 2
 
-# renaming a temp table should not move it to the public schema.
+# Renaming a temp table should not move it to the public schema.
 subtest regression_48233
 
 statement ok
@@ -256,11 +256,11 @@ SELECT * FROM system.namespace WHERE name LIKE '%48233'
 ----
 50  65  reg_48233  79
 
-statement error cannot convert a temporary table to a persistent table during renames
+statement error pq: cannot change schema of table with RENAME
 ALTER TABLE reg_48233 RENAME TO public.reg_48233
 
 statement ok
 CREATE TABLE persistent_48233(a int)
 
-statement error schema cannot be modified: "pg_temp"
-ALTER TABLE reg_48233 RENAME TO pg_temp.pers_48233
+statement error pq: cannot change schema of table with RENAME
+ALTER TABLE persistent_48233 RENAME TO pg_temp.pers_48233

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -152,8 +152,7 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 				)
 				var dependentDescQualifiedString string
 				if dbDesc.GetID() != dependentDesc.ParentID || tbDesc.GetParentSchemaID() != dependentDesc.GetParentSchemaID() {
-					var err error
-					dependentDescQualifiedString, err = p.getQualifiedTableName(ctx, dependentDesc)
+					descFQName, err := p.getQualifiedTableName(ctx, dependentDesc)
 					if err != nil {
 						log.Warningf(
 							ctx,
@@ -166,6 +165,7 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 							"cannot rename database because a relation depends on relation %q",
 							tbTableName.String())
 					}
+					dependentDescQualifiedString = descFQName.FQString()
 				} else {
 					dependentDescTableName := tree.MakeTableNameWithSchema(
 						tree.Name(dbDesc.GetName()),

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -82,39 +83,54 @@ func (n *renameTableNode) ReadingOwnWrites() {}
 func (n *renameTableNode) startExec(params runParams) error {
 	p := params.p
 	ctx := params.ctx
-	oldTn := n.oldTn
-	newTn := n.newTn
 	tableDesc := n.tableDesc
+	oldTn := n.oldTn
+	prevDBID := tableDesc.ParentID
 
-	oldUn := oldTn.ToUnresolvedObjectName()
-	prevDbDesc, prefix, err := p.ResolveUncachedDatabase(ctx, oldUn)
-	if err != nil {
-		return err
-	}
-	oldTn.ObjectNamePrefix = prefix
+	var targetDbDesc *UncachedDatabaseDescriptor
+	// If the target new name has no qualifications, then assume that the table
+	// is intended to be renamed into the same database and schema.
+	newTn := n.newTn
+	if !newTn.ExplicitSchema && !newTn.ExplicitCatalog {
+		newTn.ObjectNamePrefix = oldTn.ObjectNamePrefix
+		var err error
+		targetDbDesc, err = p.ResolveUncachedDatabaseByName(ctx, string(oldTn.CatalogName), true /* required */)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Otherwise, resolve the new qualified name of the table. We are in the
+		// process of deprecating qualified rename targets, so issue a notice.
+		// TODO (rohany): Convert this to take in an unqualified name after 20.2
+		//  is released (#51445).
+		params.p.noticeSender.AppendNotice(
+			errors.WithHintf(
+				pgnotice.Newf("renaming tables with a qualification is deprecated"),
+				"use ALTER TABLE %s RENAME TO %s instead",
+				n.n.Name.String(),
+				newTn.Table(),
+			),
+		)
 
-	// Check if target database exists.
-	// We also look at uncached descriptors here.
-	newUn := newTn.ToUnresolvedObjectName()
-	targetDbDesc, prefix, err := p.ResolveUncachedDatabase(ctx, newUn)
-	if err != nil {
-		return err
+		newUn := newTn.ToUnresolvedObjectName()
+		var prefix tree.ObjectNamePrefix
+		var err error
+		targetDbDesc, prefix, err = p.ResolveUncachedDatabase(ctx, newUn)
+		if err != nil {
+			return err
+		}
+		newTn.ObjectNamePrefix = prefix
 	}
-	newTn.ObjectNamePrefix = prefix
 
 	if err := p.CheckPrivilege(ctx, targetDbDesc, privilege.CREATE); err != nil {
 		return err
 	}
 
-	isNewSchemaTemp, _, err := temporarySchemaSessionID(newTn.Schema())
-	if err != nil {
-		return err
-	}
-
-	if newTn.ExplicitSchema && !isNewSchemaTemp && tableDesc.Temporary {
-		return pgerror.New(
-			pgcode.FeatureNotSupported,
-			"cannot convert a temporary table to a persistent table during renames",
+	// Disable renaming objects between schemas of the same database.
+	if newTn.Catalog() == oldTn.Catalog() && newTn.Schema() != oldTn.Schema() {
+		return errors.WithHint(
+			pgerror.Newf(pgcode.InvalidName, "cannot change schema of table with RENAME"),
+			"use ALTER TABLE ... SET SCHEMA instead",
 		)
 	}
 
@@ -140,7 +156,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 	parentSchemaID := tableDesc.GetParentSchemaID()
 
 	renameDetails := sqlbase.NameInfo{
-		ParentID:       prevDbDesc.GetID(),
+		ParentID:       prevDBID,
 		ParentSchemaID: parentSchemaID,
 		Name:           oldTn.Table()}
 	tableDesc.DrainingNames = append(tableDesc.DrainingNames, renameDetails)
@@ -157,7 +173,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 	if p.extendedEvalCtx.Tracing.KVTracingEnabled() {
 		log.VEventf(ctx, 2, "CPut %s -> %d", newTbKey, descID)
 	}
-	err = catalogkv.WriteDescToBatch(ctx, p.extendedEvalCtx.Tracing.KVTracingEnabled(),
+	err := catalogkv.WriteDescToBatch(ctx, p.extendedEvalCtx.Tracing.KVTracingEnabled(),
 		p.EvalContext().Settings, b, p.ExecCfg().Codec, descID, tableDesc)
 	if err != nil {
 		return err
@@ -196,14 +212,14 @@ func (p *planner) dependentViewRenameError(
 	}
 	viewName := viewDesc.Name
 	if viewDesc.ParentID != parentID {
-		var err error
-		viewName, err = p.getQualifiedTableName(ctx, viewDesc)
+		viewFQName, err := p.getQualifiedTableName(ctx, viewDesc)
 		if err != nil {
 			log.Warningf(ctx, "unable to retrieve name of view %d: %v", viewID, err)
 			return sqlbase.NewDependentObjectErrorf(
 				"cannot rename %s %q because a view depends on it",
 				typeName, objName)
 		}
+		viewName = viewFQName.FQString()
 	}
 	return errors.WithHintf(
 		sqlbase.NewDependentObjectErrorf("cannot rename %s %q because view %q depends on it",

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -304,22 +304,22 @@ func getDescriptorsFromTargetList(
 // reverse of the Resolve() functions.
 func (p *planner) getQualifiedTableName(
 	ctx context.Context, desc *sqlbase.TableDescriptor,
-) (string, error) {
+) (*tree.TableName, error) {
 	dbDesc, err := sqlbase.GetDatabaseDescFromID(ctx, p.txn, p.ExecCfg().Codec, desc.ParentID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	schemaID := desc.GetParentSchemaID()
 	schemaName, err := resolver.ResolveSchemaNameByID(ctx, p.txn, p.ExecCfg().Codec, desc.ParentID, schemaID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	tbName := tree.MakeTableNameWithSchema(
 		tree.Name(dbDesc.GetName()),
 		tree.Name(schemaName),
 		tree.Name(desc.Name),
 	)
-	return tbName.String(), nil
+	return &tbName, nil
 }
 
 // findTableContainingIndex returns the descriptor of a table

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -300,7 +300,7 @@ func ResolveExisting(
 		if u.HasExplicitCatalog() {
 			// Already 3 parts: nothing to search. Delegate to the resolver.
 			namePrefix.CatalogName = Name(u.Catalog())
-			namePrefix.SchemaName = Name(u.Schema())
+			namePrefix.SchemaName = Name(scName)
 			found, result, err := r.LookupObject(ctx, lookupFlags, u.Catalog(), scName, u.Object())
 			return found, namePrefix, result, err
 		}
@@ -316,6 +316,7 @@ func ResolveExisting(
 		if found, objMeta, err := r.LookupObject(ctx, lookupFlags, curDb, scName, u.Object()); found || err != nil {
 			if err == nil {
 				namePrefix.CatalogName = Name(curDb)
+				namePrefix.SchemaName = Name(scName)
 			}
 			return found, namePrefix, objMeta, err
 		}
@@ -375,6 +376,8 @@ func ResolveTarget(
 		}
 		if u.HasExplicitCatalog() {
 			// Already 3 parts: nothing to do.
+			namePrefix.CatalogName = Name(u.Catalog())
+			namePrefix.SchemaName = Name(scName)
 			found, scMeta, err = r.LookupSchema(ctx, u.Catalog(), scName)
 			return found, namePrefix, scMeta, err
 		}
@@ -383,6 +386,7 @@ func ResolveTarget(
 		if found, scMeta, err = r.LookupSchema(ctx, curDb, scName); found || err != nil {
 			if err == nil {
 				namePrefix.CatalogName = Name(curDb)
+				namePrefix.SchemaName = Name(scName)
 			}
 			return found, namePrefix, scMeta, err
 		}
@@ -429,6 +433,7 @@ func (tp *ObjectNamePrefix) Resolve(
 		}
 		if tp.ExplicitCatalog {
 			// Catalog name is explicit; nothing to do.
+			tp.SchemaName = Name(scName)
 			return r.LookupSchema(ctx, tp.Catalog(), scName)
 		}
 		// Try with the current database. This may be empty, because
@@ -437,6 +442,7 @@ func (tp *ObjectNamePrefix) Resolve(
 		if found, scMeta, err = r.LookupSchema(ctx, curDb, scName); found || err != nil {
 			if err == nil {
 				tp.CatalogName = Name(curDb)
+				tp.SchemaName = Name(scName)
 			}
 			return found, scMeta, err
 		}

--- a/pkg/sql/sem/tree/name_resolution_test.go
+++ b/pkg/sql/sem/tree/name_resolution_test.go
@@ -725,7 +725,7 @@ func TestResolveTablePatternOrName(t *testing.T) {
 		// Names of length 2
 
 		{`public.foo`, `db3`, tpath("pg_temp_123", "public"), true, `public.foo`, `db3.public.foo`, `db3.public[0]`, ``},
-		{`pg_temp.foo`, `db3`, tpath("pg_temp_123", "public"), true, `pg_temp.foo`, `db3.pg_temp.foo`, `db3.pg_temp[0]`, ``},
+		{`pg_temp.foo`, `db3`, tpath("pg_temp_123", "public"), true, `pg_temp_123.foo`, `db3.pg_temp_123.foo`, `db3.pg_temp_123[0]`, ``},
 		{`pg_temp_123.foo`, `db3`, tpath("pg_temp_123", "public"), true, `pg_temp_123.foo`, `db3.pg_temp_123.foo`, `db3.pg_temp_123[0]`, ``},
 
 		// Wrongly qualifying a TT/PT as a PT/TT results in an error.
@@ -738,7 +738,7 @@ func TestResolveTablePatternOrName(t *testing.T) {
 
 		// Case where the temporary table being created has the same name as an
 		// existing persistent table.
-		{`pg_temp.bar`, `db3`, tpath("pg_temp_123", "public"), false, `pg_temp.bar`, `db3.pg_temp.bar`, `db3.pg_temp_123`, ``},
+		{`pg_temp.bar`, `db3`, tpath("pg_temp_123", "public"), false, `pg_temp_123.bar`, `db3.pg_temp_123.bar`, `db3.pg_temp_123`, ``},
 
 		// Case where the persistent table being created has the same name as an
 		// existing temporary table.
@@ -750,7 +750,7 @@ func TestResolveTablePatternOrName(t *testing.T) {
 		// Names of length 3
 
 		{`db3.public.foo`, `db3`, tpath("pg_temp_123", "public"), true, `db3.public.foo`, `db3.public.foo`, `db3.public[0]`, ``},
-		{`db3.pg_temp.foo`, `db3`, tpath("pg_temp_123", "public"), true, `db3.pg_temp.foo`, `db3.pg_temp.foo`, `db3.pg_temp[0]`, ``},
+		{`db3.pg_temp.foo`, `db3`, tpath("pg_temp_123", "public"), true, `db3.pg_temp_123.foo`, `db3.pg_temp_123.foo`, `db3.pg_temp_123[0]`, ``},
 		{`db3.pg_temp_123.foo`, `db3`, tpath("pg_temp_123", "public"), true, `db3.pg_temp_123.foo`, `db3.pg_temp_123.foo`, `db3.pg_temp_123[0]`, ``},
 
 		// Wrongly qualifying a TT/PT as a PT/TT results in an error.
@@ -763,7 +763,7 @@ func TestResolveTablePatternOrName(t *testing.T) {
 
 		// Case where the temporary table being created has the same name as an
 		// existing persistent table.
-		{`db3.pg_temp.bar`, `db3`, tpath("pg_temp_123", "public"), false, `db3.pg_temp.bar`, `db3.pg_temp.bar`, `db3.pg_temp_123`, ``},
+		{`db3.pg_temp.bar`, `db3`, tpath("pg_temp_123", "public"), false, `db3.pg_temp_123.bar`, `db3.pg_temp_123.bar`, `db3.pg_temp_123`, ``},
 
 		// Case where the persistent table being created has the same name as an
 		// existing temporary table.

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -101,7 +101,7 @@ func (t *truncateNode) startExec(params runParams) error {
 			if err != nil {
 				return err
 			}
-			toTruncate[other.ID] = otherName
+			toTruncate[other.ID] = otherName.FQString()
 			toTraverse = append(toTraverse, *other)
 			return nil
 		}


### PR DESCRIPTION
Fixes #50826.

As part of our goal to make `RENAME` no longer take qualified names,
this PR adjusts `RENAME` to disallow renames across schemas in
preparation for user defined schemas. Additionally, it adds a deprecated
notice for usage of qualified names in the `RENAME` command. Lastly, it
moves the behavior of `RENAME` with an unqualified name closer to
Postgres's behavior -- the unqualified name will be treated as in the
same schema and database as the input table.

Release note (sql change): Add a deprecated notice for use of `ALTER
TABLE .. RENAME` with a qualified name.

Release note (sql change): Disable using `ALTER TABLE .. RENAME` to
change the schema of a table.

Release note (sql change): Unqualified names in the target of
`ALTER TABLE ... RENAME` are treated as having the same database and
schema as the table being renamed.