### PR TITLE
release-20.1: cli: fix dump to gracefully handle temp tables, views and sequences

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
@@ -234,14 +235,16 @@ func getDumpMetadata(
 	return mds, clusterTS, nil
 }
 
-// getTableNames retrieves all tables names in the given database.
+// getTableNames retrieves all tables names in the given database. Following
+// pg_dump, we ignore all descriptors which are part of the temp schema. This
+// includes tables, views and sequences.
 func getTableNames(conn *sqlConn, dbName string, ts string) (tableNames []string, err error) {
 	rows, err := conn.Query(fmt.Sprintf(`
 		SELECT descriptor_name
 		FROM "".crdb_internal.create_statements
 		AS OF SYSTEM TIME %s
-		WHERE database_name = $1
-		`, lex.EscapeSQLString(ts)), []driver.Value{dbName})
+		WHERE database_name = $1 AND schema_name NOT LIKE $2
+		`, lex.EscapeSQLString(ts)), []driver.Value{dbName, sessiondata.PgTempSchemaName + "%"})
 	if err != nil {
 		return nil, err
 	}
@@ -275,6 +278,7 @@ func getBasicMetadata(conn *sqlConn, dbName, tableName string, ts string) (basic
 	dbNameEscaped := tree.NameString(dbName)
 	vals, err := conn.QueryRow(fmt.Sprintf(`
 		SELECT
+			schema_name,
 			descriptor_id,
 			create_nofks,
 			descriptor_type,
@@ -294,26 +298,41 @@ func getBasicMetadata(conn *sqlConn, dbName, tableName string, ts string) (basic
 		}
 		return basicMetadata{}, errors.Wrap(err, "getBasicMetadata")
 	}
-	idI := vals[0]
+
+	// Check the schema to disallow dumping temp tables, views and sequences. This
+	// will only be triggered if a user explicitly specifies a temp construct as
+	// one of the arguments to the `cockroach dump` command. When no table names
+	// are specified on the CLI, we ignore temp tables at the stage where we read
+	// all table names in getTableNames.
+	schemaNameI := vals[0]
+	schemaName, ok := schemaNameI.(string)
+	if !ok {
+		return basicMetadata{}, fmt.Errorf("unexpected value: %T", schemaNameI)
+	}
+	if strings.HasPrefix(schemaName, sessiondata.PgTempSchemaName) {
+		return basicMetadata{}, errors.Newf("cannot dump temp table %s", tableName)
+	}
+
+	idI := vals[1]
 	id, ok := idI.(int64)
 	if !ok {
 		return basicMetadata{}, fmt.Errorf("unexpected value: %T", idI)
 	}
-	createStatementI := vals[1]
+	createStatementI := vals[2]
 	createStatement, ok := createStatementI.(string)
 	if !ok {
 		return basicMetadata{}, fmt.Errorf("unexpected value: %T", createStatementI)
 	}
-	kindI := vals[2]
+	kindI := vals[3]
 	kind, ok := kindI.(string)
 	if !ok {
 		return basicMetadata{}, fmt.Errorf("unexpected value: %T", kindI)
 	}
-	alterStatements, err := extractArray(vals[3])
+	alterStatements, err := extractArray(vals[4])
 	if err != nil {
 		return basicMetadata{}, err
 	}
-	validateStatements, err := extractArray(vals[4])
+	validateStatements, err := extractArray(vals[5])
 	if err != nil {
 		return basicMetadata{}, err
 	}

--- a/pkg/cli/main_test.go
+++ b/pkg/cli/main_test.go
@@ -13,7 +13,6 @@ package cli_test
 import (
 	"os"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -30,10 +29,6 @@ func TestMain(m *testing.M) {
 	// CLI tests are sensitive to the server version, but test binaries don't have
 	// a version injected. Pretend to be a very up-to-date version.
 	defer build.TestingOverrideTag("v999.0.0")()
-
-	// The times for Example_statement_diag are reported in the local timezone.
-	// Fix it to UTC so the output is always the same.
-	time.Local = time.UTC
 
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	os.Exit(m.Run())

--- a/pkg/cli/statement_diag.go
+++ b/pkg/cli/statement_diag.go
@@ -77,7 +77,7 @@ func runStmtDiagList(cmd *cobra.Command, args []string) error {
 		id := vals[0].(int64)
 		stmt := vals[1].(string)
 		t := vals[2].(time.Time)
-		fmt.Fprintf(w, "  %d\t%s\t%s\n", id, t.Local().Format(timeFmt), stmt)
+		fmt.Fprintf(w, "  %d\t%s\t%s\n", id, t.UTC().Format(timeFmt), stmt)
 		num++
 	}
 	if err := rows.Close(); err != nil {
@@ -118,7 +118,7 @@ func runStmtDiagList(cmd *cobra.Command, args []string) error {
 		id := vals[0].(int64)
 		stmt := vals[1].(string)
 		t := vals[2].(time.Time)
-		fmt.Fprintf(w, "  %d\t%s\t%s\n", id, t.Local().Format(timeFmt), stmt)
+		fmt.Fprintf(w, "  %d\t%s\t%s\n", id, t.UTC().Format(timeFmt), stmt)
 		num++
 	}
 	if err := rows.Close(); err != nil {


### PR DESCRIPTION
Backport 1/2 commits from #51185.

/cc @cockroachdb/release

---

pg_dump ignores temporary tables, views and sequences.  This change
makes `cockroach dump` follow the same behavior by skipping descriptors
with schema name having `pg_temp` as its prefix, when aggregating the
metadata for the tables to be dumped.

When no table names are specified in the `cockroach dump` command, we
silently ignore all temp objects.  If the user explicitly asks for a
temp object to be dumped, we error out with an informative message.

Fixes:#50899
Fixes:#51166

Release note (bug fix): `cockroach dump` no longer errors out when
dumping temporary tables, view or sequences.  It either ignores them or
throws an informative error if the temp object is explicitly requested
to be dumped via the CLI.
