### PR TITLE
security,sql: add a setting to constrain the minimum password length

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -72,6 +72,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-12</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-13</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -72,6 +72,7 @@ const (
 	VersionClientRangeInfosOnBatchResponse
 	VersionNodeMembershipStatus
 	VersionRangeStatsRespHasDesc
+	VersionMinPasswordLength
 
 	// Add new versions here (step one of two).
 )
@@ -544,6 +545,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionRangeStatsRespHasDesc adds the RangeStatsResponse.RangeInfo field.
 		Key:     VersionRangeStatsRespHasDesc,
 		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 12},
+	},
+	{
+		// VersionMinPasswordLength adds the server.user_login.min_password_length setting.
+		Key:     VersionMinPasswordLength,
+		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 13},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/clusterversion/versionkey_string.go
+++ b/pkg/clusterversion/versionkey_string.go
@@ -48,11 +48,12 @@ func _() {
 	_ = x[VersionClientRangeInfosOnBatchResponse-37]
 	_ = x[VersionNodeMembershipStatus-38]
 	_ = x[VersionRangeStatsRespHasDesc-39]
+	_ = x[VersionMinPasswordLength-40]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneralVersionAlterSystemJobsAddCreatedByColumnsVersionAddScheduledJobsTableVersionUserDefinedSchemasVersionNoOriginFKIndexesVersionClientRangeInfosOnBatchResponseVersionNodeMembershipStatusVersionRangeStatsRespHasDesc"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneralVersionAlterSystemJobsAddCreatedByColumnsVersionAddScheduledJobsTableVersionUserDefinedSchemasVersionNoOriginFKIndexesVersionClientRangeInfosOnBatchResponseVersionNodeMembershipStatusVersionRangeStatsRespHasDescVersionMinPasswordLength"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748, 760, 782, 811, 852, 880, 905, 929, 967, 994, 1022}
+var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748, 760, 782, 811, 852, 880, 905, 929, 967, 994, 1022, 1046}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/ssh/terminal"
@@ -30,6 +31,10 @@ var BcryptCost = bcrypt.DefaultCost
 
 // ErrEmptyPassword indicates that an empty password was attempted to be set.
 var ErrEmptyPassword = errors.New("empty passwords are not permitted")
+
+// ErrPasswordTooShort indicates that a client provided a password
+// that was too short according to policy.
+var ErrPasswordTooShort = errors.New("password too short")
 
 var sha256NewSum = sha256.New().Sum(nil)
 
@@ -73,3 +78,12 @@ func PromptForPassword() (string, error) {
 
 	return string(password), nil
 }
+
+// MinPasswordLength is the cluster setting that configures the
+// minimum SQL password length.
+var MinPasswordLength = settings.RegisterNonNegativeIntSetting(
+	"server.user_login.min_password_length",
+	"the minimum length accepted for passwords set in cleartext via SQL. "+
+		"Note that a value lower than 1 is ignored: passwords cannot be empty in any case.",
+	1,
+)

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -303,9 +304,18 @@ func (p *planner) checkPasswordAndGetHash(
 	if password == "" {
 		return hashedPassword, security.ErrEmptyPassword
 	}
+
+	st := p.ExecCfg().Settings
+	if st.Version.IsActive(ctx, clusterversion.VersionMinPasswordLength) {
+		if minLength := security.MinPasswordLength.Get(&st.SV); minLength >= 1 && int64(len(password)) < minLength {
+			return hashedPassword, errors.WithHintf(security.ErrPasswordTooShort,
+				"Passwords must be %d characters or longer.", minLength)
+		}
+	}
+
 	hashedPassword, err = security.HashPassword(password)
 	if err != nil {
-		return nil, err
+		return hashedPassword, err
 	}
 
 	if hashedPassword == nil {

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -504,7 +504,7 @@ func TestSetUserPasswordInsecure(t *testing.T) {
 		errString string
 	}{
 		{"CREATE USER user1", ""},
-		{"CREATE USER user2 WITH PASSWORD ''", "empty passwords are not permitted"},
+		{"CREATE USER user2 WITH PASSWORD ''", errFail},
 		{"CREATE USER user2 WITH PASSWORD 'cockroach'", errFail},
 		{"CREATE USER user3 WITH PASSWORD NULL", ""},
 		{"ALTER USER user1 WITH PASSWORD 'somepass'", errFail},

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -159,3 +159,26 @@ user4     NOLOGIN     NULL
 
 statement ok
 DROP USER user4
+
+subtest min_password_length
+
+user root
+
+statement ok
+SET CLUSTER SETTING server.user_login.min_password_length = 12
+
+statement error password too short
+CREATE USER baduser WITH PASSWORD 'abc'
+
+statement error password too short
+ALTER USER testuser WITH PASSWORD 'abc'
+
+statement ok
+CREATE USER userlongpassword WITH PASSWORD '012345678901'
+
+statement ok
+ALTER USER userlongpassword WITH PASSWORD '987654321021'
+
+statement ok
+DROP USER userlongpassword
+


### PR DESCRIPTION
Requested by @bdarnell.

First commit from #51501.

This change adds a new cluster setting
`server.user_login.min_password_length`. When set and non-zero, it
forces a minimum password length to passwords passed in cleartext to
the SQL `WITH PASSWORD` clause (`CREATE/ALTER USER/ROLE`).

This change is part of a larger set of security measures to help
the secure deployment of Cockroach Cloud. We are not yet planning
to advertise this to on-prem users until the feature matures and
is complemented by additional enhancements to password authentication.

cc @solongordon @thtruo @aaron-crl for visibility.