### PR TITLE
kvserver: reject requests when quiescing

### DIFF
--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -278,8 +278,8 @@ func extractIDs(ids []kvserverbase.CmdIDKey, ents []raftpb.Entry) []kvserverbase
 	return ids
 }
 
-// traceLocalProposals logs a trace event with the provided string for each
-// locally proposed command which corresponds to an id in ids.
+// traceProposals logs a trace event with the provided string for each proposed
+// command which corresponds to an id in ids.
 func traceProposals(r *Replica, ids []kvserverbase.CmdIDKey, event string) {
 	ctxs := make([]context.Context, 0, len(ids))
 	r.mu.RLock()


### PR DESCRIPTION
This patch makes the Store reject request once it's stopper is
quiescing. It also makes quiescing wait until all requests have been
drained. It also makes requests get canceled on quiescing so that they
drain faster.

Before this patch, we didn't seem to have good protection against
requests not running after the stopper has been stopped. We've seen this
in some tests, where requests were racing with the engine closing.
Running after the stopper has stopped is generally pretty undefined
behavior, so let's avoid it.
I think the reason why we didn't see a lot of errors from such races is
that we're stopping the gRPC server even before we start quiescing, so
at least for requests coming from remote nodes we had some draining
window.

A gotcha of this commit is that async tasks spun off by requests will
now get canceled when the requests finish. Before, most request's did
not have a cancelable ctx, so the point was moot. This cancelation
behavior is the right thing to do; callers to, say,
stopper.RunAsyncTasks() are in charge of passing a non-cancelable
context if they don't want cancelation.

Release note: None