### PR TITLE
cli: fix two issues with `cockroach dump` and comments

### DIFF
--- a/pkg/cli/testdata/dump/comments
+++ b/pkg/cli/testdata/dump/comments
@@ -1,0 +1,20 @@
+# Ensure quotes in comments are properly escaped.
+sql
+CREATE DATABASE d;
+CREATE TABLE d.t (x INT PRIMARY KEY);
+COMMENT ON TABLE d.t IS 'has '' quotes';
+COMMENT ON INDEX d.t@primary IS 'has '' more '' quotes';
+COMMENT ON COLUMN d.t.x IS 'i '' just '' love '' quotes';
+----
+COMMENT ON COLUMN
+
+dump d
+----
+CREATE TABLE t (
+	x INT8 NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (x ASC),
+	FAMILY "primary" (x)
+);
+COMMENT ON TABLE t IS e'has \' quotes';
+COMMENT ON COLUMN t.x IS e'i \' just \' love \' quotes';
+COMMENT ON INDEX t@primary IS e'has \' more \' quotes';

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -62,16 +62,16 @@ CREATE TABLE c (
 );
 COMMENT ON TABLE c IS 'table';
 COMMENT ON COLUMN c.a IS 'column';
-COMMENT ON INDEX c_a_b_idx IS 'index'  CREATE TABLE c (
-                                       a INT8 NOT NULL,
-                                       b INT8 NULL,
-                                       INDEX c_a_b_idx (a ASC, b ASC),
-                                       FAMILY fam_0_a_rowid (a, rowid),
-                                       FAMILY fam_1_b (b)
+COMMENT ON INDEX c@c_a_b_idx IS 'index'  CREATE TABLE c (
+                                         a INT8 NOT NULL,
+                                         b INT8 NULL,
+                                         INDEX c_a_b_idx (a ASC, b ASC),
+                                         FAMILY fam_0_a_rowid (a, rowid),
+                                         FAMILY fam_1_b (b)
 );
 COMMENT ON TABLE c IS 'table';
 COMMENT ON COLUMN c.a IS 'column';
-COMMENT ON INDEX c_a_b_idx IS 'index'  {}  {}
+COMMENT ON INDEX c@c_a_b_idx IS 'index'  {}  {}
 
 statement error invalid storage parameter "foo"
 CREATE TABLE a (b INT) WITH (foo=100);

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -19,7 +19,7 @@ COMMENT ON INDEX c_a_b_idx IS 'index'
 query TT colnames
 SHOW CREATE c
 ----
-table_name create_statement
+table_name  create_statement
 c           CREATE TABLE c (
             a INT8 NOT NULL,
             b INT8 NULL,
@@ -29,4 +29,4 @@ c           CREATE TABLE c (
 );
 COMMENT ON TABLE c IS 'table';
 COMMENT ON COLUMN c.a IS 'column';
-COMMENT ON INDEX c_a_b_idx IS 'index'
+COMMENT ON INDEX c@c_a_b_idx IS 'index'

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -108,7 +109,11 @@ func showComments(
 
 	if tc.comment != nil {
 		buf.WriteString(";\n")
-		buf.WriteString(fmt.Sprintf("COMMENT ON TABLE %s IS '%s'", table.Name, *tc.comment))
+		buf.WriteString(fmt.Sprintf(
+			"COMMENT ON TABLE %s IS %s",
+			table.Name,
+			lex.EscapeSQLString(*tc.comment),
+		))
 	}
 
 	for _, columnComment := range tc.columns {
@@ -118,7 +123,12 @@ func showComments(
 		}
 
 		buf.WriteString(";\n")
-		buf.WriteString(fmt.Sprintf("COMMENT ON COLUMN %s.%s IS '%s'", table.Name, col.Name, columnComment.comment))
+		buf.WriteString(fmt.Sprintf(
+			"COMMENT ON COLUMN %s.%s IS %s",
+			table.Name,
+			col.Name,
+			lex.EscapeSQLString(columnComment.comment),
+		))
 	}
 
 	for _, indexComment := range tc.indexes {
@@ -128,7 +138,12 @@ func showComments(
 		}
 
 		buf.WriteString(";\n")
-		buf.WriteString(fmt.Sprintf("COMMENT ON INDEX %s IS '%s'", idx.Name, indexComment.comment))
+		buf.WriteString(fmt.Sprintf(
+			"COMMENT ON INDEX %s@%s IS %s",
+			table.Name,
+			idx.Name,
+			lex.EscapeSQLString(indexComment.comment),
+		))
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #51115.

Release note (bug fix): Fix a bug where `cockroach dump` would not
properly escape quotes within table comments.

Release note (bug fix); Fix a bug where `cockroach dump` would not emit
a correct statement for comments on indexes.