### PR TITLE
sql: remove filter from scanNode

### DIFF
--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -59,7 +59,3 @@ func (f *filterNode) Values() tree.Datums {
 }
 
 func (f *filterNode) Close(ctx context.Context) { f.source.plan.Close(ctx) }
-
-func isFilterTrue(expr tree.TypedExpr) bool {
-	return expr == nil || expr == tree.DBoolTrue
-}

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -122,10 +122,11 @@ SELECT * FROM parent
 query TTT
 SELECT * FROM [EXPLAIN SELECT * FROM child WHERE x >= 1 AND x < 5 AND y >= 2 AND y <= 6] OFFSET 2
 ----
-scan  ·            ·
-·     table        child@primary
-·     spans        /1/2/#/57/2-/4/6/#/57/3
-·     filter       (y >= 2) AND (y <= 6)
+filter     ·       ·
+ │         filter  (y >= 2) AND (y <= 6)
+ └── scan  ·       ·
+·          table   child@primary
+·          spans   /1/2/#/57/2-/4/6/#/57/3
 
 query III rowsort
 SELECT * FROM child WHERE x >= 1 AND x < 5 AND y >= 2 AND y <= 6

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -638,19 +638,20 @@ render                    ·             ·                (v int, count int)   
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT v, count(NULL) FROM kv GROUP BY v) WHERE v > 10
 ----
-·               distribution  local           ·             ·
-·               vectorized    true            ·             ·
-group           ·             ·               (v, count)    ·
- │              aggregate 0   v               ·             ·
- │              aggregate 1   count(column5)  ·             ·
- │              group by      v               ·             ·
- └── render     ·             ·               (column5, v)  ·
-      │         render 0      NULL            ·             ·
-      │         render 1      v               ·             ·
-      └── scan  ·             ·               (v)           ·
-·               table         kv@primary      ·             ·
-·               spans         FULL SCAN       ·             ·
-·               filter        v > 10          ·             ·
+·                    distribution  local           ·             ·
+·                    vectorized    true            ·             ·
+group                ·             ·               (v, count)    ·
+ │                   aggregate 0   v               ·             ·
+ │                   aggregate 1   count(column5)  ·             ·
+ │                   group by      v               ·             ·
+ └── render          ·             ·               (column5, v)  ·
+      │              render 0      NULL            ·             ·
+      │              render 1      v               ·             ·
+      └── filter     ·             ·               (v)           ·
+           │         filter        v > 10          ·             ·
+           └── scan  ·             ·               (v)           ·
+·                    table         kv@primary      ·             ·
+·                    spans         FULL SCAN       ·             ·
 
 # Verify that FILTER works.
 
