### PR TITLE
storage: optimize MVCCGarbageCollect for large number of undeleted version

### DIFF
--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -206,6 +206,11 @@ func (i *Iterator) Stats() storage.IteratorStats {
 	return i.i.Stats()
 }
 
+// SupportsPrev is part of the engine.Iterator interface.
+func (i *Iterator) SupportsPrev() bool {
+	return i.i.SupportsPrev()
+}
+
 // MVCCOpsSpecialized is part of the engine.MVCCIterator interface.
 func (i *Iterator) MVCCOpsSpecialized() bool {
 	if mvccIt, ok := i.i.(storage.MVCCIterator); ok {

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1009,12 +1009,10 @@ func runMVCCGarbageCollect(
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		batch := eng.NewWriteOnlyBatch()
-		distinct := batch.Distinct()
-		if err := MVCCGarbageCollect(ctx, distinct, nil /* ms */, gcKeys, now); err != nil {
+		batch := eng.NewBatch()
+		if err := MVCCGarbageCollect(ctx, batch, nil /* ms */, gcKeys, now); err != nil {
 			b.Fatal(err)
 		}
-		distinct.Close()
 		batch.Close()
 	}
 }

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -122,6 +122,9 @@ type Iterator interface {
 	SetUpperBound(roachpb.Key)
 	// Stats returns statistics about the iterator.
 	Stats() IteratorStats
+	// SupportsPrev returns true if Iterator implementation supports reverse
+	// iteration with Prev() or SeekLT().
+	SupportsPrev() bool
 }
 
 // MVCCIterator is an interface that extends Iterator and provides concrete

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -427,6 +427,11 @@ func (p *pebbleIterator) Stats() IteratorStats {
 	}
 }
 
+// SupportsPrev implements the Iterator interface.
+func (p *pebbleIterator) SupportsPrev() bool {
+	return true
+}
+
 // CheckForKeyCollisions indicates if the provided SST data collides with this
 // iterator in the specified range.
 func (p *pebbleIterator) CheckForKeyCollisions(

--- a/pkg/storage/rocksdb.go
+++ b/pkg/storage/rocksdb.go
@@ -1232,6 +1232,10 @@ type batchIterator struct {
 	batch *rocksDBBatch
 }
 
+func (r *batchIterator) SupportsPrev() bool {
+	return false
+}
+
 func (r *batchIterator) Stats() IteratorStats {
 	return r.iter.Stats()
 }
@@ -1958,6 +1962,10 @@ func (r *rocksDBIterator) destroy() {
 }
 
 // The following methods implement the Iterator interface.
+
+func (r *rocksDBIterator) SupportsPrev() bool {
+	return true
+}
 
 func (r *rocksDBIterator) Stats() IteratorStats {
 	stats := C.DBIterStats(r.iter)

--- a/pkg/storage/tee.go
+++ b/pkg/storage/tee.go
@@ -1239,6 +1239,11 @@ func (t *TeeEngineIter) Stats() IteratorStats {
 	return t.iter1.Stats()
 }
 
+// SupportsPrev implements the Iterator interface.
+func (t *TeeEngineIter) SupportsPrev() bool {
+	return t.iter1.SupportsPrev() && t.iter2.SupportsPrev()
+}
+
 // MVCCOpsSpecialized implements the MVCCIterator interface.
 func (t *TeeEngineIter) MVCCOpsSpecialized() bool {
 	return true


### PR DESCRIPTION
This is a better-tested take-2 of #51184.

* The first commit introduces a `SupportsPrev` method to the `Iterator` interface.
* The second commit adjusts the benchmark to use a regular batch.
* The third commit adjusts the logic in #51184 to fix the bugs there and adds testing.

The win is now only pronounced on pebble, as might be expected. 