### PR TITLE
sql: fix UPDATE for partial indexes with non-indexed predicate columns

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -16,20 +16,29 @@ CREATE TABLE t (
     INDEX c_partial (c) WHERE a > b AND c = 'foo'
 )
 
+statement ok
+CREATE TABLE u (
+    k INT PRIMARY KEY,
+    u INT,
+    v INT,
+    FAMILY (k, u, v),
+    INDEX (u) WHERE v > 10
+)
+
 # ---------------------------------------------------------
 # INSERT
 # ---------------------------------------------------------
 
 # Inserted row matches no partial index.
 query T kvtrace
-INSERT INTO t VALUES(5, 4, 'bar')
+INSERT INTO t VALUES (5, 4, 'bar')
 ----
 CPut /Table/53/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
 InitPut /Table/53/2/4/5/0 -> /BYTES/
 
 # Inserted row matches the first partial index.
 query T kvtrace
-INSERT INTO t VALUES(6, 11, 'bar')
+INSERT INTO t VALUES (6, 11, 'bar')
 ----
 CPut /Table/53/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
 InitPut /Table/53/2/11/6/0 -> /BYTES/
@@ -37,12 +46,26 @@ InitPut /Table/53/3/11/6/0 -> /BYTES/
 
 # Inserted row matches both partial indexes.
 query T kvtrace
-INSERT INTO t VALUES(12, 11, 'foo')
+INSERT INTO t VALUES (12, 11, 'foo')
 ----
 CPut /Table/53/1/12/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
 InitPut /Table/53/2/11/12/0 -> /BYTES/
 InitPut /Table/53/3/11/12/0 -> /BYTES/
 InitPut /Table/53/4/"foo"/12/0 -> /BYTES/
+
+# Inserted row does not match partial index with predicate column that is not
+# indexed.
+query T kvtrace
+INSERT INTO u VALUES (1, 2, 3)
+----
+CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
+
+# Inserted row matches partial index with predicate column that is not indexed.
+query T kvtrace
+INSERT INTO u VALUES (2, 3, 11)
+----
+CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
+InitPut /Table/54/2/3/2/0 -> /BYTES/
 
 # ---------------------------------------------------------
 # DELETE
@@ -74,6 +97,23 @@ Del /Table/53/2/11/12/0
 Del /Table/53/3/11/12/0
 Del /Table/53/4/"foo"/12/0
 Del /Table/53/1/12/0
+
+# Deleted row does not match partial index with predicate column that is not
+# indexed.
+query T kvtrace
+DELETE FROM u WHERE k = 1
+----
+Scan /Table/54/1/1{-/#}
+Del /Table/54/1/1/0
+
+# Deleted row matches partial index with predicate column that is not
+# indexed.
+query T kvtrace
+DELETE FROM u WHERE k = 2
+----
+Scan /Table/54/1/2{-/#}
+Del /Table/54/2/3/2/0
+Del /Table/54/1/2/0
 
 # ---------------------------------------------------------
 # UPDATE
@@ -164,6 +204,27 @@ CPut /Table/53/2/11/13/0 -> /BYTES/ (expecting does not exist)
 Del /Table/53/3/12/13/0
 CPut /Table/53/3/11/13/0 -> /BYTES/ (expecting does not exist)
 CPut /Table/53/4/"foo"/13/0 -> /BYTES/ (expecting does not exist)
+
+# Update a row to match a partial index that does not index the column
+# referenced in predicate.
+statement ok
+INSERT INTO u VALUES (1, 2, 3)
+
+query T kvtrace
+UPDATE u SET v = 11 WHERE k = 1
+----
+Scan /Table/54/1/1{-/#}
+Put /Table/54/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/11
+CPut /Table/54/2/2/1/0 -> /BYTES/ (expecting does not exist)
+
+# Update a row to no longer match a partial index that does not index the column
+# referenced in predicate.
+query T kvtrace
+UPDATE u SET v = 3 WHERE k = 1
+----
+Scan /Table/54/1/1{-/#}
+Put /Table/54/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
+Del /Table/54/2/2/1/0
 
 # ---------------------------------------------------------
 # UPDATE primary key


### PR DESCRIPTION
This commit fixes a bug where an UPDATE would not correctly add or
remove entries to partial indexes when updating a column present in the
partial index predicate, but not indexed or stored.

To prevent regressions this commit adds similar test for INSERT and
DELETE.

Release note: None