### PR TITLE
sql: handle UPSERTs for partial indexes

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -374,8 +373,8 @@ func insertStmtToKVs(
 		}
 		// TODO(mgartner): Add partial index IDs to ignoreIndexes that we should
 		// not add entries to.
-		var ignoreIndexes util.FastIntSet
-		if err := ri.InsertRow(ctx, b, insertRow, ignoreIndexes, true, false /* traceKV */); err != nil {
+		var pm row.PartialIndexUpdateHelper
+		if err := ri.InsertRow(ctx, b, insertRow, pm, true, false /* traceKV */); err != nil {
 			return errors.Wrapf(err, "insert %q", insertRow)
 		}
 	}

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -280,11 +280,11 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 				oldValues[j] = tree.DNull
 			}
 		}
-		// TODO(mgartner): Add partial index IDs to ignoreIndexes that we should
-		// not add entries to or delete entries from.
-		var ignoreIndexes util.FastIntSet
+		// TODO(mgartner): Add partial index IDs to pm that we should not add
+		// entries to or delete entries from.
+		var pm row.PartialIndexUpdateHelper
 		if _, err := ru.UpdateRow(
-			ctx, b, oldValues, updateValues, ignoreIndexes, ignoreIndexes, traceKV,
+			ctx, b, oldValues, updateValues, pm, traceKV,
 		); err != nil {
 			return roachpb.Key{}, err
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -474,10 +474,11 @@ func (n *createTableNode) startExec(params runParams) error {
 					}
 				}
 
