### PR TITLE
sql: move interleaved join planning in the optimizer

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -156,23 +156,11 @@ func (e *distSQLSpecExecFactory) ConstructValues(
 // performs scanNode creation of execFactory.ConstructScan and physical
 // planning of table readers of DistSQLPlanner.createTableReaders.
 func (e *distSQLSpecExecFactory) ConstructScan(
-	table cat.Table,
-	index cat.Index,
-	needed exec.TableColumnOrdinalSet,
-	indexConstraint *constraint.Constraint,
-	invertedConstraint invertedexpr.InvertedSpans,
-	hardLimit int64,
-	softLimit int64,
-	reverse bool,
-	parallelize bool,
-	reqOrdering exec.OutputOrdering,
-	rowCount float64,
-	locking *tree.LockingItem,
+	table cat.Table, index cat.Index, params exec.ScanParams, reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
 		return constructVirtualScan(
-			e, e.planner, table, index, needed, indexConstraint, hardLimit,
-			softLimit, reverse, reqOrdering, rowCount, locking,
+			e, e.planner, table, index, params, reqOrdering,
 			func(d *delayedNode) (exec.Node, error) {
 				physPlan, err := e.dsp.wrapPlan(e.getPlanCtx(cannotDistribute), d)
 				if err != nil {
@@ -200,7 +188,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	// below. This phase is equivalent to what execFactory.ConstructScan does.
 	tabDesc := table.(*optTable).desc
 	indexDesc := index.(*optIndex).desc
-	colCfg := makeScanColumnsConfig(table, needed)
+	colCfg := makeScanColumnsConfig(table, params.NeededCols)
 	sb := span.MakeBuilder(e.planner.ExecCfg().Codec, tabDesc.TableDesc(), indexDesc)
 
 	// Note that initColsForScan and setting ResultColumns below are equivalent
@@ -211,7 +199,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	}
 	p.ResultColumns = sqlbase.ResultColumnsFromColDescPtrs(tabDesc.GetID(), cols)
 
-	if indexConstraint != nil && indexConstraint.IsContradiction() {
+	if params.IndexConstraint != nil && params.IndexConstraint.IsContradiction() {
 		// Note that empty rows argument is handled by ConstructValues first -
 		// it will always create an appropriate values processor spec, so there
 		// will be no planNodes created (which is what we want in this case).
@@ -219,10 +207,10 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	}
 
 	var spans roachpb.Spans
-	if invertedConstraint != nil {
-		spans, err = GenerateInvertedSpans(invertedConstraint, sb)
+	if params.InvertedConstraint != nil {
+		spans, err = GenerateInvertedSpans(params.InvertedConstraint, sb)
 	} else {
-		spans, err = sb.SpansFromConstraint(indexConstraint, needed, false /* forDelete */)
+		spans, err = sb.SpansFromConstraint(params.IndexConstraint, params.NeededCols, false /* forDelete */)
 	}
 	if err != nil {
 		return nil, err
@@ -246,7 +234,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	trSpec := physicalplan.NewTableReaderSpec()
 	*trSpec = execinfrapb.TableReaderSpec{
 		Table:      *tabDesc.TableDesc(),
-		Reverse:    reverse,
+		Reverse:    params.Reverse,
 		IsCheck:    false,
 		Visibility: colCfg.visibility,
 		// Retain the capacity of the spans slice.
@@ -256,9 +244,9 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	if err != nil {
 		return nil, err
 	}
-	if locking != nil {
-		trSpec.LockingStrength = sqlbase.ToScanLockingStrength(locking.Strength)
-		trSpec.LockingWaitPolicy = sqlbase.ToScanLockingWaitPolicy(locking.WaitPolicy)
+	if params.Locking != nil {
+		trSpec.LockingStrength = sqlbase.ToScanLockingStrength(params.Locking.Strength)
+		trSpec.LockingWaitPolicy = sqlbase.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
 		if trSpec.LockingStrength != sqlbase.ScanLockingStrength_FOR_NONE {
 			// Scans that are performing row-level locking cannot currently be
 			// distributed because their locks would not be propagated back to
@@ -272,10 +260,10 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	// don't know yet whether we will have it. ConstructFilter is responsible
 	// for pushing the filter down into the post-processing stage of this scan.
 	post := execinfrapb.PostProcessSpec{}
-	if hardLimit != 0 {
-		post.Limit = uint64(hardLimit)
-	} else if softLimit != 0 {
-		trSpec.LimitHint = softLimit
+	if params.HardLimit != 0 {
+		post.Limit = uint64(params.HardLimit)
+	} else if params.SoftLimit != 0 {
+		trSpec.LimitHint = params.SoftLimit
 	}
 
 	err = e.dsp.planTableReaders(
@@ -286,10 +274,10 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 			post:                   post,
 			desc:                   tabDesc,
 			spans:                  spans,
-			reverse:                reverse,
+			reverse:                params.Reverse,
 			scanVisibility:         colCfg.visibility,
-			parallelize:            parallelize,
-			estimatedRowCount:      uint64(rowCount),
+			parallelize:            params.Parallelize,
+			estimatedRowCount:      uint64(params.EstimatedRowCount),
 			reqOrdering:            ReqOrdering(reqOrdering),
 			cols:                   cols,
 			colsToTableOrdrinalMap: colsToTableOrdinalMap,

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -396,9 +396,6 @@ func (e *distSQLSpecExecFactory) ConstructApplyJoin(
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: apply join")
 }
 
-// TODO(yuzefovich): move the decision whether to use an interleaved join from
-// the physical planner into the execbuilder.
-
 func (e *distSQLSpecExecFactory) ConstructHashJoin(
 	joinType sqlbase.JoinType,
 	left, right exec.Node,
@@ -429,6 +426,24 @@ func (e *distSQLSpecExecFactory) ConstructMergeJoin(
 		joinType, left, right, onCond, leftEqCols, rightEqCols,
 		leftEqColsAreKey, rightEqColsAreKey, mergeJoinOrdering, reqOrdering,
 	)
+}
+
+// ConstructInterleavedJoin is part of the exec.Factory interface.
+func (e *distSQLSpecExecFactory) ConstructInterleavedJoin(
+	joinType sqlbase.JoinType,
+	leftTable cat.Table,
+	leftIndex cat.Index,
+	leftParams exec.ScanParams,
+	leftFilter tree.TypedExpr,
+	rightTable cat.Table,
+	rightIndex cat.Index,
+	rightParams exec.ScanParams,
+	rightFilter tree.TypedExpr,
+	leftIsAncestor bool,
+	onCond tree.TypedExpr,
+	reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: interleaved join")
 }
 
 func populateAggFuncSpec(

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -239,6 +239,11 @@ var insertFastPathClusterMode = settings.RegisterBoolSetting(
 	true,
 )
 
+var planInterleavedJoins = settings.RegisterBoolSetting(
+	"sql.distsql.interleaved_joins.enabled",
+	"if set we plan interleaved table joins instead of merge joins when possible",
+	true,
+)
 var experimentalAlterColumnTypeGeneralMode = settings.RegisterBoolSetting(
 	"sql.defaults.experimental_alter_column_type.enabled",
 	"default value for experimental_alter_column_type session setting; "+
@@ -2073,6 +2078,10 @@ func (m *sessionDataMutator) SetImplicitSelectForUpdate(val bool) {
 
 func (m *sessionDataMutator) SetInsertFastPath(val bool) {
 	m.data.InsertFastPath = val
+}
+
+func (m *sessionDataMutator) SetInterleavedJoins(val bool) {
+	m.data.InterleavedJoins = val
 }
 
 func (m *sessionDataMutator) SetSerialNormalizationMode(val sessiondata.SerialNormalizationMode) {

--- a/pkg/sql/execinfrapb/processors_sql.pb.go
+++ b/pkg/sql/execinfrapb/processors_sql.pb.go
@@ -64,7 +64,7 @@ func (x *ScanVisibility) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanVisibility) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{0}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{0}
 }
 
 // These mirror the aggregate functions supported by sql/parser. See
@@ -181,7 +181,7 @@ func (x *AggregatorSpec_Func) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Func) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{12, 0}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{12, 0}
 }
 
 type AggregatorSpec_Type int32
@@ -227,7 +227,7 @@ func (x *AggregatorSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{12, 1}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{12, 1}
 }
 
 type WindowerSpec_WindowFunc int32
@@ -291,7 +291,7 @@ func (x *WindowerSpec_WindowFunc) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_WindowFunc) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{15, 0}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{15, 0}
 }
 
 // Mode indicates which mode of framing is used.
@@ -335,7 +335,7 @@ func (x *WindowerSpec_Frame_Mode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Mode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{15, 1, 0}
 }
 
 // BoundType indicates which type of boundary is used.
@@ -382,7 +382,7 @@ func (x *WindowerSpec_Frame_BoundType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_BoundType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{15, 1, 1}
 }
 
 // Exclusion specifies the type of frame exclusion.
@@ -425,7 +425,7 @@ func (x *WindowerSpec_Frame_Exclusion) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Exclusion) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{15, 1, 2}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{15, 1, 2}
 }
 
 // ValuesCoreSpec is the core of a processor that has no inputs and generates
@@ -445,7 +445,7 @@ func (m *ValuesCoreSpec) Reset()         { *m = ValuesCoreSpec{} }
 func (m *ValuesCoreSpec) String() string { return proto.CompactTextString(m) }
 func (*ValuesCoreSpec) ProtoMessage()    {}
 func (*ValuesCoreSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{0}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{0}
 }
 func (m *ValuesCoreSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -552,7 +552,7 @@ func (m *TableReaderSpec) Reset()         { *m = TableReaderSpec{} }
 func (m *TableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*TableReaderSpec) ProtoMessage()    {}
 func (*TableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{1}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{1}
 }
 func (m *TableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -610,7 +610,7 @@ func (m *IndexSkipTableReaderSpec) Reset()         { *m = IndexSkipTableReaderSp
 func (m *IndexSkipTableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*IndexSkipTableReaderSpec) ProtoMessage()    {}
 func (*IndexSkipTableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{2}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{2}
 }
 func (m *IndexSkipTableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -712,7 +712,7 @@ func (m *JoinReaderSpec) Reset()         { *m = JoinReaderSpec{} }
 func (m *JoinReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*JoinReaderSpec) ProtoMessage()    {}
 func (*JoinReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{3}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{3}
 }
 func (m *JoinReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -756,7 +756,7 @@ func (m *SorterSpec) Reset()         { *m = SorterSpec{} }
 func (m *SorterSpec) String() string { return proto.CompactTextString(m) }
 func (*SorterSpec) ProtoMessage()    {}
 func (*SorterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{4}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{4}
 }
 func (m *SorterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -818,7 +818,7 @@ func (m *DistinctSpec) Reset()         { *m = DistinctSpec{} }
 func (m *DistinctSpec) String() string { return proto.CompactTextString(m) }
 func (*DistinctSpec) ProtoMessage()    {}
 func (*DistinctSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{5}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{5}
 }
 func (m *DistinctSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -853,7 +853,7 @@ func (m *OrdinalitySpec) Reset()         { *m = OrdinalitySpec{} }
 func (m *OrdinalitySpec) String() string { return proto.CompactTextString(m) }
 func (*OrdinalitySpec) ProtoMessage()    {}
 func (*OrdinalitySpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{6}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{6}
 }
 func (m *OrdinalitySpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -911,7 +911,7 @@ func (m *ZigzagJoinerSpec) Reset()         { *m = ZigzagJoinerSpec{} }
 func (m *ZigzagJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*ZigzagJoinerSpec) ProtoMessage()    {}
 func (*ZigzagJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{7}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{7}
 }
 func (m *ZigzagJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -987,7 +987,7 @@ func (m *MergeJoinerSpec) Reset()         { *m = MergeJoinerSpec{} }
 func (m *MergeJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*MergeJoinerSpec) ProtoMessage()    {}
 func (*MergeJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{8}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{8}
 }
 func (m *MergeJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1074,7 +1074,7 @@ func (m *HashJoinerSpec) Reset()         { *m = HashJoinerSpec{} }
 func (m *HashJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*HashJoinerSpec) ProtoMessage()    {}
 func (*HashJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{9}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{9}
 }
 func (m *HashJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1171,7 +1171,7 @@ func (m *InvertedJoinerSpec) Reset()         { *m = InvertedJoinerSpec{} }
 func (m *InvertedJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedJoinerSpec) ProtoMessage()    {}
 func (*InvertedJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{10}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{10}
 }
 func (m *InvertedJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1224,7 +1224,7 @@ func (m *InvertedFiltererSpec) Reset()         { *m = InvertedFiltererSpec{} }
 func (m *InvertedFiltererSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedFiltererSpec) ProtoMessage()    {}
 func (*InvertedFiltererSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{11}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{11}
 }
 func (m *InvertedFiltererSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1270,7 +1270,7 @@ func (m *AggregatorSpec) Reset()         { *m = AggregatorSpec{} }
 func (m *AggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec) ProtoMessage()    {}
 func (*AggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{12}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{12}
 }
 func (m *AggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1321,7 +1321,7 @@ func (m *AggregatorSpec_Aggregation) Reset()         { *m = AggregatorSpec_Aggre
 func (m *AggregatorSpec_Aggregation) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec_Aggregation) ProtoMessage()    {}
 func (*AggregatorSpec_Aggregation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{12, 0}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{12, 0}
 }
 func (m *AggregatorSpec_Aggregation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1351,7 +1351,7 @@ var xxx_messageInfo_AggregatorSpec_Aggregation proto.InternalMessageInfo
 // performs intermediate filtering on rows from each table, and performs a
 // join on the rows from the 2+ tables.
 //
-// Limitations: the InterleavedReaderJoiner currently supports only equality INNER joins
+// Limitations: the InterleavedReaderJoiner currently supports only equality joins
 // on the full interleave prefix.
 // See https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20171025_interleaved_table_joins.md.
 //
@@ -1361,8 +1361,8 @@ var xxx_messageInfo_AggregatorSpec_Aggregation proto.InternalMessageInfo
 // contain values from the left table and the following M columns contain values
 // from the right table.
 type InterleavedReaderJoinerSpec struct {
-	// For the common case of two tables, table at index 0 is the left/parent
-	// table and table at index 1 is the right/child table.
+	// The tables can be in any order. The processor figures out internally the
+	// hierarchy between them.
 	Tables  []InterleavedReaderJoinerSpec_Table `protobuf:"bytes,1,rep,name=tables" json:"tables"`
 	Reverse bool                                `protobuf:"varint,2,opt,name=reverse" json:"reverse"`
 	// A hint for how many joined rows from the tables the consumer of the
@@ -1396,7 +1396,7 @@ func (m *InterleavedReaderJoinerSpec) Reset()         { *m = InterleavedReaderJo
 func (m *InterleavedReaderJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{13}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{13}
 }
 func (m *InterleavedReaderJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1452,7 +1452,7 @@ func (m *InterleavedReaderJoinerSpec_Table) Reset()         { *m = InterleavedRe
 func (m *InterleavedReaderJoinerSpec_Table) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec_Table) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec_Table) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{13, 0}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{13, 0}
 }
 func (m *InterleavedReaderJoinerSpec_Table) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1492,7 +1492,7 @@ func (m *ProjectSetSpec) Reset()         { *m = ProjectSetSpec{} }
 func (m *ProjectSetSpec) String() string { return proto.CompactTextString(m) }
 func (*ProjectSetSpec) ProtoMessage()    {}
 func (*ProjectSetSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{14}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{14}
 }
 func (m *ProjectSetSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1534,7 +1534,7 @@ func (m *WindowerSpec) Reset()         { *m = WindowerSpec{} }
 func (m *WindowerSpec) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec) ProtoMessage()    {}
 func (*WindowerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{15}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{15}
 }
 func (m *WindowerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1570,7 +1570,7 @@ func (m *WindowerSpec_Func) Reset()         { *m = WindowerSpec_Func{} }
 func (m *WindowerSpec_Func) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Func) ProtoMessage()    {}
 func (*WindowerSpec_Func) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{15, 0}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{15, 0}
 }
 func (m *WindowerSpec_Func) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1606,7 +1606,7 @@ func (m *WindowerSpec_Frame) Reset()         { *m = WindowerSpec_Frame{} }
 func (m *WindowerSpec_Frame) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame) ProtoMessage()    {}
 func (*WindowerSpec_Frame) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{15, 1}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{15, 1}
 }
 func (m *WindowerSpec_Frame) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1647,7 +1647,7 @@ func (m *WindowerSpec_Frame_Bound) Reset()         { *m = WindowerSpec_Frame_Bou
 func (m *WindowerSpec_Frame_Bound) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bound) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bound) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{15, 1, 0}
 }
 func (m *WindowerSpec_Frame_Bound) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1683,7 +1683,7 @@ func (m *WindowerSpec_Frame_Bounds) Reset()         { *m = WindowerSpec_Frame_Bo
 func (m *WindowerSpec_Frame_Bounds) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bounds) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bounds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{15, 1, 1}
 }
 func (m *WindowerSpec_Frame_Bounds) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1733,7 +1733,7 @@ func (m *WindowerSpec_WindowFn) Reset()         { *m = WindowerSpec_WindowFn{} }
 func (m *WindowerSpec_WindowFn) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_WindowFn) ProtoMessage()    {}
 func (*WindowerSpec_WindowFn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_d2d2fa74141fd705, []int{15, 2}
+	return fileDescriptor_processors_sql_994fdcc7dfa95bad, []int{15, 2}
 }
 func (m *WindowerSpec_WindowFn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7942,10 +7942,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_d2d2fa74141fd705)
+	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_994fdcc7dfa95bad)
 }
 
-var fileDescriptor_processors_sql_d2d2fa74141fd705 = []byte{
+var fileDescriptor_processors_sql_994fdcc7dfa95bad = []byte{
 	// 2649 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x5a, 0x4b, 0x73, 0x1b, 0xc7,
 	0xf1, 0xe7, 0xe2, 0x41, 0x02, 0x8d, 0x07, 0x47, 0x23, 0xda, 0x82, 0x21, 0x17, 0x45, 0xc1, 0xfe,

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -664,7 +664,7 @@ message AggregatorSpec {
 // performs intermediate filtering on rows from each table, and performs a
 // join on the rows from the 2+ tables.
 //
-// Limitations: the InterleavedReaderJoiner currently supports only equality INNER joins
+// Limitations: the InterleavedReaderJoiner currently supports only equality joins
 // on the full interleave prefix.
 // See https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20171025_interleaved_table_joins.md.
 //
@@ -703,8 +703,8 @@ message InterleavedReaderJoinerSpec {
     repeated TableReaderSpan spans = 5 [(gogoproto.nullable) = false];
   }
 
-  // For the common case of two tables, table at index 0 is the left/parent
-  // table and table at index 1 is the right/child table.
+  // The tables can be in any order. The processor figures out internally the
+  // hierarchy between them.
   repeated Table tables = 1 [(gogoproto.nullable) = false];
 
   // Reader component

--- a/pkg/sql/interleaved_join.go
+++ b/pkg/sql/interleaved_join.go
@@ -1,0 +1,72 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+type interleavedJoinNode struct {
+	left       *scanNode
+	leftFilter tree.TypedExpr
+
+	right       *scanNode
+	rightFilter tree.TypedExpr
+
+	leftIsAncestor bool
+
+	joinType sqlbase.JoinType
+
+	// columns are the produced columns, namely the columns in the left scanNode
+	// and (unless the join type is semi or anti join) the columns in the right
+	// scanNode.
+	columns sqlbase.ResultColumns
+
+	// onCond is any ON condition to be used in conjunction with the implicit
+	// equality condition on eqCols.
+	onCond tree.TypedExpr
+
+	reqOrdering ReqOrdering
+}
+
+func (ij *interleavedJoinNode) ancestor() *scanNode {
+	if ij.leftIsAncestor {
+		return ij.left
+	}
+	return ij.right
+}
+
+func (ij *interleavedJoinNode) descendant() *scanNode {
+	if ij.leftIsAncestor {
+		return ij.right
+	}
+	return ij.left
+}
+
+func (ij *interleavedJoinNode) startExec(params runParams) error {
+	panic("interleavedJoinNode cannot be run in local mode")
+}
+
+func (ij *interleavedJoinNode) Next(params runParams) (bool, error) {
+	panic("interleavedJoinNode cannot be run in local mode")
+}
+
+func (ij *interleavedJoinNode) Values() tree.Datums {
+	panic("interleavedJoinNode cannot be run in local mode")
+}
+
+func (ij *interleavedJoinNode) Close(ctx context.Context) {
+	ij.left.Close(ctx)
+	ij.right.Close(ctx)
+}

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1732,6 +1732,7 @@ distsql                                        off                 NULL      NUL
 enable_experimental_alter_column_type_general  off                 NULL      NULL        NULL        string
 enable_implicit_select_for_update              on                  NULL      NULL        NULL        string
 enable_insert_fast_path                        on                  NULL      NULL        NULL        string
+enable_interleaved_joins                       on                  NULL      NULL        NULL        string
 enable_zigzag_join                             on                  NULL      NULL        NULL        string
 experimental_distsql_planning                  off                 NULL      NULL        NULL        string
 experimental_enable_enums                      on                  NULL      NULL        NULL        string
@@ -1800,6 +1801,7 @@ distsql                                        off                 NULL  user   
 enable_experimental_alter_column_type_general  off                 NULL  user     NULL      off                 off
 enable_implicit_select_for_update              on                  NULL  user     NULL      on                  on
 enable_insert_fast_path                        on                  NULL  user     NULL      on                  on
+enable_interleaved_joins                       on                  NULL  user     NULL      on                  on
 enable_zigzag_join                             on                  NULL  user     NULL      on                  on
 experimental_distsql_planning                  off                 NULL  user     NULL      off                 off
 experimental_enable_enums                      on                  NULL  user     NULL      off                 off
@@ -1864,6 +1866,7 @@ distsql                                        NULL    NULL     NULL     NULL   
 enable_experimental_alter_column_type_general  NULL    NULL     NULL     NULL        NULL
 enable_implicit_select_for_update              NULL    NULL     NULL     NULL        NULL
 enable_insert_fast_path                        NULL    NULL     NULL     NULL        NULL
+enable_interleaved_joins                       NULL    NULL     NULL     NULL        NULL
 enable_zigzag_join                             NULL    NULL     NULL     NULL        NULL
 experimental_distsql_planning                  NULL    NULL     NULL     NULL        NULL
 experimental_enable_enums                      NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -42,6 +42,7 @@ distsql                                        off
 enable_experimental_alter_column_type_general  off
 enable_implicit_select_for_update              on
 enable_insert_fast_path                        on
+enable_interleaved_joins                       on
 enable_zigzag_join                             on
 experimental_distsql_planning                  off
 experimental_enable_enums                      off

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -348,3 +348,41 @@ func formatFamily(family Family, buf *bytes.Buffer) {
 	}
 	buf.WriteString(")")
 }
+
+// InterleaveAncestorDescendant returns ok=true if a and b are interleaved
+// indexes and one of them is the ancestor of the other.
+// If a is an ancestor of b, aIsAncestor is true.
+// If b is an ancestor of a, aIsAncestor is false.
+func InterleaveAncestorDescendant(a, b Index) (ok bool, aIsAncestor bool) {
+	aCount := a.InterleaveAncestorCount()
+	bCount := b.InterleaveAncestorCount()
+	// If a is the ancestor of b; then:
+	//  - a has a smaller ancestor count;
+	//  - a's ancestors are a prefix of b's ancestors;
+	//  - a shows up in b's ancestor list on the position that would allow them to
+	//    share a's ancestors.
+	//
+	// For example:
+	//    x
+	//    |
+	//    y
+	//    |
+	//    a  (ancestors: x, y)
+	//    |
+	//    z
+	//    |
+	//    b  (ancestors: x, y, a, z)
+	if aCount < bCount {
+		tabID, idxID, _ := b.InterleaveAncestor(aCount)
+		if tabID == a.Table().ID() && idxID == a.ID() {
+			return true, true // a is the ancestor
+		}
+	} else if bCount < aCount {
+		tabID, idxID, _ := a.InterleaveAncestor(bCount)
+		if tabID == b.Table().ID() && idxID == b.ID() {
+			return true, false // a is not the ancestor
+		}
+	}
+
+	return false, false
+}

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -68,6 +68,8 @@ type Builder struct {
 
 	allowInsertFastPath bool
 
+	allowInterleavedJoins bool
+
 	// forceForUpdateLocking is conditionally passed through to factory methods
 	// for scan operators that serve as the input for mutation operators. When
 	// set to true, it ensures that a FOR UPDATE row-level locking mode is used
@@ -101,6 +103,7 @@ func New(
 			b.nameGen = memo.NewExprNameGenerator(evalCtx.SessionData.SaveTablesPrefix)
 		}
 		b.allowInsertFastPath = evalCtx.SessionData.InsertFastPath
+		b.allowInterleavedJoins = evalCtx.SessionData.InterleavedJoins
 	}
 	return b
 }

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -447,10 +447,9 @@ func (b *Builder) indexConstraintMaxResults(scan *memo.ScanExpr) uint64 {
 	return c.CalculateMaxResults(b.evalCtx, indexCols, rel.NotNullCols)
 }
 
-func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
-	md := b.mem.Metadata()
-	tab := md.Table(scan.Table)
-
+func (b *Builder) scanParams(
+	tab cat.Table, scan *memo.ScanExpr,
+) (exec.ScanParams, opt.ColMap, error) {
 	// Check if we tried to force a specific index but there was no Scan with that
 	// index in the memo.
 	if scan.Flags.ForceIndex && scan.Flags.Index != scan.Index {
@@ -462,7 +461,7 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 			// This should never happen.
 			err = fmt.Errorf("index \"%s\" cannot be used for this query", idx.Name())
 		}
-		return execPlan{}, err
+		return exec.ScanParams{}, opt.ColMap{}, err
 	}
 
 	locking := scan.Locking
@@ -472,12 +471,11 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 
 	// Raise error if row-level locking is part of a read-only transaction.
 	if locking != nil && locking.Strength > tree.ForNone && b.evalCtx.TxnReadOnly {
-		return execPlan{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
+		return exec.ScanParams{}, opt.ColMap{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
 			"cannot execute %s in a read-only transaction", locking.Strength.String())
 	}
 
-	needed, output := b.getColumns(scan.Cols, scan.Table)
-	res := execPlan{outputCols: output}
+	needed, outputMap := b.getColumns(scan.Cols, scan.Table)
 
 	// Get the estimated row count from the statistics.
 	// Note: if this memo was originally created as part of a PREPARE
@@ -512,7 +510,7 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		}
 	}
 
-	params := exec.ScanParams{
+	return exec.ScanParams{
 		NeededCols:         needed,
 		IndexConstraint:    scan.Constraint,
 		InvertedConstraint: scan.InvertedConstraint,
@@ -523,8 +521,17 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		Parallelize:       parallelize,
 		Locking:           locking,
 		EstimatedRowCount: rowCount,
-	}
+	}, outputMap, nil
+}
 
+func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
+	md := b.mem.Metadata()
+	tab := md.Table(scan.Table)
+	params, outputCols, err := b.scanParams(tab, scan)
+	if err != nil {
+		return execPlan{}, err
+	}
+	res := execPlan{outputCols: outputCols}
 	root, err := b.factory.ConstructScan(
 		tab,
 		tab.Index(scan.Index),
@@ -543,8 +550,7 @@ func (b *Builder) buildSelect(sel *memo.SelectExpr) (execPlan, error) {
 	if err != nil {
 		return execPlan{}, err
 	}
-	ctx := input.makeBuildScalarCtx()
-	filter, err := b.buildScalar(&ctx, &sel.Filters)
+	filter, err := b.buildScalarWithMap(input.outputCols, &sel.Filters)
 	if err != nil {
 		return execPlan{}, err
 	}
@@ -879,6 +885,12 @@ func (b *Builder) buildMergeJoin(join *memo.MergeJoinExpr) (execPlan, error) {
 		telemetry.Inc(opt.JoinTypeToUseCounter(join.JoinType))
 	}
 
+	if plan, ok, err := b.tryBuildInterleavedJoin(join); err != nil {
+		return execPlan{}, err
+	} else if ok {
+		return plan, nil
+	}
+
 	joinType := joinOpToJoinType(join.JoinType)
 
 	left, right, onExpr, outputCols, err := b.initJoinBuild(
@@ -906,6 +918,140 @@ func (b *Builder) buildMergeJoin(join *memo.MergeJoinExpr) (execPlan, error) {
 	return ep, nil
 }
 
+// tryBuildInterleavedJoin attempts to build the merge-sort as an interleaved
+// join.
+//
+// We can use an interleaved join when all following conditions are satisfied:
+//  1. Both sides of the join are Scans or Filter->Scan complexes.
+//  2. The scans have the same direction.
+//  3. The scans don't have limits.
+//  4. The tables are interleaved and one is the ancestor of the other.
+//  5. The merge join equality columns map exactly to the ancestor index key
+//     columns and the corresponding prefix of the descendant index.
+//
+// TODO(radu): this matching belongs in a rule (but for that we need to design
+// a proper optimizer operator).
+func (b *Builder) tryBuildInterleavedJoin(join *memo.MergeJoinExpr) (_ execPlan, ok bool, _ error) {
+	if !b.allowInterleavedJoins {
+		return execPlan{}, false, nil
+	}
+
+	getScanAndFilters := func(input memo.RelExpr) (scan *memo.ScanExpr, filters memo.FiltersExpr) {
+		if sel, isSelect := input.(*memo.SelectExpr); isSelect {
+			filters = sel.Filters
+			input = sel.Input
+		}
+		if scan, isScan := input.(*memo.ScanExpr); isScan {
+			return scan, filters
+		}
+		return nil, nil
+	}
+	leftScan, leftFilters := getScanAndFilters(join.Left)
+	if leftScan == nil {
+		// Condition 1 is not satisfied.
+		return execPlan{}, false, nil
+	}
+	rightScan, rightFilters := getScanAndFilters(join.Right)
+	if rightScan == nil {
+		// Condition 1 is not satisfied.
+		return execPlan{}, false, nil
+	}
+	reverse := ordering.ScanIsReverse(leftScan, &leftScan.RequiredPhysical().Ordering)
+	rightReverse := ordering.ScanIsReverse(rightScan, &rightScan.RequiredPhysical().Ordering)
+	if rightReverse != reverse {
+		// Condition 2 is not satisfied.
+		return execPlan{}, false, nil
+	}
+	if leftScan.HardLimit != 0 || rightScan.HardLimit != 0 {
+		// Condition 3 is not satisfied.
+		return execPlan{}, false, nil
+	}
+
+	md := b.mem.Metadata()
+	leftTab := md.Table(leftScan.Table)
+	leftIdx := leftTab.Index(leftScan.Index)
+	rightTab := md.Table(rightScan.Table)
+	rightIdx := rightTab.Index(rightScan.Index)
+
+	ok, leftIsAncestor := cat.InterleaveAncestorDescendant(leftIdx, rightIdx)
+	if !ok {
+		// Condition 4 is not satisfied.
+		return execPlan{}, false, nil
+	}
+	ancestorIdx := leftIdx
+	if !leftIsAncestor {
+		ancestorIdx = rightIdx
+	}
+	if ancestorIdx.LaxKeyColumnCount() != len(join.LeftEq) {
+		// Condition 5 is not satisfied.
+		return execPlan{}, false, nil
+	}
+	for i := range join.LeftEq {
+		if join.LeftEq[i].ID() != leftScan.Table.ColumnID(leftIdx.Column(i).Ordinal) {
+			// Condition 5 is not satisfied.
+			return execPlan{}, false, nil
+		}
+		if join.RightEq[i].ID() != rightScan.Table.ColumnID(rightIdx.Column(i).Ordinal) {
+			// Condition 5 is not satisfied.
+			return execPlan{}, false, nil
+		}
+	}
+
+	// All conditions are satisfied; start the build.
+	var leftFilterExpr, rightFilterExpr, onExpr tree.TypedExpr
+
+	leftScanParams, leftScanColMap, err := b.scanParams(leftTab, leftScan)
+	if err != nil {
+		return execPlan{}, false, err
+	}
+
+	if len(leftFilters) > 0 {
+		leftFilterExpr, err = b.buildScalarWithMap(leftScanColMap, &leftFilters)
+		if err != nil {
+			return execPlan{}, false, err
+		}
+	}
+	rightScanParams, rightScanColMap, err := b.scanParams(rightTab, rightScan)
+	if err != nil {
+		return execPlan{}, false, err
+	}
+	if len(rightFilters) > 0 {
+		rightFilterExpr, err = b.buildScalarWithMap(rightScanColMap, &rightFilters)
+		if err != nil {
+			return execPlan{}, false, err
+		}
+	}
+
+	joinType := joinOpToJoinType(join.JoinType)
+
+	joinCols := joinOutputMap(leftScanColMap, rightScanColMap)
+	if len(join.On) > 0 {
+		onExpr, err = b.buildScalarWithMap(joinCols, &join.On)
+		if err != nil {
+			return execPlan{}, false, err
+		}
+	}
+	if !joinType.ShouldIncludeRightColsInOutput() {
+		// For semi and anti join, only the left columns are output.
+		joinCols = leftScanColMap
+	}
+
+	ep := execPlan{outputCols: joinCols}
+
+	ep.root, err = b.factory.ConstructInterleavedJoin(
+		joinType,
+		leftTab, leftIdx, leftScanParams, leftFilterExpr,
+		rightTab, rightIdx, rightScanParams, rightFilterExpr,
+		leftIsAncestor,
+		onExpr,
+		ep.reqOrdering(join),
+	)
+	if err != nil {
+		return execPlan{}, false, err
+	}
+	return ep, true, nil
+}
+
 // initJoinBuild builds the inputs to the join as well as the ON expression.
 func (b *Builder) initJoinBuild(
 	leftChild memo.RelExpr,
@@ -924,13 +1070,8 @@ func (b *Builder) initJoinBuild(
 
 	allCols := joinOutputMap(leftPlan.outputCols, rightPlan.outputCols)
 
-	ctx := buildScalarCtx{
-		ivh:     tree.MakeIndexedVarHelper(nil /* container */, numOutputColsInMap(allCols)),
-		ivarMap: allCols,
-	}
-
 	if len(filters) != 0 {
-		onExpr, err = b.buildScalar(&ctx, &filters)
+		onExpr, err = b.buildScalarWithMap(allCols, &filters)
 		if err != nil {
 			return execPlan{}, execPlan{}, nil, opt.ColMap{}, err
 		}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -512,20 +512,24 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		}
 	}
 
+	params := exec.ScanParams{
+		NeededCols:         needed,
+		IndexConstraint:    scan.Constraint,
+		InvertedConstraint: scan.InvertedConstraint,
+		HardLimit:          hardLimit,
+		SoftLimit:          softLimit,
+		// HardLimit.Reverse() is taken into account by ScanIsReverse.
+		Reverse:           ordering.ScanIsReverse(scan, &scan.RequiredPhysical().Ordering),
+		Parallelize:       parallelize,
+		Locking:           locking,
+		EstimatedRowCount: rowCount,
+	}
+
 	root, err := b.factory.ConstructScan(
 		tab,
 		tab.Index(scan.Index),
-		needed,
-		scan.Constraint,
-		scan.InvertedConstraint,
-		hardLimit,
-		softLimit,
-		// HardLimit.Reverse() is taken into account by ScanIsReverse.
-		ordering.ScanIsReverse(scan, &scan.RequiredPhysical().Ordering),
-		parallelize,
+		params,
 		res.reqOrdering(scan),
-		rowCount,
-		locking,
 	)
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -94,6 +94,16 @@ func (b *Builder) buildScalar(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.
 	return fn(b, ctx, scalar)
 }
 
+func (b *Builder) buildScalarWithMap(
+	colMap opt.ColMap, scalar opt.ScalarExpr,
+) (tree.TypedExpr, error) {
+	ctx := buildScalarCtx{
+		ivh:     tree.MakeIndexedVarHelper(nil /* container */, numOutputColsInMap(colMap)),
+		ivarMap: colMap,
+	}
+	return b.buildScalar(&ctx, scalar)
+}
+
 func (b *Builder) buildTypedExpr(
 	ctx *buildScalarCtx, scalar opt.ScalarExpr,
 ) (tree.TypedExpr, error) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -32,17 +32,18 @@
 #################
 
 statement ok
-CREATE TABLE parent1 (pid1 INT PRIMARY KEY, pa1 INT)
+CREATE TABLE parent1 (pid1 INT PRIMARY KEY, pa1 INT, FAMILY (pid1,pa1))
 
 statement ok
-CREATE TABLE parent2 (pid2 INT PRIMARY KEY, pa2 INT)
+CREATE TABLE parent2 (pid2 INT PRIMARY KEY, pa2 INT, FAMILY (pid2, pa2))
 
 statement ok
 CREATE TABLE child1 (
   pid1 INT,
   cid1 INT,
   ca1 INT,
-  PRIMARY KEY(pid1, cid1)
+  PRIMARY KEY(pid1, cid1),
+  FAMILY (pid1,cid1,ca1)
 )
 INTERLEAVE IN PARENT parent1 (pid1)
 
@@ -52,7 +53,8 @@ CREATE TABLE child2 (
   cid2 INT,
   cid3 INT,
   ca2 INT,
-  PRIMARY KEY(pid1, cid2, cid3)
+  PRIMARY KEY(pid1, cid2, cid3),
+  FAMILY (pid1,cid2,cid3,ca2)
 )
 INTERLEAVE IN PARENT parent1 (pid1)
 
@@ -62,7 +64,8 @@ CREATE TABLE grandchild1 (
   cid1 INT,
   gcid1 INT,
   gca1 INT,
-  PRIMARY KEY(pid1, cid1, gcid1)
+  PRIMARY KEY(pid1, cid1, gcid1),
+  FAMILY (pid1,cid1,gcid1,gca1)
 )
 INTERLEAVE IN PARENT child1 (pid1, cid1)
 
@@ -75,7 +78,8 @@ CREATE TABLE grandchild2 (
   cid3 INT,
   gcid2 INT,
   gca2 INT,
-  PRIMARY KEY(pid1, cid2, cid3, gcid2)
+  PRIMARY KEY(pid1, cid2, cid3, gcid2),
+  FAMILY (pid1, cid2, cid3, gcid2, gca2)
 )
 INTERLEAVE IN PARENT child2 (pid1, cid2, cid3)
 
@@ -178,20 +182,95 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     {1}       1
 /36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  {4}       4
 /38/#/56/1/78/38/#/58/1/38  NULL                        {5}       5
 
+#########################
+# Check session setting #
+#########################
+
 statement ok
-SET CLUSTER SETTING sql.distsql.interleaved_joins.enabled = true;
+SET enable_interleaved_joins = false
+
+query TTT
+EXPLAIN SELECT * FROM parent1 JOIN child1 USING(pid1)
+----
+·                distribution       full
+·                vectorized         true
+render           ·                  ·
+ └── merge-join  ·                  ·
+      │          type               inner
+      │          equality           (pid1) = (pid1)
+      │          left cols are key  ·
+      │          mergeJoinOrder     +"(pid1=pid1)"
+      ├── scan   ·                  ·
+      │          table              parent1@primary
+      │          spans              FULL SCAN
+      └── scan   ·                  ·
+·                table              child1@primary
+·                spans              FULL SCAN
+
+statement ok
+SET enable_interleaved_joins = true
+
+query TTT
+EXPLAIN SELECT * FROM parent1 JOIN child1 USING(pid1)
+----
+·                      distribution  full
+·                      vectorized    true
+render                 ·             ·
+ └── interleaved-join  ·             ·
+·                      type          inner
+·                      left table    parent1@primary
+·                      left spans    FULL SCAN
+·                      right table   child1@primary
+·                      right spans   FULL SCAN
+·                      ancestor      left
 
 #####################
 # Interleaved joins #
 #####################
 
 # Select over two ranges for parent/child with split at children key.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5
+----
+·                      distribution  full                 ·                             ·
+·                      vectorized    true                 ·                             ·
+render                 ·             ·                    (pid1, pa1, cid1, ca1)        ·
+ │                     render 0      pid1                 ·                             ·
+ │                     render 1      pa1                  ·                             ·
+ │                     render 2      cid1                 ·                             ·
+ │                     render 3      ca1                  ·                             ·
+ └── interleaved-join  ·             ·                    (pid1, pa1, pid1, cid1, ca1)  ·
+·                      type          inner                ·                             ·
+·                      left table    parent1@primary      ·                             ·
+·                      left spans    /3-/5/#              ·                             ·
+·                      right table   child1@primary       ·                             ·
+·                      right spans   /3/#/55/1-/5/#/55/2  ·                             ·
+·                      ancestor      left                 ·                             ·
+
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzMUsFu00AQvfMVq3eKYVC9Dr1YiuSKGnAVnOIUgVR8sLzT1JLrNbtrBKry78jeSDgVVMCpN8-89-b5zc497NcWMbbpOn19JQbTijfF5r24Tj9frs-yXCzOs-3V9sM6EAfKc0_oK8Odk-Jik-Wivm1aJcXHbZa_FYu-UTIQn96lReoL8WUIwyWvxDIQZ_n5vFmvxGlQgtBpxXl1xxbxNSQIEQhLlITe6Jqt1WaE7idipr4jDglN1w_Ot13jWkaModNGsWEFgmJXNe2Il_uSUGvDiH9Rc_1S9yfRAyJBD-4wtiRYV-0YcbSnmbWcWf9mcNY5Ni1X37jgSrG50E3H5iQ8csKabxzGeM1dZX4kh4WCUDS72znitwuCnwNCyzdukcgXwcqM3OkThM3gYpFISiJKXlFyij-lkUdpov9KI59omvDxNAXbXneW_-rVw_FsWO3Y35jVg6n50uh6svHlZtJNDcXWeXTpi6zz0PiDc7F8VBweieVDcfRP4nL_7GcAAAD__-nTPX0=
 
 # Swap parent1 and child1 tables.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5
+----
+·                      distribution  full                 ·                             ·
+·                      vectorized    true                 ·                             ·
+render                 ·             ·                    (pid1, cid1, ca1, pa1)        ·
+ │                     render 0      pid1                 ·                             ·
+ │                     render 1      cid1                 ·                             ·
+ │                     render 2      ca1                  ·                             ·
+ │                     render 3      pa1                  ·                             ·
+ └── interleaved-join  ·             ·                    (pid1, cid1, ca1, pid1, pa1)  ·
+·                      type          inner                ·                             ·
+·                      left table    child1@primary       ·                             ·
+·                      left spans    /3/#/55/1-/5/#/55/2  ·                             ·
+·                      right table   parent1@primary      ·                             ·
+·                      right spans   /3-/5/#              ·                             ·
+·                      ancestor      right                ·                             ·
+
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
 ----
@@ -200,6 +279,19 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzMUtFulEAUffcrJuep6DVlIH
 # Select over two ranges for parent/child with split at grandchild key.
 # Also, rows with pid1 <= 30 should have 4 rows whereas pid1 > 30 should
 # have 3 rows.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1
+----
+·                 distribution  full                   ·                             ·
+·                 vectorized    true                   ·                             ·
+interleaved-join  ·             ·                      (pid1, pa1, pid1, cid1, ca1)  +pid1
+·                 type          inner                  ·                             ·
+·                 left table    parent1@primary        ·                             ·
+·                 left spans    /29-/31/#              ·                             ·
+·                 right table   child1@primary         ·                             ·
+·                 right spans   /29/#/55/1-/31/#/55/2  ·                             ·
+·                 ancestor      left                   ·                             ·
+
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1]
 ----
@@ -212,12 +304,50 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzUUdFu0zAUfecrru5TywyLU_
 # joins).
 # TODO(richardwu): we can remove nodes reading from just one table for INNER
 # joins or LEFT/RIGHT joins.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1
+----
+·                      distribution  full             ·                                   ·
+·                      vectorized    true             ·                                   ·
+render                 ·             ·                (pid1, pa1, cid2, cid3, ca2)        +pid1
+ │                     render 0      pid1             ·                                   ·
+ │                     render 1      pa1              ·                                   ·
+ │                     render 2      cid2             ·                                   ·
+ │                     render 3      cid3             ·                                   ·
+ │                     render 4      ca2              ·                                   ·
+ └── interleaved-join  ·             ·                (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
+·                      type          inner            ·                                   ·
+·                      left table    parent1@primary  ·                                   ·
+·                      left spans    /12-             ·                                   ·
+·                      right table   child2@primary   ·                                   ·
+·                      right spans   /12/#/56/1-      ·                                   ·
+·                      ancestor      left             ·                                   ·
+
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlFFv0zAUhd_5FdZ5atlFi9N0D5EmBViATCUZ6RCgkYcovusiZXFwHASq-t9RkklbEQPWvvTN9j3H536WfNdov1XwsQwX4etL0ZlKvEmT9-Iq_HyxeBnFYnIWLS-XHxZTcSd5Pgqa3HBtpThPolgUN2WlXPFxGcVvxaQplZyKT-_CNBT9WnztHGfGp0K6IknPwlS8-jIUMhBqrTjOb7mFfwUJggvCDAQPhDkyQmN0wW2rTS9ZD4ZI_YDvEMq66Wx_nBEKbRj-Gra0FcNHVFs2FeffOeVcsTnXZc3m2AFBsc3Lakhc8LVFn1He5uZncEcFQlqubh5WRkQQxntAqPjaTgJ5ND01vXZYgpB01heBpMClwKNgTsEJsg1Bd_a-2dbmK4YvN_QI0D2HNooNq-22A3mEbPMH6li_0M3xfEv9WLq7lS53ek55uM_p7gTkHi7QbCeg2eECeTsBeYcL9I-RlHLb6Lrl__qdTv-9Wa14HAet7kzBF0YXQ8y4TQbfcKC4tWNVjpuoHkpDgw_N8q_mky2z87vZ3Sd5to_Z28c8f5I52zz7FQAA__8hjUPy
 
 # These rows are all on the same node 1 (gateway).
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1
+----
+·                      distribution  full                                                                                   ·                                   ·
+·                      vectorized    true                                                                                   ·                                   ·
+render                 ·             ·                                                                                      (pid1, pa1, cid2, cid3, ca2)        +pid1
+ │                     render 0      pid1                                                                                   ·                                   ·
+ │                     render 1      pa1                                                                                    ·                                   ·
+ │                     render 2      cid2                                                                                   ·                                   ·
+ │                     render 3      cid3                                                                                   ·                                   ·
+ │                     render 4      ca2                                                                                    ·                                   ·
+ └── interleaved-join  ·             ·                                                                                      (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
+·                      type          inner                                                                                  ·                                   ·
+·                      left table    parent1@primary                                                                        ·                                   ·
+·                      left spans    /1-/1/# /11-/11/# /21-/21/# /31-/31/#                                                  ·                                   ·
+·                      right table   child2@primary                                                                         ·                                   ·
+·                      right spans   /1/#/56/1-/1/#/56/2 /11/#/56/1-/11/#/56/2 /21/#/56/1-/21/#/56/2 /31/#/56/1-/31/#/56/2  ·                                   ·
+·                      ancestor      left                                                                                   ·                                   ·
+
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1]
 ----
@@ -225,6 +355,32 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyMUE2L2zAQvfdXDHOK24FG6c
 
 # Parent-grandchild.
 # We add the pa1 > 0 condition so a lookup join is not considered to be a better plan.
+query TTTTT
+EXPLAIN (VERBOSE)
+  SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
+    pid1 >= 11 AND pid1 <= 13
+    OR pid1 >= 19 AND pid1 <= 21
+    OR pid1 >= 31 AND pid1 <= 33
+    OR pa1 > 0
+----
+·                      distribution  full                                                                                                                    ·                                           ·
+·                      vectorized    true                                                                                                                    ·                                           ·
+render                 ·             ·                                                                                                                       (pid1, pa1, cid2, cid3, gcid2, gca2)        ·
+ │                     render 0      pid1                                                                                                                    ·                                           ·
+ │                     render 1      pa1                                                                                                                     ·                                           ·
+ │                     render 2      cid2                                                                                                                    ·                                           ·
+ │                     render 3      cid3                                                                                                                    ·                                           ·
+ │                     render 4      gcid2                                                                                                                   ·                                           ·
+ │                     render 5      gca2                                                                                                                    ·                                           ·
+ └── interleaved-join  ·             ·                                                                                                                       (pid1, pa1, pid1, cid2, cid3, gcid2, gca2)  ·
+·                      type          inner                                                                                                                   ·                                           ·
+·                      left table    parent1@primary                                                                                                         ·                                           ·
+·                      left spans    FULL SCAN                                                                                                               ·                                           ·
+·                      left filter   ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)  ·                                           ·
+·                      right table   grandchild2@primary                                                                                                     ·                                           ·
+·                      right spans   FULL SCAN                                                                                                               ·                                           ·
+·                      ancestor      left                                                                                                                    ·                                           ·
+
 query T
 SELECT url FROM [EXPLAIN (DISTSQL)
   SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
@@ -235,6 +391,32 @@ SELECT url FROM [EXPLAIN (DISTSQL)
 ]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzsldFv0zAQxt_5K6x7SsBocdwOFqlSJtZBppKOtAikkYcovnWRsjg4DgJV_d9RnXZLqxRBK5WXvtW-78vV3--km0P1PQcPJsPR8N2U1Con19H4I7kbfr0dXQYhsa6CyXTyaWSTleRlIygThYVm5GYchGSmkkKkD1kuXPJ5EoTviVVmgtnky4dhNCSWZZkz-VY7DscBYcwml-EVad2mA8K4bZNxRLbFF11il9mdat75ac7X6jJZa4ljx0ChkALD5BEr8O6AAQUXKHCg0AMKfYgplEqmWFVSLSVzYwjET_AcCllR1np5HVNIpULw5qAznSN4EBQaVY7JD4wwEahuZFagOnOAgkCdZLnpOMJ7Dcse2WOifvmrWIGaArnOco3KMwn67fw8zwvC6dvVW_12iOvSKp227WKnzX36YoeP727H-ZbPd5_iXVeAQpTNHtrPbA0MUGiSAQo53mvLZ6_sgVoazE-gMK61R3xGfZf6Per3qX9O_TcQLyjIWj8TqHQyQ_DYgu6g9AynLqQSqFBs0IgXHRxD-VqWZ_0tYXdrd6M122tA2GlAjjog7l6U3BOlo1Lie1HiJ0pHpdTbi1LvROm_rcQOShFWpSwq_KuN5yxXJooZNvu1krVK8VbJ1LRpjmPjMxcCK91UWXMIClMyf7BtZn80n2-YnW2ze0hnfoi5d4i5_0_mePHidwAAAP__aOtjjw==
+
+query TTTTT
+EXPLAIN (VERBOSE)
+  SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
+    pid1 >= 11 AND pid1 <= 13
+    OR pid1 >= 19 AND pid1 <= 21
+    OR pid1 >= 31 AND pid1 <= 33
+    OR pa1 > 0
+----
+·                      distribution  full                                                                                                                    ·                                           ·
+·                      vectorized    true                                                                                                                    ·                                           ·
+render                 ·             ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2, pa1)        ·
+ │                     render 0      pid1                                                                                                                    ·                                           ·
+ │                     render 1      cid2                                                                                                                    ·                                           ·
+ │                     render 2      cid3                                                                                                                    ·                                           ·
+ │                     render 3      gcid2                                                                                                                   ·                                           ·
+ │                     render 4      gca2                                                                                                                    ·                                           ·
+ │                     render 5      pa1                                                                                                                     ·                                           ·
+ └── interleaved-join  ·             ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2, pid1, pa1)  ·
+·                      type          inner                                                                                                                   ·                                           ·
+·                      left table    grandchild2@primary                                                                                                     ·                                           ·
+·                      left spans    FULL SCAN                                                                                                               ·                                           ·
+·                      right table   parent1@primary                                                                                                         ·                                           ·
+·                      right spans   FULL SCAN                                                                                                               ·                                           ·
+·                      right filter  ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)  ·                                           ·
+·                      ancestor      right                                                                                                                   ·                                           ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL)
@@ -254,21 +436,17 @@ EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
   OR pid1 >= 31 AND pid1 <= 33
   OR pa1 > 0
 ----
-·                distribution        full
-·                vectorized          true
-render           ·                   ·
- └── merge-join  ·                   ·
-      │          type                inner
-      │          equality            (pid1) = (pid1)
-      │          right cols are key  ·
-      │          mergeJoinOrder      +"(pid1=pid1)"
-      ├── scan   ·                   ·
-      │          table               grandchild2@primary
-      │          spans               FULL SCAN
-      └── scan   ·                   ·
-·                table               parent1@primary
-·                spans               FULL SCAN
-·                filter              ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)
+·                      distribution  full
+·                      vectorized    true
+render                 ·             ·
+ └── interleaved-join  ·             ·
+·                      type          inner
+·                      left table    grandchild2@primary
+·                      left spans    FULL SCAN
+·                      right table   parent1@primary
+·                      right spans   FULL SCAN
+·                      right filter  ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)
+·                      ancestor      right
 
 # Join on multiple interleaved columns with an overarching ancestor (parent1).
 # Note there are 5 nodes because the filter cid2 >= 12 AND cid2 <= 14
@@ -298,20 +476,16 @@ EXPLAIN
     OR child2.cid2 >= 12 AND child2.cid2 <= 14
     OR gcid2 >= 49 AND gcid2 <= 51
 ----
-·           distribution       full
-·           vectorized         true
-merge-join  ·                  ·
- │          type               inner
- │          equality           (pid1, cid2, cid3) = (pid1, cid2, cid3)
- │          left cols are key  ·
- │          mergeJoinOrder     +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
- ├── scan   ·                  ·
- │          table              child2@primary
- │          spans              FULL SCAN
- └── scan   ·                  ·
-·           table              grandchild2@primary
-·           spans              FULL SCAN
-·           filter             (((pid1 >= 5) AND (pid1 <= 7)) OR ((cid2 >= 12) AND (cid2 <= 14))) OR ((gcid2 >= 49) AND (gcid2 <= 51))
+·                 distribution  full
+·                 vectorized    true
+interleaved-join  ·             ·
+·                 type          inner
+·                 left table    child2@primary
+·                 left spans    FULL SCAN
+·                 right table   grandchild2@primary
+·                 right spans   FULL SCAN
+·                 right filter  (((pid1 >= 5) AND (pid1 <= 7)) OR ((cid2 >= 12) AND (cid2 <= 14))) OR ((gcid2 >= 49) AND (gcid2 <= 51))
+·                 ancestor      left
 
 # Aggregation over parent and child keys.
 query T
@@ -341,7 +515,8 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzUlVFv2j4Uxd__n8K6T0R_q4
 statement ok
 CREATE TABLE outer_p1 (
   pid1 INT PRIMARY KEY,
-  pa1 INT
+  pa1 INT,
+  FAMILY (pid1, pa1)
 )
 
 statement ok
@@ -350,7 +525,8 @@ CREATE TABLE outer_c1 (
   cid1 INT,
   cid2 INT,
   ca1 INT,
-  PRIMARY KEY (pid1, cid1, cid2)
+  PRIMARY KEY (pid1, cid1, cid2),
+  FAMILY (pid1, cid1, cid2)
 ) INTERLEAVE IN PARENT outer_p1 (pid1)
 
 statement ok
@@ -360,7 +536,8 @@ CREATE TABLE outer_gc1 (
   cid2 INT,
   gcid1 INT,
   gca1 INT,
-  PRIMARY KEY (pid1, cid1, cid2, gcid1)
+  PRIMARY KEY (pid1, cid1, cid2, gcid1),
+  FAMILY (pid1, cid1, cid2)
 ) INTERLEAVE IN PARENT outer_c1 (pid1, cid1, cid2)
 
 statement ok
@@ -388,20 +565,98 @@ NULL       /0       {5}       5
 
 ### Begin OUTER queries
 
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)
+----
+·                      distribution  full                  ·                                   ·
+·                      vectorized    true                  ·                                   ·
+render                 ·             ·                     (pid1, pa1, cid1, cid2, ca1)        ·
+ │                     render 0      COALESCE(pid1, pid1)  ·                                   ·
+ │                     render 1      pa1                   ·                                   ·
+ │                     render 2      cid1                  ·                                   ·
+ │                     render 3      cid2                  ·                                   ·
+ │                     render 4      ca1                   ·                                   ·
+ └── interleaved-join  ·             ·                     (pid1, pa1, pid1, cid1, cid2, ca1)  ·
+·                      type          full outer            ·                                   ·
+·                      left table    outer_p1@primary      ·                                   ·
+·                      left spans    FULL SCAN             ·                                   ·
+·                      right table   outer_c1@primary      ·                                   ·
+·                      right spans   FULL SCAN             ·                                   ·
+·                      ancestor      left                  ·                                   ·
+
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzclM9q20AQxu99imVOdjslXknOQVBQcJWioEqpZEMhiCK0E1egaNXdVWkwfveiVUrqNP1n33TbnZlvvvnNYXagvzTgQx7G4WrNetWwyyx9z27Cj9fxRZSw2dsoX-cf4jl7KHk5FsjekPrUcXa5iWN2lUbJQ6jibJNHyTs262rB5wUgtFJQUt6RBv8GOCA4gOACggcISygQOiUr0lqqoWRnBZH4Bv4CoW673gzhAqGSisDfgalNQ-BD1BpSDZVfKaNSkLqSdUvqbLAQZMq6sY4x3RoYPOq7Ut0HPyYHhKzefv41VQ2psRUgrO878kfKdLMOM8sKCA3dmlnAX83fqKGLfQ4tqRWkfLZKL-IwX4WzgGPgzpEFDrLAQxYskQXnUOwRZG8e2bQptwQ-3-Nv-B-x-1YqQYrEAWexf2ZDiXwtu7Plk8LnrZ0Da37U6p3JrN45it-dDL97FL83GX7vKP7FZPj_cnoz0p1sNf3TZVkMp4nElsY7pmWvKrpWsrI24ze1OhsQpM2Y5eMnam3KDvizmP9RfH4gXjwVO6c4u6eIvVPEy_8SF_sX3wMAAP__E6R9Gg==
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)
+----
+·                      distribution  full                  ·                                                       ·
+·                      vectorized    true                  ·                                                       ·
+render                 ·             ·                     (pid1, cid1, cid2, gcid1, gca1, ca1)                    ·
+ │                     render 0      COALESCE(pid1, pid1)  ·                                                       ·
+ │                     render 1      COALESCE(cid1, cid1)  ·                                                       ·
+ │                     render 2      COALESCE(cid2, cid2)  ·                                                       ·
+ │                     render 3      gcid1                 ·                                                       ·
+ │                     render 4      gca1                  ·                                                       ·
+ │                     render 5      ca1                   ·                                                       ·
+ └── interleaved-join  ·             ·                     (pid1, cid1, cid2, gcid1, gca1, pid1, cid1, cid2, ca1)  ·
+·                      type          full outer            ·                                                       ·
+·                      left table    outer_gc1@primary     ·                                                       ·
+·                      left spans    FULL SCAN             ·                                                       ·
+·                      right table   outer_c1@primary      ·                                                       ·
+·                      right spans   FULL SCAN             ·                                                       ·
+·                      ancestor      right                 ·                                                       ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzklU9r20AQxe_9FMuc7HpKvJKctoLCBlcpCqqUSjYUgihCO3EFilZdrUqD8XcvktImStN_9tEXw76Zt8_zWxhtoflSgguJF3jLFWt1yc7j6D278j5eBmd-yCZv_WSVfAim7K7l-dCgWkP60ybn7HwdBOwi8sM7LedsnfjhOzapC8mR5T9-rWkKCJWSFGY31IB7BRwQLECwAcEBhAWkCLVWOTWN0l3Ltjf48hu4c4SiqlvTySlCrjSBuwVTmJLABb8ypEvKvlJMmSR9oYqK9EkXIclkRdknBnRtoMsobjJ9K36OAQhxsfn8a60vDXcBwuq2JncYOVqvvLgfHBBKujYTwWcorBkKezZ9o7vbRlIXQZUk7bJldBZ4ydKbCI7idIoPBAvFy5Fgo3g1RSYcZGKBTLyGdIegWnOPojHZhsDlO_wNrntKbaW0JE1yhCXdPQE0VC9UfbJ41Ph0tDWK5nu9lHWsL2Xthcs-Vlz2XricY8Xl7IVrfqy4_vKViampVdXQP23FebdWSW5o2MGNanVOl1rlfcxwjHpfL0hqzFDlw8Gv-lL_Bx-a-R_NpyPz_LHZOiTZPsTsHGJe_Jc53T37HgAA__8UBrYr
 
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40
+----
+·                      distribution  full                  ·                                   ·
+·                      vectorized    true                  ·                                   ·
+render                 ·             ·                     (pid1, cid1, cid2, ca1, pa1)        ·
+ │                     render 0      pid1                  ·                                   ·
+ │                     render 1      cid1                  ·                                   ·
+ │                     render 2      cid2                  ·                                   ·
+ │                     render 3      ca1                   ·                                   ·
+ │                     render 4      pa1                   ·                                   ·
+ └── interleaved-join  ·             ·                     (pid1, cid1, cid2, ca1, pid1, pa1)  ·
+·                      type          left outer            ·                                   ·
+·                      left table    outer_c1@primary      ·                                   ·
+·                      left spans    /0/#/60/1-/39/#/60/2  ·                                   ·
+·                      right table   outer_p1@primary      ·                                   ·
+·                      right spans   /0-/39/#              ·                                   ·
+·                      ancestor      right                 ·                                   ·
+
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzUVF1vlEAUffdXTM7TomPKAPpA0oTGUqVBqCyNJpUYArcrCWVwGIzNZv-7Yahpt9aPbp_2jXvPPfdwTnJnjeFbCx_LMA7f5GxULTvJ0vfsIvx0Fh9FCVscR8t8-SG22M3I83lAjprUl0qwODzJ2WkaJTetXrDzZZS8ZYu-qYXFPr4Ls3Au2OfRtl06ZLbFjpLju82KebZVgKOTNSXlFQ3wLyDA4YDDBYeHgqNXsqJhkGqC12Y4qn_Atzmarh_11C44KqkI_hq60S3BR9RpUi2V3ymjsiZ1KpuO1IENjpp02bRGLaZLjUmjuSrVdfDLITiyZvX1d6ifoHkVOPLrnvw5jfQ8DzOTCThautSLQLywDtW0xXyCIx21zwLBA4cHLg88HrxGseGQo771MehyRfDFhv_B663FsZOqJkX1lqdi80AaiXwp-wPv3uDD0s6WtNgpZrGXMTs7eXX20qu7k1d3L73-46nIaOhlN9B_XYc9nRfVK5pvcZCjquhMycrIzGVqeKZR06BnVMxF1BnI_OBdsvgr-dUW2b5Pdp6i7D6F7D2KXGye_QwAAP__qyUQHg==
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20
+----
+·                      distribution  full                  ·                                           ·
+·                      vectorized    true                  ·                                           ·
+render                 ·             ·                     (pid1, pa1, cid1, cid2, gcid1, gca1)        ·
+ │                     render 0      pid1                  ·                                           ·
+ │                     render 1      pa1                   ·                                           ·
+ │                     render 2      cid1                  ·                                           ·
+ │                     render 3      cid2                  ·                                           ·
+ │                     render 4      gcid1                 ·                                           ·
+ │                     render 5      gca1                  ·                                           ·
+ └── interleaved-join  ·             ·                     (pid1, cid1, cid2, gcid1, gca1, pid1, pa1)  ·
+·                      type          left outer            ·                                           ·
+·                      left table    outer_gc1@primary     ·                                           ·
+·                      left spans    /1/#/60/1-/20/#/60/2  ·                                           ·
+·                      right table   outer_p1@primary      ·                                           ·
+·                      right spans   /1-/20/#              ·                                           ·
+·                      ancestor      right                 ·                                           ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20]
@@ -468,15 +723,210 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzUlU9r20AQxe_9FMuckmaKvZ
 
 # If there are Limits, interleaved joins should not be used.
 query T
-SELECT url FROM [
-  EXPLAIN (DISTSQL) SELECT * FROM (SELECT * FROM parent1 ORDER BY pid1 LIMIT 2) AS parent1 INNER MERGE JOIN child1 USING(pid1)
-]
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM (SELECT * FROM parent1 ORDER BY pid1 LIMIT 2) AS parent1 INNER MERGE JOIN child1 USING(pid1)
+] WHERE node_type LIKE '%join'
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lV1v2joYx-_Pp7CecwOnRo6dhJdIR0q3sioVLx0waVOVi5R4EIkmmROkVRXffQqhL1Bqh1nhzgb_bD__n5XnCbJfK3Bg2h_0P8_QWqzQl8l4iO76328Hl94INa686Wz6ddBEuyX_lQsa-9M0EDzOKRpPrvoT9OkHSqOQooE39GaINdHl9GWFNxr1J2jYn1z30c3YG6H5MlqFFH2beqNr1Ci4pg8Y4iTko-CBZ-DcAQUMDDCYgMECDDb4GFKRzHmWJaJY8rQFvPA3OAaGKE7XefGzj2GeCA7OE-RRvuLgwCy4X_EJD0IuiAEYQp4H0Wp7TCqih0A8uru7AoZpGsSZg1qAYRA9RDli4G8wJOt8d8DrvvePaBlky_0dXQr-xseQ5cGCg0M3-O8uSo9ftMzuzT0JI_8Su00osVg57hJKGAriEJkoyZdcZFoVsA8reN1nHSci5IKHezv5Bfm85NgCcOlFedZhEkMuFvwmiWIuSHufWfGfecOlF83_RbRYlkPAMF7nDnIpdhl2LezaBzW_1mNq1HPkpqOklaSE0sPKj55t7Z1Nq78GVu01fPAYWsQqxnbxu1XXy6DnfxmdOl8Gq27HrGjnjYUWab-oapfjQlW7Ljvs_Ha6ddoxq9uxKto5LqRFunU5Mc_vpFenE6u6E7uik26LUOPZi23sJoUYatSlxTq_Fmqcq8cduciEZ2kSZ7xSBzOKUni44GU6WbIWc34rkvn2mHI63nLbjhDyLC__ZeXEi8u_igtWh20duKMD93RgSuU0PSExdhps68AdHbinAx8k9o5mh7TxljblcZtSmO7nbRzSlo4sOayQJYcVsuSwQpYcVsmydWS1deKWw4q45bAibjmsiFsOq-Lu6MTd1YlbDivilsOKuOWwIm45rIq7pxM3PaVZvv-GntItT6VVH_9T-uWptCpz-q57SEP3N__8CQAA__-JnSC4
+merge-join
 
 query T
-SELECT url FROM [
-  EXPLAIN (DISTSQL) SELECT * FROM parent1 INNER MERGE JOIN (SELECT * FROM child1 ORDER BY pid1 LIMIT 10) AS child1 USING(pid1)
-]
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM parent1 INNER MERGE JOIN (SELECT * FROM child1 ORDER BY pid1 LIMIT 10) AS child1 USING(pid1)
+] WHERE node_type LIKE '%join'
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lVtvozoQx9_Pp7DmvDSnjoy55IJ0pPScshVVLl2SlXZV8UCDN0GiwBoibVXlu68I6aahqU3XIm8Gz88z8_-PNM-Q_4jBhrkzdv5foA2P0SdvNkH3zte78ZU7RRfX7nwx_zzuoH3IP1VAFnCWFBS506njoYnj3TjodlYCx3HLdRSHFM28a8dD_31DWRRSNHYn7gJRrYOu5i8RX-bu9AZdlPcdHzAkacimwSPLwb4HChh0wGAABhMwWOBjyHi6ZHme8jLkeQe44U-wNQxRkm2K8rePYZlyBvYzFFERM7BhETzEzGNByDjRAEPIiiCKd2kyHj0G_Gm0bw4wzLMgyW3UJTr5m1g9QompV-cBoURHQRIiA6XFmvEc_C2GdFPsUx8yPjyhdZCvj3ONKPhbH0NeBCsGNt3iP2vBOt1CpeqrDgDDOHqMCkQ1pUL1dws9vJPykHEW1t-5LBMfojbJqbhdrnrDE8ZX7DaNEsZJ7_jZmH0vLkb0svMvj1br6ggYZpvCRiOKRzoemXhk1Xo-9GM06OcDlU7TbpoRSmuRp3ObR7lpc9Npw7l9Z2y7xCzPVvnfbGuG6flHo9_maOjN7dGb2vPKhi7p_faqV51Lr3pt2aOf355Bm_YYze0xmtpz2pEuGbRlinF-U4ZtmmI2N8VsasqgS6j2Yoyl7T9KZ6jWli_m-X2h2rn23IlCPJZnaZKzRltMK1th4YpV6uTphi_ZHU-XuzTV52zH7ZZCyPKiutWrDzeprsoCm8OWCtxXgYcqMKVimn5AMf1jsKUC91XgoQpcU-wNrddp7TVtiOU2hDA91lur06bKeIthyXiLYcl4i2HJeIth2XhbKmb1VOQWwxK5xbBEbjEskVsMy-Tuq8g9UJFbDEvkFsMSucWwRG4xLJN7qCI3VVqWEloiuISWKC6hJZJLaOnCfLM9hKL7279-BQAA___BmiKQ
+merge-join
+
+statement ok
+DROP TABLE grandchild2, grandchild1, child1, child2, parent1, parent2
+
+# The following tests target the decision of whether to use interleaved join or
+# not. We define the following hierarchy:
+#   name:             primary key:
+#   parent1           (pid1)
+#     child1          (pid1, cid1, cid2)
+#       grandchild1   (pid1, cid1, cid2, gcid1)
+#     child2          (pid1, cid3, cid4)
+#   parent2           (pid1)
+statement ok
+CREATE TABLE parent1 (pid1 INT PRIMARY KEY, v INT);
+CREATE TABLE child1 (pid1 INT8, cid1 INT8, cid2 INT8, v INT8, PRIMARY KEY (pid1, cid1, cid2))
+  INTERLEAVE IN PARENT parent1 (pid1);
+CREATE TABLE grandchild1 (pid1 INT, cid1 INT, cid2 INT, gcid1 INT, v INT, PRIMARY KEY (pid1, cid1, cid2, gcid1))
+  INTERLEAVE IN PARENT child1 (pid1, cid1, cid2);
+CREATE TABLE child2 (pid1 INT, cid3 INT, cid4 INT, v INT, PRIMARY KEY (pid1, cid3, cid4))
+  INTERLEAVE IN PARENT parent1 (pid1);
+CREATE TABLE parent2 (pid1 INT PRIMARY KEY, v INT);
+
+# Simple parent-child cases.
+# parent1-child1 share interleave prefix (pid1).
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM parent1 INNER MERGE JOIN child1 USING (pid1)
+] WHERE node_type LIKE '%join'
+----
+interleaved-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM parent1 INNER MERGE JOIN child1 USING (pid1, v)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM parent1 INNER MERGE JOIN child1 USING (v)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+# Parent-grandchild cases.
+# parent1-grandchild1 share interleave prefix (pid1).
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM parent1 INNER MERGE JOIN grandchild1 USING (pid1)
+] WHERE node_type LIKE '%join'
+----
+interleaved-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM parent1 INNER MERGE JOIN grandchild1 USING (pid1, v)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM parent1 INNER MERGE JOIN grandchild1 USING (v)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+# Multiple-column interleave prefix.
+# child1-grandchild1 share interleave prefix (pid1, cid1, cid2).
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1, cid2)
+] WHERE node_type LIKE '%join'
+----
+interleaved-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1, cid2, v)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (v)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+# TODO(richardwu): update these once prefix/subset of
+# interleave prefixes are permitted.
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid2)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1, v)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid2, v)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1, cid2)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1, cid2, v)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid2)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1, v)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid2, v)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+# Common ancestor example.
+# TODO(richardwu): update this when common ancestor interleaved joins are possible.
+query T
+SELECT node_type FROM [ EXPLAIN (VERBOSE)
+  SELECT * FROM child1 INNER MERGE JOIN child2 USING (pid1)
+] WHERE node_type LIKE '%join'
+----
+merge-join
+
+# Case where the merge join ordering includes a non-interleaved column (this is
+# possible if that column is constrained to a constant value). We shouldn't
+# plan an interleaved table join in this case. See issue #25838 for a case
+# where this could happen.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM parent1 INNER MERGE JOIN child1 ON parent1.pid1 = child1.pid1 AND parent1.v = child1.v WHERE parent1.v=1
+----
+·           distribution       full                     ·                               ·
+·           vectorized         true                     ·                               ·
+merge-join  ·                  ·                        (pid1, v, pid1, cid1, cid2, v)  ·
+ │          type               inner                    ·                               ·
+ │          equality           (pid1, v) = (pid1, v)    ·                               ·
+ │          left cols are key  ·                        ·                               ·
+ │          mergeJoinOrder     +"(pid1=pid1)",+"(v=v)"  ·                               ·
+ ├── scan   ·                  ·                        (pid1, v)                       +pid1
+ │          table              parent1@primary          ·                               ·
+ │          spans              FULL SCAN                ·                               ·
+ │          filter             v = 1                    ·                               ·
+ └── scan   ·                  ·                        (pid1, cid1, cid2, v)           +pid1
+·           table              child1@primary           ·                               ·
+·           spans              FULL SCAN                ·                               ·
+·           filter             v = 1                    ·                               ·
+

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -55,33 +55,11 @@ type Factory interface {
 
 	// ConstructScan returns a node that represents a scan of the given index on
 	// the given table.
-	//   - Only the given set of needed columns are part of the result.
-	//   - If indexConstraint or invertedConstraint are not nil, the scan is
-	//     restricted to the spans in in the constraint. Only one of the two may
-	//     be non-nil.
-	//   - If hardLimit > 0, then the scan returns only up to hardLimit rows.
-	//   - If softLimit > 0, then the scan may be required to return up to all
-	//     of its rows (or up to the hardLimit if it is set), but can be optimized
-	//     under the assumption that only softLimit rows will be needed.
-	//   - If parallelize is true, the scan will scan all spans in parallel. It
-	//     should only be set to true if there is a known upper bound on the
-	//     number of rows that will be scanned. It should not be set if there is
-	//     a hard or soft limit.
-	//   - If locking is provided, the scan should use the specified row-level
-	//     locking mode.
 	ConstructScan(
 		table cat.Table,
 		index cat.Index,
-		needed TableColumnOrdinalSet,
-		indexConstraint *constraint.Constraint,
-		invertedConstraint invertedexpr.InvertedSpans,
-		hardLimit int64,
-		softLimit int64,
-		reverse bool,
-		parallelize bool,
+		params ScanParams,
 		reqOrdering OutputOrdering,
-		rowCount float64,
-		locking *tree.LockingItem,
 	) (Node, error)
 
 	// ConstructFilter returns a node that applies a filter on the results of
@@ -584,6 +562,36 @@ type Factory interface {
 		fileFormat string,
 		options []KVOption,
 	) (Node, error)
+}
+
+// ScanParams contains all the parameters for a table scan.
+type ScanParams struct {
+	// Only columns in this set are scanned and produced.
+	NeededCols TableColumnOrdinalSet
+
+	// At most one of IndexConstraint or InvertedConstraint is non-nil, depending
+	// on the index type.
+	IndexConstraint    *constraint.Constraint
+	InvertedConstraint invertedexpr.InvertedSpans
+
+	// If non-zero, the scan returns this many rows.
+	HardLimit int64
+
+	// If non-zero, the scan may still be required to return up to all its rows
+	// (or up to the HardLimit if it is set0, but can be optimized under the
+	// assumption that only SoftLimit rows will be needed.
+	SoftLimit int64
+
+	Reverse bool
+
+	// If true, the scan will scan all spans in parallel. It should only be set to
+	// true if there is a known upper bound on the number of rows that will be
+	// scanned. It should not be set if there is a hard or soft limit.
+	Parallelize bool
+
+	Locking *tree.LockingItem
+
+	EstimatedRowCount float64
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being

--- a/pkg/sql/opt/exec/stub_factory.go
+++ b/pkg/sql/opt/exec/stub_factory.go
@@ -100,6 +100,24 @@ func (StubFactory) ConstructMergeJoin(
 	return struct{}{}, nil
 }
 
+// ConstructInterleavedJoin is part of the exec.Factory interface.
+func (StubFactory) ConstructInterleavedJoin(
+	joinType sqlbase.JoinType,
+	leftTable cat.Table,
+	leftIndex cat.Index,
+	leftParams ScanParams,
+	leftFilter tree.TypedExpr,
+	rightTable cat.Table,
+	rightIndex cat.Index,
+	rightParams ScanParams,
+	rightFilter tree.TypedExpr,
+	leftIsAncestor bool,
+	onCond tree.TypedExpr,
+	reqOrdering OutputOrdering,
+) (Node, error) {
+	return struct{}{}, nil
+}
+
 // ConstructGroupBy is part of the exec.Factory interface.
 func (StubFactory) ConstructGroupBy(
 	input Node,

--- a/pkg/sql/opt/exec/stub_factory.go
+++ b/pkg/sql/opt/exec/stub_factory.go
@@ -33,18 +33,7 @@ func (StubFactory) ConstructValues(
 
 // ConstructScan is part of the exec.Factory interface.
 func (StubFactory) ConstructScan(
-	table cat.Table,
-	index cat.Index,
-	needed TableColumnOrdinalSet,
-	indexConstraint *constraint.Constraint,
-	invertedConstraint invertedexpr.InvertedSpans,
-	hardLimit int64,
-	softLimit int64,
-	reverse bool,
-	parallelize bool,
-	reqOrdering OutputOrdering,
-	rowCount float64,
-	locking *tree.LockingItem,
+	table cat.Table, index cat.Index, params ScanParams, reqOrdering OutputOrdering,
 ) (Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -137,7 +137,6 @@ type Memo struct {
 	useMultiColStats  bool
 	safeUpdates       bool
 	saveTablesPrefix  string
-	insertFastPath    bool
 
 	// curID is the highest currently in-use scalar expression ID.
 	curID opt.ScalarID
@@ -170,7 +169,6 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	m.useMultiColStats = evalCtx.SessionData.OptimizerUseMultiColStats
 	m.safeUpdates = evalCtx.SessionData.SafeUpdates
 	m.saveTablesPrefix = evalCtx.SessionData.SaveTablesPrefix
-	m.insertFastPath = evalCtx.SessionData.InsertFastPath
 
 	m.curID = 0
 	m.curWithID = 0
@@ -276,8 +274,7 @@ func (m *Memo) IsStale(
 		m.useHistograms != evalCtx.SessionData.OptimizerUseHistograms ||
 		m.useMultiColStats != evalCtx.SessionData.OptimizerUseMultiColStats ||
 		m.safeUpdates != evalCtx.SessionData.SafeUpdates ||
-		m.saveTablesPrefix != evalCtx.SessionData.SaveTablesPrefix ||
-		m.insertFastPath != evalCtx.SessionData.InsertFastPath {
+		m.saveTablesPrefix != evalCtx.SessionData.SaveTablesPrefix {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -218,6 +218,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData.OptimizerUseMultiColStats = true
 	ot.evalCtx.SessionData.ReorderJoinsLimit = opt.DefaultJoinOrderLimit
 	ot.evalCtx.SessionData.InsertFastPath = true
+	ot.evalCtx.SessionData.InterleavedJoins = true
 
 	return ot
 }

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -71,31 +71,17 @@ func (ef *execFactory) ConstructValues(
 
 // ConstructScan is part of the exec.Factory interface.
 func (ef *execFactory) ConstructScan(
-	table cat.Table,
-	index cat.Index,
-	needed exec.TableColumnOrdinalSet,
-	indexConstraint *constraint.Constraint,
-	invertedConstraint invertedexpr.InvertedSpans,
-	hardLimit int64,
-	softLimit int64,
-	reverse bool,
-	parallelize bool,
-	reqOrdering exec.OutputOrdering,
-	rowCount float64,
-	locking *tree.LockingItem,
+	table cat.Table, index cat.Index, params exec.ScanParams, reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
-		return ef.constructVirtualScan(
-			table, index, needed, indexConstraint, hardLimit, softLimit, reverse,
-			reqOrdering, rowCount, locking,
-		)
+		return ef.constructVirtualScan(table, index, params, reqOrdering)
 	}
 
 	tabDesc := table.(*optTable).desc
 	indexDesc := index.(*optIndex).desc
 	// Create a scanNode.
 	scan := ef.planner.Scan()
-	colCfg := makeScanColumnsConfig(table, needed)
+	colCfg := makeScanColumnsConfig(table, params.NeededCols)
 
 	sb := span.MakeBuilder(ef.planner.ExecCfg().Codec, tabDesc.TableDesc(), indexDesc)
 
@@ -110,21 +96,21 @@ func (ef *execFactory) ConstructScan(
 		return nil, err
 	}
 
-	if indexConstraint != nil && indexConstraint.IsContradiction() {
+	if params.IndexConstraint != nil && params.IndexConstraint.IsContradiction() {
 		return newZeroNode(scan.resultColumns), nil
 	}
 
 	scan.index = indexDesc
-	scan.hardLimit = hardLimit
-	scan.softLimit = softLimit
+	scan.hardLimit = params.HardLimit
+	scan.softLimit = params.SoftLimit
 
-	scan.reverse = reverse
-	scan.parallelize = parallelize
+	scan.reverse = params.Reverse
+	scan.parallelize = params.Parallelize
 	var err error
-	if invertedConstraint != nil {
-		scan.spans, err = GenerateInvertedSpans(invertedConstraint, sb)
+	if params.InvertedConstraint != nil {
+		scan.spans, err = GenerateInvertedSpans(params.InvertedConstraint, sb)
 	} else {
-		scan.spans, err = sb.SpansFromConstraint(indexConstraint, needed, false /* forDelete */)
+		scan.spans, err = sb.SpansFromConstraint(params.IndexConstraint, params.NeededCols, false /* forDelete */)
 	}
 	if err != nil {
 		return nil, err
@@ -137,29 +123,19 @@ func (ef *execFactory) ConstructScan(
 		return nil, err
 	}
 	scan.reqOrdering = ReqOrdering(reqOrdering)
-	scan.estimatedRowCount = uint64(rowCount)
-	if locking != nil {
-		scan.lockingStrength = sqlbase.ToScanLockingStrength(locking.Strength)
-		scan.lockingWaitPolicy = sqlbase.ToScanLockingWaitPolicy(locking.WaitPolicy)
+	scan.estimatedRowCount = uint64(params.EstimatedRowCount)
+	if params.Locking != nil {
+		scan.lockingStrength = sqlbase.ToScanLockingStrength(params.Locking.Strength)
+		scan.lockingWaitPolicy = sqlbase.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
 	}
 	return scan, nil
 }
 
 func (ef *execFactory) constructVirtualScan(
-	table cat.Table,
-	index cat.Index,
-	needed exec.TableColumnOrdinalSet,
-	indexConstraint *constraint.Constraint,
-	hardLimit int64,
-	softLimit int64,
-	reverse bool,
-	reqOrdering exec.OutputOrdering,
-	rowCount float64,
-	locking *tree.LockingItem,
+	table cat.Table, index cat.Index, params exec.ScanParams, reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
 	return constructVirtualScan(
-		ef, ef.planner, table, index, needed, indexConstraint, hardLimit,
-		softLimit, reverse, reqOrdering, rowCount, locking,
+		ef, ef.planner, table, index, params, reqOrdering,
 		func(d *delayedNode) (exec.Node, error) { return d, nil },
 	)
 }

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -49,6 +49,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.columns
 	case *joinNode:
 		return n.columns
+	case *interleavedJoinNode:
+		return n.columns
 	case *ordinalityNode:
 		return n.columns
 	case *renderNode:

--- a/pkg/sql/plan_ordering.go
+++ b/pkg/sql/plan_ordering.go
@@ -58,6 +58,8 @@ func planReqOrdering(plan planNode) ReqOrdering {
 		// appropriately.
 	case *joinNode:
 		return n.reqOrdering
+	case *interleavedJoinNode:
+		return n.reqOrdering
 	case *unionNode:
 		// TODO(knz): this can be ordered if the source is ordered already.
 	case *insertNode, *insertFastPathNode:

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -130,6 +130,8 @@ type SessionData struct {
 	// InsertFastPath is true if the fast path for insert (with VALUES input) may
 	// be used.
 	InsertFastPath bool
+	// InterleavedJoins is true if interleaved joins may be used.
+	InterleavedJoins bool
 	// NoticeDisplaySeverity indicates the level of Severity to send notices for the given
 	// session.
 	NoticeDisplaySeverity pgnotice.DisplaySeverity

--- a/pkg/sql/sqlbase/locking.go
+++ b/pkg/sql/sqlbase/locking.go
@@ -14,7 +14,26 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
 )
+
+// PrettyString returns the locking strength as a user-readable string.
+func (s ScanLockingStrength) PrettyString() string {
+	switch s {
+	case ScanLockingStrength_FOR_NONE:
+		return "for none"
+	case ScanLockingStrength_FOR_KEY_SHARE:
+		return "for key share"
+	case ScanLockingStrength_FOR_SHARE:
+		return "for share"
+	case ScanLockingStrength_FOR_NO_KEY_UPDATE:
+		return "for no key update"
+	case ScanLockingStrength_FOR_UPDATE:
+		return "for update"
+	default:
+		panic(errors.AssertionFailedf("unexpected strength"))
+	}
+}
 
 // ToScanLockingStrength converts a tree.LockingStrength to its corresponding
 // ScanLockingStrength.
@@ -32,6 +51,20 @@ func ToScanLockingStrength(s tree.LockingStrength) ScanLockingStrength {
 		return ScanLockingStrength_FOR_UPDATE
 	default:
 		panic(fmt.Sprintf("unknown locking strength %s", s))
+	}
+}
+
+// PrettyString returns the locking strength as a user-readable string.
+func (wp ScanLockingWaitPolicy) PrettyString() string {
+	switch wp {
+	case ScanLockingWaitPolicy_BLOCK:
+		return "block"
+	case ScanLockingWaitPolicy_SKIP:
+		return "skip locked"
+	case ScanLockingWaitPolicy_ERROR:
+		return "nowait"
+	default:
+		panic(errors.AssertionFailedf("unexpected wait policy"))
 	}
 }
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -701,6 +701,25 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`enable_interleaved_joins`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`enable_interleaved_joins`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := parseBoolVar("enable_interleaved_joins", s)
+			if err != nil {
+				return err
+			}
+			m.SetInterleavedJoins(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.InterleavedJoins)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(planInterleavedJoins.Get(sv))
+		},
+	},
+
+	// CockroachDB extension.
 	`serial_normalization`: {
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			mode, ok := sessiondata.SerialNormalizationModeFromString(s)


### PR DESCRIPTION
#### opt: consolidate exec factory scan parameters in a struct

This is a mechanical change that moves the myriad of `ConstructScan`
arguments into an `exec.ScanParams` struct.

Release note: None

#### sql: move interleaved join planning in the optimizer

The distsql planner can convert merge joins to interleave joins. This
logic is fragile (e.g. it prevents some unrelated scanNode cleanup)
and would need to be duplicated by the new factory.

This change moves the logic that decides whether to build an
interleaved join to the execbuilder. Longer term, we will want the
rest of the optimizer to be aware of interleaved joins and cost them
differently.

Unit tests targeting this planning decision have been converted to
execbuilder logictests. We also add a session variable that controls
interleaved joins (with default value controlled by the existing
cluster setting).

Release note (sql change): Interleaved table joins now show up in
EXPLAIN (PLAN).