### PR TITLE
sql: add support for alter type rename value

### DIFF
--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -57,7 +57,7 @@ func (n *alterTypeNode) startExec(params runParams) error {
 	case *tree.AlterTypeAddValue:
 		err = unimplemented.NewWithIssue(48670, "ALTER TYPE ADD VALUE unsupported")
 	case *tree.AlterTypeRenameValue:
-		err = unimplemented.NewWithIssue(48697, "ALTER TYPE RENAME VALUE unsupported")
+		err = params.p.renameTypeValue(params, n, t.OldVal, t.NewVal)
 	case *tree.AlterTypeRename:
 		err = params.p.renameType(params, n, t.NewName)
 	case *tree.AlterTypeSetSchema:
@@ -155,6 +155,38 @@ func (p *planner) performRenameTypeDesc(
 	).Key(p.ExecCfg().Codec)
 	b.CPut(key, desc.ID, nil /* expected */)
 	return p.txn.Run(ctx, b)
+}
+
+func (p *planner) renameTypeValue(
+	params runParams, n *alterTypeNode, oldVal string, newVal string,
+) error {
+	enumMemberIndex := -1
+
+	// Do one pass to verify that the oldVal exists and there isn't already
+	// a member that is named newVal.
+	for i := range n.desc.EnumMembers {
+		member := n.desc.EnumMembers[i]
+		if member.LogicalRepresentation == oldVal {
+			enumMemberIndex = i
+		} else if member.LogicalRepresentation == newVal {
+			return pgerror.Newf(pgcode.DuplicateObject,
+				"enum label %s already exists", newVal)
+		}
+	}
+
+	// An enum member with the name oldVal was not found.
+	if enumMemberIndex == -1 {
+		return pgerror.Newf(pgcode.InvalidParameterValue,
+			"%s is not an existing enum label", oldVal)
+	}
+
+	n.desc.EnumMembers[enumMemberIndex].LogicalRepresentation = newVal
+
+	return p.writeTypeChange(
+		params.ctx,
+		n.desc,
+		tree.AsStringWithFQNames(n.n, params.Ann()),
+	)
 }
 
 func (n *alterTypeNode) Next(params runParams) (bool, error) { return false, nil }

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -80,3 +80,52 @@ query T
 SELECT ARRAY['hi']::___why
 ----
 {hi}
+
+statement ok
+CREATE TYPE names AS ENUM ('james', 'johnny')
+
+# Cannot rename a value to a value that already a member of the type.
+statement error enum label johnny already exists
+ALTER TYPE names RENAME VALUE 'james' TO 'johnny'
+
+# Cannot rename a value that is not a member of the type.
+statement error jim is not an existing enum label
+ALTER TYPE names RENAME VALUE 'jim' TO 'jimmy'
+
+statement ok
+ALTER TYPE names RENAME VALUE 'james' to 'jimmy'
+
+# Make sure james is renamed to jimmy.
+query T
+SELECT enum_range('jimmy'::names);
+----
+{jimmy,johnny}
+
+# James should not be a member of names.
+statement error invalid input value for enum names: "james"
+SELECT 'james'::names
+
+# Try multiple renames in a single transaction.
+statement ok
+BEGIN
+
+statement ok
+ALTER TYPE names RENAME VALUE 'jimmy' TO 'jim'
+
+statement ok
+ALTER TYPE names RENAME VALUE 'johnny' TO 'john'
+
+statement ok
+COMMIT
+
+# Make sure both names were renamed and the old names are not members of names.
+query T
+SELECT enum_range('jim'::names);
+----
+{jim,john}
+
+statement error invalid input value for enum names: "jimmy"
+SELECT 'jimmy'::names
+
+statement error invalid input value for enum names: "johnny"
+SELECT 'johnny'::names

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -148,9 +148,6 @@ SELECT 'hello'::greeting = 'notagreeting'
 statement error pq: unimplemented: ALTER TYPE ADD VALUE unsupported
 ALTER TYPE greeting ADD VALUE 'hola' AFTER 'hello'
 
-statement error pq: unimplemented: ALTER TYPE RENAME VALUE unsupported
-ALTER TYPE greeting RENAME VALUE 'hello' TO 'helloooooo'
-
 statement error pq: unimplemented: ALTER TYPE SET SCHEMA unsupported
 ALTER TYPE greeting SET SCHEMA newschema
 


### PR DESCRIPTION
sql: add support for alter type rename value

Fixes #48697

Release note (sql change): Add support for renaming a value
of an enum using the ALTER TYPE <type> RENAME VALUE <old> TO <new>
syntax.