@@ -759,19 +760,20 @@ group      ·             ·                (min int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test WHERE k <> 4
 ----
-·                    distribution  local                         ·               ·
-·                    vectorized    true                          ·               ·
-group                ·             ·                             (min int)       ·
- │                   aggregate 0   any_not_null(v)               ·               ·
- │                   scalar        ·                             ·               ·
- └── render          ·             ·                             (v int)         ·
-      │              render 0      (v)[int]                      ·               ·
-      └── limit      ·             ·                             (k int, v int)  +v
-           │         count         (1)[int]                      ·               ·
-           └── scan  ·             ·                             (k int, v int)  +v
-·                    table         opt_test@v                    ·               ·
-·                    spans         /!NULL-                       ·               ·
-·                    filter        ((k)[int] != (4)[int])[bool]  ·               ·
+·                         distribution  local                         ·               ·
+·                         vectorized    true                          ·               ·
+group                     ·             ·                             (min int)       ·
+ │                        aggregate 0   any_not_null(v)               ·               ·
+ │                        scalar        ·                             ·               ·
+ └── render               ·             ·                             (v int)         ·
+      │                   render 0      (v)[int]                      ·               ·
+      └── limit           ·             ·                             (k int, v int)  +v
+           │              count         (1)[int]                      ·               ·
+           └── filter     ·             ·                             (k int, v int)  +v
+                │         filter        ((k)[int] != (4)[int])[bool]  ·               ·
+                └── scan  ·             ·                             (k int, v int)  +v
+·                         table         opt_test@v                    ·               ·
+·                         spans         /!NULL-                       ·               ·
 
 # Check that the optimization doesn't work when the argument is non-trivial (we
 # can't in general guarantee an ordering on a synthesized column).

--- a/pkg/sql/opt/exec/execbuilder/testdata/array
+++ b/pkg/sql/opt/exec/execbuilder/testdata/array
@@ -9,56 +9,61 @@ CREATE TABLE t (x INT[])
 query TTT
 EXPLAIN SELECT x FROM t WHERE x = ARRAY[1,4,6]
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         t@primary
-·     spans         FULL SCAN
-·     filter        x = ARRAY[1,4,6]
+·          distribution  local
+·          vectorized    true
+filter     ·             ·
+ │         filter        x = ARRAY[1,4,6]
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x < ARRAY[1, 4, 3]
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         t@primary
-·     spans         FULL SCAN
-·     filter        x < ARRAY[1,4,3]
+·          distribution  local
+·          vectorized    true
+filter     ·             ·
+ │         filter        x < ARRAY[1,4,3]
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x > ARRAY [1, NULL]
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         t@primary
-·     spans         FULL SCAN
-·     filter        x > ARRAY[1,NULL]
+·          distribution  local
+·          vectorized    true
+filter     ·             ·
+ │         filter        x > ARRAY[1,NULL]
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x
 ----
-·          distribution  local
-·          vectorized    true
-sort       ·             ·
- │         order         +x
- └── scan  ·             ·
-·          table         t@primary
-·          spans         FULL SCAN
-·          filter        (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
+·               distribution  local
+·               vectorized    true
+sort            ·             ·
+ │              order         +x
+ └── filter     ·             ·
+      │         filter        (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
+      └── scan  ·             ·
+·               table         t@primary
+·               spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x DESC
 ----
-·          distribution  local
-·          vectorized    true
-sort       ·             ·
- │         order         -x
- └── scan  ·             ·
-·          table         t@primary
-·          spans         FULL SCAN
-·          filter        (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
+·               distribution  local
+·               vectorized    true
+sort            ·             ·
+ │              order         -x
+ └── filter     ·             ·
+      │         filter        (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
+      └── scan  ·             ·
+·               table         t@primary
+·               spans         FULL SCAN
 
 statement ok
 DROP TABLE t
@@ -70,14 +75,15 @@ CREATE TABLE t (x INT, y INT[], z INT)
 query TTT
 EXPLAIN SELECT x, y, z FROM t WHERE x = 2 AND y < ARRAY[10] ORDER BY y
 ----
-·          distribution  local
-·          vectorized    true
-sort       ·             ·
- │         order         +y
- └── scan  ·             ·
-·          table         t@primary
-·          spans         FULL SCAN
-·          filter        (x = 2) AND (y < ARRAY[10])
+·               distribution  local
+·               vectorized    true
+sort            ·             ·
+ │              order         +y
+ └── filter     ·             ·
+      │         filter        (x = 2) AND (y < ARRAY[10])
+      └── scan  ·             ·
+·               table         t@primary
+·               spans         FULL SCAN
 
 # Test span generation on interleaved tables.
 # Add x to parent PRIMARY KEY (x, y) once #50659 is fixed.
@@ -90,31 +96,34 @@ CREATE TABLE child (x INT, y INT[], z INT[], PRIMARY KEY (x), FAMILY (x, y, z)) 
 query TTT
 EXPLAIN SELECT x, y FROM parent WHERE x > 1 AND y > ARRAY[1, NULL]
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         parent@primary
-·     spans         /2-
-·     filter        y > ARRAY[1,NULL]
+·          distribution  local
+·          vectorized    true
+filter     ·             ·
+ │         filter        y > ARRAY[1,NULL]
+ └── scan  ·             ·
+·          table         parent@primary
+·          spans         /2-
 
 query TTT
 EXPLAIN SELECT y FROM parent WHERE x = 1 AND y = ARRAY[NULL, NULL]
 ----
-·          distribution  local
-·          vectorized    true
-render     ·             ·
- └── scan  ·             ·
-·          table         parent@primary
-·          spans         /1-/1/#
-·          filter        y = ARRAY[NULL,NULL]
+·               distribution  local
+·               vectorized    true
+render          ·             ·
+ └── filter     ·             ·
+      │         filter        y = ARRAY[NULL,NULL]
+      └── scan  ·             ·
+·               table         parent@primary
+·               spans         /1-/1/#
 
 query TTT
 EXPLAIN SELECT z FROM child WHERE x = 1 AND y = ARRAY[NULL, NULL]
 ----
-·          distribution  local
-·          vectorized    true
-render     ·             ·
- └── scan  ·             ·
-·          table         child@primary
-·          spans         /1/#/56/1-/1/#/56/1/#
-·          filter        y = ARRAY[NULL,NULL]
+·               distribution  local
+·               vectorized    true
+render          ·             ·
+ └── filter     ·             ·
+      │         filter        y = ARRAY[NULL,NULL]
+      └── scan  ·             ·
+·               table         child@primary
+·               spans         /1/#/56/1-/1/#/56/1/#

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -70,39 +70,41 @@ delete range  ·             ·
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v LIMIT 10
 ----
-·                         distribution  local
-·                         vectorized    false
-count                     ·             ·
- └── delete               ·             ·
-      │                   from          unindexed
-      │                   strategy      deleter
-      │                   auto commit   ·
-      └── render          ·             ·
-           └── limit      ·             ·
-                │         count         10
-                └── scan  ·             ·
-·                         table         unindexed@primary
-·                         spans         FULL SCAN
-·                         filter        v = 7
+·                              distribution  local
+·                              vectorized    false
+count                          ·             ·
+ └── delete                    ·             ·
+      │                        from          unindexed
+      │                        strategy      deleter
+      │                        auto commit   ·
+      └── render               ·             ·
+           └── limit           ·             ·
+                │              count         10
+                └── filter     ·             ·
+                     │         filter        v = 7
+                     └── scan  ·             ·
+·                              table         unindexed@primary
+·                              spans         FULL SCAN
 
 # Check DELETE with LIMIT clause (MySQL extension)
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 5 LIMIT 10
 ----
-·                         distribution  local
-·                         vectorized    false
-count                     ·             ·
- └── delete               ·             ·
-      │                   from          unindexed
-      │                   strategy      deleter
-      │                   auto commit   ·
-      └── render          ·             ·
-           └── limit      ·             ·
-                │         count         10
-                └── scan  ·             ·
-·                         table         unindexed@primary
-·                         spans         FULL SCAN
-·                         filter        v = 5
+·                              distribution  local
+·                              vectorized    false
+count                          ·             ·
+ └── delete                    ·             ·
+      │                        from          unindexed
+      │                        strategy      deleter
+      │                        auto commit   ·
+      └── render               ·             ·
+           └── limit           ·             ·
+                │              count         10
+                └── filter     ·             ·
+                     │         filter        v = 5
+                     └── scan  ·             ·
+·                              table         unindexed@primary
+·                              spans         FULL SCAN
 
 # Check fast DELETE.
 query TTT
@@ -273,17 +275,18 @@ delete range  ·             ·
 query TTT
 EXPLAIN DELETE FROM child WHERE id > 10
 ----
-·               distribution  local
-·               vectorized    false
-count           ·             ·
- └── delete     ·             ·
-      │         from          child
-      │         strategy      deleter
-      │         auto commit   ·
-      └── scan  ·             ·
-·               table         child@primary
-·               spans         FULL SCAN
-·               filter        id > 10
+·                    distribution  local
+·                    vectorized    false
+count                ·             ·
+ └── delete          ·             ·
+      │              from          child
+      │              strategy      deleter
+      │              auto commit   ·
+      └── filter     ·             ·
+           │         filter        id > 10
+           └── scan  ·             ·
+·                    table         child@primary
+·                    spans         FULL SCAN
 
 statement ok
 CREATE TABLE sibling (

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -122,17 +122,18 @@ scan  ·             ·            (x, y, z)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT z FROM (SELECT y, z FROM xyz WHERE y > 1)
 ----
-·               distribution  local      ·       ·
-·               vectorized    true       ·       ·
-distinct        ·             ·          (z)     ·
- │              distinct on   z          ·       ·
- │              order key     z          ·       ·
- └── render     ·             ·          (z)     +z
-      │         render 0      z          ·       ·
-      └── scan  ·             ·          (y, z)  +z
-·               table         xyz@foo    ·       ·
-·               spans         FULL SCAN  ·       ·
-·               filter        y > 1      ·       ·
+·                    distribution  local      ·       ·
+·                    vectorized    true       ·       ·
+distinct             ·             ·          (z)     ·
+ │                   distinct on   z          ·       ·
+ │                   order key     z          ·       ·
+ └── render          ·             ·          (z)     +z
+      │              render 0      z          ·       ·
+      └── filter     ·             ·          (y, z)  +z
+           │         filter        y > 1      ·       ·
+           └── scan  ·             ·          (y, z)  +z
+·                    table         xyz@foo    ·       ·
+·                    spans         FULL SCAN  ·       ·
 
 statement ok
 CREATE TABLE abcd (

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -452,31 +452,33 @@ render               ·             ·            (pk1)           ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x, y FROM xyz WHERE x = 1 ORDER BY x, y
 ----
-·               distribution  local        ·       ·
-·               vectorized    true         ·       ·
-limit           ·             ·            (x, y)  +y
- │              count         1            ·       ·
- └── sort       ·             ·            (x, y)  +y
-      │         order         +y           ·       ·
-      └── scan  ·             ·            (x, y)  ·
-·               table         xyz@primary  ·       ·
-·               spans         FULL SCAN    ·       ·
-·               filter        x = 1        ·       ·
+·                    distribution  local        ·       ·
+·                    vectorized    true         ·       ·
+limit                ·             ·            (x, y)  +y
+ │                   count         1            ·       ·
+ └── sort            ·             ·            (x, y)  +y
+      │              order         +y           ·       ·
+      └── filter     ·             ·            (x, y)  ·
+           │         filter        x = 1        ·       ·
+           └── scan  ·             ·            (x, y)  ·
+·                    table         xyz@primary  ·       ·
+·                    spans         FULL SCAN    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT DISTINCT ON (x) x, y FROM xyz WHERE x = 1 ORDER BY x, y)
 ----
-·                         distribution  local         ·        ·
-·                         vectorized    true          ·        ·
-group                     ·             ·             (count)  ·
- │                        aggregate 0   count_rows()  ·        ·
- │                        scalar        ·             ·        ·
- └── render               ·             ·             ()       ·
-      └── limit           ·             ·             (x, y)   +y
-           │              count         1             ·        ·
-           └── sort       ·             ·             (x, y)   +y
-                │         order         +y            ·        ·
-                └── scan  ·             ·             (x, y)   ·
-·                         table         xyz@primary   ·        ·
-·                         spans         FULL SCAN     ·        ·
-·                         filter        x = 1         ·        ·
+·                              distribution  local         ·        ·
+·                              vectorized    true          ·        ·
+group                          ·             ·             (count)  ·
+ │                             aggregate 0   count_rows()  ·        ·
+ │                             scalar        ·             ·        ·
+ └── render                    ·             ·             ()       ·
+      └── limit                ·             ·             (x, y)   +y
+           │                   count         1             ·        ·
+           └── sort            ·             ·             (x, y)   +y
+                │              order         +y            ·        ·
+                └── filter     ·             ·             (x, y)   ·
+                     │         filter        x = 1         ·        ·
+                     └── scan  ·             ·             (x, y)   ·
+·                              table         xyz@primary   ·        ·
+·                              spans         FULL SCAN     ·        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_auto_mode
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_auto_mode
@@ -44,11 +44,11 @@ SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k>1]
 ----
 false
 
-# Partial scan with filter - distribute.
+# Partial scan with filter - don't distribute.
 query B
 SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k>1 AND v=1]
 ----
-true
+false
 
 # Sort - distribute.
 query B
@@ -117,8 +117,8 @@ SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM abc WHERE b=1 AND c%2=0]
 ----
 false
 
-# Index join with filter on index scan - distribute.
+# Index join with filter on index scan - don't distribute.
 query B
 SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM abc WHERE b=1 AND a%2=0]
 ----
-true
+false

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -914,19 +914,20 @@ merge-join
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM parent1 INNER MERGE JOIN child1 ON parent1.pid1 = child1.pid1 AND parent1.v = child1.v WHERE parent1.v=1
 ----
-·           distribution       full                     ·                               ·
-·           vectorized         true                     ·                               ·
-merge-join  ·                  ·                        (pid1, v, pid1, cid1, cid2, v)  ·
- │          type               inner                    ·                               ·
- │          equality           (pid1, v) = (pid1, v)    ·                               ·
- │          left cols are key  ·                        ·                               ·
- │          mergeJoinOrder     +"(pid1=pid1)",+"(v=v)"  ·                               ·
- ├── scan   ·                  ·                        (pid1, v)                       +pid1
- │          table              parent1@primary          ·                               ·
- │          spans              FULL SCAN                ·                               ·
- │          filter             v = 1                    ·                               ·
- └── scan   ·                  ·                        (pid1, cid1, cid2, v)           +pid1
-·           table              child1@primary           ·                               ·
-·           spans              FULL SCAN                ·                               ·
-·           filter             v = 1                    ·                               ·
-
+·               distribution       full                     ·                               ·
+·               vectorized         true                     ·                               ·
+merge-join      ·                  ·                        (pid1, v, pid1, cid1, cid2, v)  ·
+ │              type               inner                    ·                               ·
+ │              equality           (pid1, v) = (pid1, v)    ·                               ·
+ │              left cols are key  ·                        ·                               ·
+ │              mergeJoinOrder     +"(pid1=pid1)",+"(v=v)"  ·                               ·
+ ├── filter     ·                  ·                        (pid1, v)                       +pid1
+ │    │         filter             v = 1                    ·                               ·
+ │    └── scan  ·                  ·                        (pid1, v)                       +pid1
+ │              table              parent1@primary          ·                               ·
+ │              spans              FULL SCAN                ·                               ·
+ └── filter     ·                  ·                        (pid1, cid1, cid2, v)           +pid1
+      │         filter             v = 1                    ·                               ·
+      └── scan  ·                  ·                        (pid1, cid1, cid2, v)           +pid1
+·               table              child1@primary           ·                               ·
+·               spans              FULL SCAN                ·                               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -80,25 +80,27 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lVGL4jwUhu-_XxHO1QxksG
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
-·                distribution        full                 ·            ·
-·                vectorized          true                 ·            ·
-render           ·                   ·                    (x, str)     ·
- │               render 0            x                    ·            ·
- │               render 1            str                  ·            ·
- └── merge-join  ·                   ·                    (x, y, str)  ·
-      │          type                inner                ·            ·
-      │          equality            (x) = (y)            ·            ·
-      │          left cols are key   ·                    ·            ·
-      │          right cols are key  ·                    ·            ·
-      │          mergeJoinOrder      +"(x=y)"             ·            ·
-      ├── scan   ·                   ·                    (x)          +x
-      │          table               numtosquare@primary  ·            ·
-      │          spans               FULL SCAN            ·            ·
-      │          filter              (x % 2) = 0          ·            ·
-      └── scan   ·                   ·                    (y, str)     +y
-·                table               numtostr@primary     ·            ·
-·                spans               FULL SCAN            ·            ·
-·                filter              (y % 2) = 0          ·            ·
+·                    distribution        full                 ·            ·
+·                    vectorized          true                 ·            ·
+render               ·                   ·                    (x, str)     ·
+ │                   render 0            x                    ·            ·
+ │                   render 1            str                  ·            ·
+ └── merge-join      ·                   ·                    (x, y, str)  ·
+      │              type                inner                ·            ·
+      │              equality            (x) = (y)            ·            ·
+      │              left cols are key   ·                    ·            ·
+      │              right cols are key  ·                    ·            ·
+      │              mergeJoinOrder      +"(x=y)"             ·            ·
+      ├── filter     ·                   ·                    (x)          +x
+      │    │         filter              (x % 2) = 0          ·            ·
+      │    └── scan  ·                   ·                    (x)          +x
+      │              table               numtosquare@primary  ·            ·
+      │              spans               FULL SCAN            ·            ·
+      └── filter     ·                   ·                    (y, str)     +y
+           │         filter              (y % 2) = 0          ·            ·
+           └── scan  ·                   ·                    (y, str)     +y
+·                    table               numtostr@primary     ·            ·
+·                    spans               FULL SCAN            ·            ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
@@ -155,55 +155,60 @@ scan  ·             ·
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b <= 3
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         p1@primary
-·     spans         -/3/3/#
-·     filter        b <= 3
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        b <= 3
+ └── scan  ·             ·
+·          table         p1@primary
+·          spans         -/3/3/#
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b < 4
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         p1@primary
-·     spans         -/3/3/#
-·     filter        b < 4
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        b < 4
+ └── scan  ·             ·
+·          table         p1@primary
+·          spans         -/3/3/#
 
 # Mixed bounds.
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a >= 2 AND b <= 3
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         p1@primary
-·     spans         /2-
-·     filter        b <= 3
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        b <= 3
+ └── scan  ·             ·
+·          table         p1@primary
+·          spans         /2-
 
 # Edge cases.
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 0 AND b <= 0
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         p1@primary
-·     spans         -/0/0/#
-·     filter        b <= 0
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        b <= 0
+ └── scan  ·             ·
+·          table         p1@primary
+·          spans         -/0/0/#
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= -1 AND b <= -1
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         p1@primary
-·     spans         -/-1/-1/#
-·     filter        b <= -1
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        b <= -1
+ └── scan  ·             ·
+·          table         p1@primary
+·          spans         -/-1/-1/#
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= -9223372036854775808
@@ -240,12 +245,13 @@ scan  ·             ·
 query TTT
 EXPLAIN SELECT * FROM c1 WHERE a <= 3 AND b <= 3
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         c1@primary
-·     spans         -/3/3/#/54/1/#
-·     filter        b <= 3
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        b <= 3
+ └── scan  ·             ·
+·          table         c1@primary
+·          spans         -/3/3/#/54/1/#
 
 # Table p2 with interleaved index.
 
@@ -280,48 +286,52 @@ scan  ·             ·
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d >= 2
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         p2@p2_id
-·     spans         /1/#/55/2/2-
-·     filter        d >= 2
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        d >= 2
+ └── scan  ·             ·
+·          table         p2@p2_id
+·          spans         /1/#/55/2/2-
 
 # Upper bound (i <= 6 AND d <= 5)
 
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         p2@p2_id
-·     spans         -/6/#/55/2/6
-·     filter        d <= 5
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        d <= 5
+ └── scan  ·             ·
+·          table         p2@p2_id
+·          spans         -/6/#/55/2/6
 
 # IS NULL
 
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NULL
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         p2@p2_id
-·     spans         /1/#/55/2/NULL-
-·     filter        d IS NULL
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        d IS NULL
+ └── scan  ·             ·
+·          table         p2@p2_id
+·          spans         /1/#/55/2/NULL-
 
 # IS NOT NULL
 
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NOT NULL
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         p2@p2_id
-·     spans         /1/#/55/2/!NULL-
-·     filter        d IS NOT NULL
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        d IS NOT NULL
+ └── scan  ·             ·
+·          table         p2@p2_id
+·          spans         /1/#/55/2/!NULL-
 
 # String table
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -532,12 +532,13 @@ lookup-join  ·                      ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ----
-·     distribution  local        ·       ·
-·     vectorized    true         ·       ·
-scan  ·             ·            (k, v)  ·
-·     table         t@primary    ·       ·
-·     spans         FULL SCAN    ·       ·
-·     filter        (k % 2) = 0  ·       ·
+·          distribution  local        ·       ·
+·          vectorized    true         ·       ·
+filter     ·             ·            (k, v)  ·
+ │         filter        (k % 2) = 0  ·       ·
+ └── scan  ·             ·            (k, v)  ·
+·          table         t@primary    ·       ·
+·          spans         FULL SCAN    ·       ·
 
 query TTT
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
@@ -656,12 +657,13 @@ scan  ·             ·          (k int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
-·     distribution  local                          ·               ·
-·     vectorized    true                           ·               ·
-scan  ·             ·                              (k int, v int)  ·
-·     table         t@primary                      ·               ·
-·     spans         FULL SCAN                      ·               ·
-·     filter        ((v)[int] > (123)[int])[bool]  ·               ·
+·          distribution  local                          ·               ·
+·          vectorized    true                           ·               ·
+filter     ·             ·                              (k int, v int)  ·
+ │         filter        ((v)[int] > (123)[int])[bool]  ·               ·
+ └── scan  ·             ·                              (k int, v int)  ·
+·          table         t@primary                      ·               ·
+·          spans         FULL SCAN                      ·               ·
 
 query TTTTT
 EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
@@ -690,39 +692,41 @@ render       ·             ·                               (z int, v int)     
 query TTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-·                    distribution  local                        ·               ·
-·                    vectorized    false                        ·               ·
-count                ·             ·                            ()              ·
- └── delete          ·             ·                            ()              ·
-      │              from          t                            ·               ·
-      │              strategy      deleter                      ·               ·
-      │              auto commit   ·                            ·               ·
-      └── render     ·             ·                            (k int)         ·
-           │         render 0      (k)[int]                     ·               ·
-           └── scan  ·             ·                            (k int, v int)  ·
-·                    table         t@primary                    ·               ·
-·                    spans         FULL SCAN                    ·               ·
-·                    filter        ((v)[int] > (1)[int])[bool]  ·               ·
+·                         distribution  local                        ·               ·
+·                         vectorized    false                        ·               ·
+count                     ·             ·                            ()              ·
+ └── delete               ·             ·                            ()              ·
+      │                   from          t                            ·               ·
+      │                   strategy      deleter                      ·               ·
+      │                   auto commit   ·                            ·               ·
+      └── render          ·             ·                            (k int)         ·
+           │              render 0      (k)[int]                     ·               ·
+           └── filter     ·             ·                            (k int, v int)  ·
+                │         filter        ((v)[int] > (1)[int])[bool]  ·               ·
+                └── scan  ·             ·                            (k int, v int)  ·
+·                         table         t@primary                    ·               ·
+·                         spans         FULL SCAN                    ·               ·
 
 query TTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-·                    distribution  local                          ·                          ·
-·                    vectorized    false                          ·                          ·
-count                ·             ·                              ()                         ·
- └── update          ·             ·                              ()                         ·
-      │              table         t                              ·                          ·
-      │              set           v                              ·                          ·
-      │              strategy      updater                        ·                          ·
-      │              auto commit   ·                              ·                          ·
-      └── render     ·             ·                              (k int, v int, v_new int)  ·
-           │         render 0      (k)[int]                       ·                          ·
-           │         render 1      (v)[int]                       ·                          ·
-           │         render 2      ((k)[int] + (1)[int])[int]     ·                          ·
-           └── scan  ·             ·                              (k int, v int)             ·
-·                    table         t@primary                      ·                          ·
-·                    spans         FULL SCAN                      ·                          ·
-·                    filter        ((v)[int] > (123)[int])[bool]  ·                          ·
+·                         distribution  local                          ·                          ·
+·                         vectorized    false                          ·                          ·
+count                     ·             ·                              ()                         ·
+ └── update               ·             ·                              ()                         ·
+      │                   table         t                              ·                          ·
+      │                   set           v                              ·                          ·
+      │                   strategy      updater                        ·                          ·
+      │                   auto commit   ·                              ·                          ·
+      └── render          ·             ·                              (k int, v int, v_new int)  ·
+           │              render 0      (k)[int]                       ·                          ·
+           │              render 1      (v)[int]                       ·                          ·
+           │              render 2      ((k)[int] + (1)[int])[int]     ·                          ·
+           └── filter     ·             ·                              (k int, v int)             ·
+                │         filter        ((v)[int] > (123)[int])[bool]  ·                          ·
+                └── scan  ·             ·                              (k int, v int)             ·
+·                         table         t@primary                      ·                          ·
+·                         spans         FULL SCAN                      ·                          ·
 
 query TTTTT
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
@@ -773,12 +777,13 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-·     distribution  local                                                                      ·               ·
-·     vectorized    true                                                                       ·               ·
-scan  ·             ·                                                                          (x int, y int)  ·
-·     table         tt@primary                                                                 ·               ·
-·     spans         FULL SCAN                                                                  ·               ·
-·     filter        ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·               ·
+·          distribution  local                                                                      ·               ·
+·          vectorized    true                                                                       ·               ·
+filter     ·             ·                                                                          (x int, y int)  ·
+ │         filter        ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·               ·
+ └── scan  ·             ·                                                                          (x int, y int)  ·
+·          table         tt@primary                                                                 ·               ·
+·          spans         FULL SCAN                                                                  ·               ·
 
 # TODO(radu): we don't support placeholders with no values.
 #query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -944,24 +944,25 @@ FROM
 WHERE
   t.z IS NULL
 ----
-tree                  field               description
-·                     distribution        local
-·                     vectorized          true
-render                ·                   ·
- └── filter           ·                   ·
-      │               filter              z IS NULL
-      └── merge-join  ·                   ·
-           │          type                left outer
-           │          equality            (a_z, a_y, a_x) = (z, y, x)
-           │          right cols are key  ·
-           │          mergeJoinOrder      +"(a_z=z)",+"(a_y=y)",+"(a_x=x)"
-           ├── scan   ·                   ·
-           │          table               b@idx
-           │          spans               /!NULL-
-           │          filter              (a_y IS NOT NULL) AND (a_x IS NOT NULL)
-           └── scan   ·                   ·
-·                     table               a@primary
-·                     spans               FULL SCAN
+tree                      field               description
+·                         distribution        local
+·                         vectorized          true
+render                    ·                   ·
+ └── filter               ·                   ·
+      │                   filter              z IS NULL
+      └── merge-join      ·                   ·
+           │              type                left outer
+           │              equality            (a_z, a_y, a_x) = (z, y, x)
+           │              right cols are key  ·
+           │              mergeJoinOrder      +"(a_z=z)",+"(a_y=y)",+"(a_x=x)"
+           ├── filter     ·                   ·
+           │    │         filter              (a_y IS NOT NULL) AND (a_x IS NOT NULL)
+           │    └── scan  ·                   ·
+           │              table               b@idx
+           │              spans               /!NULL-
+           └── scan       ·                   ·
+·                         table               a@primary
+·                         spans               FULL SCAN
 
 statement ok
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -236,23 +236,25 @@ index-join  ·             ·                                                (a,
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
 ----
-·     distribution  local      ·       ·
-·     vectorized    true       ·       ·
-scan  ·             ·          (a, b)  ·
-·     table         d@primary  ·       ·
-·     spans         FULL SCAN  ·       ·
-·     filter        b @> '[]'  ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+filter     ·             ·          (a, b)  ·
+ │         filter        b @> '[]'  ·       ·
+ └── scan  ·             ·          (a, b)  ·
+·          table         d@primary  ·       ·
+·          spans         FULL SCAN  ·       ·
 
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{}';
 ----
-·     distribution  local      ·       ·
-·     vectorized    true       ·       ·
-scan  ·             ·          (a, b)  ·
-·     table         d@primary  ·       ·
-·     spans         FULL SCAN  ·       ·
-·     filter        b @> '{}'  ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+filter     ·             ·          (a, b)  ·
+ │         filter        b @> '{}'  ·       ·
+ └── scan  ·             ·          (a, b)  ·
+·          table         d@primary  ·       ·
+·          spans         FULL SCAN  ·       ·
 
 
 query TTTTT
@@ -302,32 +304,35 @@ index-join  ·             ·                            (a, b)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
 ----
-·     distribution  local      ·       ·
-·     vectorized    true       ·       ·
-scan  ·             ·          (a, b)  ·
-·     table         d@primary  ·       ·
-·     spans         FULL SCAN  ·       ·
-·     filter        b IS NULL  ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+filter     ·             ·          (a, b)  ·
+ │         filter        b IS NULL  ·       ·
+ └── scan  ·             ·          (a, b)  ·
+·          table         d@primary  ·       ·
+·          spans         FULL SCAN  ·       ·
 
 query TTT
 EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         d@primary
-·     spans         FULL SCAN
-·     filter        b @> '{"a": []}'
+·          distribution  local
+·          vectorized    true
+filter     ·             ·
+ │         filter        b @> '{"a": []}'
+ └── scan  ·             ·
+·          table         d@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * from d where b @> '{"a": {}}' ORDER BY a;
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         d@primary
-·     spans         FULL SCAN
-·     filter        b @> '{"a": {}}'
+·          distribution  local
+·          vectorized    true
+filter     ·             ·
+ │         filter        b @> '{"a": {}}'
+ └── scan  ·             ·
+·          table         d@primary
+·          spans         FULL SCAN
 
 # Multi-path contains queries. Should create zigzag joins.
 
@@ -477,12 +482,13 @@ filter           ·             ·                         (a, b)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'
 ----
-·     distribution  local                      ·       ·
-·     vectorized    true                       ·       ·
-scan  ·             ·                          (a, b)  ·
-·     table         d@primary                  ·       ·
-·     spans         FULL SCAN                  ·       ·
-·     filter        b @> '{"a": {}, "b": {}}'  ·       ·
+·          distribution  local                      ·       ·
+·          vectorized    true                       ·       ·
+filter     ·             ·                          (a, b)  ·
+ │         filter        b @> '{"a": {}, "b": {}}'  ·       ·
+ └── scan  ·             ·                          (a, b)  ·
+·          table         d@primary                  ·       ·
+·          spans         FULL SCAN                  ·       ·
 
 subtest array
 
@@ -502,12 +508,13 @@ index-join  ·             ·          (a, b)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[]::INT[]
 ----
-·     distribution  local         ·       ·
-·     vectorized    true          ·       ·
-scan  ·             ·             (a, b)  ·
-·     table         e@primary     ·       ·
-·     spans         FULL SCAN     ·       ·
-·     filter        b @> ARRAY[]  ·       ·
+·          distribution  local         ·       ·
+·          vectorized    true          ·       ·
+filter     ·             ·             (a, b)  ·
+ │         filter        b @> ARRAY[]  ·       ·
+ └── scan  ·             ·             (a, b)  ·
+·          table         e@primary     ·       ·
+·          spans         FULL SCAN     ·       ·
 
 # Test that searching for a NULL element using the inverted index.
 query TTTTT
@@ -530,12 +537,13 @@ norows  ·             ·      (a, b)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b IS NULL
 ----
-·     distribution  local      ·       ·
-·     vectorized    true       ·       ·
-scan  ·             ·          (a, b)  ·
-·     table         e@primary  ·       ·
-·     spans         FULL SCAN  ·       ·
-·     filter        b IS NULL  ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+filter     ·             ·          (a, b)  ·
+ │         filter        b IS NULL  ·       ·
+ └── scan  ·             ·          (a, b)  ·
+·          table         e@primary  ·       ·
+·          spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1,2]
@@ -657,11 +665,12 @@ lookup-join              ·                      ·                          (k,
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM geo_table WHERE _ST_Intersects('POINT(3.0 3.0)'::geometry, geom)
 ----
-·          distribution  local                                                               ·          ·
-·          vectorized    true                                                                ·          ·
-render     ·             ·                                                                   (k)        ·
- │         render 0      k                                                                   ·          ·
- └── scan  ·             ·                                                                   (k, geom)  ·
-·          table         geo_table@primary                                                   ·          ·
-·          spans         FULL SCAN                                                           ·          ·
-·          filter        _st_intersects('010100000000000000000008400000000000000840', geom)  ·          ·
+·               distribution  local                                                               ·          ·
+·               vectorized    true                                                                ·          ·
+render          ·             ·                                                                   (k)        ·
+ │              render 0      k                                                                   ·          ·
+ └── filter     ·             ·                                                                   (k, geom)  ·
+      │         filter        _st_intersects('010100000000000000000008400000000000000840', geom)  ·          ·
+      └── scan  ·             ·                                                                   (k, geom)  ·
+·               table         geo_table@primary                                                   ·          ·
+·               spans         FULL SCAN                                                           ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -42,18 +42,19 @@ hash-join  ·             ·
 query TTT
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
-·                distribution  local
-·                vectorized    true
-render           ·             ·
- └── cross-join  ·             ·
-      │          type          cross
-      ├── scan   ·             ·
-      │          table         twocolumn@primary
-      │          spans         FULL SCAN
-      └── scan   ·             ·
-·                table         twocolumn@primary
-·                spans         FULL SCAN
-·                filter        x = 44
+·                    distribution  local
+·                    vectorized    true
+render               ·             ·
+ └── cross-join      ·             ·
+      │              type          cross
+      ├── scan       ·             ·
+      │              table         twocolumn@primary
+      │              spans         FULL SCAN
+      └── filter     ·             ·
+           │         filter        x = 44
+           └── scan  ·             ·
+·                    table         twocolumn@primary
+·                    spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
@@ -591,22 +592,24 @@ SELECT *
  WHERE b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a  < sq)
 ]
 ----
-·               distribution  local
-·               vectorized    true
-filter          ·             ·
- │              filter        ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
- └── hash-join  ·             ·
-      │         type          left outer
-      │         equality      (b) = (sq)
-      │         pred          a > 1
-      ├── scan  ·             ·
-      │         table         pairs@primary
-      │         spans         FULL SCAN
-      │         filter        b > 1
-      └── scan  ·             ·
-·               table         square@primary
-·               spans         -/5/#
-·               filter        sq > 1
+·                    distribution  local
+·                    vectorized    true
+filter               ·             ·
+ │                   filter        ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
+ └── hash-join       ·             ·
+      │              type          left outer
+      │              equality      (b) = (sq)
+      │              pred          a > 1
+      ├── filter     ·             ·
+      │    │         filter        b > 1
+      │    └── scan  ·             ·
+      │              table         pairs@primary
+      │              spans         FULL SCAN
+      └── filter     ·             ·
+           │         filter        sq > 1
+           └── scan  ·             ·
+·                    table         square@primary
+·                    spans         -/5/#
 
 query TTT
 SELECT tree, field, description FROM [
@@ -616,26 +619,27 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ]
 ----
-·                    distribution  local
-·                    vectorized    true
-render               ·             ·
- │                   render 0      a
- │                   render 1      b
- │                   render 2      n
- │                   render 3      sq
- └── filter          ·             ·
-      │              filter        ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
-      └── hash-join  ·             ·
-           │         type          left outer
-           │         equality      (sq) = (b)
-           │         pred          n < 6
-           ├── scan  ·             ·
-           │         table         square@primary
-           │         spans         /2-
-           └── scan  ·             ·
-·                    table         pairs@primary
-·                    spans         FULL SCAN
-·                    filter        a > 1
+·                         distribution  local
+·                         vectorized    true
+render                    ·             ·
+ │                        render 0      a
+ │                        render 1      b
+ │                        render 2      n
+ │                        render 3      sq
+ └── filter               ·             ·
+      │                   filter        ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
+      └── hash-join       ·             ·
+           │              type          left outer
+           │              equality      (sq) = (b)
+           │              pred          n < 6
+           ├── scan       ·             ·
+           │              table         square@primary
+           │              spans         /2-
+           └── filter     ·             ·
+                │         filter        a > 1
+                └── scan  ·             ·
+·                         table         pairs@primary
+·                         spans         FULL SCAN
 
 # The simpler plan for an inner join, to compare.
 query TTT
@@ -646,19 +650,20 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ]
 ----
-·          distribution  local
-·          vectorized    true
-hash-join  ·             ·
- │         type          inner
- │         equality      (b) = (sq)
- ├── scan  ·             ·
- │         table         pairs@primary
- │         spans         FULL SCAN
- │         filter        ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
- └── scan  ·             ·
-·          table         square@primary
-·          spans         /2-/5/#
-·          parallel      ·
+·               distribution  local
+·               vectorized    true
+hash-join       ·             ·
+ │              type          inner
+ │              equality      (b) = (sq)
+ ├── filter     ·             ·
+ │    │         filter        ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
+ │    └── scan  ·             ·
+ │              table         pairs@primary
+ │              spans         FULL SCAN
+ └── scan       ·             ·
+·               table         square@primary
+·               spans         /2-/5/#
+·               parallel      ·
 
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -148,17 +148,18 @@ filter     ·             ·             (k)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 LIMIT 10
 ----
-·               distribution  local                    ·          ·
-·               vectorized    true                     ·          ·
-render          ·             ·                        (k, w)     ·
- │              render 0      k                        ·          ·
- │              render 1      w                        ·          ·
- └── limit      ·             ·                        (k, v, w)  ·
-      │         count         10                       ·          ·
-      └── scan  ·             ·                        (k, v, w)  ·
-·               table         t@primary                ·          ·
-·               spans         FULL SCAN                ·          ·
-·               filter        (v >= 1) AND (v <= 100)  ·          ·
+·                    distribution  local                    ·          ·
+·                    vectorized    true                     ·          ·
+render               ·             ·                        (k, w)     ·
+ │                   render 0      k                        ·          ·
+ │                   render 1      w                        ·          ·
+ └── limit           ·             ·                        (k, v, w)  ·
+      │              count         10                       ·          ·
+      └── filter     ·             ·                        (k, v, w)  ·
+           │         filter        (v >= 1) AND (v <= 100)  ·          ·
+           └── scan  ·             ·                        (k, v, w)  ·
+·                    table         t@primary                ·          ·
+·                    spans         FULL SCAN                ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 ORDER BY v LIMIT 10
@@ -179,19 +180,20 @@ render           ·             ·          (k, w)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM (SELECT * FROM t WHERE v >= 1 AND v <= 100 ORDER BY k LIMIT 10) ORDER BY v
 ----
-·                    distribution  local                    ·          ·
-·                    vectorized    true                     ·          ·
-render               ·             ·                        (k, w)     ·
- │                   render 0      k                        ·          ·
- │                   render 1      w                        ·          ·
- └── sort            ·             ·                        (k, v, w)  +v
-      │              order         +v                       ·          ·
-      └── limit      ·             ·                        (k, v, w)  +k
-           │         count         10                       ·          ·
-           └── scan  ·             ·                        (k, v, w)  +k
-·                    table         t@primary                ·          ·
-·                    spans         FULL SCAN                ·          ·
-·                    filter        (v >= 1) AND (v <= 100)  ·          ·
+·                         distribution  local                    ·          ·
+·                         vectorized    true                     ·          ·
+render                    ·             ·                        (k, w)     ·
+ │                        render 0      k                        ·          ·
+ │                        render 1      w                        ·          ·
+ └── sort                 ·             ·                        (k, v, w)  +v
+      │                   order         +v                       ·          ·
+      └── limit           ·             ·                        (k, v, w)  +k
+           │              count         10                       ·          ·
+           └── filter     ·             ·                        (k, v, w)  +k
+                │         filter        (v >= 1) AND (v <= 100)  ·          ·
+                └── scan  ·             ·                        (k, v, w)  +k
+·                         table         t@primary                ·          ·
+·                         spans         FULL SCAN                ·          ·
 
 # Regression test for #47283: scan with both hard limit and soft limit.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -163,24 +163,25 @@ SELECT *
 FROM (SELECT * FROM data WHERE c = 1) AS l
 NATURAL JOIN (SELECT * FROM data WHERE c > 0) AS r
 ----
-·                 distribution           full                         ·                         ·
-·                 vectorized             true                         ·                         ·
-render            ·                      ·                            (a, b, c, d)              ·
- │                render 0               a                            ·                         ·
- │                render 1               b                            ·                         ·
- │                render 2               c                            ·                         ·
- │                render 3               d                            ·                         ·
- └── lookup-join  ·                      ·                            (a, b, c, d, a, b, c, d)  ·
-      │           table                  data@primary                 ·                         ·
-      │           type                   inner                        ·                         ·
-      │           equality               (a, b, c, d) = (a, b, c, d)  ·                         ·
-      │           equality cols are key  ·                            ·                         ·
-      │           parallel               ·                            ·                         ·
-      │           pred                   c > 0                        ·                         ·
-      └── scan    ·                      ·                            (a, b, c, d)              ·
-·                 table                  data@primary                 ·                         ·
-·                 spans                  FULL SCAN                    ·                         ·
-·                 filter                 c = 1                        ·                         ·
+·                    distribution           full                         ·                         ·
+·                    vectorized             true                         ·                         ·
+render               ·                      ·                            (a, b, c, d)              ·
+ │                   render 0               a                            ·                         ·
+ │                   render 1               b                            ·                         ·
+ │                   render 2               c                            ·                         ·
+ │                   render 3               d                            ·                         ·
+ └── lookup-join     ·                      ·                            (a, b, c, d, a, b, c, d)  ·
+      │              table                  data@primary                 ·                         ·
+      │              type                   inner                        ·                         ·
+      │              equality               (a, b, c, d) = (a, b, c, d)  ·                         ·
+      │              equality cols are key  ·                            ·                         ·
+      │              parallel               ·                            ·                         ·
+      │              pred                   c > 0                        ·                         ·
+      └── filter     ·                      ·                            (a, b, c, d)              ·
+           │         filter                 c = 1                        ·                         ·
+           └── scan  ·                      ·                            (a, b, c, d)              ·
+·                    table                  data@primary                 ·                         ·
+·                    spans                  FULL SCAN                    ·                         ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL)
@@ -518,21 +519,22 @@ render            ·             ·              (c, c)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b AND large.d < 30
 ----
