### PR TITLE
cli: add userfile ls CLI command to list uploaded files

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1411,7 +1411,7 @@ Available Commands:
   dump              dump sql tables
 
   nodelocal         upload and delete nodelocal files
-  userfile          upload and delete user scoped files
+  userfile          upload, list and delete user scoped files
   demo              open a demo sql shell
   gen               generate auxiliary files
   version           output version information

--- a/pkg/cli/userfiletable_test.go
+++ b/pkg/cli/userfiletable_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Example_userfile() {
+func Example_userfile_upload() {
 	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 

--- a/pkg/storage/cloudimpl/filetable/filetabletest/file_table_read_writer_test.go
+++ b/pkg/storage/cloudimpl/filetable/filetabletest/file_table_read_writer_test.go
@@ -95,9 +95,10 @@ func TestListAndDeleteFiles(t *testing.T) {
 	s, _, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 
+	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
+		InternalExecutor), kvDB)
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
-		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
-		security.RootUser)
+		executor, security.RootUser)
 	require.NoError(t, err)
 
 	// Create first test file with multiple chunks.
@@ -145,9 +146,10 @@ func TestReadWriteFile(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 
+	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
+		InternalExecutor), kvDB)
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
-		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
-		security.RootUser)
+		executor, security.RootUser)
 	require.NoError(t, err)
 
 	testFileName := "testfile"
@@ -281,9 +283,10 @@ func TestUserGrants(t *testing.T) {
 	require.NoError(t, err)
 
 	// Operate under non-admin user.
+	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
+		InternalExecutor), kvDB)
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
-		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
-		"john")
+		executor, "john")
 	require.NoError(t, err)
 
 	// Upload a file to test INSERT privilege.
@@ -360,9 +363,10 @@ func TestDifferentUserDisallowed(t *testing.T) {
 	require.NoError(t, err)
 
 	// Operate under non-admin user john.
+	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
+		InternalExecutor), kvDB)
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
-		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
-		"john")
+		executor, "john")
 	require.NoError(t, err)
 
 	_, err = uploadFile(ctx, "file1", 1024, 10, fileTableReadWriter)
@@ -415,9 +419,10 @@ func TestDifferentRoleDisallowed(t *testing.T) {
 	require.NoError(t, err)
 
 	// Operate under non-admin user john.
+	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
+		InternalExecutor), kvDB)
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
-		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
-		"john")
+		executor, "john")
 	require.NoError(t, err)
 
 	_, err = uploadFile(ctx, "file1", 1024, 10, fileTableReadWriter)
@@ -447,9 +452,10 @@ func TestDatabaseScope(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 
+	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
+		InternalExecutor), kvDB)
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
-		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
-		security.RootUser)
+		executor, security.RootUser)
 	require.NoError(t, err)
 
 	// Verify defaultdb has the file we wrote.
@@ -465,8 +471,7 @@ func TestDatabaseScope(t *testing.T) {
 	_, err = sqlDB.Exec(`CREATE DATABASE newdb`)
 	require.NoError(t, err)
 	newFileTableReadWriter, err := filetable.NewFileToTableSystem(ctx,
-		"newdb.file_table_read_writer",
-		s.InternalExecutor().(*sql.InternalExecutor), kvDB, security.RootUser)
+		"newdb.file_table_read_writer", executor, security.RootUser)
 	require.NoError(t, err)
 	_, err = newFileTableReadWriter.ReadFile(ctx, "file1")
 	require.True(t, os.IsNotExist(err))


### PR DESCRIPTION
This change adds support for a `userfile ls` command which allows users
to list file(s) which have been uploaded to the user-scoped
FileTableStorage.

The ls command accepts a single, optional CLI arg which can either be
a well-formed userfile URI or a glob pattern.

The semantics of userfile ls are as follows:
`userfile ls` : List all files in the default user FileTableStorage
tables `defaultdb.public.userfiles_$USERNAME`

`userfile ls userfile://db.schema.tableprefix/glob/pattern` : List all
files which match the glob pattern and are in the
`db.schema.tableprefix` tables.

`userfile ls glob/pattern` : List files which match the glob pattern in
the default user FileTableStorage tables
`defaultdb.public.userfiles_$USERNAME`

Informs: #51222

Release note (cli change): `userfile` now supports an `ls` command which
allows users to list the files they have uploaded to the user-scoped
FileTableStorage. `userfile ls` accepts a single, optional CLI arg which
can either be a well-formed userfile URI or a glob pattern.
The latter defaults to searching in the default
FileTableStorage tables `defaultdb.public.userfiles_$USRENAME`.