### PR TITLE
sql: add validation for sequence related descriptor fields

### DIFF
--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -55,6 +56,10 @@ func (n *alterSequenceNode) startExec(params runParams) error {
 
 	err := assignSequenceOptions(desc.SequenceOpts, n.n.Options, false /* setDefaults */, &params, desc.GetID())
 	if err != nil {
+		return err
+	}
+
+	if err := desc.Validate(params.ctx, params.p.txn, keys.SystemSQLCodec); err != nil {
 		return err
 	}
 

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -225,5 +225,5 @@ func MakeSequenceTableDesc(
 	// immediately.
 	desc.State = sqlbase.TableDescriptor_PUBLIC
 
-	return desc, desc.ValidateTable()
+	return desc, desc.Validate(params.ctx, params.p.txn, keys.SystemSQLCodec)
 }

--- a/pkg/sql/sqlbase/validate_test.go
+++ b/pkg/sql/sqlbase/validate_test.go
@@ -29,7 +29,7 @@ const (
 	// must add a justification for this in the map.
 	todoIAmKnowinglyAddingTechDebt
 	// iSolemnlySwearThisFieldIsValidated means that a field was added to a
-	//validate method.
+	// validate method.
 	iSolemnlySwearThisFieldIsValidated
 )
 
@@ -94,9 +94,8 @@ var validationMap = []struct {
 				status: todoIAmKnowinglyAddingTechDebt,
 				reason: "initial import: TODO(features): add validation"},
 			"MutationJobs": {status: thisFieldReferencesNoObjects},
-			"SequenceOpts": {status: todoIAmKnowinglyAddingTechDebt,
-				reason: "initial import: TODO(features): add validation"},
-			"DropTime": {status: thisFieldReferencesNoObjects},
+			"SequenceOpts": {status: iSolemnlySwearThisFieldIsValidated},
+			"DropTime":     {status: thisFieldReferencesNoObjects},
 			"ReplacementOf": {status: todoIAmKnowinglyAddingTechDebt,
 				reason: "initial import: TODO(bulkio): add validation"},
 			"AuditMode": {status: thisFieldReferencesNoObjects},
@@ -160,13 +159,9 @@ var validationMap = []struct {
 			"DefaultExpr": {
 				status: todoIAmKnowinglyAddingTechDebt,
 				reason: "initial import: TODO(features): add validation"},
-			"Hidden": {status: thisFieldReferencesNoObjects},
-			"UsesSequenceIds": {
-				status: todoIAmKnowinglyAddingTechDebt,
-				reason: "initial import: TODO(features): add validation"},
-			"OwnsSequenceIds": {
-				status: todoIAmKnowinglyAddingTechDebt,
-				reason: "initial import: TODO(features): add validation"},
+			"Hidden":          {status: thisFieldReferencesNoObjects},
+			"UsesSequenceIds": {status: iSolemnlySwearThisFieldIsValidated},
+			"OwnsSequenceIds": {status: iSolemnlySwearThisFieldIsValidated},
 			"ComputeExpr": {
 				status: todoIAmKnowinglyAddingTechDebt,
 				reason: "initial import: TODO(features): add validation"},


### PR DESCRIPTION
Previously no such validation existed. This patch adds validation
by:
- Ensuring if a sequence has an owner, then the owner is a valid table
descriptor that refers to an actual table (i.e not a view/sequence/db)
- Ensuring IDs in every column descriptor's `OwnsSequenceIDs` field
refer to a valid sequence descriptor.
- Ensuring IDs in every column descriptor's `UsesSequenceIDs` field
refer to a valid sequence descriptor.

Informs #50854

Release note: None