-·               distribution  full           ·          ·
-·               vectorized    true           ·          ·
-render          ·             ·              (c, d)     ·
- │              render 0      c              ·          ·
- │              render 1      d              ·          ·
- └── hash-join  ·             ·              (b, d, c)  ·
-      │         type          right outer    ·          ·
-      │         equality      (b) = (c)      ·          ·
-      ├── scan  ·             ·              (b, d)     ·
-      │         table         large@primary  ·          ·
-      │         spans         FULL SCAN      ·          ·
-      │         filter        d < 30         ·          ·
-      └── scan  ·             ·              (c)        ·
-·               table         small@primary  ·          ·
-·               spans         FULL SCAN      ·          ·
+·                    distribution  full           ·          ·
+·                    vectorized    true           ·          ·
+render               ·             ·              (c, d)     ·
+ │                   render 0      c              ·          ·
+ │                   render 1      d              ·          ·
+ └── hash-join       ·             ·              (b, d, c)  ·
+      │              type          right outer    ·          ·
+      │              equality      (b) = (c)      ·          ·
+      ├── filter     ·             ·              (b, d)     ·
+      │    │         filter        d < 30         ·          ·
+      │    └── scan  ·             ·              (b, d)     ·
+      │              table         large@primary  ·          ·
+      │              spans         FULL SCAN      ·          ·
+      └── scan       ·             ·              (c)        ·
+·                    table         small@primary  ·          ·
+·                    spans         FULL SCAN      ·          ·
 
 ###########################################################
 #  LOOKUP JOINS ON IMPLICIT INDEX KEY COLUMNS             #
