### PR TITLE
jobs: Add created by fields to job record.

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1363,6 +1363,21 @@ func TestJobLifecycle(t *testing.T) {
 		}
 	})
 
+	t.Run("job with created by fields", func(t *testing.T) {
+		createdByType := "internal_test"
+
+		job := registry.NewJob(jobs.Record{
+			Details:   jobspb.RestoreDetails{},
+			Progress:  jobspb.RestoreProgress{},
+			CreatedBy: &jobs.CreatedByInfo{Name: createdByType, ID: 123},
+		})
+		require.NoError(t, job.Created(ctx))
+
+		loadedJob, err := registry.LoadJob(ctx, *job.ID())
+		require.NoError(t, err)
+		require.NotNil(t, loadedJob.CreatedBy())
+		require.Equal(t, job.CreatedBy(), loadedJob.CreatedBy())
+	})
 }
 
 // TestShowJobs manually inserts a row into system.jobs and checks that the

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -349,7 +349,8 @@ func (r *Registry) Run(ctx context.Context, ex sqlutil.InternalExecutor, jobs []
 // NewJob creates a new Job.
 func (r *Registry) NewJob(record Record) *Job {
 	job := &Job{
-		registry: r,
+		registry:  r,
+		createdBy: record.CreatedBy,
 	}
 	job.mu.payload = jobspb.Payload{
 		Description:   record.Description,


### PR DESCRIPTION
Make it possible for the job creator to specify `created_by_type`
and `created_by_id` fields, which are now stored in the `system.jobs` table.

Release Notes: None