### PR TITLE
builtins: implement ST_Length2D and ST_Perimeter2D

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1208,6 +1208,10 @@ from the given Geometry.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This variant will cast all geometry_str arguments into Geometry types.</p>
 </span></td></tr>
+<tr><td><a name="st_length2d"></a><code>st_length2d(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the length of the given geometry.</p>
+<p>Note ST_Length is only valid for LineString - use ST_Perimeter for Polygon.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
 <tr><td><a name="st_linefromtext"></a><code>st_linefromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation with an SRID. If the shape underneath is not LineString, NULL is returned. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>
 </span></td></tr>
 <tr><td><a name="st_linefromtext"></a><code>st_linefromtext(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation. If the shape underneath is not LineString, NULL is returned.</p>
@@ -1338,7 +1342,11 @@ from the given Geometry.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
 </span></td></tr>
-<tr><td><a name="st_perimeter"></a><code>st_perimeter(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the perimeter of the given geometry in meters.</p>
+<tr><td><a name="st_perimeter"></a><code>st_perimeter(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the perimeter of the given geometry.</p>
+<p>Note ST_Perimeter is only valid for Polygon - use ST_Length for LineString.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_perimeter2d"></a><code>st_perimeter2d(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the perimeter of the given geometry.</p>
 <p>Note ST_Perimeter is only valid for Polygon - use ST_Length for LineString.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -608,27 +608,29 @@ invalid polygon            false  false  false  Self-intersection[1.5 1.5]     S
 self-intersecting polygon  false  false  true   Ring Self-intersection[14 20]  Ring Self-intersection  Valid Geometry     POLYGON ((14 20, 8 45, 20 35, 14 20), (14 20, 16 30, 12 30, 14 20))
 
 # Unary operators
-query TRRRR
+query TRRRRRR
 SELECT
   a.dsc,
   ST_Area(a.geom),
   ST_Area2D(a.geom),
   ST_Length(a.geom),
-  ST_Perimeter(a.geom)
+  ST_Length2D(a.geom),
+  ST_Perimeter(a.geom),
+  ST_Perimeter2D(a.geom)
 FROM geom_operators_test a
 ORDER BY a.dsc
 ----
-Empty GeometryCollection                  0     0     0     0
-Empty LineString                          0     0     0     0
-Empty Point                               0     0     0     0
-Faraway point                             0     0     0     0
-Line going through left and right square  0     0     1     0
-NULL                                      NULL  NULL  NULL  NULL
-Point middle of Left Square               0     0     0     0
-Point middle of Right Square              0     0     0     0
-Square (left)                             1     1     0     4
-Square (right)                            1     1     0     4
-Square overlapping left and right square  1.1   1.1   0     4.2
+Empty GeometryCollection                  0     0     0     0     0     0
+Empty LineString                          0     0     0     0     0     0
+Empty Point                               0     0     0     0     0     0
+Faraway point                             0     0     0     0     0     0
+Line going through left and right square  0     0     1     1     0     0
+NULL                                      NULL  NULL  NULL  NULL  NULL  NULL
+Point middle of Left Square               0     0     0     0     0     0
+Point middle of Right Square              0     0     0     0     0     0
+Square (left)                             1     1     0     0     4     4
+Square (right)                            1     1     0     0     4     4
+Square overlapping left and right square  1.1   1.1   0     0     4.2   4.2
 
 # Topology operators.
 

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -84,29 +84,6 @@ func (ib infoBuilder) String() string {
 	return sb.String()
 }
 
-// geometryFromText is the builtin for ST_GeomFromText/ST_GeometryFromText.
-var geometryFromText = makeBuiltin(
-	defProps(),
-	geomFromWKTOverload,
-	tree.Overload{
-		Types:      tree.ArgTypes{{"str", types.String}, {"srid", types.Int}},
-		ReturnType: tree.FixedReturnType(types.Geometry),
-		Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-			s := string(tree.MustBeDString(args[0]))
-			srid := geopb.SRID(tree.MustBeDInt(args[1]))
-			g, err := geo.ParseGeometryFromEWKT(geopb.EWKT(s), srid, geo.DefaultSRIDShouldOverwrite)
-			if err != nil {
-				return nil, err
-			}
-			return tree.NewDGeometry(g), nil
-		},
-		Info: infoBuilder{
-			info: `Returns the Geometry from a WKT or EWKT representation with an SRID. If the SRID is present in both the EWKT and the argument, the argument value is used.`,
-		}.String(),
-		Volatility: tree.VolatilityImmutable,
-	},
-)
-
 // geomFromWKTOverload converts an (E)WKT string to its Geometry form.
 var geomFromWKTOverload = stringOverload1(
 	func(_ *tree.EvalContext, s string) (tree.Datum, error) {
@@ -236,82 +213,6 @@ func geometryFromWKBCheckShapeBuiltin(shapeType geopb.ShapeType) builtinDefiniti
 	)
 }
 
-// geographyFromText is the builtin for ST_GeomFromText/ST_GeographyFromText.
-var geographyFromText = makeBuiltin(
-	defProps(),
-	stringOverload1(
-		func(_ *tree.EvalContext, s string) (tree.Datum, error) {
-			g, err := geo.ParseGeographyFromEWKT(geopb.EWKT(s), geopb.DefaultGeographySRID, geo.DefaultSRIDIsHint)
-			if err != nil {
-				return nil, err
-			}
-			return tree.NewDGeography(g), nil
-		},
-		types.Geography,
-		infoBuilder{info: "Returns the Geography from a WKT or EWKT representation."}.String(),
-		tree.VolatilityImmutable,
-	),
-	tree.Overload{
-		Types:      tree.ArgTypes{{"str", types.String}, {"srid", types.Int}},
-		ReturnType: tree.FixedReturnType(types.Geography),
-		Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-			s := string(tree.MustBeDString(args[0]))
-			srid := geopb.SRID(tree.MustBeDInt(args[1]))
-			g, err := geo.ParseGeographyFromEWKT(geopb.EWKT(s), srid, geo.DefaultSRIDShouldOverwrite)
-			if err != nil {
-				return nil, err
-			}
-			return tree.NewDGeography(g), nil
-		},
-		Info: infoBuilder{
-			info: `Returns the Geography from a WKT or EWKT representation with an SRID. If the SRID is present in both the EWKT and the argument, the argument value is used.`,
-		}.String(),
-		Volatility: tree.VolatilityImmutable,
-	},
-)
-
-var pointCoordsToGeomOverload = tree.Overload{
-	Types:      tree.ArgTypes{{"x", types.Float}, {"y", types.Float}},
-	ReturnType: tree.FixedReturnType(types.Geometry),
-	Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-		x := float64(*args[0].(*tree.DFloat))
-		y := float64(*args[1].(*tree.DFloat))
-		g, err := geo.NewGeometryFromPointCoords(x, y)
-		if err != nil {
-			return nil, err
-		}
-		return tree.NewDGeometry(g), nil
-	},
-	Info:       infoBuilder{info: `Returns a new Point with the given X and Y coordinates.`}.String(),
-	Volatility: tree.VolatilityImmutable,
-}
-
-var numInteriorRingsBuiltin = makeBuiltin(
-	defProps(),
-	geometryOverload1(
-		func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-			t, err := g.Geometry.AsGeomT()
-			if err != nil {
-				return nil, err
-			}
-			switch t := t.(type) {
-			case *geom.Polygon:
-				numRings := t.NumLinearRings()
-				if numRings <= 1 {
-					return tree.NewDInt(0), nil
-				}
-				return tree.NewDInt(tree.DInt(numRings - 1)), nil
-			}
-			return tree.DNull, nil
-		},
-		types.Int,
-		infoBuilder{
-			info: "Returns the number of interior rings in a Polygon Geometry. Returns NULL if the shape is not a Polygon.",
-		},
-		tree.VolatilityImmutable,
-	),
-)
-
 var areaOverloadGeometry1 = geometryOverload1(
 	func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
 		ret, err := geomfn.Area(g.Geometry)
@@ -323,6 +224,42 @@ var areaOverloadGeometry1 = geometryOverload1(
 	types.Float,
 	infoBuilder{
 		info:         "Returns the area of the given geometry.",
+		libraryUsage: usesGEOS,
+	},
+	tree.VolatilityImmutable,
+)
+
+var lengthOverloadGeometry1 = geometryOverload1(
+	func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+		ret, err := geomfn.Length(g.Geometry)
+		if err != nil {
+			return nil, err
+		}
+		return tree.NewDFloat(tree.DFloat(ret)), nil
+	},
+	types.Float,
+	infoBuilder{
+		info: `Returns the length of the given geometry.
+
+Note ST_Length is only valid for LineString - use ST_Perimeter for Polygon.`,
+		libraryUsage: usesGEOS,
+	},
+	tree.VolatilityImmutable,
+)
+
+var perimeterOverloadGeometry1 = geometryOverload1(
+	func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+		ret, err := geomfn.Perimeter(g.Geometry)
+		if err != nil {
+			return nil, err
+		}
+		return tree.NewDFloat(tree.DFloat(ret)), nil
+	},
+	types.Float,
+	infoBuilder{
+		info: `Returns the perimeter of the given geometry.
+
+Note ST_Perimeter is only valid for Polygon - use ST_Length for LineString.`,
 		libraryUsage: usesGEOS,
 	},
 	tree.VolatilityImmutable,