@@ -551,18 +553,19 @@ CREATE INDEX idx ON u (d)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
 ----
-·                 distribution  full             ·                ·
-·                 vectorized    true             ·                ·
-render            ·             ·                (a)              ·
- │                render 0      a                ·                ·
- └── lookup-join  ·             ·                (a, d, e, a, d)  ·
-      │           table         u@idx            ·                ·
-      │           type          inner            ·                ·
-      │           equality      (d, a) = (d, a)  ·                ·
-      └── scan    ·             ·                (a, d, e)        ·
-·                 table         t@primary        ·                ·
-·                 spans         FULL SCAN        ·                ·
-·                 filter        e = 5            ·                ·
+·                    distribution  full             ·                ·
+·                    vectorized    true             ·                ·
+render               ·             ·                (a)              ·
+ │                   render 0      a                ·                ·
+ └── lookup-join     ·             ·                (a, d, e, a, d)  ·
+      │              table         u@idx            ·                ·
+      │              type          inner            ·                ·
+      │              equality      (d, a) = (d, a)  ·                ·
+      └── filter     ·             ·                (a, d, e)        ·
+           │         filter        e = 5            ·                ·
+           └── scan  ·             ·                (a, d, e)        ·
+·                    table         t@primary        ·                ·
+·                    spans         FULL SCAN        ·                ·
 
 # Test unique version of same index. (Lookup join should not use column a.)
 statement ok
@@ -574,21 +577,22 @@ CREATE UNIQUE INDEX idx ON u (d)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
 ----
-·                 distribution           full       ·                ·
-·                 vectorized             true       ·                ·
-render            ·                      ·          (a)              ·
- │                render 0               a          ·                ·
- └── lookup-join  ·                      ·          (a, d, e, a, d)  ·
-      │           table                  u@idx      ·                ·
-      │           type                   inner      ·                ·
-      │           equality               (d) = (d)  ·                ·
-      │           equality cols are key  ·          ·                ·
-      │           parallel               ·          ·                ·
-      │           pred                   a = a      ·                ·
-      └── scan    ·                      ·          (a, d, e)        ·
-·                 table                  t@primary  ·                ·
-·                 spans                  FULL SCAN  ·                ·
-·                 filter                 e = 5      ·                ·
+·                    distribution           full       ·                ·
+·                    vectorized             true       ·                ·
+render               ·                      ·          (a)              ·
+ │                   render 0               a          ·                ·
+ └── lookup-join     ·                      ·          (a, d, e, a, d)  ·
+      │              table                  u@idx      ·                ·
+      │              type                   inner      ·                ·
+      │              equality               (d) = (d)  ·                ·
+      │              equality cols are key  ·          ·                ·
+      │              parallel               ·          ·                ·
+      │              pred                   a = a      ·                ·
+      └── filter     ·                      ·          (a, d, e)        ·
+           │         filter                 e = 5      ·                ·
+           └── scan  ·                      ·          (a, d, e)        ·
+·                    table                  t@primary  ·                ·
+·                    spans                  FULL SCAN  ·                ·
 
 # Test index with first primary key column explicit and the rest implicit.
 statement ok
@@ -600,18 +604,19 @@ CREATE INDEX idx ON u (d, a)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
 ----
-·                 distribution  full                   ·                      ·
-·                 vectorized    true                   ·                      ·
-render            ·             ·                      (a)                    ·
- │                render 0      a                      ·                      ·
- └── lookup-join  ·             ·                      (a, b, d, e, a, b, d)  ·
-      │           table         u@idx                  ·                      ·
-      │           type          inner                  ·                      ·
-      │           equality      (d, a, b) = (d, a, b)  ·                      ·
-      └── scan    ·             ·                      (a, b, d, e)           ·
-·                 table         t@primary              ·                      ·
-·                 spans         FULL SCAN              ·                      ·
-·                 filter        e = 5                  ·                      ·
+·                    distribution  full                   ·                      ·
+·                    vectorized    true                   ·                      ·
+render               ·             ·                      (a)                    ·
+ │                   render 0      a                      ·                      ·
+ └── lookup-join     ·             ·                      (a, b, d, e, a, b, d)  ·
+      │              table         u@idx                  ·                      ·
+      │              type          inner                  ·                      ·
+      │              equality      (d, a, b) = (d, a, b)  ·                      ·
+      └── filter     ·             ·                      (a, b, d, e)           ·
+           │         filter        e = 5                  ·                      ·
+           └── scan  ·             ·                      (a, b, d, e)           ·
+·                    table         t@primary              ·                      ·
+·                    spans         FULL SCAN              ·                      ·
 
 # Test index with middle primary key column explicit and the rest implicit.
 statement ok
@@ -623,18 +628,19 @@ CREATE INDEX idx ON u (d, b)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
 ----
-·                 distribution  full                   ·                      ·
-·                 vectorized    true                   ·                      ·
-render            ·             ·                      (a)                    ·
- │                render 0      a                      ·                      ·
- └── lookup-join  ·             ·                      (a, b, d, e, a, b, d)  ·
-      │           table         u@idx                  ·                      ·
-      │           type          inner                  ·                      ·
-      │           equality      (d, b, a) = (d, b, a)  ·                      ·
-      └── scan    ·             ·                      (a, b, d, e)           ·
-·                 table         t@primary              ·                      ·
-·                 spans         FULL SCAN              ·                      ·
-·                 filter        e = 5                  ·                      ·
+·                    distribution  full                   ·                      ·
+·                    vectorized    true                   ·                      ·
+render               ·             ·                      (a)                    ·
+ │                   render 0      a                      ·                      ·
+ └── lookup-join     ·             ·                      (a, b, d, e, a, b, d)  ·
+      │              table         u@idx                  ·                      ·
+      │              type          inner                  ·                      ·
+      │              equality      (d, b, a) = (d, b, a)  ·                      ·
+      └── filter     ·             ·                      (a, b, d, e)           ·
+           │         filter        e = 5                  ·                      ·
+           └── scan  ·             ·                      (a, b, d, e)           ·
+·                    table         t@primary              ·                      ·
+·                    spans         FULL SCAN              ·                      ·
 
 # Test index with last primary key column explicit and the rest implicit.
 statement ok
@@ -646,19 +652,20 @@ CREATE INDEX idx ON u (d, c)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = u.d WHERE t.e = 5
 ----
-·                 distribution  full       ·                ·
-·                 vectorized    true       ·                ·
-render            ·             ·          (a)              ·
- │                render 0      a          ·                ·
- └── lookup-join  ·             ·          (a, d, e, a, d)  ·
-      │           table         u@idx      ·                ·
-      │           type          inner      ·                ·
-      │           equality      (d) = (d)  ·                ·
-      │           pred          a = a      ·                ·
-      └── scan    ·             ·          (a, d, e)        ·
-·                 table         t@primary  ·                ·
-·                 spans         FULL SCAN  ·                ·
-·                 filter        e = 5      ·                ·
+·                    distribution  full       ·                ·
+·                    vectorized    true       ·                ·
+render               ·             ·          (a)              ·
+ │                   render 0      a          ·                ·
+ └── lookup-join     ·             ·          (a, d, e, a, d)  ·
+      │              table         u@idx      ·                ·
+      │              type          inner      ·                ·
+      │              equality      (d) = (d)  ·                ·
+      │              pred          a = a      ·                ·
+      └── filter     ·             ·          (a, d, e)        ·
+           │         filter        e = 5      ·                ·
+           └── scan  ·             ·          (a, d, e)        ·
+·                    table         t@primary  ·                ·
+·                    spans         FULL SCAN  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def JOIN abc ON a=f ORDER BY a
@@ -1422,54 +1429,56 @@ GROUP BY s_name
 ORDER BY numwait DESC, s_name
    LIMIT 100;
 ----
-·                                                   distribution           full
-·                                                   vectorized             true
-limit                                               ·                      ·
- │                                                  count                  100
- └── sort                                           ·                      ·
-      │                                             order                  -numwait,+s_name
-      └── group                                     ·                      ·
-           │                                        aggregate 0            s_name
-           │                                        aggregate 1            count_rows()
-           │                                        group by               s_name
-           └── render                               ·                      ·
-                └── lookup-join                     ·                      ·
-                     │                              table                  orders@primary
-                     │                              type                   inner
-                     │                              equality               (l_orderkey) = (o_orderkey)
-                     │                              equality cols are key  ·
-                     │                              parallel               ·
-                     │                              pred                   o_orderstatus = 'F'
-                     └── lookup-join                ·                      ·
-                          │                         table                  nation@primary
-                          │                         type                   inner
-                          │                         equality               (s_nationkey) = (n_nationkey)
-                          │                         equality cols are key  ·
-                          │                         parallel               ·
-                          │                         pred                   n_name = 'SAUDI ARABIA'
-                          └── lookup-join           ·                      ·
-                               │                    table                  supplier@primary
-                               │                    type                   inner
-                               │                    equality               (l_suppkey) = (s_suppkey)
-                               │                    equality cols are key  ·
-                               │                    parallel               ·
-                               └── lookup-join      ·                      ·
-                                    │               table                  lineitem@primary
-                                    │               type                   semi
-                                    │               equality               (l_orderkey) = (l_orderkey)
-                                    │               pred                   l_suppkey != l_suppkey
-                                    └── merge-join  ·                      ·
-                                         │          type                   anti
-                                         │          equality               (l_orderkey) = (l_orderkey)
-                                         │          mergeJoinOrder         +"(l_orderkey=l_orderkey)"
-                                         ├── scan   ·                      ·
-                                         │          table                  lineitem@primary
-                                         │          spans                  FULL SCAN
-                                         │          filter                 l_receiptdate > l_commitdate
-                                         └── scan   ·                      ·
-·                                                   table                  lineitem@primary
-·                                                   spans                  FULL SCAN
-·                                                   filter                 l_receiptdate > l_commitdate
+·                                                       distribution           full
+·                                                       vectorized             true
+limit                                                   ·                      ·
+ │                                                      count                  100
+ └── sort                                               ·                      ·
+      │                                                 order                  -numwait,+s_name
+      └── group                                         ·                      ·
+           │                                            aggregate 0            s_name
+           │                                            aggregate 1            count_rows()
+           │                                            group by               s_name
+           └── render                                   ·                      ·
+                └── lookup-join                         ·                      ·
+                     │                                  table                  orders@primary
+                     │                                  type                   inner
+                     │                                  equality               (l_orderkey) = (o_orderkey)
+                     │                                  equality cols are key  ·
+                     │                                  parallel               ·
+                     │                                  pred                   o_orderstatus = 'F'
+                     └── lookup-join                    ·                      ·
+                          │                             table                  nation@primary
+                          │                             type                   inner
+                          │                             equality               (s_nationkey) = (n_nationkey)
+                          │                             equality cols are key  ·
+                          │                             parallel               ·
+                          │                             pred                   n_name = 'SAUDI ARABIA'
+                          └── lookup-join               ·                      ·
+                               │                        table                  supplier@primary
+                               │                        type                   inner
+                               │                        equality               (l_suppkey) = (s_suppkey)
+                               │                        equality cols are key  ·
+                               │                        parallel               ·
+                               └── lookup-join          ·                      ·
+                                    │                   table                  lineitem@primary
+                                    │                   type                   semi
+                                    │                   equality               (l_orderkey) = (l_orderkey)
+                                    │                   pred                   l_suppkey != l_suppkey
+                                    └── merge-join      ·                      ·
+                                         │              type                   anti
+                                         │              equality               (l_orderkey) = (l_orderkey)
+                                         │              mergeJoinOrder         +"(l_orderkey=l_orderkey)"
+                                         ├── filter     ·                      ·
+                                         │    │         filter                 l_receiptdate > l_commitdate
+                                         │    └── scan  ·                      ·
+                                         │              table                  lineitem@primary
+                                         │              spans                  FULL SCAN
+                                         └── filter     ·                      ·
+                                              │         filter                 l_receiptdate > l_commitdate
+                                              └── scan  ·                      ·
+·                                                       table                  lineitem@primary
+·                                                       spans                  FULL SCAN
 
 # Regression test for #50964.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -281,15 +281,16 @@ render                ·                ·
 query TTT
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 ----
-·               distribution  local
-·               vectorized    true
-render          ·             ·
- └── sort       ·             ·
-      │         order         +b,+a,+d
-      └── scan  ·             ·
-·               table         abc@primary
-·               spans         FULL SCAN
-·               filter        b > 10
+·                    distribution  local
+·                    vectorized    true
+render               ·             ·
+ └── sort            ·             ·
+      │              order         +b,+a,+d
+      └── filter     ·             ·
+           │         filter        b > 10
+           └── scan  ·             ·
+·                    table         abc@primary
+·                    spans         FULL SCAN
 
 query III
 SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
