### PR TITLE
Makefile: filter out cockroachdb/redact related safe types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1563,10 +1563,10 @@ docs/generated/redact_safe.md:
 	@(echo "The following types are considered always safe for reporting:"; echo; \
 	  echo "File | Type"; echo "--|--") >$@.tmp || { rm -f $@.tmp; exit 1; }
 	@git grep -n '^func \(.*\) SafeValue\(\)' | \
-	  grep -v '^pkg/util/redact' | \
+	  grep -v '^vendor/github.com/cockroachdb/redact' | \
 	  sed -E -e 's/^([^:]*):[0-9]+:func \(([^ ]* )?(.*)\) SafeValue.*$$/\1 | \`\3\`/g' >>$@.tmp || { rm -f $@.tmp; exit 1; }
 	@git grep -n 'redact\.RegisterSafeType' | \
-	  grep -v '^pkg/util/redact' | \
+	  grep -v '^vendor/github.com/cockroachdb/redact' | \
 	  sed -E -e 's/^([^:]*):[0-9]+:.*redact\.RegisterSafeType\((.*)\).*/\1 | \`\2\`/g' >>$@.tmp || { rm -f $@.tmp; exit 1; }
 	@mv -f $@.tmp $@
 


### PR DESCRIPTION
Fixes #51002. We pulled out cockroachdb/redact into it's own package,
and I think we want to update our Makefile to reflect as much. I was
seeing spurious diffs like the following by not having done so.

```
diff --git a/docs/generated/redact_safe.md b/docs/generated/redact_safe.md
index 956cabe1be..251f8565c0 100644
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -10,6 +10,10 @@ pkg/roachpb/metadata.go | `RangeID`
 pkg/roachpb/metadata.go | `ReplicaID`
 pkg/roachpb/metadata.go | `ReplicaType`
 pkg/util/hlc/timestamp.go | `Timestamp`
+vendor/github.com/cockroachdb/redact/api.go | `SafeString`
+vendor/github.com/cockroachdb/redact/api.go | `SafeRune`
+vendor/github.com/cockroachdb/redact/wrappers.go:40:func Safe(a interface{}) SafeValue {
+vendor/github.com/cockroachdb/redact/wrappers.go | `safeWrapper`
 pkg/util/log/redact.go | `reflect.TypeOf(true)`
 pkg/util/log/redact.go | `reflect.TypeOf(123)`
 pkg/util/log/redact.go | `reflect.TypeOf(int8(0))`
```

---

I'm actually not sure what I'm doing here, and I'm confused by the fact
that a few other people I've asked about this have not run into this
issue. I'm able to reproduce the original issue using the following:

```
rm docs/generated/redact_safe.md; make docs/generated/redact_safe.md
```

Release note: None