@@ -438,8 +375,27 @@ var geoBuiltins = map[string]builtinDefinition{
 	// Input (Geometry)
 	//
 
-	"st_geomfromtext":     geometryFromText,
-	"st_geometryfromtext": geometryFromText,
+	"st_geometryfromtext": makeBuiltin(
+		defProps(),
+		geomFromWKTOverload,
+		tree.Overload{
+			Types:      tree.ArgTypes{{"str", types.String}, {"srid", types.Int}},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				s := string(tree.MustBeDString(args[0]))
+				srid := geopb.SRID(tree.MustBeDInt(args[1]))
+				g, err := geo.ParseGeometryFromEWKT(geopb.EWKT(s), srid, geo.DefaultSRIDShouldOverwrite)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(g), nil
+			},
+			Info: infoBuilder{
+				info: `Returns the Geometry from a WKT or EWKT representation with an SRID. If the SRID is present in both the EWKT and the argument, the argument value is used.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 	"st_geomfromewkt": makeBuiltin(
 		defProps(),
 		stringOverload1(
@@ -607,8 +563,39 @@ var geoBuiltins = map[string]builtinDefinition{
 	// Input (Geography)
 	//
 
-	"st_geogfromtext":      geographyFromText,
-	"st_geographyfromtext": geographyFromText,
+	"st_geographyfromtext": makeBuiltin(
+		defProps(),
+		stringOverload1(
+			func(_ *tree.EvalContext, s string) (tree.Datum, error) {
+				g, err := geo.ParseGeographyFromEWKT(geopb.EWKT(s), geopb.DefaultGeographySRID, geo.DefaultSRIDIsHint)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeography(g), nil
+			},
+			types.Geography,
+			infoBuilder{info: "Returns the Geography from a WKT or EWKT representation."}.String(),
+			tree.VolatilityImmutable,
+		),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"str", types.String}, {"srid", types.Int}},
+			ReturnType: tree.FixedReturnType(types.Geography),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				s := string(tree.MustBeDString(args[0]))
+				srid := geopb.SRID(tree.MustBeDInt(args[1]))
+				g, err := geo.ParseGeographyFromEWKT(geopb.EWKT(s), srid, geo.DefaultSRIDShouldOverwrite)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeography(g), nil
+			},
+			Info: infoBuilder{
+				info: `Returns the Geography from a WKT or EWKT representation with an SRID. If the SRID is present in both the EWKT and the argument, the argument value is used.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+
 	"st_geogfromewkt": makeBuiltin(
 		defProps(),
 		stringOverload1(
@@ -706,8 +693,24 @@ var geoBuiltins = map[string]builtinDefinition{
 			tree.VolatilityImmutable,
 		),
 	),
-	"st_point":     makeBuiltin(defProps(), pointCoordsToGeomOverload),
-	"st_makepoint": makeBuiltin(defProps(), pointCoordsToGeomOverload),
+	"st_point": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"x", types.Float}, {"y", types.Float}},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				x := float64(*args[0].(*tree.DFloat))
+				y := float64(*args[1].(*tree.DFloat))
+				g, err := geo.NewGeometryFromPointCoords(x, y)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(g), nil
+			},
+			Info:       infoBuilder{info: `Returns a new Point with the given X and Y coordinates.`}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 
 	//
 	// Output
@@ -1548,8 +1551,31 @@ Flags shown square brackets after the geometry type have the following meaning:
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
-	"st_numinteriorring":  numInteriorRingsBuiltin,
-	"st_numinteriorrings": numInteriorRingsBuiltin,
+	"st_numinteriorrings": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.Polygon:
+					numRings := t.NumLinearRings()
+					if numRings <= 1 {
+						return tree.NewDInt(0), nil
+					}
+					return tree.NewDInt(tree.DInt(numRings - 1)), nil
+				}
+				return tree.DNull, nil
+			},
+			types.Int,
+			infoBuilder{
+				info: "Returns the number of interior rings in a Polygon Geometry. Returns NULL if the shape is not a Polygon.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
 	"st_nrings": makeBuiltin(
 		defProps(),
 		geometryOverload1(
@@ -1733,24 +1759,12 @@ Flags shown square brackets after the geometry type have the following meaning:
 				},
 				tree.VolatilityImmutable,
 			),
-			geometryOverload1(
-				func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-					ret, err := geomfn.Length(g.Geometry)
-					if err != nil {
-						return nil, err
-					}
-					return tree.NewDFloat(tree.DFloat(ret)), nil
-				},
-				types.Float,
-				infoBuilder{
-					info: `Returns the length of the given geometry.
-
-Note ST_Length is only valid for LineString - use ST_Perimeter for Polygon.`,
-					libraryUsage: usesGEOS,
-				},
-				tree.VolatilityImmutable,
-			),
+			lengthOverloadGeometry1,
 		)...,