@@ -306,14 +307,15 @@ SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
 ----
-·          distribution  local        ·             ·
-·          vectorized    true         ·             ·
-sort       ·             ·            (a, b, c, d)  +b,+a,+c
- │         order         +b,+a,+c     ·             ·
- └── scan  ·             ·            (a, b, c, d)  ·
-·          table         abc@primary  ·             ·
-·          spans         FULL SCAN    ·             ·
-·          filter        b > 10       ·             ·
+·               distribution  local        ·             ·
+·               vectorized    true         ·             ·
+sort            ·             ·            (a, b, c, d)  +b,+a,+c
+ │              order         +b,+a,+c     ·             ·
+ └── filter     ·             ·            (a, b, c, d)  ·
+      │         filter        b > 10       ·             ·
+      └── scan  ·             ·            (a, b, c, d)  ·
+·               table         abc@primary  ·             ·
+·               spans         FULL SCAN    ·             ·
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -11,12 +11,13 @@ PREPARE change_index AS SELECT * FROM [EXPLAIN SELECT * FROM ab WHERE b=10]
 query TTT
 EXECUTE change_index
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         ab@primary
-·     spans         FULL SCAN
-·     filter        b = 10
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        b = 10
+ └── scan  ·             ·
+·          table         ab@primary
+·          spans         FULL SCAN
 
 statement ok
 CREATE INDEX bindex ON ab (b)
@@ -36,12 +37,13 @@ DROP INDEX bindex
 query TTT
 EXECUTE change_index
 ----
-·     distribution  full
-·     vectorized    true
-scan  ·             ·
-·     table         ab@primary
-·     spans         FULL SCAN
-·     filter        b = 10
+·          distribution  full
+·          vectorized    true
+filter     ·             ·
+ │         filter        b = 10
+ └── scan  ·             ·
+·          table         ab@primary
+·          spans         FULL SCAN
 
 ## Statistics change: Create statistics and ensure that the plan is recalculated.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -581,26 +581,28 @@ render       ·              ·                                    ("coalesce") 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a BETWEEN b AND d
 ----
-·          distribution  local                  ·          ·
-·          vectorized    true                   ·          ·
-render     ·             ·                      (a)        ·
- │         render 0      a                      ·          ·
- └── scan  ·             ·                      (a, b, d)  ·
-·          table         t@primary              ·          ·
-·          spans         FULL SCAN              ·          ·
-·          filter        (a >= b) AND (a <= d)  ·          ·
+·               distribution  local                  ·          ·
+·               vectorized    true                   ·          ·
+render          ·             ·                      (a)        ·
+ │              render 0      a                      ·          ·
+ └── filter     ·             ·                      (a, b, d)  ·
+      │         filter        (a >= b) AND (a <= d)  ·          ·
+      └── scan  ·             ·                      (a, b, d)  ·
+·               table         t@primary              ·          ·
+·               spans         FULL SCAN              ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a NOT BETWEEN b AND d
 ----
-·          distribution  local               ·          ·
-·          vectorized    true                ·          ·
-render     ·             ·                   (a)        ·
- │         render 0      a                   ·          ·
- └── scan  ·             ·                   (a, b, d)  ·
-·          table         t@primary           ·          ·
-·          spans         FULL SCAN           ·          ·
-·          filter        (a < b) OR (a > d)  ·          ·
+·               distribution  local               ·          ·
+·               vectorized    true                ·          ·
+render          ·             ·                   (a)        ·
+ │              render 0      a                   ·          ·
+ └── filter     ·             ·                   (a, b, d)  ·
+      │         filter        (a < b) OR (a > d)  ·          ·
+      └── scan  ·             ·                   (a, b, d)  ·
+·               table         t@primary           ·          ·
+·               spans         FULL SCAN           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a BETWEEN SYMMETRIC b AND d AS r FROM t

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -283,12 +283,13 @@ scan  ·             ·          (x, y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE y > 10
 ----
-·     distribution  local      ·       ·
-·     vectorized    true       ·       ·
-scan  ·             ·          (x, y)  ·
-·     table         a@primary  ·       ·
-·     spans         FULL SCAN  ·       ·
-·     filter        y > 10     ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+filter     ·             ·          (x, y)  ·
+ │         filter        y > 10     ·       ·
+ └── scan  ·             ·          (x, y)  ·
+·          table         a@primary  ·       ·
+·          spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND x < 3
@@ -302,12 +303,13 @@ scan  ·             ·          (x, y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND y < 30
 ----
-·     distribution  local      ·       ·
-·     vectorized    true       ·       ·
-scan  ·             ·          (x, y)  ·
-·     table         a@primary  ·       ·
-·     spans         /2-        ·       ·
-·     filter        y < 30     ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+filter     ·             ·          (x, y)  ·
+ │         filter        y < 30     ·       ·
+ └── scan  ·             ·          (x, y)  ·
+·          table         a@primary  ·       ·
+·          spans         /2-        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x + 1 AS r FROM a
@@ -366,15 +368,16 @@ render     ·             ·          (x, x, y, x)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x + 1 AS a, x + y AS b FROM a WHERE x + y > 20
 ----
-·          distribution  local         ·       ·
-·          vectorized    true          ·       ·
-render     ·             ·             (a, b)  ·
- │         render 0      x + 1         ·       ·
- │         render 1      x + y         ·       ·
- └── scan  ·             ·             (x, y)  ·
-·          table         a@primary     ·       ·
-·          spans         FULL SCAN     ·       ·
-·          filter        (x + y) > 20  ·       ·
+·               distribution  local         ·       ·
+·               vectorized    true          ·       ·
+render          ·             ·             (a, b)  ·
+ │              render 0      x + 1         ·       ·
+ │              render 1      x + y         ·       ·
+ └── filter     ·             ·             (x, y)  ·
+      │         filter        (x + y) > 20  ·       ·
+      └── scan  ·             ·             (x, y)  ·
+·               table         a@primary     ·       ·
+·               spans         FULL SCAN     ·       ·
 
 statement ok
 DROP TABLE a
@@ -829,12 +832,13 @@ scan  ·             ·                (d decimal)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE isnan(d)
 ----
-·     distribution  local                        ·            ·
-·     vectorized    true                         ·            ·
-scan  ·             ·                            (d decimal)  ·
-·     table         dec2@primary                 ·            ·
-·     spans         FULL SCAN                    ·            ·
-·     filter        (isnan((d)[decimal]))[bool]  ·            ·
+·          distribution  local                        ·            ·
+·          vectorized    true                         ·            ·
+filter     ·             ·                            (d decimal)  ·
+ │         filter        (isnan((d)[decimal]))[bool]  ·            ·
+ └── scan  ·             ·                            (d decimal)  ·
+·          table         dec2@primary                 ·            ·
+·          spans         FULL SCAN                    ·            ·
 
 statement ok
 DROP TABLE dec2
@@ -869,12 +873,13 @@ scan  ·             ·                    (f float)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM flt WHERE isnan(f)
 ----
-·     distribution  local                      ·          ·
-·     vectorized    true                       ·          ·
-scan  ·             ·                          (f float)  ·
-·     table         flt@primary                ·          ·
-·     spans         FULL SCAN                  ·          ·
-·     filter        (isnan((f)[float]))[bool]  ·          ·
+·          distribution  local                      ·          ·
+·          vectorized    true                       ·          ·
+filter     ·             ·                          (f float)  ·
+ │         filter        (isnan((f)[float]))[bool]  ·          ·
+ └── scan  ·             ·                          (f float)  ·
+·          table         flt@primary                ·          ·
+·          spans         FULL SCAN                  ·          ·
 
 statement ok
 DROP TABLE flt
@@ -1171,24 +1176,26 @@ render        ·             ·                  ("?column?")  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a > b ORDER BY a
 ----
-·     distribution  local         ·             ·
-·     vectorized    true          ·             ·
-scan  ·             ·             (a, b, c, d)  +a
-·     table         abcd@primary  ·             ·
-·     spans         FULL SCAN     ·             ·
-·     filter        a > b         ·             ·
+·          distribution  local         ·             ·
+·          vectorized    true          ·             ·
+filter     ·             ·             (a, b, c, d)  +a
+ │         filter        a > b         ·             ·
+ └── scan  ·             ·             (a, b, c, d)  +a
+·          table         abcd@primary  ·             ·
+·          spans         FULL SCAN     ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a > b ORDER BY a DESC, b DESC
 ----
-·          distribution  local         ·             ·
-·          vectorized    true          ·             ·
-sort       ·             ·             (a, b, c, d)  -a,-b
- │         order         -a,-b         ·             ·
- └── scan  ·             ·             (a, b, c, d)  ·
-·          table         abcd@primary  ·             ·
-·          spans         FULL SCAN     ·             ·
-·          filter        a > b         ·             ·
+·               distribution  local         ·             ·
+·               vectorized    true          ·             ·
+sort            ·             ·             (a, b, c, d)  -a,-b
+ │              order         -a,-b         ·             ·
+ └── filter     ·             ·             (a, b, c, d)  ·
+      │         filter        a > b         ·             ·
+      └── scan  ·             ·             (a, b, c, d)  ·
+·               table         abcd@primary  ·             ·
+·               spans         FULL SCAN     ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a, b FROM abcd LIMIT 10) WHERE a > b ORDER BY a

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -469,74 +469,80 @@ CREATE TABLE t (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1
 ----
-·          distribution  local      ·       ·
-·          vectorized    true       ·       ·
-render     ·             ·          (a)     ·
- │         render 0      a          ·       ·
- └── scan  ·             ·          (a, c)  ·
-·          table         t@primary  ·       ·
-·          spans         FULL SCAN  ·       ·
-·          filter        c > 1      ·       ·
+·               distribution  local      ·       ·
+·               vectorized    true       ·       ·
+render          ·             ·          (a)     ·
+ │              render 0      a          ·       ·
+ └── filter     ·             ·          (a, c)  ·
+      │         filter        c > 1      ·       ·
+      └── scan  ·             ·          (a, c)  ·
+·               table         t@primary  ·       ·
+·               spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c < 1 AND b < 5
 ----
-·          distribution  local        ·          ·
-·          vectorized    true         ·          ·
-render     ·             ·            (a)        ·
- │         render 0      a            ·          ·
- └── scan  ·             ·            (a, b, c)  ·
-·          table         t@bc         ·          ·
-·          spans         /!NULL-/4/1  ·          ·
-·          filter        c < 1        ·          ·
+·               distribution  local        ·          ·
+·               vectorized    true         ·          ·
+render          ·             ·            (a)        ·
+ │              render 0      a            ·          ·
+ └── filter     ·             ·            (a, b, c)  ·
+      │         filter        c < 1        ·          ·
+      └── scan  ·             ·            (a, b, c)  ·
+·               table         t@bc         ·          ·
+·               spans         /!NULL-/4/1  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1.0
 ----
-·          distribution  local      ·       ·
-·          vectorized    true       ·       ·
-render     ·             ·          (a)     ·
- │         render 0      a          ·       ·
- └── scan  ·             ·          (a, c)  ·
-·          table         t@primary  ·       ·
-·          spans         FULL SCAN  ·       ·
-·          filter        c > 1      ·       ·
+·               distribution  local      ·       ·
+·               vectorized    true       ·       ·
+render          ·             ·          (a)     ·
+ │              render 0      a          ·       ·
+ └── filter     ·             ·          (a, c)  ·
+      │         filter        c > 1      ·       ·
+      └── scan  ·             ·          (a, c)  ·
+·               table         t@primary  ·       ·
+·               spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c < 1.0
 ----
-·          distribution  local      ·       ·
-·          vectorized    true       ·       ·
-render     ·             ·          (a)     ·
- │         render 0      a          ·       ·
- └── scan  ·             ·          (a, c)  ·
-·          table         t@primary  ·       ·
-·          spans         FULL SCAN  ·       ·
-·          filter        c < 1      ·       ·
+·               distribution  local      ·       ·
+·               vectorized    true       ·       ·
+render          ·             ·          (a)     ·
+ │              render 0      a          ·       ·
+ └── filter     ·             ·          (a, c)  ·
+      │         filter        c < 1      ·       ·
+      └── scan  ·             ·          (a, c)  ·
+·               table         t@primary  ·       ·
+·               spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1.0 AND b < 5
 ----
-·          distribution  local      ·          ·
-·          vectorized    true       ·          ·
-render     ·             ·          (a)        ·
- │         render 0      a          ·          ·
- └── scan  ·             ·          (a, b, c)  ·
-·          table         t@bc       ·          ·
-·          spans         /!NULL-/5  ·          ·
-·          filter        c > 1      ·          ·
+·               distribution  local      ·          ·
+·               vectorized    true       ·          ·
+render          ·             ·          (a)        ·
+ │              render 0      a          ·          ·
+ └── filter     ·             ·          (a, b, c)  ·
+      │         filter        c > 1      ·          ·
+      └── scan  ·             ·          (a, b, c)  ·
+·               table         t@bc       ·          ·
+·               spans         /!NULL-/5  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE b < 5.0 AND c < 1
 ----
-·          distribution  local        ·          ·
-·          vectorized    true         ·          ·
-render     ·             ·            (a)        ·
- │         render 0      a            ·          ·
- └── scan  ·             ·            (a, b, c)  ·
-·          table         t@bc         ·          ·
-·          spans         /!NULL-/4/1  ·          ·
-·          filter        c < 1        ·          ·
+·               distribution  local        ·          ·
+·               vectorized    true         ·          ·
+render          ·             ·            (a)        ·
+ │              render 0      a            ·          ·
+ └── filter     ·             ·            (a, b, c)  ·
+      │         filter        c < 1        ·          ·
+      └── scan  ·             ·            (a, b, c)  ·
+·               table         t@bc         ·          ·
+·               spans         /!NULL-/4/1  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5, 1)
@@ -563,14 +569,15 @@ render     ·             ·          (a)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5.1, 1)
 ----
