### PR TITLE
release-20.1: vendor: Bump pebble to 4b2d866d3e13abc16ee28660b0e4bd00d934c477

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -464,7 +464,7 @@
 
 [[projects]]
   branch = "crl-release-20.1"
-  digest = "1:f02f152cbec6360abf68b83c9972633023bfafc1005ee3bec8ec7de447b1e51b"
+  digest = "1:adc7a8600aeef436e5a518fdd9b9fd41baaa3e0b1dea53c60429ec07142d261d"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -490,7 +490,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "0ad759a48c93537f21ceeeb1a1f97cb816033433"
+  revision = "4b2d866d3e13abc16ee28660b0e4bd00d934c477"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
Changes pulled in:
 - 4b2d866d3e13abc16ee28660b0e4bd00d934c477 sstable: Fadvise sequential when max readahead size is reached
 - 0d1d1abf018f106fd3dacdfb84199ac4f9a10ab9 db: bump nextFileNum past obsolete file numbers on Open
 - 6544a141ca68014bd9599a686a5f76cba803602c db: tighten merging iterator's seek conditions
 - a7cb8d2a6289379a6719778fa15a0e78f6c4ec9f db: fix mergingIter corner case surrounding range tombstones

Release note: None