### PR TITLE
opt: use separate exec.Builder for explain

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -74,85 +74,82 @@ func (b *Builder) buildCreateView(cv *memo.CreateViewExpr) (execPlan, error) {
 	return execPlan{root: root}, err
 }
 
+func (b *Builder) buildExplainOpt(explain *memo.ExplainExpr) (execPlan, error) {
+	fmtFlags := memo.ExprFmtHideAll
+	switch {
+	case explain.Options.Flags[tree.ExplainFlagVerbose]:
+		fmtFlags = memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars |
+			memo.ExprFmtHideTypes | memo.ExprFmtHideNotNull
+
+	case explain.Options.Flags[tree.ExplainFlagTypes]:
+		fmtFlags = memo.ExprFmtHideQualifications
+	}
+
+	// Format the plan here and pass it through to the exec factory.
+
+	// If catalog option was passed, show catalog object details for all tables.
+	var planText bytes.Buffer
+	if explain.Options.Flags[tree.ExplainFlagCatalog] {
+		for _, t := range b.mem.Metadata().AllTables() {
+			tp := treeprinter.New()
+			cat.FormatTable(b.catalog, t.Table, tp)
+			planText.WriteString(tp.String())
+		}
+		// TODO(radu): add views, sequences
+	}
+
+	f := memo.MakeExprFmtCtx(fmtFlags, b.mem, b.catalog)
+	f.FormatExpr(explain.Input)
+	planText.WriteString(f.Buffer.String())
+
+	// If we're going to display the environment, there's a bunch of queries we
+	// need to run to get that information, and we can't run them from here, so
+	// tell the exec factory what information it needs to fetch.
+	var envOpts exec.ExplainEnvData
+	if explain.Options.Flags[tree.ExplainFlagEnv] {
+		envOpts = b.getEnvData()
+	}
+
+	node, err := b.factory.ConstructExplainOpt(planText.String(), envOpts)
+	if err != nil {
+		return execPlan{}, err
+	}
+	return planWithColumns(node, explain.ColList), nil
+}
+
 func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
-	var node exec.Node
-
 	if explain.Options.Mode == tree.ExplainOpt {
-		fmtFlags := memo.ExprFmtHideAll
-		switch {
-		case explain.Options.Flags[tree.ExplainFlagVerbose]:
-			fmtFlags = memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars |
-				memo.ExprFmtHideTypes | memo.ExprFmtHideNotNull
-
-		case explain.Options.Flags[tree.ExplainFlagTypes]:
-			fmtFlags = memo.ExprFmtHideQualifications
-		}
-
-		// Format the plan here and pass it through to the exec factory.
-
-		// If catalog option was passed, show catalog object details for all tables.
-		var planText bytes.Buffer
-		if explain.Options.Flags[tree.ExplainFlagCatalog] {
-			for _, t := range b.mem.Metadata().AllTables() {
-				tp := treeprinter.New()
-				cat.FormatTable(b.catalog, t.Table, tp)
-				planText.WriteString(tp.String())
-			}
-			// TODO(radu): add views, sequences
-		}
-
-		f := memo.MakeExprFmtCtx(fmtFlags, b.mem, b.catalog)
-		f.FormatExpr(explain.Input)
-		planText.WriteString(f.Buffer.String())
-
-		// If we're going to display the environment, there's a bunch of queries we
-		// need to run to get that information, and we can't run them from here, so
-		// tell the exec factory what information it needs to fetch.
-		var envOpts exec.ExplainEnvData
-		if explain.Options.Flags[tree.ExplainFlagEnv] {
-			envOpts = b.getEnvData()
-		}
-
-		var err error
-		node, err = b.factory.ConstructExplainOpt(planText.String(), envOpts)
-		if err != nil {
-			return execPlan{}, err
-		}
-	} else {
-
-		// The auto commit flag should reflect what would happen if this statement
-		// was run without the explain, so recalculate it.
-		defer func(oldVal bool) {
-			b.allowAutoCommit = oldVal
-		}(b.allowAutoCommit)
-		b.allowAutoCommit = b.canAutoCommit(explain.Input)
-
-		input, err := b.buildRelational(explain.Input)
-		if err != nil {
-			return execPlan{}, err
-		}
-
-		plan, err := b.factory.ConstructPlan(input.root, b.subqueries, b.cascades, b.checks)
-		if err != nil {
-			return execPlan{}, err
-		}
-
-		node, err = b.factory.ConstructExplain(&explain.Options, explain.StmtType, plan)
-		if err != nil {
-			return execPlan{}, err
-		}
+		return b.buildExplainOpt(explain)
 	}
 
