### PR TITLE
server,sql: limit max SQL connections over TCP

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -208,6 +208,11 @@ type Config struct {
 	// Enables the use of an PTP hardware clock user space API for HLC current time.
 	// This contains the path to the device to be used (i.e. /dev/ptp0)
 	ClockDevicePath string
+
+	// MaxSQLClients establishes a limit on the number of simultaneous SQL client
+	// connections on the main SQL listener.
+	// TODO(knz): make this configurable per listener.
+	MaxSQLClients int
 }
 
 // HistogramWindowInterval is used to determine the approximate length of time
@@ -246,6 +251,7 @@ func (cfg *Config) InitDefaults() {
 	cfg.ClusterName = ""
 	cfg.DisableClusterNameVerification = false
 	cfg.ClockDevicePath = ""
+	cfg.MaxSQLClients = 0
 }
 
 // HTTPRequestScheme returns "http" or "https" based on the value of

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -88,6 +88,7 @@ type TestServerArgs struct {
 	TimeSeriesQueryMemoryBudget int64
 	SQLMemoryPoolSize           int64
 	CacheSize                   int64
+	MaxSQLClients               int
 
 	// If set, this will be appended to the Postgres URL by functions that
 	// automatically open a connection to the server. That's equivalent to running

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -518,6 +518,16 @@ An IPv6 address can also be specified with the notation [...], for
 example [::1]:26257 or [fe80::f6f2:::]:26257.`,
 	}
 
+	ListenSQLMaxClients = FlagInfo{
+		Name: "sql-max-clients",
+		Description: `
+Maximum number of client SQL sessions that can be opened via TCP.
+If left unspecified, there is no limit. This setting can
+be used to protect a cluster against misconfiguration of client
+apps. For good security, a rate limiter should be used in combination
+with this setting. This setting is experimental.`,
+	}
+
 	ListenHTTPAddr = FlagInfo{
 		Name: "http-addr",
 		Description: `

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -428,6 +428,12 @@ func init() {
 			_ = f.MarkHidden(cliflags.SQLAdvertiseAddr.Name)
 		}
 
+		// SQL max clients using TCP. Unix socket is not affected.
+		// TODO(knz): Make this configurable per listener.
+		// See: https://github.com/cockroachdb/cockroach/issues/44842
+		// See: https://github.com/cockroachdb/cockroach/issues/51453
+		intFlag(f, &baseCfg.MaxSQLClients, cliflags.ListenSQLMaxClients)
+
 		// Engine flags.
 		varFlag(f, cacheSizeValue, cliflags.Cache)
 		varFlag(f, sqlSizeValue, cliflags.SQLMem)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -150,6 +150,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.SocketFile = params.SocketFile
 	cfg.RetryOptions = params.RetryOptions
 	cfg.Locality = params.Locality
+	cfg.MaxSQLClients = params.MaxSQLClients
 	if knobs := params.Knobs.Store; knobs != nil {
 		if mo := knobs.(*kvserver.StoreTestingKnobs).MaxOffset; mo != 0 {
 			cfg.MaxOffset = MaxOffsetType(mo)


### PR DESCRIPTION
Fixes #35428.

We are interested to protect a CockroachDB cluster in case a client
app is misconfigured and opens too many connections to a CockroachDB
node.

Too many connections are a problem because they incur memory load and
a hostspot on the `system.users` table for authentication.

This patch introduces a new server flag `--max-sql-clients` that
limits the number of SQL client connections that can be established
over TCP.

The limit applies to all SQL authn principals, including `root` and
admin sessions. The choice was made not to carve an exception for
`root` and `admin` because the determination of the authn principal
is done late in connection set-up and we want to avoid the authn load
altogether when there are too many connections.

The connections via the unix socket nor HTTP/RPC connections are not
limited; so that an administrator can use these interfaces to inspect
the system and determine the origin of the connection load.

Note that this is not a security feature; a separate rate limiting
mechanism should be deployed in front of CockroachDB nodes for proper
protection against malicious attackers.


This is configurable as a CLI flag and not a cluster setting, so that
nodes running on different types of hardware (or, possibly, running
different crdb versions with different load sensitivity) can be subject to
different limits. It makes it also possible to lift the limit for just
some nodes in the cluster.


The feature is marked experimental because we are expecting it to
change somewhat soon, when the option to open multiple SQL servers
side-by-side is introduced.

Release note (cli change): It is now possible to configure the maximum
number of SQL connections accepted via TCP using the command-line flag
`--max-sql-clients`. This feature is intended to protect CockroachDB
node against mis-configured client apps. When the limit is reached,
further connections are refused. Administrator can use the HTTP APIs,
the Admin UI, the RPC client commands (to retrieve logs) or a SQL
connection using the unix socket to inspect the system and determine
where connections come from.

Note that this is does not offer protection against DoS attacks. Usage
of a rate limiter is still recommended.

This feature is experimental.

cc @piyush-singh @thtruo @aaron-crl @solongordon for visibility.