### PR TITLE
geo/geomfn: implement ST_Translate

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1509,6 +1509,8 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 <tr><td><a name="st_transform"></a><code>st_transform(geometry: geometry, to_proj_text: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Transforms a geometry into the coordinate reference system referenced by the projection text by projecting its coordinates.</p>
 <p>This function utilizes the PROJ library for coordinate projections.</p>
 </span></td></tr>
+<tr><td><a name="st_translate"></a><code>st_translate(g: geometry, deltaX: <a href="float.html">float</a>, deltaY: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified Geometry translated by the given deltas</p>
+</span></td></tr>
 <tr><td><a name="st_union"></a><code>st_union(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the union of the given geometries as a single Geometry object.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>

--- a/pkg/geo/geomfn/translate.go
+++ b/pkg/geo/geomfn/translate.go
@@ -1,0 +1,114 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/errors"
+	"github.com/twpayne/go-geom"
+)
+
+// Translate returns a modified Geometry whose coordinates are incremented or decremented by the deltas.
+func Translate(geometry *geo.Geometry, deltas []float64) (*geo.Geometry, error) {
+	g, err := geometry.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+
+	g, err = translate(g, deltas)
+	if err != nil {
+		return nil, err
+	}
+
+	return geo.NewGeometryFromGeomT(g)
+}
+
+func translate(g geom.T, deltas []float64) (geom.T, error) {
+	if geomCollection, ok := g.(*geom.GeometryCollection); ok {
+		return translateCollection(geomCollection, deltas)
+	}
+
+	newCoords, err := translateCoords(g.FlatCoords(), g.Layout(), deltas)
+	if err != nil {
+		return nil, err
+	}
+
+	switch t := g.(type) {
+	case *geom.Point:
+		g = geom.NewPointFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.LineString:
+		g = geom.NewLineStringFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.Polygon:
+		g = geom.NewPolygonFlat(t.Layout(), newCoords, t.Ends()).SetSRID(g.SRID())
+	case *geom.MultiPoint:
+		g = geom.NewMultiPointFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.MultiLineString:
+		g = geom.NewMultiLineStringFlat(t.Layout(), newCoords, t.Ends()).SetSRID(g.SRID())
+	case *geom.MultiPolygon:
+		g = geom.NewMultiPolygonFlat(t.Layout(), newCoords, t.Endss()).SetSRID(g.SRID())
+	default:
+		return nil, geom.ErrUnsupportedType{Value: g}
+	}
+
+	return g, nil
+}
+
+// translateCoords increments or decrements the given flatCoords array and returns the translated coordinates.
+// Note: M coordinates are not affected.
+func translateCoords(
+	flatCoords []float64, layout geom.Layout, deltas []float64,
+) ([]float64, error) {
+	if layout.Stride() != len(deltas) {
+		err := geom.ErrStrideMismatch{
+			Got:  len(deltas),
+			Want: layout.Stride(),
+		}
+		return nil, errors.Wrap(err, "translating coordinates")
+	}
+
+	newCoords := make([]float64, len(flatCoords))
+
+	for i := 0; i < len(flatCoords); i += layout.Stride() {
+		newCoords[i] = flatCoords[i] + deltas[0]
+		newCoords[i+1] = flatCoords[i+1] + deltas[1]
+
+		z := layout.ZIndex()
+		if z != -1 {
+			newCoords[i+z] = flatCoords[i+z] + deltas[z]
+		}
+
+		// m coords are only copied over
+		m := layout.MIndex()
+		if m != -1 {
+			newCoords[i+m] = deltas[m]
+		}
+	}
+
+	return newCoords, nil
+}
+
+// translateCollection iterates through a GeometryCollection and calls Translate() on each item.
+func translateCollection(
+	geomCollection *geom.GeometryCollection, deltas []float64,
+) (*geom.GeometryCollection, error) {
+	res := geom.NewGeometryCollection()
+	for _, subG := range geomCollection.Geoms() {
+		subGeom, err := translate(subG, deltas)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := res.Push(subGeom); err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}

--- a/pkg/geo/geomfn/translate_test.go
+++ b/pkg/geo/geomfn/translate_test.go
@@ -1,0 +1,150 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
+)
+
+func TestTranslate(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		input    geom.T
+		deltas   []float64
+		expected geom.T
+	}{
+		{
+			desc:     "translate a 2D point",
+			input:    geom.NewPointFlat(geom.XY, []float64{10, 10}),
+			deltas:   []float64{5, -5},
+			expected: geom.NewPointFlat(geom.XY, []float64{15, 5}),
+		},
+		{
+			desc:     "translate a line string",
+			input:    geom.NewLineStringFlat(geom.XY, []float64{10, 15, 20, 30}),
+			deltas:   []float64{1, 5},
+			expected: geom.NewLineStringFlat(geom.XY, []float64{11, 20, 21, 35}),
+		},
+		{
+			desc:     "translate a polygon",
+			input:    geom.NewPolygonFlat(geom.XY, []float64{0, 0, 5, 5, 0, 10, 0, 0}, []int{8}),
+			deltas:   []float64{1, 1},
+			expected: geom.NewPolygonFlat(geom.XY, []float64{1, 1, 6, 6, 1, 11, 1, 1}, []int{8}),
+		},
+		{
+			desc:     "translate multiple 2D points",
+			input:    geom.NewMultiPointFlat(geom.XY, []float64{5, 10, -30, 40}),
+			deltas:   []float64{1, 0.5},
+			expected: geom.NewMultiPointFlat(geom.XY, []float64{6, 10.5, -29, 40.5}),
+		},
+		{
+			desc:     "translate multiple line strings",
+			input:    geom.NewMultiLineStringFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3, 4, 4}, []int{4, 8}),
+			deltas:   []float64{.1, .1},
+			expected: geom.NewMultiLineStringFlat(geom.XY, []float64{1.1, 1.1, 2.1, 2.1, 3.1, 3.1, 4.1, 4.1}, []int{4, 8}),
+		},
+		{
+			desc:     "translate empty line string",
+			input:    geom.NewLineString(geom.XY),
+			deltas:   []float64{1, 1},
+			expected: geom.NewLineString(geom.XY),
+		},
+		{
+			desc:     "translate empty polygon",
+			input:    geom.NewPolygon(geom.XY),
+			deltas:   []float64{1, 1},
+			expected: geom.NewPolygon(geom.XY),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			geometry, err := geo.NewGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+
+			got, err := Translate(geometry, tc.deltas)
+			require.NoError(t, err)
+
+			want, err := geo.NewGeometryFromGeomT(tc.expected)
+			require.NoError(t, err)
+
+			require.Equal(t, want, got)
+			require.EqualValues(t, tc.input.SRID(), got.SRID())
+		})
+	}
+}
+
+func TestTranslateCollection(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		input    *geom.GeometryCollection
+		deltas   []float64
+		expected *geom.GeometryCollection
+	}{
+		{
+			desc: "translate non-empty collection",
+			input: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{10, 10}),
+				geom.NewLineStringFlat(geom.XY, []float64{0, 0, 5, 5}),
+				geom.NewMultiPointFlat(geom.XY, []float64{0, 0, -5, -5, -10, -10}),
+			),
+			deltas: []float64{1, -1},
+			expected: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{11, 9}),
+				geom.NewLineStringFlat(geom.XY, []float64{1, -1, 6, 4}),
+				geom.NewMultiPointFlat(geom.XY, []float64{1, -1, -4, -6, -9, -11}),
+			),
+		},
+		{
+			desc:     "translate empty collection",
+			input:    geom.NewGeometryCollection(),
+			deltas:   []float64{1, 1},
+			expected: geom.NewGeometryCollection(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			geometry, err := geo.NewGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+
+			geometry, err = Translate(geometry, tc.deltas)
+			require.NoError(t, err)
+
+			g, err := geometry.AsGeomT()
+			require.NoError(t, err)
+
+			gotCollection, ok := g.(*geom.GeometryCollection)
+			require.True(t, ok)
+
+			require.Equal(t, tc.expected, gotCollection)
+		})
+	}
+
+}
+
+func TestTranslateErrorMismatchedDeltas(t *testing.T) {
+	deltas := []float64{1, 1, 1}
+	geometry, err := geo.NewGeometryFromPointCoords(0, 0)
+	require.NoError(t, err)
+
+	_, err = Translate(geometry, deltas)
+	isErr := errors.Is(err, geom.ErrStrideMismatch{
+		Got:  3,
+		Want: 2,
+	})
+	require.True(t, isErr)
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -3735,6 +3735,33 @@ SRID=4326;MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)))                            
 SRID=4326;POINT (1 1)                                                           false  false
 SRID=4326;POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                                   false  false
 
