### PR TITLE
rowflow,colexec: make routers propagate errors to all non-closed outputs

### DIFF
--- a/pkg/sql/colexec/routers.go
+++ b/pkg/sql/colexec/routers.go
@@ -634,10 +634,10 @@ func newHashRouterWithOutputs(
 	return r
 }
 
-// cancelOutputs cancels all outputs and forwards the given error to one output
-// if non-nil. The only case where the error is not forwarded if no output could
-// be canceled due to an error. In this case each output will forward the error
-// returned during cancellation.
+// cancelOutputs cancels all outputs and forwards the given error to all of
+// them if non-nil. The only case where the error is not forwarded is if no
+// output could be canceled due to an error. In this case each output will
+// forward the error returned during cancellation.
 func (r *HashRouter) cancelOutputs(ctx context.Context, errToForward error) {
 	for _, o := range r.outputs {
 		if err := colexecerror.CatchVectorizedRuntimeError(func() {
@@ -646,10 +646,6 @@ func (r *HashRouter) cancelOutputs(ctx context.Context, errToForward error) {
 			// If there was an error canceling this output, this error can be
 			// forwarded to whoever is calling Next.
 			o.forwardErr(err)
-		} else {
-			// Successful cancellation, which means errToForward was also consumed.
-			// Set it to nil to not forward it to another output.
-			errToForward = nil
 		}
 	}
 }

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -1097,29 +1097,16 @@ func TestHashRouterRandom(t *testing.T) {
 						require.NoError(t, resultsByOp[i].err)
 					}
 				}
-				requireOneError := func(t *testing.T, err error) {
+				requireErrFromEachOutput := func(t *testing.T, err error) {
 					t.Helper()
 					if err == nil {
 						t.Fatal("use requireNoErrors instead")
 					}
 					for i := range resultsByOp {
-						if err == nil {
-							// A match was already found. Since we only expect one error, this
-							// error must be nil.
-							require.Nil(t, resultsByOp[i].err, "expected error to be nil")
-							continue
-						}
 						if resultsByOp[i].err == nil {
-							// This result has no error but we have not yet found the expected
-							// error, continue to another result.
-							continue
+							t.Fatalf("unexpectedly no error from %d output", i)
 						}
 						require.True(t, testutils.IsError(resultsByOp[i].err, err.Error()), "unexpected error %v", resultsByOp[i].err)
-						err = nil
-					}
-					if err != nil {
-						// err is set to nil when a match is found.
-						t.Fatal("no matching error found")
 					}
 				}
 
@@ -1156,10 +1143,10 @@ func TestHashRouterRandom(t *testing.T) {
 						}
 					}
 				case hashRouterContextCanceled:
-					requireOneError(t, context.Canceled)
+					requireErrFromEachOutput(t, context.Canceled)
 					checkMetadata(t, []string{hashRouterMetadataMsg})
 				case hashRouterOutputErrorOnAddBatch:
-					requireOneError(t, errors.New(addBatchErrMsg))
+					requireErrFromEachOutput(t, errors.New(addBatchErrMsg))
 					checkMetadata(t, []string{hashRouterMetadataMsg})
 				case hashRouterOutputErrorOnNext:
 					// If an error is encountered in Next, it is returned to the caller,

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -779,9 +779,6 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 	// onerow is a table created to test #51458. The value of the only row in this
 	// table is explicitly set to 2 so that it is routed by hash to a desired
 	// destination.
-	// TODO(asubiotto): The vectorized execution engine probably has the same
-	//  problem and might need a separate table since the hash functions are
-	//  different.
 	sqlutils.CreateTable(t, dbConn, "onerow", "x INT", 1, sqlutils.ToRowFn(func(_ int) tree.Datum { return tree.NewDInt(tree.DInt(2)) }))
 	_, err := dbConn.Exec(fmt.Sprintf(`
 	ALTER TABLE t SPLIT AT VALUES (10), (20);
@@ -833,7 +830,6 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 					tableNames: []string{"t"},
 				},
 			},
-			skip: "https://github.com/cockroachdb/cockroach/issues/51458",
 		},
 	}
 


### PR DESCRIPTION
This commit changes the way we propagate the errors in the hash router
so that the error metadata is sent on all non-closed streams.
Previously, we would be sending it over only the first non-closed stream
which could result in the processors on the same stage as that single
stream end to treat the absence of rows and errors as the input being
exhausted successfully, which is wrong because the input did encounter
an error.

The same thing has been happening in the vectorized flow, but in that
case the problem is less severe - the issue will present itself only
when we have wrapped processors (because the materializers will prevent
the propagation throughout the whole flow as described below):
In the vectorized engine we use panic-catch mechanism of error
propagation, and we end up with the following sequence of events:
1. an operator encounters an error on any node (e.g. `colBatchScan`
encounters RWUI error on a remote node). It is not an internal vectorized
error, so the operator will panic with `colexecerror.ExpectedError`.
2. the panic is caught by one of the catchers (it can be a parallel
unordered synchronizer goroutine, an outbox goroutine, a materializer,
a hash router)
3. that component will then decide how to propagate the error further:
3.1 if it is a parallel unordered synchronizer, then it will cancel all
of its inputs and will repanic
3.2 if it is an outbox, the error is sent as metadata which will be
received by an inbox which will panic with it
3.3. if it is a materializer, then it might swallow the error (this is
the reason we need for the vectorized hash router to send the error to
all of its inputs). The swallowing is acceptable if it is the root
materializer though.
3.4 if it is a hash router, it'll cancel all of its outputs and will
forward the error on each of the outputs.

Fixes: #51458.

Release note (bug fix): Previously, CockroachDB could return incorrect
results on query that encountered ReadWithinUncertaintyInterval error,
and this has been fixed.