-				// TODO(mgartner): Add partial index IDs to ignoreIndexes that we should
-				// not add entries to.
-				var ignoreIndexes util.FastIntSet
-				if err := tw.row(params.ctx, rowBuffer, ignoreIndexes, params.extendedEvalCtx.Tracing.KVTracingEnabled()); err != nil {
+				// CREATE TABLE AS does not copy indexes from the input table.
+				// An empty row.PartialIndexUpdateHelper is used here because
+				// there are no indexes, partial or otherwise, to update.
+				var pm row.PartialIndexUpdateHelper
+				if err := tw.row(params.ctx, rowBuffer, pm, params.extendedEvalCtx.Tracing.KVTracingEnabled()); err != nil {
 					return err
 				}
 			}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -14,10 +14,10 @@ import (
 	"context"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -174,38 +174,27 @@ func (d *deleteNode) BatchedNext(params runParams) (bool, error) {
 // processSourceRow processes one row from the source for deletion and, if
 // result rows are needed, saves it in the result row container
 func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) error {
-	// Create a set of index IDs to not delete from. Indexes should not be
-	// deleted from when they are partial indexes and the row does not satisfy
-	// the predicate and therefore do not exist in the partial index. This
-	// set is passed as a argument to tableDeleter.row below.
-	var ignoreIndexes util.FastIntSet
+	// Create a set of partial index IDs to not delete from. Indexes should not
+	// be deleted from when they are partial indexes and the row does not
+	// satisfy the predicate and therefore do not exist in the partial index.
+	// This set is passed as a argument to tableDeleter.row below.
+	var pm row.PartialIndexUpdateHelper
 	partialIndexOrds := d.run.td.tableDesc().PartialIndexOrds()
 	if !partialIndexOrds.Empty() {
 		partialIndexDelVals := sourceVals[d.run.partialIndexDelValsOffset:]
-		colIdx := 0
-		indexes := d.run.td.tableDesc().Indexes
-		for i, ok := partialIndexOrds.Next(0); ok; i, ok = partialIndexOrds.Next(i + 1) {
-			index := &indexes[i]
-			if index.IsPartial() {
-				val, err := tree.GetBool(partialIndexDelVals[colIdx])
-				if err != nil {
-					return err
-				}
 
-				if !val {
-					// If the value of the column for the index predicate expression
-					// is false, the row should not be removed from the partial
-					// index because it does not exist.
-					ignoreIndexes.Add(int(index.ID))
-				}
-
-				colIdx++
-			}
+		err := pm.Init(tree.Datums{}, partialIndexDelVals, d.run.td.tableDesc())
+		if err != nil {
+			return err
 		}
+
+		// Truncate sourceVals so that it no longer includes partial index
+		// predicate values.
+		sourceVals = sourceVals[:d.run.partialIndexDelValsOffset]
 	}
 
 	// Queue the deletion in the KV batch.
-	if err := d.run.td.row(params.ctx, sourceVals, ignoreIndexes, d.run.traceKV); err != nil {
+	if err := d.run.td.row(params.ctx, sourceVals, pm, d.run.traceKV); err != nil {
 		return err
 	}
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -14,10 +14,10 @@ import (
 	"context"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -139,37 +139,23 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 		return err
 	}
 
-	// Create a set of index IDs to not write to. Indexes should not be written
-	// to when they are partial indexes and the row does not satisfy the
+	// Create a set of partial index IDs to not write to. Indexes should not be
+	// written to when they are partial indexes and the row does not satisfy the
 	// predicate. This set is passed as a parameter to tableInserter.row below.
-	var ignoreIndexes util.FastIntSet
+	var pm row.PartialIndexUpdateHelper
 	partialIndexOrds := r.ti.tableDesc().PartialIndexOrds()
 	if !partialIndexOrds.Empty() {
 		partialIndexPutVals := rowVals[len(r.insertCols)+r.checkOrds.Len():]
-		colIdx := 0
-		indexes := r.ti.tableDesc().Indexes
-		for i, ok := partialIndexOrds.Next(0); ok; i, ok = partialIndexOrds.Next(i + 1) {
-			index := &indexes[i]
-			if index.IsPartial() {
-				val, err := tree.GetBool(partialIndexPutVals[colIdx])
-				if err != nil {
-					return err
-				}
 
-				if !val {
-					// If the value of the column for the index predicate expression
-					// is false, the row should not be added to the partial index.
-					ignoreIndexes.Add(int(index.ID))
-				}
-
-				colIdx++
-			}
+		err := pm.Init(partialIndexPutVals, tree.Datums{}, r.ti.tableDesc())
+		if err != nil {
+			return err
 		}
-	}
 
-	// Truncate rowVals so that it no longer includes partial index predicate
-	// values.
-	rowVals = rowVals[:len(r.insertCols)+r.checkOrds.Len()]
+		// Truncate rowVals so that it no longer includes partial index predicate
+		// values.
+		rowVals = rowVals[:len(r.insertCols)+r.checkOrds.Len()]
+	}
 
 	// Verify the CHECK constraint results, if any.
 	if !r.checkOrds.Empty() {
@@ -181,7 +167,7 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 	}
 
 	// Queue the insert in the KV batch.
-	if err := r.ti.row(params.ctx, rowVals, ignoreIndexes, r.traceKV); err != nil {
+	if err := r.ti.row(params.ctx, rowVals, pm, r.traceKV); err != nil {
 		return err
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -361,7 +361,8 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	//
 	// TODO(andyk): Using ensureColumns here can result in an extra Render.
 	// Upgrade execution engine to not require this.
-	cnt := len(ups.InsertCols) + len(ups.FetchCols) + len(ups.UpdateCols) + len(ups.CheckCols) + 1
+	cnt := len(ups.InsertCols) + len(ups.FetchCols) + len(ups.UpdateCols) + len(ups.CheckCols) +
+		len(ups.PartialIndexPutCols) + len(ups.PartialIndexDelCols) + 1
 	colList := make(opt.ColList, 0, cnt)
 	colList = appendColsWhenPresent(colList, ups.InsertCols)
 	colList = appendColsWhenPresent(colList, ups.FetchCols)
@@ -370,6 +371,8 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 		colList = append(colList, ups.CanaryCol)
 	}
 	colList = appendColsWhenPresent(colList, ups.CheckCols)
+	colList = appendColsWhenPresent(colList, ups.PartialIndexPutCols)
+	colList = appendColsWhenPresent(colList, ups.PartialIndexDelCols)
 
 	input, err := b.buildMutationInput(ups, ups.Input, colList, &ups.MutationPrivate)
 	if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -13,7 +13,7 @@ CREATE TABLE t (
     CHECK (b > 0),
     INDEX b_full (b),
     INDEX b_partial (b) WHERE b > 10,
-    INDEX c_partial (c) WHERE a > b AND c = 'foo'
+    INDEX c_partial (c) WHERE a > b AND c IN ('foo', 'foobar')
 )
 
 statement ok
@@ -135,6 +135,13 @@ Del /Table/54/1/2/0
 # ---------------------------------------------------------
 # UPDATE
 # ---------------------------------------------------------
+
+# Clear the tables.
+statement ok
+DELETE FROM t
+
+statement ok
+DELETE FROM u
 
 # Insert a row that matches no partial index.
 statement ok
@@ -277,6 +284,396 @@ Del /Table/53/1/21/0
 CPut /Table/53/1/22/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/foo
 InitPut /Table/53/2/9/22/0 -> /BYTES/
 InitPut /Table/53/4/"foo"/22/0 -> /BYTES/
+
+# ---------------------------------------------------------
+# INSERT ON CONFLICT DO NOTHING
+# ---------------------------------------------------------
+
+# Clear the tables.
+statement ok
+DELETE FROM t
+
+statement ok
+DELETE FROM u
+
+# Insert a row that matches no partial index.
+query T kvtrace
+INSERT INTO t VALUES (5, 4, 'bar') ON CONFLICT DO NOTHING
+----
+Scan /Table/53/1/5{-/#}
+CPut /Table/53/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+InitPut /Table/53/2/4/5/0 -> /BYTES/
+
+# Insert a conflicting row that matches no partial index.
+query T kvtrace
+INSERT INTO t VALUES (5, 4, 'bar') ON CONFLICT DO NOTHING
+----
+Scan /Table/53/1/5{-/#}
+
+# Insert a row that matches the first partial index.
+query T kvtrace
+INSERT INTO t VALUES (6, 11, 'bar') ON CONFLICT DO NOTHING
+----
+Scan /Table/53/1/6{-/#}
+CPut /Table/53/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
+InitPut /Table/53/2/11/6/0 -> /BYTES/
+InitPut /Table/53/3/11/6/0 -> /BYTES/
+
+# Insert a conflicting row that matches the first partial index.
+query T kvtrace
+INSERT INTO t VALUES (6, 11, 'bar') ON CONFLICT DO NOTHING
+----
+Scan /Table/53/1/6{-/#}
+
+# Insert a row that matches both partial indexes.
+query T kvtrace
+INSERT INTO t VALUES (12, 11, 'foo') ON CONFLICT DO NOTHING
+----
+Scan /Table/53/1/12{-/#}
+CPut /Table/53/1/12/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
+InitPut /Table/53/2/11/12/0 -> /BYTES/
+InitPut /Table/53/3/11/12/0 -> /BYTES/
+InitPut /Table/53/4/"foo"/12/0 -> /BYTES/
+
+# Insert a conflicting row that matches both partial indexes.
+query T kvtrace
+INSERT INTO t VALUES (12, 11, 'foo') ON CONFLICT DO NOTHING
+----
+Scan /Table/53/1/12{-/#}
+
+# Insert a non-conflicting row that does not match the partial index with
+# predicate column that is not indexed.
+query T kvtrace
+INSERT INTO u VALUES (1, 2, 3) ON CONFLICT DO NOTHING
+----
+Scan /Table/54/1/1{-/#}
+CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
+
+# Insert a conflicting row that does not match the partial index with predicate
+# column that is not indexed.
+query T kvtrace
+INSERT INTO u VALUES (1, 4, 6) ON CONFLICT DO NOTHING
+----
+Scan /Table/54/1/1{-/#}
+
+# Insert a non-conflicting row that matches the partial index with predicate
+# column that is not indexed.
+query T kvtrace
+INSERT INTO u VALUES (2, 3, 11) ON CONFLICT DO NOTHING
+----
+Scan /Table/54/1/2{-/#}
+CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
+InitPut /Table/54/2/3/2/0 -> /BYTES/
+
+# Insert a conflicting row that matches the partial index with predicate column
+# that is not indexed.
+query T kvtrace
+INSERT INTO u VALUES (2, 3, 11) ON CONFLICT DO NOTHING
+----
+Scan /Table/54/1/2{-/#}
+
+# ---------------------------------------------------------
+# INSERT ON CONFLICT DO UPDATE
+# ---------------------------------------------------------
+
+# Clear the tables.
+statement ok
+DELETE FROM t
+
+statement ok
+DELETE FROM u
+
+# Insert a non-conflicting row that matches no partial indexes.
+query T kvtrace
+INSERT INTO t VALUES (5, 4, 'bar') ON CONFLICT (a) DO UPDATE SET b = 3
+----
+Scan /Table/53/1/5{-/#}
+CPut /Table/53/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+InitPut /Table/53/2/4/5/0 -> /BYTES/
+
+# Insert a conflicting row that matches no partial indexes before or after
+# the update.
+query T kvtrace
+INSERT INTO t VALUES (5, 3, 'foo') ON CONFLICT (a) DO UPDATE SET b = 3
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
+Del /Table/53/2/4/5/0
+CPut /Table/53/2/3/5/0 -> /BYTES/ (expecting does not exist)
+
+# Insert a conflicting row that does not match the first partial index
+# before the update, but does match after the update.
+query T kvtrace
+INSERT INTO t VALUES (5, 7, 'foo') ON CONFLICT (a) DO UPDATE SET b = 11
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
+Del /Table/53/2/3/5/0
+CPut /Table/53/2/11/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/53/3/11/5/0 -> /BYTES/ (expecting does not exist)
+
+# Insert a conflicting row that currently matches the first partial index before
+# the update. Update the row so that the row no longer matches the first partial
+# index but now matches the second.
+query T kvtrace
+INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 4, c = 'foo'
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
+Del /Table/53/2/11/5/0
+CPut /Table/53/2/4/5/0 -> /BYTES/ (expecting does not exist)
+Del /Table/53/3/11/5/0
+CPut /Table/53/4/"foo"/5/0 -> /BYTES/ (expecting does not exist)
+
+# Insert a conflicting row that that matches the second partial index before and
+# after the update and the index entry does not change.
+query T kvtrace
+INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 3
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
+Del /Table/53/2/4/5/0
+CPut /Table/53/2/3/5/0 -> /BYTES/ (expecting does not exist)
+
+# Insert a conflicting row that that matches the second partial index before and
+# after the update and the index entry changes.
+query T kvtrace
+INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET c = 'foobar'
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foobar
+Del /Table/53/4/"foo"/5/0
+CPut /Table/53/4/"foobar"/5/0 -> /BYTES/ (expecting does not exist)
+
+# Insert a non-conflicting row that matches the first partial index.
+query T kvtrace
+INSERT INTO t VALUES (6, 11, 'baz') ON CONFLICT (a) DO UPDATE SET b = 3
+----
+Scan /Table/53/1/6{-/#}
+CPut /Table/53/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
+InitPut /Table/53/2/11/6/0 -> /BYTES/
+InitPut /Table/53/3/11/6/0 -> /BYTES/
+
+# Insert a non-conflicting row that does not match the partial index with
+# predicate column that is not indexed.
+query T kvtrace
+INSERT INTO u VALUES (1, 2, 3) ON CONFLICT (k) DO UPDATE SET u = 5
+----
+Scan /Table/54/1/1{-/#}
+CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
+
+# Insert a conflicting row that does not match the partial index with predicate
+# column that is not indexed.
+query T kvtrace
+INSERT INTO u VALUES (1, 4, 6) ON CONFLICT (k) DO UPDATE SET v = 8
+----
+Scan /Table/54/1/1{-/#}
+Put /Table/54/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/8
+
+# Insert a non-conflicting row that matches the partial index with predicate
+# column that is not indexed.
+query T kvtrace
+INSERT INTO u VALUES (2, 3, 11) ON CONFLICT (k) DO UPDATE SET u = 5
+----
+Scan /Table/54/1/2{-/#}
+CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
+InitPut /Table/54/2/3/2/0 -> /BYTES/
+
+# Insert a conflicting row that matches the partial index with predicate column
+# that is not indexed.
+query T kvtrace
+INSERT INTO u VALUES (2, 3, 11) ON CONFLICT (k) DO UPDATE SET u = 4, v = 12
+----
+Scan /Table/54/1/2{-/#}
+Put /Table/54/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
+Del /Table/54/2/3/2/0
+CPut /Table/54/2/4/2/0 -> /BYTES/ (expecting does not exist)
+
+# ---------------------------------------------------------
+# INSERT ON CONFLICT DO UPDATE primary key
+# ---------------------------------------------------------
+
+# Clear the tables.
+statement ok
+DELETE FROM t
+
+statement ok
+DELETE FROM u
+
+# Insert a non-conflicting row that matches no partial indexes.
+query T kvtrace
+INSERT INTO t VALUES (5, 4, 'bar') ON CONFLICT (a) DO UPDATE SET a = 5
+----
+Scan /Table/53/1/5{-/#}
+CPut /Table/53/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+InitPut /Table/53/2/4/5/0 -> /BYTES/
+
+# Insert a conflicting row that matches no partial indexes before or after
+# the update.
+query T kvtrace
+INSERT INTO t VALUES (5, 3, 'baz') ON CONFLICT (a) DO UPDATE SET a = 6
+----
+Scan /Table/53/1/5{-/#}
+Del /Table/53/2/4/5/0
+Del /Table/53/1/5/0
+CPut /Table/53/1/6/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+InitPut /Table/53/2/4/6/0 -> /BYTES/
+
+# Insert a conflicting row that currently does not match the second partial
+# index before the update, but does match after the update.
+query T kvtrace
+INSERT INTO t VALUES (6, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 7, c = 'foo'
+----
+Scan /Table/53/1/6{-/#}
+Del /Table/53/2/4/6/0
+Del /Table/53/1/6/0
+CPut /Table/53/1/7/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
+InitPut /Table/53/2/4/7/0 -> /BYTES/
+InitPut /Table/53/4/"foo"/7/0 -> /BYTES/
+
+# Insert a conflicting row that currently matches the second partial index
+# before the update. Update the row so that the row no longer matches the second
+# partial index but now matches the first.
+query T kvtrace
+INSERT INTO t VALUES (7, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 8, b = 11
+----
+Scan /Table/53/1/7{-/#}
+Del /Table/53/2/4/7/0
+Del /Table/53/4/"foo"/7/0
+Del /Table/53/1/7/0
+CPut /Table/53/1/8/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
+InitPut /Table/53/2/11/8/0 -> /BYTES/
+InitPut /Table/53/3/11/8/0 -> /BYTES/
+
+# Insert a conflicting row that that matches the first partial index before and
+# after the update and the index entry changes.
+query T kvtrace
+INSERT INTO t VALUES (8, 4, 'bar') ON CONFLICT (a) DO UPDATE SET a = 9, c = 'foobar'
+----
+Scan /Table/53/1/8{-/#}
+Del /Table/53/2/11/8/0
+Del /Table/53/3/11/8/0
+Del /Table/53/1/8/0
+CPut /Table/53/1/9/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foobar
+InitPut /Table/53/2/11/9/0 -> /BYTES/
+InitPut /Table/53/3/11/9/0 -> /BYTES/
+
+# ---------------------------------------------------------
+# UPSERT
+# ---------------------------------------------------------
+
+# Clear the tables.
+statement ok
+DELETE FROM t
+
+statement ok
+DELETE FROM u
+
+# Upsert a non-conflicting row that matches no partial indexes.
+query T kvtrace
+UPSERT INTO t VALUES (5, 4, 'bar')
+----
+Scan /Table/53/1/5{-/#}
+CPut /Table/53/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+InitPut /Table/53/2/4/5/0 -> /BYTES/
+
+# Upsert a conflicting row that matches no partial indexes before or after
+# the update.
+query T kvtrace
+UPSERT INTO t VALUES (5, 3, 'bar')
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
+Del /Table/53/2/4/5/0
+CPut /Table/53/2/3/5/0 -> /BYTES/ (expecting does not exist)
+
+# Upsert a conflicting row that does not match the first partial index before
+# the update, but does match after the update.
+query T kvtrace
+UPSERT INTO t VALUES (5, 11, 'bar')
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
+Del /Table/53/2/3/5/0
+CPut /Table/53/2/11/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/53/3/11/5/0 -> /BYTES/ (expecting does not exist)
+
+# Upsert a conflicting row that currently matches the first partial index before
+# the update. Update the row so that the row no longer matches the first partial
+# index but now matches the second.
+query T kvtrace
+UPSERT INTO t VALUES (5, 3, 'foo')
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
+Del /Table/53/2/11/5/0
+CPut /Table/53/2/3/5/0 -> /BYTES/ (expecting does not exist)
+Del /Table/53/3/11/5/0
+CPut /Table/53/4/"foo"/5/0 -> /BYTES/ (expecting does not exist)
+
+# Upsert a conflicting row that that matches the second partial index before and
+# after the update and the index entry does not change.
+query T kvtrace
+UPSERT INTO t VALUES (5, 4, 'foo')
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
+Del /Table/53/2/3/5/0
+CPut /Table/53/2/4/5/0 -> /BYTES/ (expecting does not exist)
+
+# Upsert a conflicting row that that matches the second partial index before and
+# after the update and the index entry changes.
+query T kvtrace
+UPSERT INTO t VALUES (5, 4, 'foobar')
+----
+Scan /Table/53/1/5{-/#}
+Put /Table/53/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foobar
+Del /Table/53/4/"foo"/5/0
+CPut /Table/53/4/"foobar"/5/0 -> /BYTES/ (expecting does not exist)
+
+# Upsert a non-conflicting row that matches the first partial index.
+query T kvtrace
+UPSERT INTO t VALUES (9, 11, 'baz')
+----
+Scan /Table/53/1/9{-/#}
+CPut /Table/53/1/9/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
+InitPut /Table/53/2/11/9/0 -> /BYTES/
+InitPut /Table/53/3/11/9/0 -> /BYTES/
+
+# Upsert a non-conflicting row that does not match the partial index with
+# predicate column that is not indexed.
+query T kvtrace
+UPSERT INTO u VALUES (1, 2, 3)
+----
+Scan /Table/54/1/1{-/#}
+CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
+
+# Upsert a conflicting row that does not match the partial index with predicate
+# column that is not indexed.
+query T kvtrace
+UPSERT INTO u VALUES (1, 4, 6)
+----
+Scan /Table/54/1/1{-/#}
+Put /Table/54/1/1/0 -> /TUPLE/2:2:Int/4/1:3:Int/6
+
+# Upsert a non-conflicting row that matches the partial index with predicate
+# column that is not indexed.
+query T kvtrace
+UPSERT INTO u VALUES (2, 3, 11)
+----
+Scan /Table/54/1/2{-/#}
+CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
+InitPut /Table/54/2/3/2/0 -> /BYTES/
+
+# Upsert a conflicting row that matches the partial index with predicate column
+# that is not indexed.
+query T kvtrace
+UPSERT INTO u VALUES (2, 4, 12)
+----
+Scan /Table/54/1/2{-/#}
+Put /Table/54/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
+Del /Table/54/2/3/2/0
+CPut /Table/54/2/4/2/0 -> /BYTES/ (expecting does not exist)
 
 # ---------------------------------------------------------
 # EXPLAIN

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -530,6 +530,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				f.formatMutationCols(e, tp, "upsert-mapping:", t.InsertCols, t.Table)
 			}
 			f.formatColList(e, tp, "check columns:", t.CheckCols)
+			f.formatColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
+			f.formatColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
 

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1946,12 +1946,12 @@ update partial_indexes
  ├── fetch columns: a:5 b:6 c:7
  ├── update-mapping:
  │    └── c_new:11 => c:3
- ├── partial index put columns: partial_index_put1:12 partial_index_put2:13
- ├── partial index del columns: partial_index_del1:9 partial_index_del2:10
+ ├── partial index put columns: column12:12 column13:13
+ ├── partial index del columns: column9:9 column10:10
  ├── volatile, mutations
  ├── key: (1)
  └── project
-      ├── columns: partial_index_put1:12!null partial_index_put2:13 c_new:11!null partial_index_del1:9 partial_index_del2:10 a:5!null b:6 c:7
+      ├── columns: column12:12!null column13:13 c_new:11!null column9:9 column10:10 a:5!null b:6 c:7
       ├── key: (5)
       ├── fd: ()-->(11,12), (5)-->(6,7,10,13), (7)-->(9)
       ├── scan partial_indexes
@@ -1965,11 +1965,11 @@ update partial_indexes
       │    ├── key: (5)
       │    └── fd: (5)-->(6,7)
       └── projections
-           ├── false [as=partial_index_put1:12]
-           ├── a:5 > b:6 [as=partial_index_put2:13, outer=(5,6)]
+           ├── false [as=column12:12]
+           ├── a:5 > b:6 [as=column13:13, outer=(5,6)]
            ├── 'bar' [as=c_new:11]
-           ├── c:7 = 'foo' [as=partial_index_del1:9, outer=(7)]
-           └── (a:5 > b:6) AND (c:7 = 'bar') [as=partial_index_del2:10, outer=(5-7)]
+           ├── c:7 = 'foo' [as=column9:9, outer=(7)]
+           └── (a:5 > b:6) AND (c:7 = 'bar') [as=column10:10, outer=(5-7)]
 
 # Prune secondary family column not needed for the update.
 norm expect=(PruneMutationFetchCols,PruneMutationInputCols)

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -74,13 +74,6 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 // buildDelete constructs a Delete operator, possibly wrapped by a Project
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildDelete(returning tree.ReturningExprs) {
-	// Disambiguate names so that references in any expressions, such as a
-	// partial index predicate, refer to the correct columns.
-	mb.disambiguateColumns()
-
-	// Add partial index boolean columns to the input.
-	mb.addPartialIndexDelCols()
-
 	mb.buildFKChecksAndCascadesForDelete()
 
 	private := mb.makeMutationPrivate(returning != nil)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -641,11 +641,16 @@ func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
 	// check constraint, refer to the correct columns.
 	mb.disambiguateColumns()
 
+	// Keep a reference to the scope before the check constraint columns are
+	// projected. We use this scope when projecting the partial index put
+	// columns because the check columns are not in-scope for those expressions.
+	preCheckScope := mb.outScope
+
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols()
 
-	// Add any partial index boolean columns to the input.
-	mb.addPartialIndexPutCols()
+	// Add any partial index put boolean columns to the input.
+	mb.projectPartialIndexPutCols(preCheckScope)
 
 	mb.buildFKChecksForInsert()
 
@@ -881,6 +886,9 @@ func (mb *mutationBuilder) buildInputForUpsert(
 
 	mb.targetColList = make(opt.ColList, 0, mb.tab.ColumnCount())
 	mb.targetColSet = opt.ColSet{}
+
+	// Add any partial index del boolean columns to the input for UPSERTs.
+	mb.projectPartialIndexDelCols(fetchScope)
 }
 
 // setUpsertCols sets the list of columns to be updated in case of conflict.
@@ -941,8 +949,33 @@ func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 	// check constraint, refer to the correct columns.
 	mb.disambiguateColumns()
 
+	// Keep a reference to the scope before the check constraint columns are
+	// projected. We use this scope when projecting the partial index put
+	// columns because the check columns are not in-scope for those expressions.
+	preCheckScope := mb.outScope
+
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols()
+
+	// Add any partial index put boolean columns. The variables in these partial
+	// index predicates must resolve to the new column values of the row which
+	// are either the existing values of the columns or new values provided in
+	// the upsert. Therefore, the variables must resolve to the upsert CASE
+	// expression columns, so the project must be added after the upsert columns
+	// are.
+	//
+	// For example, consider the table and upsert:
+	//
+	//   CREATE TABLE t (a INT PRIMARY KEY, b INT, INDEX (b) WHERE a > 1)
+	//   INSERT INTO t (a, b) VALUES (1, 2) ON CONFLICT (a) DO UPDATE a = t.a + 1
+	//
+	// An entry in the partial index should only be added when a > 1. The
+	// resulting value of a is dependent on whether or not there is a conflict.
+	// In the case of no conflict, the (1, 2) is inserted into the table, and no
+	// partial index entry should be added. But if there is a conflict, The
+	// existing row where a = 1 has a incremented to 2, and an entry should be
+	// added to the partial index.
+	mb.projectPartialIndexPutCols(preCheckScope)
 
 	mb.buildFKChecksForUpsert()
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -230,7 +230,7 @@ func (mb *mutationBuilder) buildInputForUpdate(
 	//
 	// NOTE: Include mutation columns, but be careful to never use them for any
 	//       reason other than as "fetch columns". See buildScan comment.
-	mb.outScope = mb.b.buildScan(
+	scanScope := mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		nil, /* ordinals */
 		indexFlags,
@@ -238,6 +238,7 @@ func (mb *mutationBuilder) buildInputForUpdate(
 		includeMutations,
 		inScope,
 	)
+	mb.outScope = scanScope
 
 	// Set list of columns that will be fetched by the input expression.
 	for i := range mb.outScope.cols {
@@ -309,6 +310,9 @@ func (mb *mutationBuilder) buildInputForUpdate(
 				pkCols, mb.outScope, false /* nullsAreDistinct */, "" /* errorOnDup */)
 		}
 	}
+
+	// Add partial index del boolean columns to the input.
+	mb.projectPartialIndexDelCols(scanScope)
 }
 
 // buildInputForDelete constructs a Select expression from the fields in
@@ -340,7 +344,7 @@ func (mb *mutationBuilder) buildInputForDelete(
 	// NOTE: Include mutation columns, but be careful to never use them for any
 	//       reason other than as "fetch columns". See buildScan comment.
 	// TODO(andyk): Why does execution engine need mutation columns for Delete?
-	mb.outScope = mb.b.buildScan(
+	scanScope := mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		nil, /* ordinals */
 		indexFlags,
@@ -348,6 +352,7 @@ func (mb *mutationBuilder) buildInputForDelete(
 		includeMutations,
 		inScope,
 	)
+	mb.outScope = scanScope
 
 	// WHERE
 	mb.b.buildWhere(where, mb.outScope)
@@ -373,6 +378,9 @@ func (mb *mutationBuilder) buildInputForDelete(
 			mb.fetchColIDs[i] = mb.outScope.cols[i].id
 		}
 	}
+
+	// Add partial index boolean columns to the input.
+	mb.projectPartialIndexDelCols(scanScope)
 }
 
 // addTargetColsByName adds one target column for each of the names in the given
@@ -728,27 +736,34 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 	}
 }
 
-// addPartialIndexCols synthesizes boolean output columns for each partial index
-// defined on the target table. The execution code uses these booleans to
-// determine whether or not to add a row in the partial index.
-func (mb *mutationBuilder) addPartialIndexPutCols() {
-	mb.addPartialIndexCols("partial_index_put", mb.partialIndexPutColIDs)
+// projectPartialIndexPutCols builds a Project that synthesizes boolean output
+// columns for each partial index defined on the target table. The execution
+// code uses these booleans to determine whether or not to add a row in the
+// partial index.
+//
+// predScope is the scope of columns available to the partial index predicate
+// expression.
+func (mb *mutationBuilder) projectPartialIndexPutCols(predScope *scope) {
+	mb.projectPartialIndexCols(mb.partialIndexPutColIDs, predScope)
 }
 
-// addPartialIndexPutCols synthesizes a boolean output column for each partial
-// index defined on the target table. The execution code uses these booleans to
-// determine whether or not to delete a row in the partial index.
-func (mb *mutationBuilder) addPartialIndexDelCols() {
-	mb.addPartialIndexCols("partial_index_del", mb.partialIndexDelColIDs)
+// projectPartialIndexPutCols builds a Project that synthesizes boolean output
+// columns for each partial index defined on the target table. The execution
+// code uses these booleans to determine whether or not to remove a row in the
+// partial index.
+//
+// predScope is the scope of columns available to the partial index predicate
+// expression.
+func (mb *mutationBuilder) projectPartialIndexDelCols(predScope *scope) {
+	mb.projectPartialIndexCols(mb.partialIndexDelColIDs, predScope)
 }
 
-// addPartialIndexCols synthesizes a boolean output column for each partial
-// index defined on the target table. Each synthesized column is prefixed with
-// aliasPrefix and added to the ords list.
-func (mb *mutationBuilder) addPartialIndexCols(aliasPrefix string, colIDs opt.ColList) {
+// projectPartialIndexCols builds a Project that synthesizes boolean output
+// columns for each partial index defined on the target table.
+func (mb *mutationBuilder) projectPartialIndexCols(colIDs opt.ColList, predScope *scope) {
 	if partialIndexCount(mb.tab) > 0 {
-		projectionsScope := mb.outScope.replace()
-		projectionsScope.appendColumnsFromScope(mb.outScope)
+		projectionScope := mb.outScope.replace()
+		projectionScope.appendColumnsFromScope(mb.outScope)
 
 		ord := 0
 		for i, n := 0, mb.tab.DeletableIndexCount(); i < n; i++ {
@@ -763,18 +778,17 @@ func (mb *mutationBuilder) addPartialIndexCols(aliasPrefix string, colIDs opt.Co
 				panic(err)
 			}
 
-			alias := fmt.Sprintf("%s%d", aliasPrefix, ord+1)
-			texpr := mb.outScope.resolveAndRequireType(expr, types.Bool)
-			scopeCol := mb.b.addColumn(projectionsScope, alias, texpr)
+			texpr := predScope.resolveAndRequireType(expr, types.Bool)
+			scopeCol := mb.b.addColumn(projectionScope, "", texpr)
 
-			mb.b.buildScalar(texpr, mb.outScope, projectionsScope, scopeCol, nil)
+			mb.b.buildScalar(texpr, predScope, projectionScope, scopeCol, nil)
 			colIDs[ord] = scopeCol.id
 
 			ord++
 		}
 
-		mb.b.constructProjectForScope(mb.outScope, projectionsScope)
-		mb.outScope = projectionsScope
+		mb.b.constructProjectForScope(mb.outScope, projectionScope)
+		mb.outScope = projectionScope
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -461,9 +461,9 @@ DELETE FROM partial_indexes
 delete partial_indexes
  ├── columns: <none>
  ├── fetch columns: a:5 b:6 c:7
- ├── partial index del columns: partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12
+ ├── partial index del columns: column9:9 column10:10 column11:11 column12:12
  └── project
-      ├── columns: partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
+      ├── columns: column9:9 column10:10 column11:11 column12:12 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
       ├── scan partial_indexes
       │    ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
       │    └── partial index predicates
@@ -473,7 +473,7 @@ delete partial_indexes
       │              ├── a:5 > b:6
       │              └── c:7 = 'bar'
       └── projections
-           ├── c:7 = 'foo' [as=partial_index_del1:9]
-           ├── (a:5 > b:6) AND (c:7 = 'bar') [as=partial_index_del2:10]
-           ├── c:7 = 'delete-only' [as=partial_index_del3:11]
-           └── c:7 = 'write-only' [as=partial_index_del4:12]
+           ├── c:7 = 'foo' [as=column9:9]
+           ├── (a:5 > b:6) AND (c:7 = 'bar') [as=column10:10]
+           ├── c:7 = 'delete-only' [as=column11:11]
+           └── c:7 = 'write-only' [as=column12:12]

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1260,14 +1260,14 @@ insert partial_indexes
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
  │    └── column3:7 => c:3
- ├── partial index put columns: partial_index_put1:8 partial_index_put2:9 partial_index_put3:10 partial_index_put4:11
+ ├── partial index put columns: column8:8 column9:9 column10:10 column11:11
  └── project
-      ├── columns: partial_index_put1:8!null partial_index_put2:9!null partial_index_put3:10!null partial_index_put4:11!null column1:5!null column2:6!null column3:7!null
+      ├── columns: column8:8!null column9:9!null column10:10!null column11:11!null column1:5!null column2:6!null column3:7!null
       ├── values
       │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    └── (2, 1, 'bar')
       └── projections
-           ├── column3:7 = 'foo' [as=partial_index_put1:8]
-           ├── (column1:5 > column2:6) AND (column3:7 = 'bar') [as=partial_index_put2:9]
-           ├── column3:7 = 'delete-only' [as=partial_index_put3:10]
-           └── column3:7 = 'write-only' [as=partial_index_put4:11]
+           ├── column3:7 = 'foo' [as=column8:8]
+           ├── (column1:5 > column2:6) AND (column3:7 = 'bar') [as=column9:9]
+           ├── column3:7 = 'delete-only' [as=column10:10]
+           └── column3:7 = 'write-only' [as=column11:11]

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1686,14 +1686,14 @@ update partial_indexes
  ├── fetch columns: a:5 b:6 c:7
  ├── update-mapping:
  │    └── a_new:13 => a:1
- ├── partial index put columns: partial_index_del1:9 partial_index_put2:14 partial_index_del3:11 partial_index_del4:12
- ├── partial index del columns: partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12
+ ├── partial index put columns: column9:9 column14:14 column11:11 column12:12
+ ├── partial index del columns: column9:9 column10:10 column11:11 column12:12
  └── project
-      ├── columns: partial_index_put2:14 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12 a_new:13!null
+      ├── columns: column14:14 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column9:9 column10:10 column11:11 column12:12 a_new:13!null
       ├── project
-      │    ├── columns: a_new:13!null a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12
+      │    ├── columns: a_new:13!null a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column9:9 column10:10 column11:11 column12:12
       │    ├── project
-      │    │    ├── columns: partial_index_del1:9 partial_index_del2:10 partial_index_del3:11 partial_index_del4:12 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
+      │    │    ├── columns: column9:9 column10:10 column11:11 column12:12 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
       │    │    ├── scan partial_indexes
       │    │    │    ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
       │    │    │    └── partial index predicates
@@ -1703,11 +1703,45 @@ update partial_indexes
       │    │    │              ├── a:5 > b:6
       │    │    │              └── c:7 = 'bar'
       │    │    └── projections
-      │    │         ├── c:7 = 'foo' [as=partial_index_del1:9]
-      │    │         ├── (a:5 > b:6) AND (c:7 = 'bar') [as=partial_index_del2:10]
-      │    │         ├── c:7 = 'delete-only' [as=partial_index_del3:11]
-      │    │         └── c:7 = 'write-only' [as=partial_index_del4:12]
+      │    │         ├── c:7 = 'foo' [as=column9:9]
+      │    │         ├── (a:5 > b:6) AND (c:7 = 'bar') [as=column10:10]
+      │    │         ├── c:7 = 'delete-only' [as=column11:11]
+      │    │         └── c:7 = 'write-only' [as=column12:12]
       │    └── projections
       │         └── 1 [as=a_new:13]
       └── projections
-           └── (a_new:13 > b:6) AND (c:7 = 'bar') [as=partial_index_put2:14]
+           └── (a_new:13 > b:6) AND (c:7 = 'bar') [as=column14:14]
+
+build
+UPDATE partial_indexes SET a = a + 5 RETURNING *
+----
+update partial_indexes
+ ├── columns: a:1!null b:2 c:3
+ ├── fetch columns: a:5 b:6 c:7
+ ├── update-mapping:
+ │    └── a_new:13 => a:1
+ ├── partial index put columns: column9:9 column14:14 column11:11 column12:12
+ ├── partial index del columns: column9:9 column10:10 column11:11 column12:12
+ └── project
+      ├── columns: column14:14 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column9:9 column10:10 column11:11 column12:12 a_new:13!null
+      ├── project
+      │    ├── columns: a_new:13!null a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column9:9 column10:10 column11:11 column12:12
+      │    ├── project
+      │    │    ├── columns: column9:9 column10:10 column11:11 column12:12 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
+      │    │    ├── scan partial_indexes
+      │    │    │    ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
+      │    │    │    └── partial index predicates
+      │    │    │         ├── secondary: filters
+      │    │    │         │    └── c:7 = 'foo'
+      │    │    │         └── secondary: filters
+      │    │    │              ├── a:5 > b:6
+      │    │    │              └── c:7 = 'bar'
+      │    │    └── projections
+      │    │         ├── c:7 = 'foo' [as=column9:9]
+      │    │         ├── (a:5 > b:6) AND (c:7 = 'bar') [as=column10:10]
+      │    │         ├── c:7 = 'delete-only' [as=column11:11]
+      │    │         └── c:7 = 'write-only' [as=column12:12]
+      │    └── projections
+      │         └── a:5 + 5 [as=a_new:13]
+      └── projections
+           └── (a_new:13 > b:6) AND (c:7 = 'bar') [as=column14:14]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1869,3 +1869,223 @@ upsert decimals
       └── projections
            ├── round(upsert_a:23) = upsert_a:23 [as=check1:27]
            └── upsert_b:24[0] > 1 [as=check2:28]
+
+# ------------------------------------------------------------------------------
+# Test partial index column values.
+# ------------------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE partial_indexes (
+    a INT PRIMARY KEY,
+    b INT,
+    c STRING,
+    UNIQUE (b, c),
+    INDEX (b),
+    INDEX (b) WHERE c = 'foo',
+    INDEX (c) WHERE a > b AND c = 'bar',
+    INDEX "b:delete-only" (b) WHERE c = 'delete-only',
+    INDEX "b:write-only" (b) WHERE c = 'write-only'
+)
+----
+
+build
+INSERT INTO partial_indexes VALUES (2, 1, 'bar') ON CONFLICT DO NOTHING
+----
+insert partial_indexes
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column2:6 => b:2
+ │    └── column3:7 => c:3
+ ├── partial index put columns: column16:16 column17:17 column18:18 column19:19
+ └── project
+      ├── columns: column16:16!null column17:17!null column18:18!null column19:19!null column1:5!null column2:6!null column3:7!null
+      ├── upsert-distinct-on
+      │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    ├── grouping columns: column2:6!null column3:7!null
+      │    ├── project
+      │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    └── select
+      │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14 crdb_internal_mvcc_timestamp:15
+      │    │         ├── left-join (hash)
+      │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14 crdb_internal_mvcc_timestamp:15
+      │    │         │    ├── upsert-distinct-on
+      │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │         │    │    ├── grouping columns: column1:5!null
+      │    │         │    │    ├── project
+      │    │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │         │    │    │    └── select
+      │    │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │         │    │    │         ├── left-join (hash)
+      │    │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │         │    │    │         │    ├── values
+      │    │         │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │         │    │    │         │    │    └── (2, 1, 'bar')
+      │    │         │    │    │         │    ├── scan partial_indexes
+      │    │         │    │    │         │    │    ├── columns: a:8!null b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │         │    │    │         │    │    └── partial index predicates
+      │    │         │    │    │         │    │         ├── secondary: filters
+      │    │         │    │    │         │    │         │    └── c:10 = 'foo'
+      │    │         │    │    │         │    │         └── secondary: filters
+      │    │         │    │    │         │    │              ├── a:8 > b:9
+      │    │         │    │    │         │    │              └── c:10 = 'bar'
+      │    │         │    │    │         │    └── filters
+      │    │         │    │    │         │         └── column1:5 = a:8
+      │    │         │    │    │         └── filters
+      │    │         │    │    │              └── a:8 IS NULL
+      │    │         │    │    └── aggregations
+      │    │         │    │         ├── first-agg [as=column2:6]
+      │    │         │    │         │    └── column2:6
+      │    │         │    │         └── first-agg [as=column3:7]
+      │    │         │    │              └── column3:7
+      │    │         │    ├── scan partial_indexes
+      │    │         │    │    ├── columns: a:12!null b:13 c:14 crdb_internal_mvcc_timestamp:15
+      │    │         │    │    └── partial index predicates
+      │    │         │    │         ├── secondary: filters
+      │    │         │    │         │    └── c:14 = 'foo'
+      │    │         │    │         └── secondary: filters
+      │    │         │    │              ├── a:12 > b:13
+      │    │         │    │              └── c:14 = 'bar'
+      │    │         │    └── filters
+      │    │         │         ├── column2:6 = b:13
+      │    │         │         └── column3:7 = c:14
+      │    │         └── filters
+      │    │              └── a:12 IS NULL
+      │    └── aggregations
+      │         └── first-agg [as=column1:5]
+      │              └── column1:5
+      └── projections
+           ├── column3:7 = 'foo' [as=column16:16]
+           ├── (column1:5 > column2:6) AND (column3:7 = 'bar') [as=column17:17]
+           ├── column3:7 = 'delete-only' [as=column18:18]
+           └── column3:7 = 'write-only' [as=column19:19]
+
+build
+INSERT INTO partial_indexes VALUES (2, 1, 'bar') ON CONFLICT (b, c) DO UPDATE SET b = partial_indexes.b + 1, c = 'baz'
+----
+upsert partial_indexes
+ ├── columns: <none>
+ ├── canary column: 8
+ ├── fetch columns: a:8 b:9 c:10
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column2:6 => b:2
+ │    └── column3:7 => c:3
+ ├── update-mapping:
+ │    ├── upsert_b:19 => b:2
+ │    └── upsert_c:20 => c:3
+ ├── partial index put columns: column21:21 column22:22 column23:23 column24:24
+ ├── partial index del columns: column12:12 column13:13 column14:14 column15:15
+ └── project
+      ├── columns: column21:21!null column22:22 column23:23!null column24:24!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 column12:12 column13:13 column14:14 column15:15 b_new:16 c_new:17!null upsert_a:18 upsert_b:19 upsert_c:20!null
+      ├── project
+      │    ├── columns: upsert_a:18 upsert_b:19 upsert_c:20!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 column12:12 column13:13 column14:14 column15:15 b_new:16 c_new:17!null
+      │    ├── project
+      │    │    ├── columns: b_new:16 c_new:17!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 column12:12 column13:13 column14:14 column15:15
+      │    │    ├── project
+      │    │    │    ├── columns: column12:12 column13:13 column14:14 column15:15 column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │    │    ├── left-join (hash)
+      │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │    │    │    ├── grouping columns: column2:6!null column3:7!null
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │    │    │    │    └── (2, 1, 'bar')
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         └── first-agg [as=column1:5]
+      │    │    │    │    │              └── column1:5
+      │    │    │    │    ├── scan partial_indexes
+      │    │    │    │    │    ├── columns: a:8!null b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │    │    │    │    └── partial index predicates
+      │    │    │    │    │         ├── secondary: filters
+      │    │    │    │    │         │    └── c:10 = 'foo'
+      │    │    │    │    │         └── secondary: filters
+      │    │    │    │    │              ├── a:8 > b:9
+      │    │    │    │    │              └── c:10 = 'bar'
+      │    │    │    │    └── filters
+      │    │    │    │         ├── column2:6 = b:9
+      │    │    │    │         └── column3:7 = c:10
+      │    │    │    └── projections
+      │    │    │         ├── c:10 = 'foo' [as=column12:12]
+      │    │    │         ├── (a:8 > b:9) AND (c:10 = 'bar') [as=column13:13]
+      │    │    │         ├── c:10 = 'delete-only' [as=column14:14]
+      │    │    │         └── c:10 = 'write-only' [as=column15:15]
+      │    │    └── projections
+      │    │         ├── b:9 + 1 [as=b_new:16]
+      │    │         └── 'baz' [as=c_new:17]
+      │    └── projections
+      │         ├── CASE WHEN a:8 IS NULL THEN column1:5 ELSE a:8 END [as=upsert_a:18]
+      │         ├── CASE WHEN a:8 IS NULL THEN column2:6 ELSE b_new:16 END [as=upsert_b:19]
+      │         └── CASE WHEN a:8 IS NULL THEN column3:7 ELSE c_new:17 END [as=upsert_c:20]
+      └── projections
+           ├── upsert_c:20 = 'foo' [as=column21:21]
+           ├── (upsert_a:18 > upsert_b:19) AND (upsert_c:20 = 'bar') [as=column22:22]
+           ├── upsert_c:20 = 'delete-only' [as=column23:23]
+           └── upsert_c:20 = 'write-only' [as=column24:24]
+
+build
+UPSERT INTO partial_indexes VALUES (2, 1, 'bar')
+----
+upsert partial_indexes
+ ├── columns: <none>
+ ├── canary column: 8
+ ├── fetch columns: a:8 b:9 c:10
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column2:6 => b:2
+ │    └── column3:7 => c:3
+ ├── update-mapping:
+ │    ├── column2:6 => b:2
+ │    └── column3:7 => c:3
+ ├── partial index put columns: column17:17 column18:18 column19:19 column20:20
+ ├── partial index del columns: column12:12 column13:13 column14:14 column15:15
+ └── project
+      ├── columns: column17:17!null column18:18 column19:19!null column20:20!null column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 column12:12 column13:13 column14:14 column15:15 upsert_a:16
+      ├── project
+      │    ├── columns: upsert_a:16 column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 column12:12 column13:13 column14:14 column15:15
+      │    ├── project
+      │    │    ├── columns: column12:12 column13:13 column14:14 column15:15 column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │    │    ├── grouping columns: column1:5!null
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    │    │    │    └── (2, 1, 'bar')
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=column2:6]
+      │    │    │    │         │    └── column2:6
+      │    │    │    │         └── first-agg [as=column3:7]
+      │    │    │    │              └── column3:7
+      │    │    │    ├── scan partial_indexes
+      │    │    │    │    ├── columns: a:8!null b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │    │    │    └── partial index predicates
+      │    │    │    │         ├── secondary: filters
+      │    │    │    │         │    └── c:10 = 'foo'
+      │    │    │    │         └── secondary: filters
+      │    │    │    │              ├── a:8 > b:9
+      │    │    │    │              └── c:10 = 'bar'
+      │    │    │    └── filters
+      │    │    │         └── column1:5 = a:8
+      │    │    └── projections
+      │    │         ├── c:10 = 'foo' [as=column12:12]
+      │    │         ├── (a:8 > b:9) AND (c:10 = 'bar') [as=column13:13]
+      │    │         ├── c:10 = 'delete-only' [as=column14:14]
+      │    │         └── c:10 = 'write-only' [as=column15:15]
+      │    └── projections
+      │         └── CASE WHEN a:8 IS NULL THEN column1:5 ELSE a:8 END [as=upsert_a:16]
+      └── projections
+           ├── column3:7 = 'foo' [as=column17:17]
+           ├── (upsert_a:16 > column2:6) AND (column3:7 = 'bar') [as=column18:18]
+           ├── column3:7 = 'delete-only' [as=column19:19]
+           └── column3:7 = 'write-only' [as=column20:20]
+
+# Columns referenced in the SET expression are ambiguous without a table name.
+# Is it the value of the column being inserted or the value of the column
+# currently in the table?
+build
+INSERT INTO partial_indexes (a, b, c) VALUES (1, 1, 'foo') ON CONFLICT (a) DO UPDATE SET b = b + 1
+----
+error (42702): column reference "b" is ambiguous (candidates: excluded.b, partial_indexes.b)

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -118,7 +117,7 @@ func (ri *Inserter) InsertRow(
 	ctx context.Context,
 	b putter,
 	values []tree.Datum,
-	ignoreIndexes util.FastIntSet,
+	pm PartialIndexUpdateHelper,
 	overwrite bool,
 	traceKV bool,
 ) error {
@@ -155,7 +154,7 @@ func (ri *Inserter) InsertRow(
 	// We don't want to insert empty k/v's like this, so we
 	// set includeEmpty to false.
 	primaryIndexKey, secondaryIndexEntries, err := ri.Helper.encodeIndexes(
-		ri.InsertColIDtoRowIndex, values, ignoreIndexes, false /* includeEmpty */)
+		ri.InsertColIDtoRowIndex, values, pm.IgnoreForPut, false /* includeEmpty */)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/row/partial_index.go
+++ b/pkg/sql/row/partial_index.go
@@ -1,0 +1,89 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package row
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// PartialIndexUpdateHelper keeps track of partial indexes that should be not
+// be updated during a mutation. When a newly inserted or updated row does not
+// satisfy a partial index predicate, it should not be added to the index.
+// Likewise, deleting a row from a partial index should not be attempted during
+// an update or a delete when the row did not already exist in the partial
+// index.
+type PartialIndexUpdateHelper struct {
+	// IgnoreForPut is a set of index IDs to ignore for Put operations.
+	IgnoreForPut util.FastIntSet
+
+	// IgnoreForDel is a set of index IDs to ignore for Del operations.
+	IgnoreForDel util.FastIntSet
+}
+
+// Init initializes a PartialIndexUpdateHelper to track partial index IDs that
+// should be ignored for Put and Del operations. The partialIndexPutVals and
+// partialIndexDelVals arguments must be lists of boolean expressions where the
+// i-th element corresponds to the i-th partial index defined on the table. If
+// the expression evaluates to false, the index should be ignored.
+//
+// For example, partialIndexPutVals[2] evaluating to true indicates that the
+// second partial index of the table should not be ignored for Put operations.
+// Meanwhile, partialIndexPutVals[3] evaluating to false indicates that the
+// third partial index should be ignored.
+func (pm *PartialIndexUpdateHelper) Init(
+	partialIndexPutVals tree.Datums,
+	partialIndexDelVals tree.Datums,
+	tabDesc *sqlbase.ImmutableTableDescriptor,
+) error {
+	colIdx := 0
+	partialIndexOrds := tabDesc.PartialIndexOrds()
+	indexes := tabDesc.Indexes
+
+	for i, ok := partialIndexOrds.Next(0); ok; i, ok = partialIndexOrds.Next(i + 1) {
+		index := &indexes[i]
+		if index.IsPartial() {
+
+			// Check the boolean partial index put column, if it exists.
+			if colIdx < len(partialIndexPutVals) {
+				val, err := tree.GetBool(partialIndexPutVals[colIdx])
+				if err != nil {
+					return err
+				}
+				if !val {
+					// If the value of the column for the index predicate
+					// expression is false, the row should not be added to the
+					// partial index.
+					pm.IgnoreForPut.Add(int(index.ID))
+				}
+			}
+
+			// Check the boolean partial index del column, if it exists.
+			if colIdx < len(partialIndexDelVals) {
+				val, err := tree.GetBool(partialIndexDelVals[colIdx])
+				if err != nil {
+					return err
+				}
+				if !val {
+					// If the value of the column for the index predicate
+					// expression is false, the row should not be removed from
+					// the partial index.
+					pm.IgnoreForDel.Add(int(index.ID))
+				}
+			}
+
+			colIdx++
+		}
+	}
+
+	return nil
+}

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
@@ -513,7 +512,7 @@ func (c *DatumRowConverter) Row(ctx context.Context, sourceID int32, rowIndex in
 	}
 	// TODO(mgartner): Add partial index IDs to ignoreIndexes that we should
 	// not delete entries from.
-	var ignoreIndexes util.FastIntSet
+	var pm PartialIndexUpdateHelper
 	if err := c.ri.InsertRow(
 		ctx,
 		KVInserter(func(kv roachpb.KeyValue) {
@@ -521,7 +520,7 @@ func (c *DatumRowConverter) Row(ctx context.Context, sourceID int32, rowIndex in
 			c.KvBatch.KVs = append(c.KvBatch.KVs, kv)
 		}),
 		insertRow,
-		ignoreIndexes,
+		pm,
 		true,  /* ignoreConflicts */
 		false, /* traceKV */
 	); err != nil {

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -266,8 +266,7 @@ func (ru *Updater) UpdateRow(
 	batch *kv.Batch,
 	oldValues []tree.Datum,
 	updateValues []tree.Datum,
-	ignoreIndexesForPut util.FastIntSet,
-	ignoreIndexesForDel util.FastIntSet,
+	pm PartialIndexUpdateHelper,
 	traceKV bool,
 ) ([]tree.Datum, error) {
 	if len(oldValues) != len(ru.FetchCols) {
@@ -347,7 +346,7 @@ func (ru *Updater) UpdateRow(
 		// exists in ignoreIndexesForDel and ignoreIndexesForPut, respectively.
 		// Index IDs in these sets indicate that old and new values for the row
 		// do not satisfy a partial index's predicate expression.
-		if !ignoreIndexesForDel.Contains(int(index.ID)) {
+		if !pm.IgnoreForDel.Contains(int(index.ID)) {
 			ru.oldIndexEntries[i], err = sqlbase.EncodeSecondaryIndex(
 				ru.Helper.Codec,
 				ru.Helper.TableDesc.TableDesc(),
@@ -360,7 +359,7 @@ func (ru *Updater) UpdateRow(
 				return nil, err
 			}
 		}
-		if !ignoreIndexesForPut.Contains(int(index.ID)) {
+		if !pm.IgnoreForPut.Contains(int(index.ID)) {
 			ru.newIndexEntries[i], err = sqlbase.EncodeSecondaryIndex(
 				ru.Helper.Codec,
 				ru.Helper.TableDesc.TableDesc(),
@@ -410,11 +409,11 @@ func (ru *Updater) UpdateRow(
 	}
 
 	if rowPrimaryKeyChanged {
-		if err := ru.rd.DeleteRow(ctx, batch, oldValues, ignoreIndexesForDel, traceKV); err != nil {
+		if err := ru.rd.DeleteRow(ctx, batch, oldValues, pm, traceKV); err != nil {
 			return nil, err
 		}
 		if err := ru.ri.InsertRow(
-			ctx, batch, ru.newValues, ignoreIndexesForPut, false /* ignoreConflicts */, traceKV,
+			ctx, batch, ru.newValues, pm, false /* ignoreConflicts */, traceKV,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -53,16 +52,16 @@ type tableWriter interface {
 	//
 	// The passed Datums is not used after `row` returns.
 	//
-	// The ignoreIndexes parameter is a set of IndexIDs to avoid updating when
-	// performing the row modification. It is necessary to avoid writing to
-	// partial indexes when rows do not satisfy the partial index predicate.
+	// The PartialIndexUpdateHelper is used to determine which partial indexes
+	// to avoid updating when performing row modification. This is necessary
+	// because not all rows are indexed by partial indexes.
 	//
 	// The traceKV parameter determines whether the individual K/V operations
 	// should be logged to the context. We use a separate argument here instead
 	// of a Value field on the context because Value access in context.Context
 	// is rather expensive and the tableWriter interface is used on the
 	// inner loop of table accesses.
-	row(context.Context, tree.Datums, util.FastIntSet /* ignoreIndexes */, bool /* traceKV */) error
+	row(context.Context, tree.Datums, row.PartialIndexUpdateHelper, bool /* traceKV */) error
 
 	// finalize flushes out any remaining writes. It is called after all calls to
 	// row.  It returns a slice of all Datums not yet returned by calls to `row`.

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // tableInserter handles writing kvs and forming table rows for inserts.
@@ -40,10 +39,10 @@ func (ti *tableInserter) init(_ context.Context, txn *kv.Txn, _ *tree.EvalContex
 
 // row is part of the tableWriter interface.
 func (ti *tableInserter) row(
-	ctx context.Context, values tree.Datums, ignoreIndexes util.FastIntSet, traceKV bool,
+	ctx context.Context, values tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,
 ) error {
 	ti.batchSize++
-	return ti.ri.InsertRow(ctx, ti.b, values, ignoreIndexes, false /* overwrite */, traceKV)
+	return ti.ri.InsertRow(ctx, ti.b, values, pm, false /* overwrite */, traceKV)
 }
 
 // atBatchEnd is part of the tableWriter interface.

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // tableUpdater handles writing kvs and forming table rows for updates.
@@ -42,7 +41,9 @@ func (tu *tableUpdater) init(_ context.Context, txn *kv.Txn, _ *tree.EvalContext
 // We don't implement this because tu.ru.UpdateRow wants two slices
 // and it would be a shame to split the incoming slice on every call.
 // Instead provide a separate rowForUpdate() below.
-func (tu *tableUpdater) row(context.Context, tree.Datums, util.FastIntSet, bool) error {
+func (tu *tableUpdater) row(
+	context.Context, tree.Datums, row.PartialIndexUpdateHelper, bool,
+) error {
 	panic("unimplemented")
 }
 
@@ -50,12 +51,11 @@ func (tu *tableUpdater) row(context.Context, tree.Datums, util.FastIntSet, bool)
 func (tu *tableUpdater) rowForUpdate(
 	ctx context.Context,
 	oldValues, updateValues tree.Datums,
-	ignoreIndexesForPut util.FastIntSet,
-	ignoreIndexesForDel util.FastIntSet,
+	pm row.PartialIndexUpdateHelper,
 	traceKV bool,
 ) (tree.Datums, error) {
 	tu.batchSize++
-	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, ignoreIndexesForPut, ignoreIndexesForDel, traceKV)
+	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, pm, traceKV)
 }
 
 // atBatchEnd is part of the tableWriter interface.

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // optTableUpserter implements the upsert operation when it is planned by the
@@ -205,10 +204,8 @@ func (tu *optTableUpserter) makeResultFromRow(
 func (*optTableUpserter) desc() string { return "opt upserter" }
 
 // row is part of the tableWriter interface.
-// TODO(mgartner): Use ignoreIndexes to avoid writing to partial indexes when
-// the row does not match the partial index predicate.
 func (tu *optTableUpserter) row(
-	ctx context.Context, row tree.Datums, ignoreIndexes util.FastIntSet, traceKV bool,
+	ctx context.Context, row tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,
 ) error {
 	tu.batchSize++
 	tu.resultCount++
@@ -220,11 +217,11 @@ func (tu *optTableUpserter) row(
 	if tu.canaryOrdinal == -1 {
 		// No canary column means that existing row should be overwritten (i.e.
 		// the insert and update columns are the same, so no need to choose).
-		return tu.insertNonConflictingRow(ctx, tu.b, row[:insertEnd], true /* overwrite */, traceKV)
+		return tu.insertNonConflictingRow(ctx, tu.b, row[:insertEnd], pm, true /* overwrite */, traceKV)
 	}
 	if row[tu.canaryOrdinal] == tree.DNull {
 		// No conflict, so insert a new row.
-		return tu.insertNonConflictingRow(ctx, tu.b, row[:insertEnd], false /* overwrite */, traceKV)
+		return tu.insertNonConflictingRow(ctx, tu.b, row[:insertEnd], pm, false /* overwrite */, traceKV)
 	}
 
 	// If no columns need to be updated, then possibly collect the unchanged row.
@@ -244,6 +241,7 @@ func (tu *optTableUpserter) row(
 		tu.b,
 		row[insertEnd:fetchEnd],
 		row[fetchEnd:updateEnd],
+		pm,
 		tu.tableDesc(),
 		traceKV,
 	)
@@ -259,13 +257,14 @@ func (tu *optTableUpserter) atBatchEnd(ctx context.Context, traceKV bool) error 
 // there was no conflict. If the RETURNING clause was specified, then the
 // inserted row is stored in the rowsUpserted collection.
 func (tu *optTableUpserter) insertNonConflictingRow(
-	ctx context.Context, b *kv.Batch, insertRow tree.Datums, overwrite, traceKV bool,
+	ctx context.Context,
+	b *kv.Batch,
+	insertRow tree.Datums,
+	pm row.PartialIndexUpdateHelper,
+	overwrite, traceKV bool,
 ) error {
 	// Perform the insert proper.
-	// TODO(mgartner): Pass ignoreIndexes to InsertRow and do not write index
-	// entries for indexes in the set.
-	var ignoreIndexes util.FastIntSet
-	if err := tu.ri.InsertRow(ctx, b, insertRow, ignoreIndexes, overwrite, traceKV); err != nil {
+	if err := tu.ri.InsertRow(ctx, b, insertRow, pm, overwrite, traceKV); err != nil {
 		return err
 	}
 
@@ -310,6 +309,7 @@ func (tu *optTableUpserter) updateConflictingRow(
 	b *kv.Batch,
 	fetchRow tree.Datums,
 	updateValues tree.Datums,
+	pm row.PartialIndexUpdateHelper,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	traceKV bool,
 ) error {
@@ -327,10 +327,7 @@ func (tu *optTableUpserter) updateConflictingRow(
 	// Queue the update in KV. This also returns an "update row"
 	// containing the updated values for every column in the
 	// table. This is useful for RETURNING, which we collect below.
-	// TODO(mgartner): Add partial index IDs to ignoreIndexes that we should
-	// not add entries to or delete entries from.
-	var ignoreIndexes util.FastIntSet
-	_, err := tu.ru.UpdateRow(ctx, b, fetchRow, updateValues, ignoreIndexes, ignoreIndexes, traceKV)
+	_, err := tu.ru.UpdateRow(ctx, b, fetchRow, updateValues, pm, traceKV)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -14,9 +14,9 @@ import (
 	"context"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -153,6 +153,28 @@ func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) err
 		return err
 	}
 
+	// Create a set of partial index IDs to not add or remove entries from.
+	var pm row.PartialIndexUpdateHelper
+	partialIndexOrds := n.run.tw.tableDesc().PartialIndexOrds()
+	if !partialIndexOrds.Empty() {
+		partialIndexValOffset := len(n.run.insertCols) + len(n.run.tw.fetchCols) + len(n.run.tw.updateCols) + n.run.checkOrds.Len()
+		if n.run.tw.canaryOrdinal != -1 {
+			partialIndexValOffset++
+		}
+		partialIndexVals := rowVals[partialIndexValOffset:]
+		partialIndexPutVals := partialIndexVals[:len(partialIndexVals)/2]
+		partialIndexDelVals := partialIndexVals[len(partialIndexVals)/2:]
+
+		err := pm.Init(partialIndexPutVals, partialIndexDelVals, n.run.tw.tableDesc())
+		if err != nil {
+			return err
+		}
+
+		// Truncate rowVals so that it no longer includes partial index predicate
+		// values.
+		rowVals = rowVals[:partialIndexValOffset]
+	}
+
 	// Verify the CHECK constraints by inspecting boolean columns from the input that
 	// contain the results of evaluation.
 	if !n.run.checkOrds.Empty() {
@@ -169,10 +191,7 @@ func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) err
 
 	// Process the row. This is also where the tableWriter will accumulate
 	// the row for later.
-	// TODO(mgartner): Add partial index IDs to ignoreIndexes that we should
-	// not write entries to.
-	var ignoreIndexes util.FastIntSet
-	return n.run.tw.row(params.ctx, rowVals, ignoreIndexes, n.run.traceKV)
+	return n.run.tw.row(params.ctx, rowVals, pm, n.run.traceKV)
 }
 
 // BatchedCount implements the batchedPlanNode interface.


### PR DESCRIPTION
This commit allows partial indexes to maintain a consistent state when
`UPSERT` statements are issued on the table. There were some structural
changes made in order to better facilitate this functionality.

First, `optbuilder` now keeps track of the column IDs of synthesized
partial index predicate columns rather than ordinals. This simplifies
the complex scoping logic needed for `UPSERT`s.

Second, this commit introduces the PartialIndexUpdateManager which
helps track which partial indexes need to be updated for a given row.
Instead of passing around two `util.FastIntSet`s, this single struct is
now used. It also de-duplicates code for interpretting the synthesized
partial index predicate columns.

Fixes #50222

Release note: None