+subtest translate_test
+
+query TT
+SELECT
+  ST_AsText(a.geom) d,
+  ST_AsText(ST_Translate(a.geom, 1, 1))
+FROM geom_operators_test a
+ORDER BY d ASC
+----
+NULL                                                   NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (1 1)))
+GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY
+LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (0.5 1.5, 1.5 1.5)
+LINESTRING EMPTY                                       LINESTRING EMPTY
+POINT (-0.5 0.5)                                       POINT (0.5 1.5)
+POINT (0.5 0.5)                                        POINT (1.5 1.5)
+POINT (5 5)                                            POINT (6 6)
+POINT EMPTY                                            POINT EMPTY
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((0.9 1, 2 1, 2 2, 0.9 2, 0.9 1))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((0 1, 1 1, 1 2, 0 2, 0 1))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((1 1, 2 1, 2 2, 1 2, 1 1))
+
+query T
+SELECT ST_Summary('POINT(0 0)'::geometry)
+----
+Point[B]
+
 subtest st_summary
 
 query T

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3029,6 +3029,33 @@ For flags=1, validity considers self-intersecting rings forming holes as valid a
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_translate": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"g", types.Geometry},
+				{"deltaX", types.Float},
+				{"deltaY", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := args[0].(*tree.DGeometry)
+				deltaX := float64(*args[1].(*tree.DFloat))
+				deltaY := float64(*args[2].(*tree.DFloat))
+
+				ret, err := geomfn.Translate(g.Geometry, []float64{deltaX, deltaY})
+				if err != nil {
+					return nil, err
+				}
+
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: `Returns a modified Geometry translated by the given deltas`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 	"st_segmentize": makeBuiltin(
 		defProps(),
 		tree.Overload{


### PR DESCRIPTION
Implement ST_Translate on arguments {geometry,float8,float8}, which should adopt PostGIS behaviour.

Release note (sql change): Implemented geometry builtin `ST_Translate`