### PR TITLE
builtins: add num_nulls, num_nonnulls builtins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -304,6 +304,10 @@
 <tr><td><a name="greatest"></a><code>greatest(anyelement...) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the element with the greatest value.</p>
 </span></td></tr>
 <tr><td><a name="least"></a><code>least(anyelement...) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the element with the lowest value.</p>
+</span></td></tr>
+<tr><td><a name="num_nonnulls"></a><code>num_nonnulls(anyelement...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of nonnull arguments.</p>
+</span></td></tr>
+<tr><td><a name="num_nulls"></a><code>num_nulls(anyelement...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of null arguments.</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2741,3 +2741,17 @@ SELECT set_bit(b'', 0, 1)
 
 query error set_bit\(\): new bit must be 0 or 1.
 SELECT set_bit(b'\145\x6C\l', 0, 2)
+
+statement ok
+CREATE TABLE nulls_test(a INT, b STRING)
+
+statement ok
+INSERT INTO nulls_test VALUES(1, 'foo'), (1, NULL), (NULL, 'foo'), (NULL, NULL)
+
+query II rowsort
+SELECT num_nulls(a, b), num_nonnulls(a, b) FROM nulls_test
+----
+0  2
+1  1
+1  1
+2  0

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3955,6 +3955,53 @@ may increase either contention or retry errors, or both.`,
 			Volatility: tree.VolatilityVolatile,
 		},
 	),
+
+	"num_nulls": makeBuiltin(
+		tree.FunctionProperties{
+			Category:     categoryComparison,
+			NullableArgs: true,
+		},
+		tree.Overload{
+			Types: tree.VariadicType{
+				VarType: types.Any,
+			},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				var numNulls int
+				for _, arg := range args {
+					if arg == tree.DNull {
+						numNulls++
+					}
+				}
+				return tree.NewDInt(tree.DInt(numNulls)), nil
+			},
+			Info:       "Returns the number of null arguments.",
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+	"num_nonnulls": makeBuiltin(
+		tree.FunctionProperties{
+			Category:     categoryComparison,
+			NullableArgs: true,
+		},
+		tree.Overload{
+			Types: tree.VariadicType{
+				VarType: types.Any,
+			},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				var numNonNulls int
+				for _, arg := range args {
+					if arg != tree.DNull {
+						numNonNulls++
+					}
+				}
+				return tree.NewDInt(tree.DInt(numNonNulls)), nil
+			},
+			Info:       "Returns the number of nonnull arguments.",
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {

--- a/pkg/sql/sem/tree/testdata/eval/builtins
+++ b/pkg/sql/sem/tree/testdata/eval/builtins
@@ -102,3 +102,53 @@ eval
 octet_length('1011'::bit(12))
 ----
 2
+
+eval
+num_nulls(1, 3)
+----
+0
+
+eval
+num_nulls(1, NULL, 3)
+----
+1
+
+eval
+num_nulls(NULL, 1, NULL, 'foo', NULL)
+----
+3
+
+eval
+num_nulls()
+----
+0
+
+eval
+num_nulls(NULL, NULL)
+----
+2
+
+eval
+num_nonnulls(1, 3)
+----
+2
+
+eval
+num_nonnulls(1, NULL, 3)
+----
+2
+
+eval
+num_nonnulls(NULL, 1, NULL, 'foo', NULL)
+----
+2
+
+eval
+num_nonnulls()
+----
+0
+
+eval
+num_nonnulls(NULL, NULL)
+----
+0


### PR DESCRIPTION
Fixes #51507.

Release note (sql change): added the num_nulls and num_nonnulls builtin
functions, which count the number of arguments that are passed to it
which are NULL or non-NULL respectively.