### PR TITLE
opt, cat: rename Table.AllColumnCount to Table.ColumnCount

### DIFF
--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -41,9 +41,9 @@ type Table interface {
 	// information_schema tables.
 	IsVirtualTable() bool
 
-	// AllColumnCount returns the number of columns in the table. This includes
+	// ColumnCount returns the number of columns in the table. This includes
 	// public columns, write-only columns, etc.
-	AllColumnCount() int
+	ColumnCount() int
 
 	// Column returns a Column interface to the column at the ith ordinal
 	// position within the table, where i < ColumnCount. Note that the Columns

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -130,7 +130,7 @@ func FormatTable(cat Catalog, tab Table, tp treeprinter.Node) {
 	}
 
 	var buf bytes.Buffer
-	for i := 0; i < tab.AllColumnCount(); i++ {
+	for i := 0; i < tab.ColumnCount(); i++ {
 		buf.Reset()
 		formatColumn(tab.Column(i), IsMutationColumn(tab, i), &buf)
 		child.Child(buf.String())

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -702,7 +702,7 @@ func mutationOutputColMap(mutation memo.RelExpr) opt.ColMap {
 
 	var colMap opt.ColMap
 	ord := 0
-	for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+	for i, n := 0, tab.ColumnCount(); i < n; i++ {
 		colID := private.Table.ColumnID(i)
 		if outCols.Contains(colID) {
 			colMap.Set(int(colID), ord)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -411,7 +411,7 @@ func (b *Builder) getColumns(
 	var needed exec.TableColumnOrdinalSet
 	var output opt.ColMap
 
-	columnCount := b.mem.Metadata().Table(tableID).AllColumnCount()
+	columnCount := b.mem.Metadata().Table(tableID).ColumnCount()
 	n := 0
 	for i := 0; i < columnCount; i++ {
 		colID := tableID.ColumnID(i)

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -173,13 +173,13 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 
 	case *InsertExpr:
 		tab := m.Metadata().Table(t.Table)
-		m.checkColListLen(t.InsertCols, tab.AllColumnCount(), "InsertCols")
+		m.checkColListLen(t.InsertCols, tab.ColumnCount(), "InsertCols")
 		m.checkColListLen(t.FetchCols, 0, "FetchCols")
 		m.checkColListLen(t.UpdateCols, 0, "UpdateCols")
 
 		// Ensure that insert columns include all columns except for delete-only
 		// mutation columns (which do not need to be part of INSERT).
-		for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+		for i, n := 0, tab.ColumnCount(); i < n; i++ {
 			if tab.ColumnKind(i) != cat.DeleteOnly && t.InsertCols[i] == 0 {
 				panic(errors.AssertionFailedf("insert values not provided for all table columns"))
 			}
@@ -190,8 +190,8 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 	case *UpdateExpr:
 		tab := m.Metadata().Table(t.Table)
 		m.checkColListLen(t.InsertCols, 0, "InsertCols")
-		m.checkColListLen(t.FetchCols, tab.AllColumnCount(), "FetchCols")
-		m.checkColListLen(t.UpdateCols, tab.AllColumnCount(), "UpdateCols")
+		m.checkColListLen(t.FetchCols, tab.ColumnCount(), "FetchCols")
+		m.checkColListLen(t.UpdateCols, tab.ColumnCount(), "UpdateCols")
 		m.checkMutationExpr(t, &t.MutationPrivate)
 
 	case *ZigzagJoinExpr:
@@ -250,7 +250,7 @@ func (m *Memo) checkMutationExpr(rel RelExpr, private *MutationPrivate) {
 	// Output columns should never include mutation columns.
 	tab := m.Metadata().Table(private.Table)
 	var mutCols opt.ColSet
-	for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+	for i, n := 0, tab.ColumnCount(); i < n; i++ {
 		if cat.IsMutationColumn(tab, i) {
 			mutCols.Add(private.Table.ColumnID(i))
 		}

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -640,7 +640,7 @@ func (m *MutationPrivate) MapToInputCols(tabCols opt.ColSet) opt.ColSet {
 // AddEquivTableCols adds an FD to the given set that declares an equivalence
 // between each table column and its corresponding input column.
 func (m *MutationPrivate) AddEquivTableCols(md *opt.Metadata, fdset *props.FuncDepSet) {
-	for i, n := 0, md.Table(m.Table).AllColumnCount(); i < n; i++ {
+	for i, n := 0, md.Table(m.Table).ColumnCount(); i < n; i++ {
 		t := m.Table.ColumnID(i)
 		id := m.MapToInputID(t)
 		if id != 0 {

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1268,7 +1268,7 @@ func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Re
 	// Output Columns
 	// --------------
 	// Only non-mutation columns are output columns.
-	for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+	for i, n := 0, tab.ColumnCount(); i < n; i++ {
 		if private.IsColumnOutput(i) {
 			colID := private.Table.ColumnID(i)
 			rel.OutputCols.Add(colID)
@@ -1289,7 +1289,7 @@ func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Re
 	// null or the corresponding insert and fetch/update columns are not null. In
 	// other words, if either the source or destination column is not null, then
 	// the column must be not null.
-	for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+	for i, n := 0, tab.ColumnCount(); i < n; i++ {
 		tabColID := private.Table.ColumnID(i)
 		if !rel.OutputCols.Contains(tabColID) {
 			continue
@@ -1562,7 +1562,7 @@ func MakeTableFuncDep(md *opt.Metadata, tabID opt.TableID) *props.FuncDepSet {
 	// Make now and annotate the metadata table with it for next time.
 	var allCols opt.ColSet
 	tab := md.Table(tabID)
-	for i := 0; i < tab.AllColumnCount(); i++ {
+	for i := 0; i < tab.ColumnCount(); i++ {
 		allCols.Add(tabID.ColumnID(i))
 	}
 
@@ -1819,7 +1819,7 @@ func tableNotNullCols(md *opt.Metadata, tabID opt.TableID) opt.ColSet {
 
 	// Only iterate over non-mutation columns, since even non-null mutation
 	// columns can be null during backfill.
-	for i := 0; i < tab.AllColumnCount(); i++ {
+	for i := 0; i < tab.ColumnCount(); i++ {
 		// Non-null mutation columns can be null during backfill.
 		if !cat.IsMutationColumn(tab, i) && !tab.Column(i).IsNullable() {
 			cs.Add(tabID.ColumnID(i))

--- a/pkg/sql/opt/memo/multiplicity_builder.go
+++ b/pkg/sql/opt/memo/multiplicity_builder.go
@@ -107,7 +107,7 @@ func deriveUnfilteredCols(in RelExpr) opt.ColSet {
 		md := t.Memo().Metadata()
 		baseTable := md.Table(t.Table)
 		if t.IsUnfiltered(md) {
-			for i, cnt := 0, baseTable.AllColumnCount(); i < cnt; i++ {
+			for i, cnt := 0, baseTable.ColumnCount(); i < cnt; i++ {
 				unfilteredCols.Add(t.Table.ColumnID(i))
 			}
 		}

--- a/pkg/sql/opt/memo/multiplicity_builder_test.go
+++ b/pkg/sql/opt/memo/multiplicity_builder_test.go
@@ -329,7 +329,7 @@ func (ob *testOpBuilder) makeScan(tableName tree.Name) (scan RelExpr, vars []*Va
 	tab := ob.cat.Table(tn)
 	tabID := ob.mem.Metadata().AddTable(tab, tn)
 	var cols opt.ColSet
-	for i := 0; i < tab.AllColumnCount(); i++ {
+	for i := 0; i < tab.ColumnCount(); i++ {
 		col := tabID.ColumnID(i)
 		cols.Add(col)
 		newVar := ob.mem.MemoizeVariable(col)

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -99,7 +99,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		t.Helper()
 
 		var cols opt.ColSet
-		for i := 0; i < tab.AllColumnCount(); i++ {
+		for i := 0; i < tab.ColumnCount(); i++ {
 			cols.Add(tabID.ColumnID(i))
 		}
 

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -336,7 +336,7 @@ func (md *Metadata) AddTable(tab cat.Table, alias *tree.TableName) TableID {
 	}
 	md.tables = append(md.tables, TableMeta{MetaID: tabID, Table: tab, Alias: *alias})
 
-	colCount := tab.AllColumnCount()
+	colCount := tab.ColumnCount()
 	if md.cols == nil {
 		md.cols = make([]ColumnMeta, 0, colCount)
 	}

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -366,7 +366,7 @@ func (mb *mutationBuilder) needExistingRows() bool {
 	// TODO(andyk): This is not true in the case of composite key encodings. See
 	// issue #34518.
 	keyOrds := getIndexLaxKeyOrdinals(mb.tab.Index(cat.PrimaryIndex))
-	for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
+	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
 		if keyOrds.Contains(i) {
 			// #1: Don't consider key columns.
 			continue
@@ -512,7 +512,7 @@ func (mb *mutationBuilder) addTargetTableColsForInsert(maxCols int) {
 	// Only consider non-mutation columns, since mutation columns are hidden from
 	// the SQL user.
 	numCols := 0
-	for i, n := 0, mb.tab.AllColumnCount(); i < n && numCols < maxCols; i++ {
+	for i, n := 0, mb.tab.ColumnCount(); i < n && numCols < maxCols; i++ {
 		// Skip mutation or hidden columns.
 		if cat.IsMutationColumn(mb.tab, i) || mb.tab.Column(i).IsHidden() {
 			continue
@@ -559,8 +559,8 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 			desiredTypes[i] = mb.md.ColumnMeta(colID).Type
 		}
 	} else {
-		desiredTypes = make([]*types.T, 0, mb.tab.AllColumnCount())
-		for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
+		desiredTypes = make([]*types.T, 0, mb.tab.ColumnCount())
+		for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
 			if !cat.IsMutationColumn(mb.tab, i) {
 				tabCol := mb.tab.Column(i)
 				if !tabCol.IsHidden() {
@@ -759,7 +759,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, conflictOrds u
 			conflictCols, mb.outScope, true /* nullsAreDistinct */, "" /* errorOnDup */)
 	}
 
-	mb.targetColList = make(opt.ColList, 0, mb.tab.AllColumnCount())
+	mb.targetColList = make(opt.ColList, 0, mb.tab.ColumnCount())
 	mb.targetColSet = opt.ColSet{}
 }
 
@@ -873,7 +873,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 		mb.b.buildWhere(where, mb.outScope)
 	}
 
-	mb.targetColList = make(opt.ColList, 0, mb.tab.AllColumnCount())
+	mb.targetColList = make(opt.ColList, 0, mb.tab.ColumnCount())
 	mb.targetColSet = opt.ColSet{}
 }
 
@@ -912,7 +912,7 @@ func (mb *mutationBuilder) setUpsertCols(insertCols tree.NameList) {
 	}
 
 	// Never update mutation columns.
-	for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
+	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
 		if cat.IsMutationColumn(mb.tab, i) {
 			mb.updateOrds[i] = -1
 		}
@@ -971,7 +971,7 @@ func (mb *mutationBuilder) projectUpsertColumns() {
 
 	// Add a new column for each target table column that needs to be upserted.
 	// This can include mutation columns.
-	for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
+	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
 		insertScopeOrd := mb.insertOrds[i]
 		updateScopeOrd := mb.updateOrds[i]
 		if updateScopeOrd == -1 {
@@ -1058,7 +1058,7 @@ func (mb *mutationBuilder) mapPublicColumnNamesToOrdinals(names tree.NameList) u
 	var ords util.FastIntSet
 	for _, name := range names {
 		found := false
-		for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
+		for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
 			tabCol := mb.tab.Column(i)
 			if tabCol.ColName() == name && !cat.IsMutationColumn(mb.tab, i) {
 				ords.Add(i)

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -170,7 +170,7 @@ func (mb *mutationBuilder) init(b *Builder, opName string, tab cat.Table, alias 
 	mb.tab = tab
 	mb.alias = alias
 
-	n := tab.AllColumnCount()
+	n := tab.ColumnCount()
 	mb.targetColList = make(opt.ColList, 0, n)
 
 	// Allocate segmented array of scope column ordinals.
@@ -546,7 +546,7 @@ func (mb *mutationBuilder) addSynthesizedCols(
 ) {
 	var projectionsScope *scope
 
-	for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
+	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
 		if mb.tab.ColumnKind(i) == cat.DeleteOnly {
 			// Skip delete-only mutation columns, since they are ignored by all
 			// mutation operators that synthesize columns.
@@ -779,7 +779,7 @@ func (mb *mutationBuilder) addPartialIndexCols(aliasPrefix string, ords []scopeO
 func (mb *mutationBuilder) disambiguateColumns() {
 	// Determine the set of scope columns that will have their names preserved.
 	var preserve util.FastIntSet
-	for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
+	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
 		scopeOrd := mb.mapToReturnScopeOrd(i)
 		if scopeOrd != -1 {
 			preserve.Add(int(scopeOrd))
@@ -829,8 +829,8 @@ func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationP
 	}
 
 	if needResults {
-		private.ReturnCols = make(opt.ColList, mb.tab.AllColumnCount())
-		for i, n := 0, mb.tab.AllColumnCount(); i < n; i++ {
+		private.ReturnCols = make(opt.ColList, mb.tab.ColumnCount())
+		for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
 			if cat.IsMutationColumn(mb.tab, i) {
 				// Only non-mutation columns are output columns.
 				continue
@@ -941,7 +941,7 @@ func (mb *mutationBuilder) checkNumCols(expected, actual int) {
 // reuse.
 func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.Expr {
 	if mb.parsedExprs == nil {
-		mb.parsedExprs = make([]tree.Expr, mb.tab.AllColumnCount())
+		mb.parsedExprs = make([]tree.Expr, mb.tab.ColumnCount())
 	}
 
 	// Return expression from cache, if it was already parsed previously.

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -227,9 +227,9 @@ func (s *scope) appendColumnsFromScope(src *scope) {
 func (s *scope) appendColumnsFromTable(tabMeta *opt.TableMeta, alias *tree.TableName) {
 	tab := tabMeta.Table
 	if s.cols == nil {
-		s.cols = make([]scopeColumn, 0, tab.AllColumnCount())
+		s.cols = make([]scopeColumn, 0, tab.ColumnCount())
 	}
-	for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+	for i, n := 0, tab.ColumnCount(); i < n; i++ {
 		if cat.IsMutationColumn(tab, i) {
 			continue
 		}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -463,8 +463,8 @@ func (b *Builder) buildScan(
 	if ordinals == nil {
 		// If no ordinals are requested, then add in all of the table columns
 		// (including mutation columns if scanMutationCols is true).
-		outScope.cols = make([]scopeColumn, 0, tab.AllColumnCount())
-		for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+		outScope.cols = make([]scopeColumn, 0, tab.ColumnCount())
+		for i, n := 0, tab.ColumnCount(); i < n; i++ {
 			if scanMutationCols || !cat.IsMutationColumn(tab, i) {
 				addCol(i)
 			}
@@ -579,7 +579,7 @@ func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
 	// Find the non-nullable table columns. Mutation columns can be NULL during
 	// backfill, so they should be excluded.
 	var notNullCols opt.ColSet
-	for i := 0; i < tab.AllColumnCount(); i++ {
+	for i := 0; i < tab.ColumnCount(); i++ {
 		if !tab.Column(i).IsNullable() && !cat.IsMutationColumn(tab, i) {
 			notNullCols.Add(tabMeta.MetaID.ColumnID(i))
 		}
@@ -628,7 +628,7 @@ func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
 func (b *Builder) addComputedColsForTable(tabMeta *opt.TableMeta) {
 	var tableScope *scope
 	tab := tabMeta.Table
-	for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+	for i, n := 0, tab.ColumnCount(); i < n; i++ {
 		tabCol := tab.Column(i)
 		if !tabCol.IsComputed() {
 			continue

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -644,7 +644,7 @@ func resolveNumericColumnRefs(tab cat.Table, columns []tree.ColumnID) (ordinals 
 	ordinals = make([]int, len(columns))
 	for i, c := range columns {
 		ord := 0
-		cnt := tab.AllColumnCount()
+		cnt := tab.ColumnCount()
 		for ord < cnt {
 			if tab.Column(ord).ColID() == cat.StableID(c) && !cat.IsMutationColumn(tab, ord) {
 				break
@@ -663,7 +663,7 @@ func resolveNumericColumnRefs(tab cat.Table, columns []tree.ColumnID) (ordinals 
 // having the given name, if one exists in the given table. Otherwise, it
 // returns -1.
 func findPublicTableColumnByName(tab cat.Table, name tree.Name) int {
-	for ord, n := 0, tab.AllColumnCount(); ord < n; ord++ {
+	for ord, n := 0, tab.ColumnCount(); ord < n; ord++ {
 		if tab.Column(ord).ColName() == name && !cat.IsMutationColumn(tab, ord) {
 			return ord
 		}

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -94,7 +94,7 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 
 	if !hasPrimaryIndex {
 		rowid := &Column{
-			Ordinal:     tab.AllColumnCount(),
+			Ordinal:     tab.ColumnCount(),
 			Name:        "rowid",
 			Type:        types.Int,
 			Hidden:      true,
@@ -254,7 +254,7 @@ func (tc *Catalog) CreateTableAs(name tree.TableName, columns []*Column) *Table 
 	tab := &Table{TabID: tc.nextStableID(), TabName: name, Catalog: tc, Columns: columns}
 
 	rowid := &Column{
-		Ordinal:     tab.AllColumnCount(),
+		Ordinal:     tab.ColumnCount(),
 		Name:        "rowid",
 		Type:        types.Int,
 		Hidden:      true,
@@ -380,7 +380,7 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 func (tt *Table) addColumn(def *tree.ColumnTableDef) {
 	nullable := !def.PrimaryKey.IsPrimaryKey && def.Nullable.Nullability != tree.NotNull
 	col := &Column{
-		Ordinal:  tt.AllColumnCount(),
+		Ordinal:  tt.ColumnCount(),
 		Name:     string(def.Name),
 		Type:     tree.MustBeStaticallyKnownType(def.Type),
 		Nullable: nullable,
@@ -480,7 +480,7 @@ func (tt *Table) addIndex(def *tree.IndexTableDef, typ indexType) *Index {
 			pkOrdinals.Add(c.Ordinal)
 		}
 		// Add the rest of the columns in the table.
-		for i, n := 0, tt.AllColumnCount(); i < n; i++ {
+		for i, n := 0, tt.ColumnCount(); i < n; i++ {
 			if !pkOrdinals.Contains(i) {
 				idx.addColumnByOrdinal(tt, i, tree.Ascending, nonKeyCol)
 			}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -596,8 +596,8 @@ func (tt *Table) IsVirtualTable() bool {
 	return tt.IsVirtual
 }
 
-// AllColumnCount is part of the cat.Table interface.
-func (tt *Table) AllColumnCount() int {
+// ColumnCount is part of the cat.Table interface.
+func (tt *Table) ColumnCount() int {
 	return len(tt.Columns)
 }
 

--- a/pkg/sql/opt/xform/memo_format.go
+++ b/pkg/sql/opt/xform/memo_format.go
@@ -275,7 +275,7 @@ func (mf *memoFormatter) formatPrivate(e opt.Expr, physProps *physical.Required)
 	switch t := e.(type) {
 	case *memo.ScanExpr:
 		tab := m.Metadata().Table(t.Table)
-		if tab.AllColumnCount() != t.Cols.Len() {
+		if tab.ColumnCount() != t.Cols.Len() {
 			fmt.Fprintf(mf.buf, ",cols=%s", t.Cols)
 		}
 		if t.Constraint != nil {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -565,8 +565,8 @@ func newOptTable(
 	}
 
 	// Create the table's column mapping from sqlbase.ColumnID to column ordinal.
-	ot.colMap = make(map[sqlbase.ColumnID]int, ot.AllColumnCount())
-	for i, n := 0, ot.AllColumnCount(); i < n; i++ {
+	ot.colMap = make(map[sqlbase.ColumnID]int, ot.ColumnCount())
+	for i, n := 0, ot.ColumnCount(); i < n; i++ {
 		ot.colMap[sqlbase.ColumnID(ot.Column(i).ColID())] = i
 	}
 
@@ -634,7 +634,7 @@ func newOptTable(
 
 	// Synthesize any check constraints for user defined types.
 	var synthesizedChecks []cat.CheckConstraint
-	for i := 0; i < ot.AllColumnCount(); i++ {
+	for i := 0; i < ot.ColumnCount(); i++ {
 		if cat.IsMutationColumn(ot, i) {
 			// TODO (rohany): We don't allow referencing columns in mutations in these
 			//  expressions. However, it seems like we will need to have these checks
@@ -784,8 +784,8 @@ func (ot *optTable) IsVirtualTable() bool {
 	return false
 }
 
-// AllColumnCount is part of the cat.Table interface.
-func (ot *optTable) AllColumnCount() int {
+// ColumnCount is part of the cat.Table interface.
+func (ot *optTable) ColumnCount() int {
 	return len(ot.desc.DeletableColumns())
 }
 
@@ -925,18 +925,18 @@ func (oi *optIndex) init(
 		// Although the primary index contains all columns in the table, the index
 		// descriptor does not contain columns that are not explicitly part of the
 		// primary key. Retrieve those columns from the table descriptor.
-		oi.storedCols = make([]sqlbase.ColumnID, 0, tab.AllColumnCount()-len(desc.ColumnIDs))
+		oi.storedCols = make([]sqlbase.ColumnID, 0, tab.ColumnCount()-len(desc.ColumnIDs))
 		var pkCols util.FastIntSet
 		for i := range desc.ColumnIDs {
 			pkCols.Add(int(desc.ColumnIDs[i]))
 		}
-		for i, n := 0, tab.AllColumnCount(); i < n; i++ {
+		for i, n := 0, tab.ColumnCount(); i < n; i++ {
 			id := tab.Column(i).ColID()
 			if !pkCols.Contains(int(id)) {
 				oi.storedCols = append(oi.storedCols, sqlbase.ColumnID(id))
 			}
 		}
-		oi.numCols = tab.AllColumnCount()
+		oi.numCols = tab.ColumnCount()
 	} else {
 		oi.storedCols = desc.StoreColumnIDs
 		oi.numCols = len(desc.ColumnIDs) + len(desc.ExtraColumnIDs) + len(desc.StoreColumnIDs)
@@ -1397,8 +1397,8 @@ func newOptVirtualTable(
 	}
 
 	// Create the table's column mapping from sqlbase.ColumnID to column ordinal.
-	ot.colMap = make(map[sqlbase.ColumnID]int, ot.AllColumnCount())
-	for i, n := 0, ot.AllColumnCount(); i < n; i++ {
+	ot.colMap = make(map[sqlbase.ColumnID]int, ot.ColumnCount())
+	for i, n := 0, ot.ColumnCount(); i < n; i++ {
 		ot.colMap[sqlbase.ColumnID(ot.Column(i).ColID())] = i
 	}
 
@@ -1414,7 +1414,7 @@ func newOptVirtualTable(
 	ot.indexes[0] = optVirtualIndex{
 		tab:          ot,
 		indexOrdinal: 0,
-		numCols:      ot.AllColumnCount(),
+		numCols:      ot.ColumnCount(),
 		isPrimary:    true,
 		desc: &sqlbase.IndexDescriptor{
 			ID:   0,
@@ -1434,7 +1434,7 @@ func newOptVirtualTable(
 			desc:         idxDesc,
 			indexOrdinal: i + 1,
 			// The virtual indexes don't return the bogus PK key?
-			numCols: ot.AllColumnCount(),
+			numCols: ot.ColumnCount(),
 		}
 	}
 
@@ -1478,8 +1478,8 @@ func (ot *optVirtualTable) IsVirtualTable() bool {
 	return true
 }
 
-// AllColumnCount is part of the cat.Table interface.
-func (ot *optVirtualTable) AllColumnCount() int {
+// ColumnCount is part of the cat.Table interface.
+func (ot *optVirtualTable) ColumnCount() int {
 	return len(ot.desc.Columns) + 1
 }
 
@@ -1802,7 +1802,7 @@ func (oi *optVirtualFamily) Name() tree.Name {
 
 // ColumnCount is part of the cat.Family interface.
 func (oi *optVirtualFamily) ColumnCount() int {
-	return oi.tab.AllColumnCount()
+	return oi.tab.ColumnCount()
 }
 
 // Column is part of the cat.Family interface.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1782,7 +1782,7 @@ func (rb *renderBuilder) setOutput(exprs tree.TypedExprs, columns sqlbase.Result
 // included if their ordinal position in the table schema is in the cols set.
 func makeColDescList(table cat.Table, cols exec.TableColumnOrdinalSet) []sqlbase.ColumnDescriptor {
 	colDescs := make([]sqlbase.ColumnDescriptor, 0, cols.Len())
-	for i, n := 0, table.AllColumnCount(); i < n; i++ {
+	for i, n := 0, table.ColumnCount(); i < n; i++ {
 		if !cols.Contains(i) {
 			continue
 		}


### PR DESCRIPTION
This change renames AllColumnCount to ColumnCount. In #51400 I meant
to rename before merging but I forgot.

Release note: None