### PR TITLE
sql: be more strict with validating EXPLAIN

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -2911,6 +2911,49 @@ EXPLAIN EXECUTE a
 HINT: try \h EXPLAIN`,
 		},
 		{
+			`EXPLAIN ANALYZE (PLAN) SELECT 1`,
+			`at or near "EOF": syntax error: EXPLAIN ANALYZE cannot be used with PLAN
+DETAIL: source SQL:
+EXPLAIN ANALYZE (PLAN) SELECT 1
+                               ^`,
+		},
+		{
+			`EXPLAIN (ANALYZE, PLAN) SELECT 1`,
+			`at or near "analyze": syntax error
+DETAIL: source SQL:
+EXPLAIN (ANALYZE, PLAN) SELECT 1
+         ^
+HINT: try \h <SELECTCLAUSE>`,
+		},
+		{
+			`EXPLAIN ANALYZE (OPT) SELECT 1`,
+			`at or near "EOF": syntax error: EXPLAIN ANALYZE cannot be used with OPT
+DETAIL: source SQL:
+EXPLAIN ANALYZE (OPT) SELECT 1
+                              ^`,
+		},
+		{
+			`EXPLAIN ANALYZE (VEC) SELECT 1`,
+			`at or near "EOF": syntax error: EXPLAIN ANALYZE cannot be used with VEC
+DETAIL: source SQL:
+EXPLAIN ANALYZE (VEC) SELECT 1
+                              ^`,
+		},
+		{
+			`EXPLAIN (DEBUG) SELECT 1`,
+			`at or near "EOF": syntax error: DEBUG flag can only be used with EXPLAIN ANALYZE
+DETAIL: source SQL:
+EXPLAIN (DEBUG) SELECT 1
+                        ^`,
+		},
+		{
+			`EXPLAIN (PLAN, DEBUG) SELECT 1`,
+			`at or near "EOF": syntax error: DEBUG flag can only be used with EXPLAIN ANALYZE
+DETAIL: source SQL:
+EXPLAIN (PLAN, DEBUG) SELECT 1
+                              ^`,
+		},
+		{
 			`SELECT $0`,
 			`lexical error: placeholder index must be between 1 and 65536
 DETAIL: source SQL:

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -122,13 +122,15 @@ func (f ExplainFlag) String() string {
 // Format implements the NodeFormatter interface.
 func (node *Explain) Format(ctx *FmtCtx) {
 	ctx.WriteString("EXPLAIN ")
+	showMode := node.Mode != ExplainPlan
 	// ANALYZE is a special case because it is a statement implemented as an
 	// option to EXPLAIN.
 	if node.Flags[ExplainFlagAnalyze] {
 		ctx.WriteString("ANALYZE ")
+		showMode = true
 	}
 	wroteFlag := false
-	if node.Mode != ExplainPlan {
+	if showMode {
 		fmt.Fprintf(ctx, "(%s", node.Mode)
 		wroteFlag = true
 	}
@@ -185,8 +187,21 @@ func MakeExplain(options []string, stmt Statement) (Statement, error) {
 		}
 		opts.Flags[flag] = true
 	}
+	analyze := opts.Flags[ExplainFlagAnalyze]
+	if opts.Mode == 0 {
+		if analyze {
+			// ANALYZE implies DISTSQL.
+			opts.Mode = ExplainDistSQL
+		} else {
+			// Default mode is ExplainPlan.
+			opts.Mode = ExplainPlan
+		}
+	} else if analyze && opts.Mode != ExplainDistSQL {
+		return nil, pgerror.Newf(pgcode.Syntax, "EXPLAIN ANALYZE cannot be used with %s", opts.Mode)
+	}
+
 	if opts.Flags[ExplainFlagDebug] {
-		if !opts.Flags[ExplainFlagAnalyze] {
+		if !analyze {
 			return nil, pgerror.Newf(pgcode.Syntax, "DEBUG flag can only be used with EXPLAIN ANALYZE")
 		}
 		if len(options) != 2 {
@@ -196,10 +211,7 @@ func MakeExplain(options []string, stmt Statement) (Statement, error) {
 		}
 		return &ExplainAnalyzeDebug{Statement: stmt}, nil
 	}
-	if opts.Mode == 0 {
-		// Default mode is ExplainPlan.
-		opts.Mode = ExplainPlan
-	}
+
 	return &Explain{
 		ExplainOptions: opts,
 		Statement:      stmt,

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -2068,13 +2068,15 @@ func (node *Export) doc(p *PrettyCfg) pretty.Doc {
 
 func (node *Explain) doc(p *PrettyCfg) pretty.Doc {
 	d := pretty.Keyword("EXPLAIN")
+	showMode := node.Mode != ExplainPlan
 	// ANALYZE is a special case because it is a statement implemented as an
 	// option to EXPLAIN.
 	if node.Flags[ExplainFlagAnalyze] {
 		d = pretty.ConcatSpace(d, pretty.Keyword("ANALYZE"))
+		showMode = true
 	}
 	var opts []pretty.Doc
-	if node.Mode != ExplainPlan {
+	if showMode {
 		opts = append(opts, pretty.Keyword(node.Mode.String()))
 	}
 	for f := ExplainFlag(1); f <= numExplainFlags; f++ {


### PR DESCRIPTION
#### sql: be more strict with validating EXPLAIN

Verify during paring that we are not specifying an invalid mode for
`EXPLAIN ANALYZE`.

Fixes #51473.

Release note: None