### PR TITLE
tracing: fix a recording data race

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -287,11 +287,6 @@ func (t *Tracer) StartSpan(
 	}
 	s.SpanID = uint64(rand.Int63())
 
-	// Start recording if necessary.
-	if recordingType != NoRecording {
-		s.enableRecording(parentCtx.span, recordingType, false /* separateRecording */)
-	}
-
 	if t.useNetTrace() {
 		s.netTr = trace.New("tracing", operationName)
 		s.netTr.SetMaxEvents(maxLogsPerSpan)
@@ -326,6 +321,12 @@ func (t *Tracer) StartSpan(
 		linkShadowSpan(s, shadowTr, parentShadowCtx, parentType)
 	}
 
+	// Start recording if necessary. This publishes the span to be retrieved by
+	// recordings and so it's done after all of s' fields not protected by a lock
+	// are set.
+	if recordingType != NoRecording {
+		s.enableRecording(parentCtx.span, recordingType, false /* separateRecording */)
+	}
 	return s
 }
 


### PR DESCRIPTION
This patch fixes a data race between creating a child span and
collecting the parent's recording. The bug was that the child span was
"published" in the parent's `recording` collecting while its non-lock
protected (i.e. readonly-after-init) fields were still being set (in
particular ParentID). Reading the recording would race when reading that
field. We generally (but not necessarily) collect recordings after the
traced operation is completed, but the race can still happen for async
child spans (FollowsFrom), which might still be created when the
operation is otherwise done. In particular, this was caught by the async
spans we create for Raft command application.

The fix is to publish the span in the recording after all its fields are
set.

Release note: None