### PR TITLE
opt: clear disabledRules

### DIFF
--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -108,6 +108,7 @@ func (o *Optimizer) Init(evalCtx *tree.EvalContext, catalog cat.Catalog) {
 	o.stateMap = make(map[groupStateKey]*groupState)
 	o.matchedRule = nil
 	o.appliedRule = nil
+	o.disabledRules = util.FastIntSet{}
 	if evalCtx.TestingKnobs.DisableOptimizerRuleProbability > 0 {
 		o.disableRules(evalCtx.TestingKnobs.DisableOptimizerRuleProbability)
 	}


### PR DESCRIPTION
I was trying to use `disabledRules` as a poor man's optsteps.
Optimizer.Init wasn't resetting disabledRules so the set of disabled
rules would just keep growing.

All rules got disabled after a bunch of queries, so the later queries
in a test file wouldn't see any variation. It's possible we may get
more test failures when we use this flag in the nightlies now.

Release note: None