-·          distribution  local                  ·          ·
-·          vectorized    true                   ·          ·
-render     ·             ·                      (a)        ·
- │         render 0      a                      ·          ·
- └── scan  ·             ·                      (a, b, c)  ·
-·          table         t@bc                   ·          ·
-·          spans         /!NULL-                ·          ·
-·          filter        (b = 5.1) AND (c = 1)  ·          ·
+·               distribution  local                  ·          ·
+·               vectorized    true                   ·          ·
+render          ·             ·                      (a)        ·
+ │              render 0      a                      ·          ·
+ └── filter     ·             ·                      (a, b, c)  ·
+      │         filter        (b = 5.1) AND (c = 1)  ·          ·
+      └── scan  ·             ·                      (a, b, c)  ·
+·               table         t@bc                   ·          ·
+·               spans         /!NULL-                ·          ·
 
 # Note the span is reversed because of #20203.
 query TTTTT
@@ -627,15 +634,16 @@ CREATE TABLE ab (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT i, s FROM ab WHERE (i, s) < (1, 'c')
 ----
-·          distribution  local              ·       ·
-·          vectorized    true               ·       ·
-render     ·             ·                  (i, s)  ·
- │         render 0      i                  ·       ·
- │         render 1      s                  ·       ·
- └── scan  ·             ·                  (s, i)  ·
-·          table         ab@primary         ·       ·
-·          spans         FULL SCAN          ·       ·
-·          filter        (i, s) < (1, 'c')  ·       ·
+·               distribution  local              ·       ·
+·               vectorized    true               ·       ·
+render          ·             ·                  (i, s)  ·
+ │              render 0      i                  ·       ·
+ │              render 1      s                  ·       ·
+ └── filter     ·             ·                  (s, i)  ·
+      │         filter        (i, s) < (1, 'c')  ·       ·
+      └── scan  ·             ·                  (s, i)  ·
+·               table         ab@primary         ·       ·
+·               spans         FULL SCAN          ·       ·
 
 statement ok
 CREATE INDEX baz ON ab (i, s)
@@ -643,15 +651,16 @@ CREATE INDEX baz ON ab (i, s)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 ----
-·          distribution  local              ·       ·
-·          vectorized    true               ·       ·
-render     ·             ·                  (i, s)  ·
- │         render 0      i                  ·       ·
- │         render 1      s                  ·       ·
- └── scan  ·             ·                  (s, i)  ·
-·          table         ab@baz             ·       ·
-·          spans         /!NULL-/1/"c"      ·       ·
-·          filter        (i, s) < (1, 'c')  ·       ·
+·               distribution  local              ·       ·
+·               vectorized    true               ·       ·
+render          ·             ·                  (i, s)  ·
+ │              render 0      i                  ·       ·
+ │              render 1      s                  ·       ·
+ └── filter     ·             ·                  (s, i)  ·
+      │         filter        (i, s) < (1, 'c')  ·       ·
+      └── scan  ·             ·                  (s, i)  ·
+·               table         ab@baz             ·       ·
+·               spans         /!NULL-/1/"c"      ·       ·
 
 # Check that primary key definitions can indicate index ordering,
 # and this information is subsequently used during index selection
@@ -697,14 +706,15 @@ CREATE TABLE tab0(
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
 ----
-·          distribution  local                                  ·          ·
-·          vectorized    true                                   ·          ·
-render     ·             ·                                      (k)        ·
- │         render 0      k                                      ·          ·
- └── scan  ·             ·                                      (k, a, b)  ·
-·          table         tab0@primary                           ·          ·
-·          spans         FULL SCAN                              ·          ·
-·          filter        ((a IN (6,)) AND (a > 6)) OR (b >= 4)  ·          ·
+·               distribution  local                                  ·          ·
+·               vectorized    true                                   ·          ·
+render          ·             ·                                      (k)        ·
+ │              render 0      k                                      ·          ·
+ └── filter     ·             ·                                      (k, a, b)  ·
+      │         filter        ((a IN (6,)) AND (a > 6)) OR (b >= 4)  ·          ·
+      └── scan  ·             ·                                      (k, a, b)  ·
+·               table         tab0@primary                           ·          ·
+·               spans         FULL SCAN                              ·          ·
 
 # Check that no extraneous rows are fetched due to excessive batching (#15910)
 # The test is composed of three parts: populate a table, check
@@ -873,14 +883,15 @@ CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY(d,e), UNIQUE INDEX(f))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT f FROM def WHERE f = 1 and d = 3
 ----
-·          distribution  local          ·       ·
-·          vectorized    true           ·       ·
-render     ·             ·              (f)     ·
- │         render 0      f              ·       ·
- └── scan  ·             ·              (d, f)  ·
-·          table         def@def_f_key  ·       ·
-·          spans         /1-/2          ·       ·
-·          filter        d = 3          ·       ·
+·               distribution  local          ·       ·
+·               vectorized    true           ·       ·
+render          ·             ·              (f)     ·
+ │              render 0      f              ·       ·
+ └── filter     ·             ·              (d, f)  ·
+      │         filter        d = 3          ·       ·
+      └── scan  ·             ·              (d, f)  ·
+·               table         def@def_f_key  ·       ·
+·               spans         /1-/2          ·       ·
 
 statement ok
 DROP TABLE def
@@ -893,14 +904,15 @@ CREATE TABLE def (d INT, e INT, f INT NOT NULL, PRIMARY KEY(d,e), UNIQUE INDEX(f
 query TTTTT
 EXPLAIN (VERBOSE) SELECT f FROM def WHERE f = 1 and d = 3
 ----
-·          distribution  local          ·       ·
-·          vectorized    true           ·       ·
-render     ·             ·              (f)     ·
- │         render 0      f              ·       ·
- └── scan  ·             ·              (d, f)  ·
-·          table         def@def_f_key  ·       ·
-·          spans         /1-/2          ·       ·
-·          filter        d = 3          ·       ·
+·               distribution  local          ·       ·
+·               vectorized    true           ·       ·
+render          ·             ·              (f)     ·
+ │              render 0      f              ·       ·
+ └── filter     ·             ·              (d, f)  ·
+      │         filter        d = 3          ·       ·
+      └── scan  ·             ·              (d, f)  ·
+·               table         def@def_f_key  ·       ·
+·               spans         /1-/2          ·       ·
 
 # Regression test for #20504.
 query TTTTT
@@ -928,22 +940,24 @@ scan  ·             ·              (k, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v LIKE 'ABC%Z'
 ----
-·     distribution  local           ·       ·
-·     vectorized    true            ·       ·
-scan  ·             ·               (k, v)  ·
-·     table         str@str_v_idx   ·       ·
-·     spans         /"ABC"-/"ABD"   ·       ·
-·     filter        v LIKE 'ABC%Z'  ·       ·
+·          distribution  local           ·       ·
+·          vectorized    true            ·       ·
+filter     ·             ·               (k, v)  ·
+ │         filter        v LIKE 'ABC%Z'  ·       ·
+ └── scan  ·             ·               (k, v)  ·
+·          table         str@str_v_idx   ·       ·
+·          spans         /"ABC"-/"ABD"   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v SIMILAR TO 'ABC_*'
 ----
-·     distribution  local                 ·       ·
-·     vectorized    true                  ·       ·
-scan  ·             ·                     (k, v)  ·
-·     table         str@str_v_idx         ·       ·
-·     spans         /"ABC"-/"ABD"         ·       ·
-·     filter        v SIMILAR TO 'ABC_*'  ·       ·
+·          distribution  local                 ·       ·
+·          vectorized    true                  ·       ·
+filter     ·             ·                     (k, v)  ·
+ │         filter        v SIMILAR TO 'ABC_*'  ·       ·
+ └── scan  ·             ·                     (k, v)  ·
+·          table         str@str_v_idx         ·       ·
+·          spans         /"ABC"-/"ABD"         ·       ·
 
 # Test that we generate spans for IS (NOT) DISTINCT FROM.
 statement ok
@@ -990,22 +1004,24 @@ render           ·             ·            (x)                 ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL
 ----
-·     distribution  local          ·       ·
-·     vectorized    true           ·       ·
-scan  ·             ·              (x, y)  ·
-·     table         xy@primary     ·       ·
-·     spans         FULL SCAN      ·       ·
-·     filter        y IS NOT NULL  ·       ·
+·          distribution  local          ·       ·
+·          vectorized    true           ·       ·
+filter     ·             ·              (x, y)  ·
+ │         filter        y IS NOT NULL  ·       ·
+ └── scan  ·             ·              (x, y)  ·
+·          table         xy@primary     ·       ·
+·          spans         FULL SCAN      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM 4
 ----
-·     distribution  local                 ·       ·
-·     vectorized    true                  ·       ·
-scan  ·             ·                     (x, y)  ·
-·     table         xy@primary            ·       ·
-·     spans         FULL SCAN             ·       ·
-·     filter        y IS DISTINCT FROM 4  ·       ·
+·          distribution  local                 ·       ·
+·          vectorized    true                  ·       ·
+filter     ·             ·                     (x, y)  ·
+ │         filter        y IS DISTINCT FROM 4  ·       ·
+ └── scan  ·             ·                     (x, y)  ·
+·          table         xy@primary            ·       ·
+·          spans         FULL SCAN             ·       ·
 
 # Regression tests for #22670.
 statement ok
@@ -1109,36 +1125,39 @@ output row: [5 6 7 8]
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 ORDER BY c DESC
 ----
-·          distribution  local             ·             ·
-·          vectorized    true              ·             ·
-sort       ·             ·                 (a, b, c, d)  -c
- │         order         -c                ·             ·
- └── scan  ·             ·                 (a, b, c, d)  ·
-·          table         noncover@primary  ·             ·
-·          spans         FULL SCAN         ·             ·
-·          filter        c > 0             ·             ·
+·               distribution  local             ·             ·
+·               vectorized    true              ·             ·
+sort            ·             ·                 (a, b, c, d)  -c
+ │              order         -c                ·             ·
+ └── filter     ·             ·                 (a, b, c, d)  ·
+      │         filter        c > 0             ·             ·
+      └── scan  ·             ·                 (a, b, c, d)  ·
+·               table         noncover@primary  ·             ·
+·               spans         FULL SCAN         ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 ORDER BY c
 ----
-·          distribution  local             ·             ·
-·          vectorized    true              ·             ·
-sort       ·             ·                 (a, b, c, d)  +c
- │         order         +c                ·             ·
- └── scan  ·             ·                 (a, b, c, d)  ·
-·          table         noncover@primary  ·             ·
-·          spans         FULL SCAN         ·             ·
-·          filter        c > 0             ·             ·
+·               distribution  local             ·             ·
+·               vectorized    true              ·             ·
+sort            ·             ·                 (a, b, c, d)  +c
+ │              order         +c                ·             ·
+ └── filter     ·             ·                 (a, b, c, d)  ·
+      │         filter        c > 0             ·             ·
+      └── scan  ·             ·                 (a, b, c, d)  ·
+·               table         noncover@primary  ·             ·
+·               spans         FULL SCAN         ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 AND d = 8
 ----
-·     distribution  local                ·             ·
-·     vectorized    true                 ·             ·
-scan  ·             ·                    (a, b, c, d)  ·
-·     table         noncover@primary     ·             ·
-·     spans         FULL SCAN            ·             ·
-·     filter        (c > 0) AND (d = 8)  ·             ·
+·          distribution  local                ·             ·
+·          vectorized    true                 ·             ·
+filter     ·             ·                    (a, b, c, d)  ·
+ │         filter        (c > 0) AND (d = 8)  ·             ·
+ └── scan  ·             ·                    (a, b, c, d)  ·
+·          table         noncover@primary     ·             ·
+·          spans         FULL SCAN            ·             ·
 
 # The following testcases verify that when we have a small limit, we prefer an
 # order-matching index.
@@ -1261,15 +1280,16 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0
 ]
 ----
-·           distribution  local
-·           vectorized    true
-index-join  ·             ·
- │          table         t2@primary
- │          key columns   a
- └── scan   ·             ·
-·           table         t2@bc
-·           spans         /2-/3
-·           filter        (c % 2) = 0
+·               distribution  local
+·               vectorized    true
+index-join      ·             ·
+ │              table         t2@primary
+ │              key columns   a
+ └── filter     ·             ·
+      │         filter        (c % 2) = 0
+      └── scan  ·             ·
+·               table         t2@bc
+·               spans         /2-/3
 
 # We do NOT look up the table row for '21' and '23'.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -174,24 +174,26 @@ filter           ·             ·
 query TTT
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         abcd@bcd
-·     spans         FULL SCAN
-·     filter        (a >= 20) AND (a <= 30)
+·          distribution  local
+·          vectorized    true
+filter     ·             ·
+ │         filter        (a >= 20) AND (a <= 30)
+ └── scan  ·             ·
+·          table         abcd@bcd
+·          spans         FULL SCAN
 
 # Force index b (covering)
 query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-·          distribution  local
-·          vectorized    true
-render     ·             ·
- └── scan  ·             ·
-·          table         abcd@b
-·          spans         FULL SCAN
-·          filter        (a >= 20) AND (a <= 30)
+·               distribution  local
+·               vectorized    true
+render          ·             ·
+ └── filter     ·             ·
+      │         filter        (a >= 20) AND (a <= 30)
+      └── scan  ·             ·
+·               table         abcd@b
+·               spans         FULL SCAN
 
 # Force index b (non-covering due to WHERE clause)
 query TTT
@@ -223,12 +225,13 @@ scan  ·             ·
 query TTT
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         abcd@primary
-·     spans         FULL SCAN
-·     filter        (c >= 20) AND (c < 40)
+·          distribution  local
+·          vectorized    true
+filter     ·             ·
+ │         filter        (c >= 20) AND (c < 40)
+ └── scan  ·             ·
+·          table         abcd@primary
+·          spans         FULL SCAN
 
 # Force index b
 query TTT
@@ -274,29 +277,32 @@ index-join  ·             ·
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         abcd@primary
-·     spans         FULL SCAN
-·     filter        c = 10
+·          distribution  local
+·          vectorized    true
+filter     ·             ·
+ │         filter        c = 10
+ └── scan  ·             ·
+·          table         abcd@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd} WHERE c = 10
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         abcd@bcd
-·     spans         FULL SCAN
-·     filter        c = 10
+·          distribution  local
+·          vectorized    true
+filter     ·             ·
+ │         filter        c = 10
+ └── scan  ·             ·
+·          table         abcd@bcd
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary} WHERE c = 10
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         abcd@primary
-·     spans         FULL SCAN
-·     filter        c = 10
+·          distribution  local
+·          vectorized    true
+filter     ·             ·
+ │         filter        c = 10
+ └── scan  ·             ·
+·          table         abcd@primary
+·          spans         FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -22,12 +22,13 @@ set enable_zigzag_join = false
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·     distribution  full         ·       ·
-·     vectorized    true         ·       ·
-scan  ·             ·            (u, v)  ·
-·     table         uv@uv_v_idx  ·       ·
-·     spans         /1-/2        ·       ·
-·     filter        u = 1        ·       ·
+·          distribution  full         ·       ·
+·          vectorized    true         ·       ·
+filter     ·             ·            (u, v)  ·
+ │         filter        u = 1        ·       ·
+ └── scan  ·             ·            (u, v)  ·
+·          table         uv@uv_v_idx  ·       ·
+·          spans         /1-/2        ·       ·
 
 # Verify that injecting different statistics changes the plan.
 statement ok
@@ -49,12 +50,13 @@ ALTER TABLE uv INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·     distribution  full         ·       ·
-·     vectorized    true         ·       ·
-scan  ·             ·            (u, v)  ·
-·     table         uv@uv_u_idx  ·       ·
-·     spans         /1-/2        ·       ·
-·     filter        v = 1        ·       ·
+·          distribution  full         ·       ·
+·          vectorized    true         ·       ·
+filter     ·             ·            (u, v)  ·
+ │         filter        v = 1        ·       ·
+ └── scan  ·             ·            (u, v)  ·
+·          table         uv@uv_u_idx  ·       ·
+·          spans         /1-/2        ·       ·
 
 # Verify that injecting different statistics with null counts
 # changes the plan.
@@ -79,12 +81,13 @@ ALTER TABLE uv INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·     distribution  full         ·       ·
-·     vectorized    true         ·       ·
-scan  ·             ·            (u, v)  ·
-·     table         uv@uv_u_idx  ·       ·
-·     spans         /1-/2        ·       ·
-·     filter        v = 1        ·       ·
+·          distribution  full         ·       ·
+·          vectorized    true         ·       ·
+filter     ·             ·            (u, v)  ·
+ │         filter        v = 1        ·       ·
+ └── scan  ·             ·            (u, v)  ·
+·          table         uv@uv_u_idx  ·       ·
+·          spans         /1-/2        ·       ·
 
 statement ok
 ALTER TABLE uv INJECT STATISTICS '[
@@ -107,12 +110,13 @@ ALTER TABLE uv INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·     distribution  full         ·       ·
-·     vectorized    true         ·       ·
-scan  ·             ·            (u, v)  ·
-·     table         uv@uv_v_idx  ·       ·
-·     spans         /1-/2        ·       ·
-·     filter        u = 1        ·       ·
+·          distribution  full         ·       ·
+·          vectorized    true         ·       ·
+filter     ·             ·            (u, v)  ·
+ │         filter        u = 1        ·       ·
+ └── scan  ·             ·            (u, v)  ·
+·          table         uv@uv_v_idx  ·       ·
+·          spans         /1-/2        ·       ·
 
 statement ok
 ALTER TABLE uv INJECT STATISTICS '[

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -45,56 +45,60 @@ root            ·             ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
 ----
-·                            distribution  local                                                                        ·               ·
-·                            vectorized    true                                                                         ·               ·
-root                         ·             ·                                                                            (a, b, c)       ·
- ├── scan                    ·             ·                                                                            (a, b, c)       ·
- │                           table         abc@primary                                                                  ·               ·
- │                           spans         FULL SCAN                                                                    ·               ·
- │                           filter        a = @S2                                                                      ·               ·
- ├── subquery                ·             ·                                                                            ·               ·
- │    │                      id            @S1                                                                          ·               ·
- │    │                      original sql  EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·               ·
- │    │                      exec mode     exists                                                                       ·               ·
- │    └── limit              ·             ·                                                                            (a, b, c)       ·
- │         │                 count         1                                                                            ·               ·
- │         └── scan          ·             ·                                                                            (a, b, c)       ·
- │                           table         abc@primary                                                                  ·               ·
- │                           spans         FULL SCAN                                                                    ·               ·
- │                           filter        c = (a + 3)                                                                  ·               ·
- └── subquery                ·             ·                                                                            ·               ·
-      │                      id            @S2                                                                          ·               ·
-      │                      original sql  (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·               ·
-      │                      exec mode     one row                                                                      ·               ·
-      └── group              ·             ·                                                                            (any_not_null)  ·
-           │                 aggregate 0   any_not_null(a)                                                              ·               ·
-           │                 scalar        ·                                                                            ·               ·
-           └── limit         ·             ·                                                                            (a)             -a
-                │            count         1                                                                            ·               ·
-                └── revscan  ·             ·                                                                            (a)             -a
-·                            table         abc@primary                                                                  ·               ·
-·                            spans         FULL SCAN                                                                    ·               ·
-·                            filter        @S1                                                                          ·               ·
+·                                 distribution  local                                                                        ·               ·
+·                                 vectorized    true                                                                         ·               ·
+root                              ·             ·                                                                            (a, b, c)       ·
+ ├── filter                       ·             ·                                                                            (a, b, c)       ·
+ │    │                           filter        a = @S2                                                                      ·               ·
+ │    └── scan                    ·             ·                                                                            (a, b, c)       ·
+ │                                table         abc@primary                                                                  ·               ·
+ │                                spans         FULL SCAN                                                                    ·               ·
+ ├── subquery                     ·             ·                                                                            ·               ·
+ │    │                           id            @S1                                                                          ·               ·
+ │    │                           original sql  EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·               ·
+ │    │                           exec mode     exists                                                                       ·               ·
+ │    └── limit                   ·             ·                                                                            (a, b, c)       ·
+ │         │                      count         1                                                                            ·               ·
+ │         └── filter             ·             ·                                                                            (a, b, c)       ·
+ │              │                 filter        c = (a + 3)                                                                  ·               ·
+ │              └── scan          ·             ·                                                                            (a, b, c)       ·
+ │                                table         abc@primary                                                                  ·               ·
+ │                                spans         FULL SCAN                                                                    ·               ·
+ └── subquery                     ·             ·                                                                            ·               ·
+      │                           id            @S2                                                                          ·               ·
+      │                           original sql  (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·               ·
+      │                           exec mode     one row                                                                      ·               ·
+      └── group                   ·             ·                                                                            (any_not_null)  ·
+           │                      aggregate 0   any_not_null(a)                                                              ·               ·
+           │                      scalar        ·                                                                            ·               ·
+           └── limit              ·             ·                                                                            (a)             -a
+                │                 count         1                                                                            ·               ·
+                └── filter        ·             ·                                                                            (a)             -a
+                     │            filter        @S1                                                                          ·               ·
+                     └── revscan  ·             ·                                                                            (a)             -a
+·                                 table         abc@primary                                                                  ·               ·
+·                                 spans         FULL SCAN                                                                    ·               ·
 
 # IN expression transformed into semi-join.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM abc WHERE a IN (SELECT a FROM abc WHERE b < 0)
 ----
-·           distribution        local        ·       ·
-·           vectorized          true         ·       ·
-merge-join  ·                   ·            (a)     ·
- │          type                semi         ·       ·
- │          equality            (a) = (a)    ·       ·
- │          left cols are key   ·            ·       ·
- │          right cols are key  ·            ·       ·
- │          mergeJoinOrder      +"(a=a)"     ·       ·
- ├── scan   ·                   ·            (a)     +a
- │          table               abc@primary  ·       ·
- │          spans               FULL SCAN    ·       ·
- └── scan   ·                   ·            (a, b)  +a
-·           table               abc@primary  ·       ·
-·           spans               FULL SCAN    ·       ·
-·           filter              b < 0        ·       ·
+·               distribution        local        ·       ·
+·               vectorized          true         ·       ·
+merge-join      ·                   ·            (a)     ·
+ │              type                semi         ·       ·
+ │              equality            (a) = (a)    ·       ·
+ │              left cols are key   ·            ·       ·
+ │              right cols are key  ·            ·       ·
+ │              mergeJoinOrder      +"(a=a)"     ·       ·
+ ├── scan       ·                   ·            (a)     +a
+ │              table               abc@primary  ·       ·
+ │              spans               FULL SCAN    ·       ·
+ └── filter     ·                   ·            (a, b)  +a
+      │         filter              b < 0        ·       ·
+      └── scan  ·                   ·            (a, b)  +a
+·               table               abc@primary  ·       ·
+·               spans               FULL SCAN    ·       ·
 
 query TTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
@@ -140,17 +144,18 @@ WHERE
     OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27))
     AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
-·                distribution  local            ·                                  ·
-·                vectorized    true             ·                                  ·
-render           ·             ·                (col0)                             ·
- │               render 0      col0             ·                                  ·
- └── index-join  ·             ·                (col0, col3, col4, rowid[hidden])  ·
-      │          table         tab4@primary     ·                                  ·
-      │          key columns   rowid            ·                                  ·
-      └── scan   ·             ·                (col0, col4, rowid[hidden])        ·
-·                table         tab4@idx_tab4_0  ·                                  ·
-·                spans         /!NULL-/5.38/1   ·                                  ·
-·                filter        col0 <= 0        ·                                  ·
+·                    distribution  local            ·                                  ·
+·                    vectorized    true             ·                                  ·
+render               ·             ·                (col0)                             ·
+ │                   render 0      col0             ·                                  ·
+ └── index-join      ·             ·                (col0, col3, col4, rowid[hidden])  ·
+      │              table         tab4@primary     ·                                  ·
+      │              key columns   rowid            ·                                  ·
+      └── filter     ·             ·                (col0, col4, rowid[hidden])        ·
+           │         filter        col0 <= 0        ·                                  ·
+           └── scan  ·             ·                (col0, col4, rowid[hidden])        ·
+·                    table         tab4@idx_tab4_0  ·                                  ·
+·                    spans         /!NULL-/5.38/1   ·                                  ·
 
 # ------------------------------------------------------------------------------
 # Correlated subqueries.

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -29,32 +29,35 @@ scan  ·             ·                  (u, v, w)  +u,+v,+w
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
 ----
-·     distribution  local                   ·          ·
-·     vectorized    true                    ·          ·
-scan  ·             ·                       (u, v, w)  +u,+v,+w
-·     table         uvw@uvw_u_v_w_idx       ·          ·
-·     spans         /!NULL-/2/3/2           ·          ·
-·     filter        (u, v, w) <= (2, 3, 1)  ·          ·
+·          distribution  local                   ·          ·
+·          vectorized    true                    ·          ·
+filter     ·             ·                       (u, v, w)  +u,+v,+w
+ │         filter        (u, v, w) <= (2, 3, 1)  ·          ·
+ └── scan  ·             ·                       (u, v, w)  +u,+v,+w
+·          table         uvw@uvw_u_v_w_idx       ·          ·
+·          spans         /!NULL-/2/3/2           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
 ----
-·     distribution  local                  ·          ·
-·     vectorized    true                   ·          ·
-scan  ·             ·                      (u, v, w)  +u,+v,+w
-·     table         uvw@uvw_u_v_w_idx      ·          ·
-·     spans         /!NULL-/2/2/2          ·          ·
-·     filter        (u, v, w) < (2, 2, 2)  ·          ·
+·          distribution  local                  ·          ·
+·          vectorized    true                   ·          ·
+filter     ·             ·                      (u, v, w)  +u,+v,+w
+ │         filter        (u, v, w) < (2, 2, 2)  ·          ·
+ └── scan  ·             ·                      (u, v, w)  +u,+v,+w
+·          table         uvw@uvw_u_v_w_idx      ·          ·
+·          spans         /!NULL-/2/2/2          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
 ----
-·     distribution  local                   ·          ·
-·     vectorized    true                    ·          ·
-scan  ·             ·                       (u, v, w)  +u,+v,+w
-·     table         uvw@uvw_u_v_w_idx       ·          ·
-·     spans         -/1/2/3 /1/2/4-         ·          ·
-·     filter        (u, v, w) != (1, 2, 3)  ·          ·
+·          distribution  local                   ·          ·
+·          vectorized    true                    ·          ·
+filter     ·             ·                       (u, v, w)  +u,+v,+w
+ │         filter        (u, v, w) != (1, 2, 3)  ·          ·
+ └── scan  ·             ·                       (u, v, w)  +u,+v,+w
+·          table         uvw@uvw_u_v_w_idx       ·          ·
+·          spans         -/1/2/3 /1/2/4-         ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
@@ -104,12 +107,13 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b DESC, c))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3)
 ----
