### PR TITLE
parser: allow USING GIST syntax for creating inverted indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -27,6 +27,12 @@ statement error unknown SRID for Geography: 404
 SELECT 'SRID=404;POINT(1.0 2.0)'::geography
 
 statement ok
+CREATE INDEX geo_table_geom_idx ON geo_table USING GIST(geom)
+
+statement ok
+CREATE INDEX geo_table_geog_idx ON geo_table USING GIST(geog)
+
+statement ok
 CREATE TABLE geom_table_negative_values(
   a geometry(geometry, -1)
 )
@@ -81,10 +87,10 @@ SELECT orphan FROM geo_table
 query TTBTTTB rowsort
 SHOW COLUMNS FROM geo_table
 ----
-id      INT8                      false  NULL  ·  {primary}  false
-geog    GEOGRAPHY(GEOMETRY,4326)  true   NULL  ·  {}         false
-geom    GEOMETRY(POINT)           true   NULL  ·  {}         false
-orphan  GEOGRAPHY                 true   NULL  ·  {}         false
+id      INT8                      false  NULL  ·  {primary,geo_table_geom_idx,geo_table_geog_idx}  false
+geog    GEOGRAPHY(GEOMETRY,4326)  true   NULL  ·  {geo_table_geog_idx}                             false
+geom    GEOMETRY(POINT)           true   NULL  ·  {geo_table_geom_idx}                             false
+orphan  GEOGRAPHY                 true   NULL  ·  {}                                               false
 
 statement error column bad_pk is of type geography and thus is not indexable
 CREATE TABLE bad_geog_table(bad_pk geography primary key)

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1569,6 +1569,8 @@ func TestParse2(t *testing.T) {
 
 		{`CREATE INDEX a ON b USING GIN (c)`,
 			`CREATE INVERTED INDEX a ON b (c)`},
+		{`CREATE INDEX a ON b USING GIST (c)`,
+			`CREATE INVERTED INDEX a ON b (c)`},
 		{`CREATE UNIQUE INDEX a ON b USING GIN (c)`,
 			`CREATE UNIQUE INVERTED INDEX a ON b (c)`},
 
@@ -3376,7 +3378,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`ALTER TYPE db.s.t ADD ATTRIBUTE foo bar RESTRICT, DROP ATTRIBUTE foo`, 48701, `ALTER TYPE ATTRIBUTE`, ``},
 
 		{`CREATE INDEX a ON b USING HASH (c)`, 0, `index using hash`, ``},
-		{`CREATE INDEX a ON b USING GIST (c)`, 0, `index using gist`, ``},
 		{`CREATE INDEX a ON b USING SPGIST (c)`, 0, `index using spgist`, ``},
 		{`CREATE INDEX a ON b USING BRIN (c)`, 0, `index using brin`, ``},
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6010,11 +6010,11 @@ opt_using_gin_btree:
   {
     /* FORCE DOC */
     switch $2 {
-      case "gin":
+      case "gin", "gist":
         $$.val = true
       case "btree":
         $$.val = false
-      case "hash", "gist", "spgist", "brin":
+      case "hash", "spgist", "brin":
         return unimplemented(sqllex, "index using " + $2)
       default:
         sqllex.Error("unrecognized access method: " + $2)


### PR DESCRIPTION
Release note (sql change): Allow the `USING GIST` syntax to create an
inverted index on geometry and geography columns.