### PR TITLE
kvserver: Allow rebalances between stores on the same nodes.

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -502,8 +502,8 @@ func (a *Allocator) allocateTargetFromList(
 	analyzedConstraints := constraint.AnalyzeConstraints(
 		ctx, a.storePool.getStoreDescriptor, candidateReplicas, zone)
 	candidates := allocateCandidates(
-		sl, analyzedConstraints, candidateReplicas, a.storePool.getLocalities(candidateReplicas),
-		options,
+		sl, analyzedConstraints, candidateReplicas,
+		a.storePool.getLocalitiesByStore(candidateReplicas), options,
 	)
 	log.VEventf(ctx, 3, "allocate candidates: %s", candidates)
 	if target := candidates.selectGood(a.randGen); target != nil {
@@ -568,7 +568,7 @@ func (a Allocator) RemoveTarget(
 	rankedCandidates := removeCandidates(
 		sl,
 		analyzedConstraints,
-		a.storePool.getLocalities(existingReplicas),
+		a.storePool.getLocalitiesByStore(existingReplicas),
 		options,
 	)
 	log.VEventf(ctx, 3, "remove candidates: %s", rankedCandidates)
@@ -663,8 +663,7 @@ func (a Allocator) RebalanceTarget(
 		sl,
 		analyzedConstraints,
 		existingReplicas,
-		a.storePool.getLocalities(existingReplicas),
-		a.storePool.getNodeLocalityString,
+		a.storePool.getLocalitiesByStore(existingReplicas),
 		options,
 	)
 
@@ -1005,7 +1004,7 @@ func (a Allocator) shouldTransferLeaseUsingStats(
 	if stats == nil || !enableLoadBasedLeaseRebalancing.Get(&a.storePool.st.SV) {
 		return decideWithoutStats, roachpb.ReplicaDescriptor{}
 	}
-	replicaLocalities := a.storePool.getLocalities(existing)
+	replicaLocalities := a.storePool.getLocalitiesByNode(existing)
 	for _, locality := range replicaLocalities {
 		if len(locality.Tiers) == 0 {
 			return decideWithoutStats, roachpb.ReplicaDescriptor{}

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -550,28 +550,32 @@ func TestAllocatorMultipleStoresPerNode(t *testing.T) {
 	gossiputil.NewStoreGossiper(g).GossipStores(stores, t)
 
 	testCases := []struct {
-		existing     []roachpb.ReplicaDescriptor
-		expectTarget bool
+		existing              []roachpb.ReplicaDescriptor
+		expectTargetAllocate  bool
+		expectTargetRebalance bool
 	}{
 		{
 			existing: []roachpb.ReplicaDescriptor{
 				{NodeID: 1, StoreID: 1},
 			},
-			expectTarget: true,
+			expectTargetAllocate:  true,
+			expectTargetRebalance: true,
 		},
 		{
 			existing: []roachpb.ReplicaDescriptor{
 				{NodeID: 1, StoreID: 2},
 				{NodeID: 2, StoreID: 3},
 			},
-			expectTarget: true,
+			expectTargetAllocate:  true,
+			expectTargetRebalance: true,
 		},
 		{
 			existing: []roachpb.ReplicaDescriptor{
 				{NodeID: 1, StoreID: 2},
 				{NodeID: 3, StoreID: 6},
 			},
-			expectTarget: true,
+			expectTargetAllocate:  true,
+			expectTargetRebalance: true,
 		},
 		{
 			existing: []roachpb.ReplicaDescriptor{
@@ -579,7 +583,8 @@ func TestAllocatorMultipleStoresPerNode(t *testing.T) {
 				{NodeID: 2, StoreID: 3},
 				{NodeID: 3, StoreID: 5},
 			},
-			expectTarget: false,
+			expectTargetAllocate:  false,
+			expectTargetRebalance: true,
 		},
 		{
 			existing: []roachpb.ReplicaDescriptor{
@@ -587,7 +592,8 @@ func TestAllocatorMultipleStoresPerNode(t *testing.T) {
 				{NodeID: 2, StoreID: 4},
 				{NodeID: 3, StoreID: 6},
 			},
-			expectTarget: false,
+			expectTargetAllocate:  false,
+			expectTargetRebalance: false,
 		},
 	}
 
@@ -598,9 +604,9 @@ func TestAllocatorMultipleStoresPerNode(t *testing.T) {
 				zonepb.EmptyCompleteZoneConfig(),
 				tc.existing,
 			)
-			if e, a := tc.expectTarget, result != nil; e != a {
+			if e, a := tc.expectTargetAllocate, result != nil; e != a {
 				t.Errorf("AllocateTarget(%v) got target %v, err %v; expectTarget=%v",
-					tc.existing, result, err, tc.expectTarget)
+					tc.existing, result, err, tc.expectTargetAllocate)
 			}
 		}
 
@@ -614,11 +620,115 @@ func TestAllocatorMultipleStoresPerNode(t *testing.T) {
 				rangeUsageInfo,
 				storeFilterThrottled,
 			)
-			if e, a := tc.expectTarget, ok; e != a {
+			if e, a := tc.expectTargetRebalance, ok; e != a {
 				t.Errorf("RebalanceTarget(%v) got target %v, details %v; expectTarget=%v",
-					tc.existing, target, details, tc.expectTarget)
+					tc.existing, target, details, tc.expectTargetRebalance)
 			}
 		}
+	}
+}
+
+func TestAllocatorMultipleStoresPerNodeLopsided(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	store1 := roachpb.StoreDescriptor{
+		StoreID:  1,
+		Node:     roachpb.NodeDescriptor{NodeID: 1},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 100, RangeCount: 40},
+	}
+	store2 := roachpb.StoreDescriptor{
+		StoreID:  2,
+		Node:     roachpb.NodeDescriptor{NodeID: 1},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 100, RangeCount: 0},
+	}
+
+	// We start out with 40 ranges on 3 nodes and 3 stores, we then add a new store
+	// on Node 1 and try to rebalance all the ranges. What we want to see happen
+	// is an equilibrium where 20 ranges move from Store 1 to Store 2.
+	stores := []*roachpb.StoreDescriptor{
+		&store1,
+		&store2,
+		{
+			StoreID:  3,
+			Node:     roachpb.NodeDescriptor{NodeID: 2},
+			Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 100, RangeCount: 40},
+		},
+		{
+			StoreID:  4,
+			Node:     roachpb.NodeDescriptor{NodeID: 3},
+			Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 100, RangeCount: 40},
+		},
+	}
+
+	ranges := make([]roachpb.RangeDescriptor, 40)
+	for i := 0; i < 40; i++ {
+		ranges[i] = roachpb.RangeDescriptor{
+			InternalReplicas: []roachpb.ReplicaDescriptor{
+				{NodeID: 1, StoreID: 1},
+				{NodeID: 2, StoreID: 3},
+				{NodeID: 3, StoreID: 4},
+			},
+		}
+	}
+
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
+	defer stopper.Stop(context.Background())
+	storeGossiper := gossiputil.NewStoreGossiper(g)
+	storeGossiper.GossipStores(stores, t)
+
+	// We run through all the ranges once to get the cluster to balance.
+	// After that we should not be seeing replicas move.
+	var rangeUsageInfo RangeUsageInfo
+	for i := 1; i < 40; i++ {
+		add, remove, _, ok := a.RebalanceTarget(
+			context.Background(),
+			zonepb.EmptyCompleteZoneConfig(),
+			nil, /* raftStatus */
+			ranges[i].InternalReplicas,
+			rangeUsageInfo,
+			storeFilterThrottled,
+		)
+		if ok {
+			// Update the descriptor.
+			newReplicas := make([]roachpb.ReplicaDescriptor, 0, len(ranges[i].InternalReplicas))
+			for _, repl := range ranges[i].InternalReplicas {
+				if remove.StoreID != repl.StoreID {
+					newReplicas = append(newReplicas, repl)
+				}
+			}
+			newReplicas = append(newReplicas, roachpb.ReplicaDescriptor{
+				StoreID: add.StoreID,
+				NodeID:  add.NodeID,
+			})
+			ranges[i].InternalReplicas = newReplicas
+
+			for _, store := range stores {
+				if store.StoreID == add.StoreID {
+					store.Capacity.RangeCount = store.Capacity.RangeCount + 1
+				} else if store.StoreID == remove.StoreID {
+					store.Capacity.RangeCount = store.Capacity.RangeCount - 1
+				}
+			}
+			storeGossiper.GossipStores(stores, t)
+		}
+	}
+
+	// Verify that the stores are reasonably balanced.
+	require.True(t, math.Abs(float64(
+		store1.Capacity.RangeCount-store2.Capacity.RangeCount)) <= minRangeRebalanceThreshold*2)
+	// We dont expect any range wanting to move since the system should have
+	// reached a stable state at this point.
+	for i := 1; i < 40; i++ {
+		_, _, _, ok := a.RebalanceTarget(
+			context.Background(),
+			zonepb.EmptyCompleteZoneConfig(),
+			nil, /* raftStatus */
+			ranges[i].InternalReplicas,
+			rangeUsageInfo,
+			storeFilterThrottled,
+		)
+		require.False(t, ok)
 	}
 }
 
@@ -2559,7 +2669,7 @@ func TestAllocateCandidatesNumReplicasConstraints(t *testing.T) {
 			sl,
 			analyzed,
 			existingRepls,
-			a.storePool.getLocalities(existingRepls),
+			a.storePool.getLocalitiesByStore(existingRepls),
 			a.scorerOptions(),
 		)
 		best := candidates.best()
@@ -2782,7 +2892,7 @@ func TestRemoveCandidatesNumReplicasConstraints(t *testing.T) {
 		candidates := removeCandidates(
 			sl,
 			analyzed,
-			a.storePool.getLocalities(existingRepls),
+			a.storePool.getLocalitiesByStore(existingRepls),
 			a.scorerOptions(),
 		)
 		if !expectedStoreIDsMatch(tc.expected, candidates.worst()) {
@@ -3579,8 +3689,7 @@ func TestRebalanceCandidatesNumReplicasConstraints(t *testing.T) {
 			sl,
 			analyzed,
 			existingRepls,
-			a.storePool.getLocalities(existingRepls),
-			a.storePool.getNodeLocalityString,
+			a.storePool.getLocalitiesByStore(existingRepls),
 			a.scorerOptions(),
 		)
 		match := true
@@ -5477,9 +5586,9 @@ func TestAllocatorRebalanceAway(t *testing.T) {
 	}
 
 	existingReplicas := []roachpb.ReplicaDescriptor{
-		{StoreID: stores[0].StoreID},
-		{StoreID: stores[1].StoreID},
-		{StoreID: stores[2].StoreID},
+		{StoreID: stores[0].StoreID, NodeID: stores[0].Node.NodeID},
+		{StoreID: stores[1].StoreID, NodeID: stores[1].Node.NodeID},
+		{StoreID: stores[2].StoreID, NodeID: stores[2].Node.NodeID},
 	}
 	testCases := []struct {
 		constraint zonepb.Constraint

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1125,50 +1125,95 @@ func validateReplicationChanges(
 ) error {
 	// First make sure that the changes don't self-overlap (i.e. we're not adding
 	// a replica twice, or removing and immediately re-adding it).
-	byNodeID := make(map[roachpb.NodeID]roachpb.ReplicationChange, len(chgs))
+	byNodeAndStoreID := make(map[roachpb.NodeID]map[roachpb.StoreID]roachpb.ReplicationChange, len(chgs))
 	for _, chg := range chgs {
-		if _, ok := byNodeID[chg.Target.NodeID]; ok {
-			return fmt.Errorf("changes %+v refer to n%d twice", chgs, chg.Target.NodeID)
+		byStoreID, ok := byNodeAndStoreID[chg.Target.NodeID]
+		if !ok {
+			byStoreID = make(map[roachpb.StoreID]roachpb.ReplicationChange)
+			byNodeAndStoreID[chg.Target.NodeID] = byStoreID
+		} else {
+			// The only operation that is allowed within a node is an Add/Remove.
+			for _, prevChg := range byStoreID {
+				if prevChg.ChangeType == chg.ChangeType {
+					return fmt.Errorf("changes %+v refer to n%d twice for change %v",
+						chgs, chg.Target.NodeID, chg.ChangeType)
+				}
+				if prevChg.ChangeType != roachpb.ADD_REPLICA {
+					return fmt.Errorf("can only add-remove a replica within a node, but got %+v", chgs)
+				}
+			}
 		}
-		byNodeID[chg.Target.NodeID] = chg
+		if _, ok := byStoreID[chg.Target.StoreID]; ok {
+			return fmt.Errorf("changes %+v refer to n%d and s%d twice", chgs,
+				chg.Target.NodeID, chg.Target.StoreID)
+		}
+		byStoreID[chg.Target.StoreID] = chg
 	}
 
 	// Then, check that we're not adding a second replica on nodes that already
-	// have one, or "re-add" an existing replica. We delete from byNodeID so that
-	// after this loop, it contains only StoreIDs that we haven't seen in desc.
+	// have one, or "re-add" an existing replica. We delete from byNodeAndStoreID so that
+	// after this loop, it contains only Nodes that we haven't seen in desc.
 	for _, rDesc := range desc.Replicas().All() {
-		chg, ok := byNodeID[rDesc.NodeID]
-		delete(byNodeID, rDesc.NodeID)
-		if !ok || chg.ChangeType != roachpb.ADD_REPLICA {
+		byStoreID, ok := byNodeAndStoreID[rDesc.NodeID]
+		if !ok {
 			continue
 		}
-		// We're adding a replica that's already there. This isn't allowed, even
-		// when the newly added one would be on a different store.
-		if rDesc.StoreID != chg.Target.StoreID {
-			return errors.Errorf("unable to add replica %v; node already has a replica in %s", chg.Target.StoreID, desc)
+		delete(byNodeAndStoreID, rDesc.NodeID)
+		if len(byStoreID) == 2 {
+			chg, k := byStoreID[rDesc.StoreID]
+			// We should be removing the replica from the existing store during a
+			// rebalance within the node.
+			if !k || chg.ChangeType != roachpb.REMOVE_REPLICA {
+				return errors.Errorf(
+					"Expected replica to be removed from %v during a lateral rebalance %v within the node.", rDesc, chgs)
+			}
+			continue
+		}
+		chg, ok := byStoreID[rDesc.StoreID]
+		// There are two valid conditions here:
+		// (1) removal of an existing store.
+		// (2) add on the node, when we only have one replica.
+		// See https://github.com/cockroachdb/cockroach/issues/40333.
+		if ok {
+			if chg.ChangeType == roachpb.REMOVE_REPLICA {
+				continue
+			}
+			// Looks like we found a replica with the same store and node id. If the
+			// replica is already a learner, then either some previous leaseholder was
+			// trying to add it with the learner+snapshot+voter cycle and got
+			// interrupted or else we hit a race between the replicate queue and
+			// AdminChangeReplicas.
+			if rDesc.GetType() == roachpb.LEARNER {
+				return errors.Errorf(
+					"unable to add replica %v which is already present as a learner in %s", chg.Target, desc)
+			}
+
+			// Otherwise, we already had a full voter replica. Can't add another to
+			// this store.
+			return errors.Errorf("unable to add replica %v which is already present in %s", chg.Target, desc)
 		}
 
-		// Looks like we found a replica with the same store and node id. If the
-		// replica is already a learner, then either some previous leaseholder was
-		// trying to add it with the learner+snapshot+voter cycle and got
-		// interrupted or else we hit a race between the replicate queue and
-		// AdminChangeReplicas.
-		if rDesc.GetType() == roachpb.LEARNER {
-			return errors.Errorf(
-				"unable to add replica %v which is already present as a learner in %s", chg.Target, desc)
+		for _, c := range byStoreID {
+			// We're adding a replica that's already there. This isn't allowed, even
+			// when the newly added one would be on a different store.
+			if c.ChangeType == roachpb.ADD_REPLICA {
+				if len(desc.Replicas().All()) > 1 {
+					return errors.Errorf("unable to add replica %v; node already has a replica in %s", c.Target.StoreID, desc)
+				}
+			} else {
+				return errors.Errorf("removing %v which is not in %s", c.Target, desc)
+			}
 		}
-
-		// Otherwise, we already had a full voter replica. Can't add another to
-		// this store.
-		return errors.Errorf("unable to add replica %v which is already present in %s", chg.Target, desc)
 	}
 
 	// Any removals left in the map now refer to nonexisting replicas, and we refuse them.
-	for _, chg := range byNodeID {
-		if chg.ChangeType != roachpb.REMOVE_REPLICA {
-			continue
+	for _, byStoreID := range byNodeAndStoreID {
+		for _, chg := range byStoreID {
+			if chg.ChangeType != roachpb.REMOVE_REPLICA {
+				continue
+			}
+			return errors.Errorf("removing %v which is not in %s", chg.Target, desc)
 		}
-		return errors.Errorf("removing %v which is not in %s", chg.Target, desc)
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6432,6 +6432,12 @@ func TestChangeReplicasDuplicateError(t *testing.T) {
 	defer stopper.Stop(context.Background())
 	tc.Start(t, stopper)
 
+	// We now allow adding a replica to the same node, to support rebalances
+	// within the same node when replication is 1x, so add another replica to the
+	// range descriptor to avoid this case.
+	if _, err := tc.addBogusReplicaToRangeDesc(context.Background()); err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
 	chgs := roachpb.MakeReplicationChanges(roachpb.ADD_REPLICA, roachpb.ReplicationTarget{
 		NodeID:  tc.store.Ident.NodeID,
 		StoreID: 9999,

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -509,7 +509,7 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 		// Check the range's existing diversity score, since we want to ensure we
 		// don't hurt locality diversity just to improve QPS.
 		curDiversity := rangeDiversityScore(
-			sr.rq.allocator.storePool.getLocalities(currentReplicas))
+			sr.rq.allocator.storePool.getLocalitiesByStore(currentReplicas))
 
 		// Check the existing replicas, keeping around those that aren't overloaded.
 		for i := range currentReplicas {
@@ -579,7 +579,7 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 				desc.RangeID, len(targets), desiredReplicas)
 			continue
 		}
-		newDiversity := rangeDiversityScore(sr.rq.allocator.storePool.getLocalities(targetReplicas))
+		newDiversity := rangeDiversityScore(sr.rq.allocator.storePool.getLocalitiesByStore(targetReplicas))
 		if newDiversity < curDiversity {
 			log.VEventf(ctx, 3,
 				"new diversity %.2f for r%d worse than current diversity %.2f; not rebalancing",

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -659,3 +659,21 @@ var DefaultLocationInformation = []struct {
 		Longitude: "3.81886",
 	},
 }
+
+// Locality returns the locality of the Store, which is the Locality of the node
+// plus an extra tier for the node itself.
+func (s StoreDescriptor) Locality() Locality {
+	return s.Node.Locality.AddTier(
+		Tier{Key: "node", Value: s.Node.NodeID.String()})
+}
+
+// AddTier creates a new Locality with a Tier at the end.
+func (l Locality) AddTier(tier Tier) Locality {
+	if len(l.Tiers) > 0 {
+		tiers := make([]Tier, len(l.Tiers), len(l.Tiers)+1)
+		copy(tiers, l.Tiers)
+		tiers = append(tiers, tier)
+		return Locality{Tiers: tiers}
+	}
+	return Locality{Tiers: []Tier{tier}}
+}

--- a/pkg/roachpb/metadata_test.go
+++ b/pkg/roachpb/metadata_test.go
@@ -268,3 +268,15 @@ func TestDiversityScore(t *testing.T) {
 		})
 	}
 }
+
+func TestAddTier(t *testing.T) {
+	l1 := Locality{}
+	l2 := Locality{
+		Tiers: []Tier{{Key: "foo", Value: "bar"}},
+	}
+	l3 := Locality{
+		Tiers: []Tier{{Key: "foo", Value: "bar"}, {Key: "bar", Value: "foo"}},
+	}
+	require.Equal(t, l2, l1.AddTier(Tier{Key: "foo", Value: "bar"}))
+	require.Equal(t, l3, l2.AddTier(Tier{Key: "bar", Value: "foo"}))
+}

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -329,6 +329,13 @@ func startServer(t *testing.T) *TestServer {
 			base.DefaultTestStoreSpec,
 			base.DefaultTestStoreSpec,
 		},
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				// Now that we allow same node rebalances, disable it in these tests,
+				// as they dont expect replicas to move.
+				DisableReplicaRebalancing: true,
+			},
+		},
 	})
 
 	ts := tsI.(*TestServer)


### PR DESCRIPTION
Closes #6782

This change modifies the replica_queue to allow rebalances between multiple stores within a single node. 
This is possible because we previously introduced atomic rebalances in #12768. 

The first step was to remove the constraints in the allocator that prevented same node rebalances and update the validation in the replica_queue to accept these rebalance proposals. There is one caveat that with 1x replication an atomic rebalance is not possible, so we now support adding multiple replicas of the range to the same node under this condition. 

With the constraints removed there would be nothing in the allocator to prevent it from placing multiple replicas of a range on the same node across multiple stores. This is not desired because in a simple 3x replication scenario a single node crash may result in a whole range becoming unavailable. Allocator uses locality tags to model failure domains, but a node was not considered to be a locality. It is thus natural to extend the failure domain definition to the node and model it as a locality tier. Now stores on the same node would be factored into the diversity_score and repel each other, just like nodes in the same datacenter do in a multi-region setup. 

Release note (performance improvement): This change removes the last roadblock to running CockroachDB with multiple stores (i.e. disks) per node. The allocation algorithm now supports intra-node rebalances, which means CRDB can fully utilize the additional stores on the same node.