-·     distribution  local                  ·          ·
-·     vectorized    true                   ·          ·
-scan  ·             ·                      (a, b, c)  ·
-·     table         abc@abc_a_b_c_idx      ·          ·
-·     spans         /1-                    ·          ·
-·     filter        (a, b, c) > (1, 2, 3)  ·          ·
+·          distribution  local                  ·          ·
+·          vectorized    true                   ·          ·
+filter     ·             ·                      (a, b, c)  ·
+ │         filter        (a, b, c) > (1, 2, 3)  ·          ·
+ └── scan  ·             ·                      (a, b, c)  ·
+·          table         abc@abc_a_b_c_idx      ·          ·
+·          spans         /1-                    ·          ·
 
 statement ok
 DROP TABLE abc

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -118,19 +118,20 @@ query TTTTT
 EXPLAIN (VERBOSE)
 SELECT 1 FROM (SELECT k FROM uniontest WHERE k > 3 UNION ALL SELECT k FROM uniontest)
 ----
-·                    distribution  local              ·             ·
-·                    vectorized    true               ·             ·
-render               ·             ·                  ("?column?")  ·
- │                   render 0      1                  ·             ·
- └── append          ·             ·                  ()            ·
-      ├── scan       ·             ·                  ()            ·
-      │              table         uniontest@primary  ·             ·
-      │              spans         FULL SCAN          ·             ·
-      └── render     ·             ·                  ()            ·
-           └── scan  ·             ·                  (k)           ·
-·                    table         uniontest@primary  ·             ·
-·                    spans         FULL SCAN          ·             ·
-·                    filter        k > 3              ·             ·
+·                         distribution  local              ·             ·
+·                         vectorized    true               ·             ·
+render                    ·             ·                  ("?column?")  ·
+ │                        render 0      1                  ·             ·
+ └── append               ·             ·                  ()            ·
+      ├── scan            ·             ·                  ()            ·
+      │                   table         uniontest@primary  ·             ·
+      │                   spans         FULL SCAN          ·             ·
+      └── render          ·             ·                  ()            ·
+           └── filter     ·             ·                  (k)           ·
+                │         filter        k > 3              ·             ·
+                └── scan  ·             ·                  (k)           ·
+·                         table         uniontest@primary  ·             ·
+·                         spans         FULL SCAN          ·             ·
 
 statement ok
 CREATE TABLE a (a INT PRIMARY KEY)

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -528,43 +528,44 @@ EXPLAIN (VERBOSE)
 INSERT INTO target SELECT x, y, z FROM source WHERE (y IS NULL OR y > 0) AND x <> 1
 ON CONFLICT (b, c) DO UPDATE SET b=5
 ----