-	ep := execPlan{root: node}
-	for i, c := range explain.ColList {
-		ep.outputCols.Set(int(c), i)
+	// The auto commit flag should reflect what would happen if this statement
+	// was run without the explain, so recalculate it.
+	defer func(oldVal bool) {
+		b.allowAutoCommit = oldVal
+	}(b.allowAutoCommit)
+	b.allowAutoCommit = b.canAutoCommit(explain.Input)
+
+	input, err := b.buildRelational(explain.Input)
+	if err != nil {
+		return execPlan{}, err
 	}
+
+	plan, err := b.factory.ConstructPlan(input.root, b.subqueries, b.cascades, b.checks)
+	if err != nil {
+		return execPlan{}, err
+	}
+
+	node, err := b.factory.ConstructExplain(&explain.Options, explain.StmtType, plan)
+	if err != nil {
+		return execPlan{}, err
+	}
+
 	// The subqueries/cascades/checks are now owned by the explain node;
 	// remove them so they don't also show up in the final plan.
 	b.subqueries = nil
 	b.cascades = nil
 	b.checks = nil
-	return ep, nil
+	return planWithColumns(node, explain.ColList), nil
 }
 
 func (b *Builder) buildShowTrace(show *memo.ShowTraceForSessionExpr) (execPlan, error) {
@@ -160,11 +157,7 @@ func (b *Builder) buildShowTrace(show *memo.ShowTraceForSessionExpr) (execPlan, 
 	if err != nil {
 		return execPlan{}, err
 	}
-	ep := execPlan{root: node}
-	for i, c := range show.ColList {
-		ep.outputCols.Set(int(c), i)
-	}
-	return ep, nil
+	return planWithColumns(node, show.ColList), nil
 }
 
 func (b *Builder) buildAlterTableSplit(split *memo.AlterTableSplitExpr) (execPlan, error) {
@@ -186,11 +179,7 @@ func (b *Builder) buildAlterTableSplit(split *memo.AlterTableSplitExpr) (execPla
 	if err != nil {
 		return execPlan{}, err
 	}
-	ep := execPlan{root: node}
-	for i, c := range split.Columns {
-		ep.outputCols.Set(int(c), i)
-	}
-	return ep, nil
+	return planWithColumns(node, split.Columns), nil
 }
 
 func (b *Builder) buildAlterTableUnsplit(unsplit *memo.AlterTableUnsplitExpr) (execPlan, error) {
@@ -206,11 +195,7 @@ func (b *Builder) buildAlterTableUnsplit(unsplit *memo.AlterTableUnsplitExpr) (e
 	if err != nil {
 		return execPlan{}, err
 	}
-	ep := execPlan{root: node}
-	for i, c := range unsplit.Columns {
-		ep.outputCols.Set(int(c), i)
-	}
-	return ep, nil
+	return planWithColumns(node, unsplit.Columns), nil
 }
 
 func (b *Builder) buildAlterTableUnsplitAll(
@@ -221,11 +206,7 @@ func (b *Builder) buildAlterTableUnsplitAll(
 	if err != nil {
 		return execPlan{}, err
 	}
-	ep := execPlan{root: node}
-	for i, c := range unsplitAll.Columns {
-		ep.outputCols.Set(int(c), i)
-	}
-	return ep, nil
+	return planWithColumns(node, unsplitAll.Columns), nil
 }
 
 func (b *Builder) buildAlterTableRelocate(relocate *memo.AlterTableRelocateExpr) (execPlan, error) {
@@ -242,11 +223,7 @@ func (b *Builder) buildAlterTableRelocate(relocate *memo.AlterTableRelocateExpr)
 	if err != nil {
 		return execPlan{}, err
 	}
-	ep := execPlan{root: node}
-	for i, c := range relocate.Columns {
-		ep.outputCols.Set(int(c), i)
-	}
-	return ep, nil
+	return planWithColumns(node, relocate.Columns), nil
 }
 
 func (b *Builder) buildControlJobs(ctl *memo.ControlJobsExpr) (execPlan, error) {
@@ -328,9 +305,15 @@ func (b *Builder) buildExport(export *memo.ExportExpr) (execPlan, error) {
 	if err != nil {
 		return execPlan{}, err
 	}
+	return planWithColumns(node, export.Columns), nil
+}
+
+// planWithColumns creates an execPlan for a node which has a fixed output
+// schema.
+func planWithColumns(node exec.Node, cols opt.ColList) execPlan {
 	ep := execPlan{root: node}
-	for i, c := range export.Columns {
+	for i, c := range cols {
 		ep.outputCols.Set(int(c), i)
 	}
-	return ep, nil
+	return ep
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1082,3 +1082,17 @@ group      ·             ·
  └── scan  ·             ·
 ·          table         tc@primary
 ·          spans         FULL SCAN
+
+# Verify that subqueries are handled correctly, namely that we can have
+# subqueries outside of the EXPLAINed query.
+query ITTT
+WITH
+  a AS MATERIALIZED (SELECT max(k) FROM t WHERE k > (SELECT v FROM t WHERE v = k + 1)),
+  b AS MATERIALIZED (EXPLAIN SELECT k, v FROM t)
+SELECT * FROM a, b
+----
+NULL  ·     distribution  local
+NULL  ·     vectorized    true
+NULL  scan  ·             ·
+NULL  ·     table         t@primary
+NULL  ·     spans         FULL SCAN


### PR DESCRIPTION
#### opt: minor clean up of explain in execbuilder

Separate the code for EXPLAIN OPT, where we don't actually need to
execbuild the inner query. Add a helper function to set up output
plans with ColLists.

Release note: None

#### opt: use separate builder for explain

The explain code uses the same builder for execbuilding the "inner"
query. This is hacky as we have to deal with saving and
restoring state and is error-prone. I added a test which was failing,
where we are incorrectly dropping a subquery that came from outside
the Explain.

The new code is much cleaner: we create a new builder and use the
regular Build() API.

Release note: None