+	),
+	"st_length2d": makeBuiltin(
+		defProps(),
+		lengthOverloadGeometry1,
 	),
 	"st_perimeter": makeBuiltin(
 		defProps(),
@@ -1769,24 +1783,12 @@ Note ST_Length is only valid for LineString - use ST_Perimeter for Polygon.`,
 				},
 				tree.VolatilityImmutable,
 			),
-			geometryOverload1(
-				func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-					ret, err := geomfn.Perimeter(g.Geometry)
-					if err != nil {
-						return nil, err
-					}
-					return tree.NewDFloat(tree.DFloat(ret)), nil
-				},
-				types.Float,
-				infoBuilder{
-					info: `Returns the perimeter of the given geometry in meters.
-
-Note ST_Perimeter is only valid for Polygon - use ST_Length for LineString.`,
-					libraryUsage: usesGEOS,
-				},
-				tree.VolatilityImmutable,
-			),
+			perimeterOverloadGeometry1,
 		)...,
+	),
+	"st_perimeter2d": makeBuiltin(
+		defProps(),
+		perimeterOverloadGeometry1,
 	),
 	"st_srid": makeBuiltin(
 		defProps(),
@@ -3442,6 +3444,25 @@ func toUseSphereOrSpheroid(useSpheroid *tree.DBool) geogfn.UseSphereOrSpheroid {
 }
 
 func initGeoBuiltins() {
+	// Some functions have exactly the same definition - in which case,
+	// we can just copy them.
+	for _, alias := range []struct {
+		alias       string
+		builtinName string
+	}{
+		{"st_geogfromtext", "st_geographyfromtext"},
+		{"st_geomfromtext", "st_geometryfromtext"},
+		{"st_numinteriorring", "st_numinteriorrings"},
+		{"st_makepoint", "st_point"},
+	} {
+		if _, ok := geoBuiltins[alias.builtinName]; !ok {
+			panic("expected builtin definition for alias: " + alias.builtinName)
+		}
+		geoBuiltins[alias.alias] = geoBuiltins[alias.builtinName]
+	}
+
+	// Indexed functions have an alternative version with an underscore prepended
+	// to the name, which tells the optimizer to not utilize the index.
 	for indexBuiltinName := range geoindex.RelationshipMap {
 		builtin, exists := geoBuiltins[indexBuiltinName]
 		if !exists {


### PR DESCRIPTION
In addition, refactor builtins which are aliases to be initalized by
initGeoBuiltins, instead of having to define them twice in the map.

Resolves #48966.
Resolves #49006

Release note (sql change): Implement ST_Length2D and ST_Perimeter2D for
geometry types.