### PR TITLE
sql: remove ccl-only from grant/revoke role help message

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3325,7 +3325,7 @@ deallocate_stmt:
 // %Text:
 // Grant privileges:
 //   GRANT {ALL | <privileges...> } ON <targets...> TO <grantees...>
-// Grant role membership (CCL only):
+// Grant role membership:
 //   GRANT <roles...> TO <grantees...> [WITH ADMIN OPTION]
 //
 // Privileges:
@@ -3356,7 +3356,7 @@ grant_stmt:
 // %Text:
 // Revoke privileges:
 //   REVOKE {ALL | <privileges...> } ON <targets...> FROM <grantees...>
-// Revoke role membership (CCL only):
+// Revoke role membership:
 //   REVOKE [ADMIN OPTION FOR] <roles...> FROM <grantees...>
 //
 // Privileges:

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -165,9 +165,6 @@ type CCLOnlyStatement interface {
 var _ CCLOnlyStatement = &Backup{}
 var _ CCLOnlyStatement = &ShowBackup{}
 var _ CCLOnlyStatement = &Restore{}
-var _ CCLOnlyStatement = &CreateRole{}
-var _ CCLOnlyStatement = &GrantRole{}
-var _ CCLOnlyStatement = &RevokeRole{}
 var _ CCLOnlyStatement = &CreateChangefeed{}
 var _ CCLOnlyStatement = &Import{}
 var _ CCLOnlyStatement = &Export{}
@@ -370,8 +367,6 @@ func (*CreateRole) StatementType() StatementType { return Ack }
 // StatementTag returns a short string identifying the type of statement.
 func (*CreateRole) StatementTag() string { return "CREATE ROLE" }
 
-func (*CreateRole) cclOnlyStatement() {}
-
 func (*CreateRole) hiddenFromShowQueries() {}
 
 // StatementType implements the Statement interface.
@@ -500,8 +495,6 @@ func (*GrantRole) StatementType() StatementType { return DDL }
 // StatementTag returns a short string identifying the type of statement.
 func (*GrantRole) StatementTag() string { return "GRANT" }
 
-func (*GrantRole) cclOnlyStatement() {}
-
 // StatementType implements the Statement interface.
 func (n *Insert) StatementType() StatementType { return n.Returning.statementType() }
 
@@ -597,8 +590,6 @@ func (*RevokeRole) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*RevokeRole) StatementTag() string { return "REVOKE" }
-
-func (*RevokeRole) cclOnlyStatement() {}
 
 // StatementType implements the Statement interface.
 func (*RollbackToSavepoint) StatementType() StatementType { return Ack }


### PR DESCRIPTION
sql: remove ccl-only from grant/revoke role help message

Release note (sql change): Minor change to remove outdated
CCL-only message from GRANT and REVOKE ROLE's help message.