### PR TITLE
builtins: implement ST_Force2D

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1029,6 +1029,8 @@ given Geometry.</p>
 </span></td></tr>
 <tr><td><a name="st_exteriorring"></a><code>st_exteriorring(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the exterior ring of a Polygon as a LineString. Returns NULL if the shape is not a Polygon.</p>
 </span></td></tr>
+<tr><td><a name="st_force2d"></a><code>st_force2d(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry which only contains X and Y coordinates.</p>
+</span></td></tr>
 <tr><td><a name="st_geogfromewkb"></a><code>st_geogfromewkb(val: <a href="bytes.html">bytes</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an EWKB representation.</p>
 </span></td></tr>
 <tr><td><a name="st_geogfromewkt"></a><code>st_geogfromewkt(val: <a href="string.html">string</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an EWKT representation.</p>

--- a/pkg/geo/geomfn/force.go
+++ b/pkg/geo/geomfn/force.go
@@ -1,0 +1,123 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/errors"
+	"github.com/twpayne/go-geom"
+)
+
+// ForceLayout forces a geometry into the given layout.
+// If dimensions are added, 0 coordinates are padded to them.
+func ForceLayout(g *geo.Geometry, layout geom.Layout) (*geo.Geometry, error) {
+	geomT, err := g.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+	retGeomT, err := forceLayout(geomT, layout)
+	if err != nil {
+		return nil, err
+	}
+	return geo.NewGeometryFromGeomT(retGeomT)
+}
+
+// forceLayout forces a geom.T into the given layout.
+func forceLayout(t geom.T, layout geom.Layout) (geom.T, error) {
+	if t.Layout() == layout {
+		return t, nil
+	}
+	switch t := t.(type) {
+	case *geom.GeometryCollection:
+		ret := geom.NewGeometryCollection().SetSRID(t.SRID())
+		for i := 0; i < t.NumGeoms(); i++ {
+			toPush, err := forceLayout(t.Geom(i), layout)
+			if err != nil {
+				return nil, err
+			}
+			if err := ret.Push(toPush); err != nil {
+				return nil, err
+			}
+		}
+		return ret, nil
+	case *geom.Point:
+		return geom.NewPointFlat(layout, forceFlatCoordsLayout(t, layout)).SetSRID(t.SRID()), nil
+	case *geom.LineString:
+		return geom.NewLineStringFlat(layout, forceFlatCoordsLayout(t, layout)).SetSRID(t.SRID()), nil
+	case *geom.Polygon:
+		return geom.NewPolygonFlat(
+			layout,
+			forceFlatCoordsLayout(t, layout),
+			forceEnds(t.Ends(), t.Layout(), layout),
+		).SetSRID(t.SRID()), nil
+	case *geom.MultiPoint:
+		return geom.NewMultiPointFlat(
+			layout,
+			forceFlatCoordsLayout(t, layout),
+			geom.NewMultiPointFlatOptionWithEnds(forceEnds(t.Ends(), t.Layout(), layout)),
+		).SetSRID(t.SRID()), nil
+	case *geom.MultiLineString:
+		return geom.NewMultiLineStringFlat(
+			layout,
+			forceFlatCoordsLayout(t, layout),
+			forceEnds(t.Ends(), t.Layout(), layout),
+		).SetSRID(t.SRID()), nil
+	case *geom.MultiPolygon:
+		endss := make([][]int, len(t.Endss()))
+		for i := range t.Endss() {
+			endss[i] = forceEnds(t.Endss()[i], t.Layout(), layout)
+		}
+		return geom.NewMultiPolygonFlat(
+			layout,
+			forceFlatCoordsLayout(t, layout),
+			endss,
+		).SetSRID(t.SRID()), nil
+	default:
+		return nil, errors.Newf("unknown geom.T type: %T", t)
+	}
+}
+
+// forceEnds forces the Endss layout of a geometry into the new layout.
+func forceEnds(ends []int, oldLayout geom.Layout, newLayout geom.Layout) []int {
+	if oldLayout.Stride() == newLayout.Stride() {
+		return ends
+	}
+	newEnds := make([]int, len(ends))
+	for i := range ends {
+		newEnds[i] = (ends[i] / oldLayout.Stride()) * newLayout.Stride()
+	}
+	return newEnds
+}
+
+// forceFlatCoordsLayout forces the flatCoords layout of a geometry into the new layout.
+func forceFlatCoordsLayout(t geom.T, layout geom.Layout) []float64 {
+	oldFlatCoords := t.FlatCoords()
+	newFlatCoords := make([]float64, (len(oldFlatCoords)/t.Stride())*layout.Stride())
+	for coordIdx := 0; coordIdx < len(oldFlatCoords)/t.Stride(); coordIdx++ {
+		newFlatCoords[coordIdx*layout.Stride()] = oldFlatCoords[coordIdx*t.Stride()]
+		newFlatCoords[coordIdx*layout.Stride()+1] = oldFlatCoords[coordIdx*t.Stride()+1]
+		if layout.ZIndex() != -1 {
+			z := float64(0)
+			if t.Layout().ZIndex() != -1 {
+				z = oldFlatCoords[coordIdx*t.Stride()+t.Layout().ZIndex()]
+			}
+			newFlatCoords[coordIdx*layout.Stride()+layout.ZIndex()] = z
+		}
+		if layout.MIndex() != -1 {
+			m := float64(0)
+			if t.Layout().MIndex() != -1 {
+				m = oldFlatCoords[coordIdx*t.Stride()+t.Layout().MIndex()]
+			}
+			newFlatCoords[coordIdx*layout.Stride()+layout.MIndex()] = m
+		}
+	}
+	return newFlatCoords
+}

--- a/pkg/geo/geomfn/force_test.go
+++ b/pkg/geo/geomfn/force_test.go
@@ -1,0 +1,249 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
+	"github.com/twpayne/go-geom/encoding/wkt"
+)
+
+func TestForceLayout(t *testing.T) {
+	// We only support 2D on geo.Geometry, so test the forceLayout function instead.
+	testCases := []struct {
+		g        geom.T
+		layout   geom.Layout
+		expected geom.T
+	}{
+		{
+			geom.NewPolygonFlat(
+				geom.XY,
+				[]float64{
+					0, 0,
+					0, 1,
+					1, 1,
+					1, 0,
+					0, 0,
+				},
+				[]int{10},
+			).SetSRID(4326),
+			geom.XY,
+			geom.NewPolygonFlat(
+				geom.XY,
+				[]float64{
+					0, 0,
+					0, 1,
+					1, 1,
+					1, 0,
+					0, 0,
+				},
+				[]int{10},
+			).SetSRID(4326),
+		},
+		{
+			geom.NewPolygonFlat(
+				geom.XYZ,
+				[]float64{
+					0, 0, 1,
+					0, 1, 2,
+					1, 1, 3,
+					1, 0, 4,
+					0, 0, 1,
+				},
+				[]int{15},
+			).SetSRID(4326),
+			geom.XY,
+			geom.NewPolygonFlat(
+				geom.XY,
+				[]float64{
+					0, 0,
+					0, 1,
+					1, 1,
+					1, 0,
+					0, 0,
+				},
+				[]int{10},
+			).SetSRID(4326),
+		},
+		{
+			geom.NewPolygonFlat(
+				geom.XYM,
+				[]float64{
+					0, 0, 1,
+					0, 1, 2,
+					1, 1, 3,
+					1, 0, 4,
+					0, 0, 1,
+				},
+				[]int{15},
+			).SetSRID(4326),
+			geom.XYZM,
+			geom.NewPolygonFlat(
+				geom.XYZM,
+				[]float64{
+					0, 0, 0, 1,
+					0, 1, 0, 2,
+					1, 1, 0, 3,
+					1, 0, 0, 4,
+					0, 0, 0, 1,
+				},
+				[]int{20},
+			).SetSRID(4326),
+		},
+		{
+			geom.NewPolygonFlat(
+				geom.XYZM,
+				[]float64{
+					0, 0, 0, 1,
+					0, 1, 0, 2,
+					1, 1, 0, 3,
+					1, 0, 0, 4,
+					0, 0, 0, 1,
+				},
+				[]int{20},
+			).SetSRID(4326),
+			geom.XYM,
+			geom.NewPolygonFlat(
+				geom.XYM,
+				[]float64{
+					0, 0, 1,
+					0, 1, 2,
+					1, 1, 3,
+					1, 0, 4,
+					0, 0, 1,
+				},
+				[]int{15},
+			).SetSRID(4326),
+		},
+		{
+			geom.NewPolygonFlat(
+				geom.XYZM,
+				[]float64{
+					0, 0, 0, 1,
+					0, 1, 0, 2,
+					1, 1, 0, 3,
+					1, 0, 0, 4,
+					0, 0, 0, 1,
+				},
+				[]int{20},
+			).SetSRID(4326),
+			geom.XY,
+			geom.NewPolygonFlat(
+				geom.XY,
+				[]float64{
+					0, 0,
+					0, 1,
+					1, 1,
+					1, 0,
+					0, 0,
+				},
+				[]int{10},
+			).SetSRID(4326),
+		},
+		{
+			geom.NewPolygonFlat(
+				geom.XYZ,
+				[]float64{
+					0, 0, 1,
+					0, 1, 2,
+					1, 1, 3,
+					1, 0, 4,
+					0, 0, 1,
+				},
+				[]int{15},
+			).SetSRID(4326),
+			geom.XYM,
+			geom.NewPolygonFlat(
+				geom.XYM,
+				[]float64{
+					0, 0, 0,
+					0, 1, 0,
+					1, 1, 0,
+					1, 0, 0,
+					0, 0, 0,
+				},
+				[]int{15},
+			).SetSRID(4326),
+		},
+		{
+			geom.NewPolygonFlat(
+				geom.XY,
+				[]float64{
+					0, 0,
+					0, 1,
+					1, 1,
+					1, 0,
+					0, 0,
+				},
+				[]int{10},
+			).SetSRID(4326),
+			geom.XYZ,
+			geom.NewPolygonFlat(
+				geom.XYZ,
+				[]float64{
+					0, 0, 0,
+					0, 1, 0,
+					1, 1, 0,
+					1, 0, 0,
+					0, 0, 0,
+				},
+				[]int{15},
+			).SetSRID(4326),
+		},
+		{
+			geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XYZ, []float64{1, 2, 3}),
+				geom.NewLineStringFlat(geom.XYZ, []float64{1, 2, 3, 4, 5, 6}),
+				geom.NewMultiPointFlat(geom.XYZ, []float64{1, 2, 3, 4, 5, 6}, geom.NewMultiPointFlatOptionWithEnds([]int{3, 3, 6})),
+				geom.NewMultiLineStringFlat(geom.XYZ, []float64{1, 2, 3, 4, 5, 6}, []int{3, 3, 6, 6}),
+				geom.NewMultiPolygonFlat(geom.XYZ, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3}, [][]int{{12}, {12}}),
+			).SetSRID(4326),
+			geom.XY,
+			geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1, 2}),
+				geom.NewLineStringFlat(geom.XY, []float64{1, 2, 4, 5}),
+				geom.NewMultiPointFlat(geom.XY, []float64{1, 2, 4, 5}, geom.NewMultiPointFlatOptionWithEnds([]int{2, 2, 4})),
+				geom.NewMultiLineStringFlat(geom.XY, []float64{1, 2, 4, 5}, []int{2, 2, 4, 4}),
+				geom.NewMultiPolygonFlat(geom.XY, []float64{1, 2, 4, 5, 7, 8, 1, 2}, [][]int{{8}, {8}}),
+			).SetSRID(4326),
+		},
+		{
+			geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1, 2}),
+				geom.NewLineStringFlat(geom.XY, []float64{1, 2, 4, 5}),
+				geom.NewMultiPointFlat(geom.XY, []float64{1, 2, 4, 5}, geom.NewMultiPointFlatOptionWithEnds([]int{2, 2, 4})),
+				geom.NewMultiLineStringFlat(geom.XY, []float64{1, 2, 4, 5}, []int{2, 2, 4, 4}),
+				geom.NewMultiPolygonFlat(geom.XY, []float64{1, 2, 4, 5, 7, 8, 1, 2}, [][]int{{8}, {8}}),
+			).SetSRID(4326),
+			geom.XYZ,
+			geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XYZ, []float64{1, 2, 0}),
+				geom.NewLineStringFlat(geom.XYZ, []float64{1, 2, 0, 4, 5, 0}),
+				geom.NewMultiPointFlat(geom.XYZ, []float64{1, 2, 0, 4, 5, 0}, geom.NewMultiPointFlatOptionWithEnds([]int{3, 3, 6})),
+				geom.NewMultiLineStringFlat(geom.XYZ, []float64{1, 2, 0, 4, 5, 0}, []int{3, 3, 6, 6}),
+				geom.NewMultiPolygonFlat(geom.XYZ, []float64{1, 2, 0, 4, 5, 0, 7, 8, 0, 1, 2, 0}, [][]int{{12}, {12}}),
+			).SetSRID(4326),
+		},
+	}
+
+	for _, tc := range testCases {
+		text, err := wkt.Marshal(tc.g)
+		require.NoError(t, err)
+		t.Run(fmt.Sprintf("%s->%s", text, tc.layout), func(t *testing.T) {
+			ret, err := forceLayout(tc.g, tc.layout)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, ret)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -3010,6 +3010,26 @@ MULTIPOINT (0 0, 1 1)
 statement error st_segmentize\(\): maximum segment length must be positive
 SELECT ST_Segmentize('POLYGON ((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))'::geometry, -1)
 
+# ST_Force*
+query TT
+SELECT
+  dsc,
+  ST_AsEWKT(ST_Force2D(geom))
+FROM geom_operators_test
+ORDER BY dsc
+----
+Empty GeometryCollection                  GEOMETRYCOLLECTION EMPTY
+Empty LineString                          LINESTRING EMPTY
+Empty Point                               POINT EMPTY
+Faraway point                             POINT (5 5)
+Line going through left and right square  LINESTRING (-0.5 0.5, 0.5 0.5)
+NULL                                      NULL
+Point middle of Left Square               POINT (-0.5 0.5)
+Point middle of Right Square              POINT (0.5 0.5)
+Square (left)                             POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
+Square (right)                            POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+Square overlapping left and right square  POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+
 subtest st_srid
 
 statement ok

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1570,6 +1570,23 @@ Flags shown square brackets after the geometry type have the following meaning:
 			tree.VolatilityImmutable,
 		),
 	),
+	"st_force2d": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.ForceLayout(g.Geometry, geom.XY)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Returns a Geometry which only contains X and Y coordinates.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
 	"st_numgeometries": makeBuiltin(
 		defProps(),
 		geometryOverload1(


### PR DESCRIPTION
This unblocks use of GeoServer.

Force_3D, 4D, etc. variants are not yet implemented as we do not store
3D/4D objects in CRDB yet. But the building blocks are all there.

Resolves https://github.com/cockroachdb/cockroach/issues/48933.

Release note (sql change): Implement the ST_Force2D functionality for
geometry types.