### PR TITLE
release-20.1: cli: fix two issues with `cockroach dump` and comments

### DIFF
--- a/pkg/cli/testdata/dump/comments
+++ b/pkg/cli/testdata/dump/comments
@@ -1,0 +1,21 @@
+# Ensure quotes in comments are properly escaped, also that the object names
+# are properly escaped in the output of the COMMENT statements.
+sql
+CREATE DATABASE d;
+CREATE TABLE d."t   t" ("x'" INT PRIMARY KEY);
+COMMENT ON TABLE d."t   t" IS 'has '' quotes';
+COMMENT ON INDEX d."t   t"@primary IS 'has '' more '' quotes';
+COMMENT ON COLUMN d."t   t"."x'" IS 'i '' just '' love '' quotes';
+----
+COMMENT ON COLUMN
+
+dump d
+----
+CREATE TABLE "t   t" (
+	"x'" INT8 NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY ("x'" ASC),
+	FAMILY "primary" ("x'")
+);
+COMMENT ON TABLE "t   t" IS e'has \' quotes';
+COMMENT ON COLUMN "t   t"."x'" IS e'i \' just \' love \' quotes';
+COMMENT ON INDEX "t   t"@primary IS e'has \' more \' quotes';

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -66,16 +66,16 @@ CREATE TABLE c (
 );
 COMMENT ON TABLE c IS 'table';
 COMMENT ON COLUMN c.a IS 'column';
-COMMENT ON INDEX c_a_b_idx IS 'index'  CREATE TABLE c (
-                                       a INT8 NOT NULL,
-                                       b INT8 NULL,
-                                       INDEX c_a_b_idx (a ASC, b ASC),
-                                       FAMILY fam_0_a_rowid (a, rowid),
-                                       FAMILY fam_1_b (b)
+COMMENT ON INDEX c@c_a_b_idx IS 'index'  CREATE TABLE c (
+                                         a INT8 NOT NULL,
+                                         b INT8 NULL,
+                                         INDEX c_a_b_idx (a ASC, b ASC),
+                                         FAMILY fam_0_a_rowid (a, rowid),
+                                         FAMILY fam_1_b (b)
 );
 COMMENT ON TABLE c IS 'table';
 COMMENT ON COLUMN c.a IS 'column';
-COMMENT ON INDEX c_a_b_idx IS 'index'  {}  {}
+COMMENT ON INDEX c@c_a_b_idx IS 'index'  {}  {}
 
 statement error invalid storage parameter "foo"
 CREATE TABLE a (b INT) WITH (foo=100);

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -19,7 +19,7 @@ COMMENT ON INDEX c_a_b_idx IS 'index'
 query TT colnames
 SHOW CREATE c
 ----
-table_name create_statement
+table_name  create_statement
 c           CREATE TABLE c (
             a INT8 NOT NULL,
             b INT8 NULL,
@@ -29,4 +29,4 @@ c           CREATE TABLE c (
 );
 COMMENT ON TABLE c IS 'table';
 COMMENT ON COLUMN c.a IS 'column';
-COMMENT ON INDEX c_a_b_idx IS 'index'
+COMMENT ON INDEX c@c_a_b_idx IS 'index'


### PR DESCRIPTION
Backport 1/1 commits from #51463.

/cc @cockroachdb/release

---

Fixes #51115.

Release note (bug fix): Fix a bug where `cockroach dump` would not
properly escape quotes within table comments.

Release note (bug fix); Fix a bug where `cockroach dump` would not emit
a correct statement for comments on indexes.
