### PR TITLE
vendor: Bump pebble to 073e15ee2ccf4fb37b42aac0e1b366bdff0c92b2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200713154309-36c1b9c7a833
+	github.com/cockroachdb/pebble v0.0.0-20200716211707-073e15ee2ccf
 	github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200713154309-36c1b9c7a833 h1:JHkdOh1KafUgHyNoTYHDcv3kE5Gp5C1LbNLSQwm5uYU=
-github.com/cockroachdb/pebble v0.0.0-20200713154309-36c1b9c7a833/go.mod h1:TipC4T/j2WXDHhGHuPue5m00pjk21v7qPMYIVj4Ay+I=
+github.com/cockroachdb/pebble v0.0.0-20200716211707-073e15ee2ccf h1:USQzgQROUOcOtbSGjMuGybOX0oFTzX34qPtOiOGpGyg=
+github.com/cockroachdb/pebble v0.0.0-20200716211707-073e15ee2ccf/go.mod h1:TipC4T/j2WXDHhGHuPue5m00pjk21v7qPMYIVj4Ay+I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd h1:KFOt5I9nEKZgCnOSmy8r4Oykh8BYQO8bFOTgHDS8YZA=


### PR DESCRIPTION
Changes pulled in:
 - 073e15ee2ccf4fb37b42aac0e1b366bdff0c92b2 sstable: Fadvise sequential when max readahead size is reached
 - c5262485cbd825e77062854178f9f47f2ea6593f db: use LevelSlice in compaction picking
 - 48cce3557718732cf8448a3da6a2f661a1a8d868 db: use manifest.LevelIterator in additional places
 - 31066e44abe9881e1a08bcc81795af5e772dbca6 internal/manifest: add LevelMetadata type alias
 - 819d4f9c5e78c43cc7584d15443812d949dbf977 db: use redact.StringWithoutMarkers

Release note: None