### PR TITLE
sql: fix a bug with unset type metadata on some join processors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1062,3 +1062,14 @@ query T
 SELECT to_json('hello'::greeting)
 ----
 "hello"
+
+# Regression for #51474.
+statement ok
+CREATE TABLE t51474 (x greeting);
+INSERT INTO t51474 VALUES ('hello'), ('howdy')
+
+query T rowsort
+SELECT * FROM t51474 INTERSECT ALL SELECT * FROM t51474
+----
+hello
+howdy

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -268,6 +268,15 @@ func (f *rowBasedFlow) setupInputSyncs(
 				return nil, errors.Errorf("unsupported input sync type %s", is.Type)
 			}
 
+			// Before we can safely use types we received over the wire in the
+			// processors, we need to make sure they are hydrated. All processors other
+			// than processors that scan over tables get their inputs from here, so
+			// this is a convenient place to do the hydration. Processors that scan
+			// over tables will have their hydration performed in ProcessorBase.Init.
+			if err := execinfrapb.HydrateTypeSlice(f.EvalCtx, is.ColumnTypes); err != nil {
+				return nil, err
+			}
+
 			if is.Type == execinfrapb.InputSyncSpec_UNORDERED {
 				if opt == flowinfra.FuseNormally || len(is.Streams) == 1 {
 					// Unordered synchronizer: create a RowChannel for each input.


### PR DESCRIPTION
Fixes #51474.

This commit fixes a bug where some joiner processors would not hydrate
their input type metadata in certain cases, leading to panics at
execution.

Release note: None