-·                                   distribution        local                                  ·                                ·
-·                                   vectorized          false                                  ·                                ·
-count                               ·                   ·                                      ()                               ·
- └── upsert                         ·                   ·                                      ()                               ·
-      │                             into                target(a, b, c)                        ·                                ·
-      │                             strategy            opt upserter                           ·                                ·
-      │                             auto commit         ·                                      ·                                ·
-      └── render                    ·                   ·                                      (x, y, z, a, b, c, upsert_b, a)  ·
-           │                        render 0            x                                      ·                                ·
-           │                        render 1            y                                      ·                                ·
-           │                        render 2            z                                      ·                                ·
-           │                        render 3            a                                      ·                                ·
-           │                        render 4            b                                      ·                                ·
-           │                        render 5            c                                      ·                                ·
-           │                        render 6            upsert_b                               ·                                ·
-           │                        render 7            a                                      ·                                ·
-           └── render               ·                   ·                                      (upsert_b, x, y, z, a, b, c)     ·
-                │                   render 0            CASE WHEN a IS NULL THEN y ELSE 5 END  ·                                ·
-                │                   render 1            x                                      ·                                ·
-                │                   render 2            y                                      ·                                ·
-                │                   render 3            z                                      ·                                ·
-                │                   render 4            a                                      ·                                ·
-                │                   render 5            b                                      ·                                ·
-                │                   render 6            c                                      ·                                ·
-                └── merge-join      ·                   ·                                      (a, b, c, x, y, z)               ·
-                     │              type                right outer                            ·                                ·
-                     │              equality            (b, c) = (y, z)                        ·                                ·
-                     │              mergeJoinOrder      +"(b=y)",+"(c=z)"                      ·                                ·
-                     ├── scan       ·                   ·                                      (a, b, c)                        +b,+c
-                     │              table               target@target_b_c_key                  ·                                ·
-                     │              spans               FULL SCAN                              ·                                ·
-                     └── distinct   ·                   ·                                      (x, y, z)                        +y,+z
-                          │         distinct on         y, z                                   ·                                ·
-                          │         nulls are distinct  ·                                      ·                                ·
-                          │         error on duplicate  ·                                      ·                                ·
-                          │         order key           y, z                                   ·                                ·
-                          └── scan  ·                   ·                                      (x, y, z)                        +y,+z
-·                                   table               source@source_y_z_idx                  ·                                ·
-·                                   spans               /NULL-/!NULL /1-                       ·                                ·
-·                                   filter              x != 1                                 ·                                ·
+·                                        distribution        local                                  ·                                ·
+·                                        vectorized          false                                  ·                                ·
+count                                    ·                   ·                                      ()                               ·
+ └── upsert                              ·                   ·                                      ()                               ·
+      │                                  into                target(a, b, c)                        ·                                ·
+      │                                  strategy            opt upserter                           ·                                ·
+      │                                  auto commit         ·                                      ·                                ·
+      └── render                         ·                   ·                                      (x, y, z, a, b, c, upsert_b, a)  ·
+           │                             render 0            x                                      ·                                ·
+           │                             render 1            y                                      ·                                ·
+           │                             render 2            z                                      ·                                ·
+           │                             render 3            a                                      ·                                ·
+           │                             render 4            b                                      ·                                ·
+           │                             render 5            c                                      ·                                ·
+           │                             render 6            upsert_b                               ·                                ·
+           │                             render 7            a                                      ·                                ·
+           └── render                    ·                   ·                                      (upsert_b, x, y, z, a, b, c)     ·
+                │                        render 0            CASE WHEN a IS NULL THEN y ELSE 5 END  ·                                ·
+                │                        render 1            x                                      ·                                ·
+                │                        render 2            y                                      ·                                ·
+                │                        render 3            z                                      ·                                ·
+                │                        render 4            a                                      ·                                ·
+                │                        render 5            b                                      ·                                ·
+                │                        render 6            c                                      ·                                ·
+                └── merge-join           ·                   ·                                      (a, b, c, x, y, z)               ·
+                     │                   type                right outer                            ·                                ·
+                     │                   equality            (b, c) = (y, z)                        ·                                ·
+                     │                   mergeJoinOrder      +"(b=y)",+"(c=z)"                      ·                                ·
+                     ├── scan            ·                   ·                                      (a, b, c)                        +b,+c
+                     │                   table               target@target_b_c_key                  ·                                ·
+                     │                   spans               FULL SCAN                              ·                                ·
+                     └── distinct        ·                   ·                                      (x, y, z)                        +y,+z
+                          │              distinct on         y, z                                   ·                                ·
+                          │              nulls are distinct  ·                                      ·                                ·
+                          │              error on duplicate  ·                                      ·                                ·
+                          │              order key           y, z                                   ·                                ·
+                          └── filter     ·                   ·                                      (x, y, z)                        +y,+z
+                               │         filter              x != 1                                 ·                                ·
+                               └── scan  ·                   ·                                      (x, y, z)                        +y,+z
+·                                        table               source@source_y_z_idx                  ·                                ·
+·                                        spans               /NULL-/!NULL /1-                       ·                                ·

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -152,14 +152,6 @@ func asDataSource(n exec.Node) planDataSource {
 func (ef *execFactory) ConstructFilter(
 	n exec.Node, filter tree.TypedExpr, reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
-	// Push the filter into the scanNode. We cannot do this if the scanNode has a
-	// limit (it would make the limit apply AFTER the filter).
-	if s, ok := n.(*scanNode); ok && s.filter == nil && s.hardLimit == 0 {
-		s.filter = s.filterVars.Rebind(filter)
-		// Note: if the filter statically evaluates to true, s.filter stays nil.
-		s.reqOrdering = ReqOrdering(reqOrdering)
-		return s, nil
-	}
 	// Create a filterNode.
 	src := asDataSource(n)
 	f := &filterNode{

--- a/pkg/sql/scan_test.go
+++ b/pkg/sql/scan_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -192,21 +191,17 @@ func TestKVLimitHint(t *testing.T) {
 	testCases := []struct {
 		hardLimit int64
 		softLimit int64
-		filter    tree.TypedExpr
 		expected  int64
 	}{
-		{hardLimit: 0, softLimit: 0, filter: nil, expected: 0},
-		{hardLimit: 0, softLimit: 1, filter: nil, expected: 2},
-		{hardLimit: 0, softLimit: 23, filter: nil, expected: 46},
-		{hardLimit: 0, softLimit: 1, filter: tree.DBoolFalse, expected: 2},
-		{hardLimit: 1, softLimit: 0, filter: nil, expected: 1},
-		{hardLimit: 1, softLimit: 23, filter: nil, expected: 1},
-		{hardLimit: 5, softLimit: 23, filter: nil, expected: 5},
-		{hardLimit: 1, softLimit: 23, filter: tree.DBoolTrue, expected: 1},
-		{hardLimit: 1, softLimit: 23, filter: tree.DBoolFalse, expected: 2},
+		{hardLimit: 0, softLimit: 0, expected: 0},
+		{hardLimit: 0, softLimit: 1, expected: 2},
+		{hardLimit: 0, softLimit: 23, expected: 46},
+		{hardLimit: 1, softLimit: 0, expected: 1},
+		{hardLimit: 1, softLimit: 23, expected: 1},
+		{hardLimit: 5, softLimit: 23, expected: 5},
 	}
 	for _, tc := range testCases {
-		sn := scanNode{hardLimit: tc.hardLimit, softLimit: tc.softLimit, filter: tc.filter}
+		sn := scanNode{hardLimit: tc.hardLimit, softLimit: tc.softLimit}
 		if limitHint := sn.limitHint(); limitHint != tc.expected {
 			t.Errorf("%+v: got %d", tc, limitHint)
 		}

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -55,26 +55,27 @@ children:
 plan-string
 SELECT cid, sum(value) FROM t.orders WHERE date > '2015-01-01' GROUP BY cid ORDER BY 1 - sum(value)
 ----
-render                                                                                 (cid int, sum decimal)
- │                             render 0     (@2)[int]
- │                             render 1     (@3)[decimal]
- └── sort                                                                              (column6 decimal, cid int, sum decimal)  +column6
-      │                        order        +column6
-      └── render                                                                       (column6 decimal, cid int, sum decimal)
-           │                   render 0     ((1)[decimal] - (@2)[decimal])[decimal]
-           │                   render 1     (@1)[int]
-           │                   render 2     (@2)[decimal]
-           └── group                                                                   (cid int, sum decimal)
-                │              aggregate 0  cid
-                │              aggregate 1  sum(value)
-                │              group by     cid
-                └── render                                                             (cid int, value decimal)
-                     │         render 0     (@1)[int]
-                     │         render 1     (@2)[decimal]
-                     └── scan                                                          (cid int, value decimal, date date)
-                               table        orders@primary
-                               spans        FULL SCAN
-                               filter       ((@3)[date] > ('2015-01-01')[date])[bool]
+render                                                                                      (cid int, sum decimal)
+ │                                  render 0     (@2)[int]
+ │                                  render 1     (@3)[decimal]
+ └── sort                                                                                   (column6 decimal, cid int, sum decimal)  +column6
+      │                             order        +column6
+      └── render                                                                            (column6 decimal, cid int, sum decimal)
+           │                        render 0     ((1)[decimal] - (@2)[decimal])[decimal]
+           │                        render 1     (@1)[int]
+           │                        render 2     (@2)[decimal]
+           └── group                                                                        (cid int, sum decimal)
+                │                   aggregate 0  cid
+                │                   aggregate 1  sum(value)
+                │                   group by     cid
+                └── render                                                                  (cid int, value decimal)
+                     │              render 0     (@1)[int]
+                     │              render 1     (@2)[decimal]
+                     └── filter                                                             (cid int, value decimal, date date)
+                          │         filter       ((@3)[date] > ('2015-01-01')[date])[bool]
+                          └── scan                                                          (cid int, value decimal, date date)
+                                    table        orders@primary
+                                    spans        FULL SCAN
 
 plan-tree
 SELECT cid, sum(value) FROM t.orders WHERE date > '2015-01-01' GROUP BY cid ORDER BY 1 - sum(value)
@@ -116,15 +117,18 @@ children:
         - key: render
           value: value
         children:
-        - name: scan
+        - name: filter
           attrs:
-          - key: table
-            value: orders@primary
-          - key: spans
-            value: FULL SCAN
           - key: filter
             value: date > _
-          children: []
+          children:
+          - name: scan
+            attrs:
+            - key: table
+              value: orders@primary
+            - key: spans
+              value: FULL SCAN
+            children: []
 
 plan-string
 SELECT value FROM (SELECT cid, date, value FROM t.orders)
@@ -224,23 +228,24 @@ CREATE TABLE t.actors (
 plan-string
 SELECT id AS movie_id, title, (SELECT name FROM t.actors WHERE name = 'Foo') FROM t.movies
 ----
-root                                                                               (movie_id int, title string, name string)
- ├── render                                                                        (movie_id int, title string, name string)
- │    │              render 0      (@1)[int]
- │    │              render 1      (@2)[string]
- │    │              render 2      (@S1)[string]
- │    └── scan                                                                     (id int, title string)
- │                   table         movies@primary
- │                   spans         FULL SCAN
+root                                                                                    (movie_id int, title string, name string)
+ ├── render                                                                             (movie_id int, title string, name string)
+ │    │                   render 0      (@1)[int]
+ │    │                   render 1      (@2)[string]
+ │    │                   render 2      (@S1)[string]
+ │    └── scan                                                                          (id int, title string)
+ │                        table         movies@primary
+ │                        spans         FULL SCAN
  └── subquery
-      │              id            @S1
-      │              original sql  (SELECT name FROM t.actors WHERE name = 'Foo')
-      │              exec mode     one row
-      └── max1row                                                                  (name string)
-           └── scan                                                                (name string)
-                     table         actors@primary
-                     spans         FULL SCAN
-                     filter        ((@1)[string] = ('Foo')[string])[bool]
+      │                   id            @S1
+      │                   original sql  (SELECT name FROM t.actors WHERE name = 'Foo')
+      │                   exec mode     one row
+      └── max1row                                                                       (name string)
+           └── filter                                                                   (name string)
+                │         filter        ((@1)[string] = ('Foo')[string])[bool]
+                └── scan                                                                (name string)
+                          table         actors@primary
+                          spans         FULL SCAN
 
 plan-tree
 SELECT id AS movie_id, title, (SELECT name FROM t.actors WHERE name = 'Foo') FROM t.movies
@@ -276,12 +281,15 @@ children:
   - name: max1row
     attrs: []
     children:
-    - name: scan
+    - name: filter
       attrs:
-      - key: table
-        value: actors@primary
-      - key: spans
-        value: FULL SCAN
       - key: filter
         value: name = _
-      children: []
+      children:
+      - name: scan
+        attrs:
+        - key: table
+          value: actors@primary
+        - key: spans
+          value: FULL SCAN
+        children: []

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -185,7 +185,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			if n.index.IsPartial() {
 				v.observer.attr(name, "partial index", "")
 			}
-			if n.hardLimit > 0 && isFilterTrue(n.filter) {
+			if n.hardLimit > 0 {
 				v.observer.attr(name, "limit", fmt.Sprintf("%d", n.hardLimit))
 			}
 			if n.lockingStrength != sqlbase.ScanLockingStrength_FOR_NONE {
@@ -194,9 +194,6 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			if n.lockingWaitPolicy != sqlbase.ScanLockingWaitPolicy_BLOCK {
 				v.observer.attr(name, "locking wait policy", n.lockingWaitPolicy.PrettyString())
 			}
-		}
-		if v.observer.expr != nil {
-			v.expr(name, "filter", -1, n.filter)
 		}
 
 	case *filterNode:
@@ -222,7 +219,6 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 				cols[i] = inputCols[c].Name
 			}
 			v.observer.attr(name, "key columns", strings.Join(cols, ", "))
-			v.expr(name, "filter", -1, n.table.filter)
 		}
 		n.input = v.visit(n.input)
 


### PR DESCRIPTION
Remove the filter from scanNode. It doesn't provide any benefit
anymore and it just causes confusion (e.g. soft limit handling). In
addition, we want EXPLAIN to map to exec.Factory calls as much as
possible; in this case we want the filter to be shown as a separate
node.

Release note (sql change): EXPLAIN (PLAN) now shows any filter on a
scan as a separate `filter` node.