### PR TITLE
opt: simplify mutation builder to use column IDs

### DIFF
--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -113,7 +113,7 @@ func (cb *onDeleteCascadeBuilder) Build(
 
 	// Set list of columns that will be fetched by the input expression.
 	for i := range mb.outScope.cols {
-		mb.fetchOrds[i] = scopeOrdinal(i)
+		mb.fetchColIDs[i] = mb.outScope.cols[i].id
 	}
 	mb.buildDelete(nil /* returning */)
 	return mb.outScope.expr, nil
@@ -223,7 +223,7 @@ func (cb *onDeleteSetBuilder) Build(
 
 	// Set list of columns that will be fetched by the input expression.
 	for i := range mb.outScope.cols {
-		mb.fetchOrds[i] = scopeOrdinal(i)
+		mb.fetchColIDs[i] = mb.outScope.cols[i].id
 	}
 	// Add target columns.
 	numFKCols := fk.ColumnCount()
@@ -445,7 +445,7 @@ func (cb *onUpdateCascadeBuilder) Build(
 
 	// Set list of columns that will be fetched by the input expression.
 	for i := range tableScopeCols {
-		mb.fetchOrds[i] = scopeOrdinal(i)
+		mb.fetchColIDs[i] = tableScopeCols[i].id
 	}
 	// Add target columns.
 	for i := 0; i < numFKCols; i++ {

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -371,12 +371,12 @@ func (mb *mutationBuilder) needExistingRows() bool {
 			// #1: Don't consider key columns.
 			continue
 		}
-		insertColID := mb.insertColID(i)
+		insertColID := mb.insertColIDs[i]
 		if insertColID == 0 {
 			// #2: Non-key column does not have insert value specified.
 			return true
 		}
-		if insertColID != mb.scopeOrdToColID(mb.updateOrds[i]) {
+		if insertColID != mb.updateColIDs[i] {
 			// #3: Update value is not same as corresponding insert value.
 			return true
 		}
@@ -585,7 +585,7 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 	// Loop over input columns and:
 	//   1. Type check each column
 	//   2. Assign name to each column
-	//   3. Add scope column ordinal to the insertOrds list.
+	//   3. Add column ID to the insertColIDs list.
 	for i := range mb.outScope.cols {
 		inCol := &mb.outScope.cols[i]
 		ord := mb.tabID.ColumnOrdinal(mb.targetColList[i])
@@ -596,9 +596,9 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 		// Assign name of input column.
 		inCol.name = tree.Name(mb.md.ColumnMeta(mb.targetColList[i]).Alias)
 
-		// Record the ordinal position of the scope column that contains the
-		// value to be inserted into the corresponding target table column.
-		mb.insertOrds[ord] = scopeOrdinal(i)
+		// Record the ID of the column that contains the value to be inserted
+		// into the corresponding target table column.
+		mb.insertColIDs[ord] = inCol.id
 	}
 }
 
@@ -612,22 +612,22 @@ func (mb *mutationBuilder) addSynthesizedColsForInsert() {
 	// specified in the query. Do this before adding computed columns, since those
 	// may depend on non-computed columns.
 	mb.addSynthesizedCols(
-		mb.insertOrds,
+		mb.insertColIDs,
 		func(colOrd int) bool { return !mb.tab.Column(colOrd).IsComputed() },
 	)
 
 	// Possibly round DECIMAL-related columns containing insertion values (whether
 	// synthesized or not).
-	mb.roundDecimalValues(mb.insertOrds, false /* roundComputedCols */)
+	mb.roundDecimalValues(mb.insertColIDs, false /* roundComputedCols */)
 
 	// Now add all computed columns.
 	mb.addSynthesizedCols(
-		mb.insertOrds,
+		mb.insertColIDs,
 		func(colOrd int) bool { return mb.tab.Column(colOrd).IsComputed() },
 	)
 
 	// Possibly round DECIMAL-related computed columns.
-	mb.roundDecimalValues(mb.insertOrds, true /* roundComputedCols */)
+	mb.roundDecimalValues(mb.insertColIDs, true /* roundComputedCols */)
 }
 
 // buildInsert constructs an Insert operator, possibly wrapped by a Project
@@ -716,7 +716,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, conflictOrds u
 			scanColID := scanScope.cols[indexCol.Ordinal].id
 
 			condition := mb.b.factory.ConstructEq(
-				mb.b.factory.ConstructVariable(mb.insertColID(indexCol.Ordinal)),
+				mb.b.factory.ConstructVariable(mb.insertColIDs[indexCol.Ordinal]),
 				mb.b.factory.ConstructVariable(scanColID),
 			)
 			on = append(on, mb.b.factory.ConstructFiltersItem(condition))
@@ -750,7 +750,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, conflictOrds u
 		var conflictCols opt.ColSet
 		for i, n := 0, index.LaxKeyColumnCount(); i < n; i++ {
 			indexCol := index.Column(i)
-			conflictCols.Add(mb.outScope.cols[mb.insertOrds[indexCol.Ordinal]].id)
+			conflictCols.Add(mb.insertColIDs[indexCol.Ordinal])
 		}
 
 		// Treat NULL values as distinct from one another. And if duplicates are
@@ -788,7 +788,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 	// misleading error in buildDistinctOn if present).
 	var conflictCols opt.ColSet
 	for ord, ok := conflictOrds.Next(0); ok; ord, ok = conflictOrds.Next(ord + 1) {
-		conflictCols.Add(mb.outScope.cols[mb.insertOrds[ord]].id)
+		conflictCols.Add(mb.insertColIDs[ord])
 	}
 	mb.outScope.ordering = nil
 	mb.outScope = mb.b.buildDistinctOn(
@@ -821,10 +821,9 @@ func (mb *mutationBuilder) buildInputForUpsert(
 	canaryScopeCol := &fetchScope.cols[findNotNullIndexCol(mb.tab.Index(cat.PrimaryIndex))]
 	mb.canaryColID = canaryScopeCol.id
 
-	// Set fetchOrds to point to the scope columns created for the fetch values.
+	// Set fetchColIDs to reference the columns created for the fetch values.
 	for i := range fetchScope.cols {
-		// Fetch columns come after insert columns.
-		mb.fetchOrds[i] = scopeOrdinal(len(mb.outScope.cols) + i)
+		mb.fetchColIDs[i] = fetchScope.cols[i].id
 	}
 
 	// Add the fetch columns to the current scope. It's OK to modify the current
@@ -842,7 +841,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 		// Include fetch columns with ordinal positions in conflictOrds.
 		if conflictOrds.Contains(i) {
 			condition := mb.b.factory.ConstructEq(
-				mb.b.factory.ConstructVariable(mb.insertColID(i)),
+				mb.b.factory.ConstructVariable(mb.insertColIDs[i]),
 				mb.b.factory.ConstructVariable(fetchScope.cols[i].id),
 			)
 			on = append(on, mb.b.factory.ConstructFiltersItem(condition))
@@ -905,23 +904,23 @@ func (mb *mutationBuilder) setUpsertCols(insertCols tree.NameList) {
 			// Table column must exist, since existence of insertCols has already
 			// been checked previously.
 			ord := findPublicTableColumnByName(mb.tab, name)
-			mb.updateOrds[ord] = mb.insertOrds[ord]
+			mb.updateColIDs[ord] = mb.insertColIDs[ord]
 		}
 	} else {
-		copy(mb.updateOrds, mb.insertOrds)
+		copy(mb.updateColIDs, mb.insertColIDs)
 	}
 
 	// Never update mutation columns.
 	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
 		if cat.IsMutationColumn(mb.tab, i) {
-			mb.updateOrds[i] = -1
+			mb.updateColIDs[i] = 0
 		}
 	}
 
 	// Never update primary key columns.
 	conflictIndex := mb.tab.Index(cat.PrimaryIndex)
 	for i, n := 0, conflictIndex.KeyColumnCount(); i < n; i++ {
-		mb.updateOrds[conflictIndex.Column(i).Ordinal] = -1
+		mb.updateColIDs[conflictIndex.Column(i).Ordinal] = 0
 	}
 }
 
@@ -972,19 +971,19 @@ func (mb *mutationBuilder) projectUpsertColumns() {
 	// Add a new column for each target table column that needs to be upserted.
 	// This can include mutation columns.
 	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
-		insertScopeOrd := mb.insertOrds[i]
-		updateScopeOrd := mb.updateOrds[i]
-		if updateScopeOrd == -1 {
-			updateScopeOrd = mb.fetchOrds[i]
+		insertColID := mb.insertColIDs[i]
+		updateColID := mb.updateColIDs[i]
+		if updateColID == 0 {
+			updateColID = mb.fetchColIDs[i]
 		}
 
 		// Skip columns that will only be inserted or only updated.
-		if insertScopeOrd == -1 || updateScopeOrd == -1 {
+		if insertColID == 0 || updateColID == 0 {
 			continue
 		}
 
 		// Skip columns where the insert value and update value are the same.
-		if mb.scopeOrdToColID(insertScopeOrd) == mb.scopeOrdToColID(updateScopeOrd) {
+		if insertColID == updateColID {
 			continue
 		}
 
@@ -997,16 +996,15 @@ func (mb *mutationBuilder) projectUpsertColumns() {
 						mb.b.factory.ConstructVariable(mb.canaryColID),
 						memo.NullSingleton,
 					),
-					mb.b.factory.ConstructVariable(mb.outScope.cols[insertScopeOrd].id),
+					mb.b.factory.ConstructVariable(insertColID),
 				),
 			},
-			mb.b.factory.ConstructVariable(mb.outScope.cols[updateScopeOrd].id),
+			mb.b.factory.ConstructVariable(updateColID),
 		)
 
 		alias := fmt.Sprintf("upsert_%s", mb.tab.Column(i).ColName())
-		typ := mb.outScope.cols[insertScopeOrd].typ
+		typ := mb.md.ColumnMeta(insertColID).Type
 		scopeCol := mb.b.synthesizeColumn(projectionsScope, alias, typ, nil /* expr */, caseExpr)
-		scopeColOrd := scopeOrdinal(len(projectionsScope.cols) - 1)
 
 		// Assign name to synthesized column.
 		scopeCol.name = mb.tab.Column(i).ColName()
@@ -1015,10 +1013,10 @@ func (mb *mutationBuilder) projectUpsertColumns() {
 		// the Upsert. The new columns will be used by the Upsert operator in place
 		// of the original columns. Also set the scope ordinals for the upsert
 		// columns, as those columns can be used by RETURNING columns.
-		if mb.updateOrds[i] != -1 {
-			mb.updateOrds[i] = scopeColOrd
+		if mb.updateColIDs[i] != 0 {
+			mb.updateColIDs[i] = scopeCol.id
 		}
-		mb.upsertOrds[i] = scopeColOrd
+		mb.upsertColIDs[i] = scopeCol.id
 	}
 
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -52,15 +52,7 @@ type mutationBuilder struct {
 
 	// outScope contains the current set of columns that are in scope, as well as
 	// the output expression as it is incrementally built. Once the final mutation
-	// expression is completed, it will be contained in outScope.expr. Columns,
-	// when present, are arranged in this order:
-	//
-	//   +--------+-------+--------+--------+-------+-------------------+-------------------+
-	//   | Insert | Fetch | Update | Upsert | Check | Partial Index Put | Partial Index Del |
-	//   +--------+-------+--------+--------+-------+-------------------+-------------------+
-	//
-	// Each column is identified by its ordinal position in outScope, and those
-	// ordinals are stored in the corresponding ScopeOrds fields (see below).
+	// expression is completed, it will be contained in outScope.expr.
 	outScope *scope
 
 	// targetColList is an ordered list of IDs of the table columns into which
@@ -71,69 +63,73 @@ type mutationBuilder struct {
 	// targetColSet contains the same column IDs as targetColList, but as a set.
 	targetColSet opt.ColSet
 
-	// insertOrds lists the outScope columns providing values to insert. Its
+	// insertColIDs lists the input column IDs providing values to insert. Its
 	// length is always equal to the number of columns in the target table,
 	// including mutation columns. Table columns which will not have values
-	// inserted are set to -1 (e.g. delete-only mutation columns). insertOrds
+	// inserted are set to 0 (e.g. delete-only mutation columns). insertColIDs
 	// is empty if this is not an Insert/Upsert operator.
-	insertOrds []scopeOrdinal
+	insertColIDs opt.ColList
 
-	// fetchOrds lists the outScope columns storing values which are fetched
+	// fetchColIDs lists the input column IDs storing values which are fetched
 	// from the target table in order to provide existing values that will form
 	// lookup and update values. Its length is always equal to the number of
 	// columns in the target table, including mutation columns. Table columns
-	// which do not need to be fetched are set to -1. fetchOrds is empty if
+	// which do not need to be fetched are set to 0. fetchColIDs is empty if
 	// this is an Insert operator.
-	fetchOrds []scopeOrdinal
+	fetchColIDs opt.ColList
 
-	// updateOrds lists the outScope columns providing update values. Its length
-	// is always equal to the number of columns in the target table, including
-	// mutation columns. Table columns which do not need to be updated are set
-	// to -1.
-	updateOrds []scopeOrdinal
+	// updateColIDs lists the input column IDs providing update values. Its
+	// length is always equal to the number of columns in the target table,
+	// including mutation columns. Table columns which do not need to be
+	// updated are set to 0.
+	updateColIDs opt.ColList
 
-	// upsertOrds lists the outScope columns that choose between an insert or
+	// upsertColIDs lists the input column IDs that choose between an insert or
 	// update column using a CASE expression:
 	//
 	//   CASE WHEN canary_col IS NULL THEN ins_col ELSE upd_col END
 	//
 	// These columns are used to compute constraints and to return result rows.
-	// The length of upsertOrds is always equal to the number of columns in
+	// The length of upsertColIDs is always equal to the number of columns in
 	// the target table, including mutation columns. Table columns which do not
-	// need to be updated are set to -1. upsertOrds is empty if this is not
+	// need to be updated are set to 0. upsertColIDs is empty if this is not
 	// an Upsert operator.
-	upsertOrds []scopeOrdinal
+	upsertColIDs opt.ColList
 
-	// checkOrds lists the outScope columns storing the boolean results of
+	// checkColIDs lists the input column IDs storing the boolean results of
 	// evaluating check constraint expressions defined on the target table. Its
 	// length is always equal to the number of check constraints on the table
 	// (see opt.Table.CheckCount).
-	checkOrds []scopeOrdinal
+	checkColIDs opt.ColList
 
-	// partialIndexPutOrds lists the outScope columns storing the boolean
+	// partialIndexPutColIDs lists the input column IDs storing the boolean
 	// results of evaluating partial index predicate expressions of the target
 	// table. The predicate expressions are evaluated with their variables
 	// assigned from newly inserted or updated row values. When these columns
 	// evaluate to true, it signifies that the inserted or updated row should be
 	// added to the corresponding partial index. The length of
-	// partialIndexPutOrds is always equal to the number of partial indexes on
+	// partialIndexPutColIDs is always equal to the number of partial indexes on
 	// the table.
-	partialIndexPutOrds []scopeOrdinal
+	partialIndexPutColIDs opt.ColList
 
-	// partialIndexDelOrds lists the outScope columns storing the boolean
+	// partialIndexDelColIDs lists the input column IDs storing the boolean
 	// results of evaluating partial index predicate expressions of the target
 	// table. The predicate expressions are evaluated with their variables
 	// assigned from existing row values of deleted or updated rows. When these
 	// columns evaluate to true, it signifies that the deleted or updated row
 	// should be removed from the corresponding partial index. The length of
-	// partialIndexPutOrds is always equal to the number of partial indexes on
+	// partialIndexPutColIDs is always equal to the number of partial indexes on
 	// the table.
-	partialIndexDelOrds []scopeOrdinal
+	partialIndexDelColIDs opt.ColList
 
 	// canaryColID is the ID of the column that is used to decide whether to
 	// insert or update each row. If the canary column's value is null, then it's
 	// an insert; otherwise it's an update.
 	canaryColID opt.ColumnID
+
+	// roundedDecimalCols is the set of columns that have already been rounded.
+	// Keeping this set avoids rounding the same column multiple times.
+	roundedDecimalCols opt.ColSet
 
 	// subqueries temporarily stores subqueries that were built during initial
 	// analysis of SET expressions. They will be used later when the subqueries
@@ -173,38 +169,19 @@ func (mb *mutationBuilder) init(b *Builder, opName string, tab cat.Table, alias 
 	n := tab.ColumnCount()
 	mb.targetColList = make(opt.ColList, 0, n)
 
-	// Allocate segmented array of scope column ordinals.
+	// Allocate segmented array of column IDs.
 	numPartialIndexes := partialIndexCount(tab)
-	scopeOrds := make([]scopeOrdinal, n*4+tab.CheckCount()+2*numPartialIndexes)
-	for i := range scopeOrds {
-		scopeOrds[i] = -1
-	}
-	mb.insertOrds = scopeOrds[:n]
-	mb.fetchOrds = scopeOrds[n : n*2]
-	mb.updateOrds = scopeOrds[n*2 : n*3]
-	mb.upsertOrds = scopeOrds[n*3 : n*4]
-	mb.checkOrds = scopeOrds[n*4 : n*4+tab.CheckCount()]
-	mb.partialIndexPutOrds = scopeOrds[n*4+tab.CheckCount() : n*4+tab.CheckCount()+numPartialIndexes]
-	mb.partialIndexDelOrds = scopeOrds[n*4+tab.CheckCount()+numPartialIndexes:]
+	colIDs := make(opt.ColList, n*4+tab.CheckCount()+2*numPartialIndexes)
+	mb.insertColIDs = colIDs[:n]
+	mb.fetchColIDs = colIDs[n : n*2]
+	mb.updateColIDs = colIDs[n*2 : n*3]
+	mb.upsertColIDs = colIDs[n*3 : n*4]
+	mb.checkColIDs = colIDs[n*4 : n*4+tab.CheckCount()]
+	mb.partialIndexPutColIDs = colIDs[n*4+tab.CheckCount() : n*4+tab.CheckCount()+numPartialIndexes]
+	mb.partialIndexDelColIDs = colIDs[n*4+tab.CheckCount()+numPartialIndexes:]
 
 	// Add the table and its columns (including mutation columns) to metadata.
 	mb.tabID = mb.md.AddTable(tab, &mb.alias)
-}
-
-// scopeOrdToColID returns the ID of the given scope column. If no scope column
-// is defined, scopeOrdToColID returns 0.
-func (mb *mutationBuilder) scopeOrdToColID(ord scopeOrdinal) opt.ColumnID {
-	if ord == -1 {
-		return 0
-	}
-	return mb.outScope.cols[ord].id
-}
-
-// insertColID is a convenience method that returns the ID of the input column
-// that provides the insertion value for the given table column (specified by
-// ordinal position in the table).
-func (mb *mutationBuilder) insertColID(tabOrd int) opt.ColumnID {
-	return mb.scopeOrdToColID(mb.insertOrds[tabOrd])
 }
 
 // buildInputForUpdate constructs a Select expression from the fields in
@@ -262,11 +239,14 @@ func (mb *mutationBuilder) buildInputForUpdate(
 		inScope,
 	)
 
-	fromClausePresent := len(from) > 0
-	numCols := len(mb.outScope.cols)
+	// Set list of columns that will be fetched by the input expression.
+	for i := range mb.outScope.cols {
+		mb.fetchColIDs[i] = mb.outScope.cols[i].id
+	}
 
 	// If there is a FROM clause present, we must join all the tables
 	// together with the table being updated.
+	fromClausePresent := len(from) > 0
 	if fromClausePresent {
 		fromScope := mb.b.buildFromTables(from, noRowLocking, inScope)
 
@@ -325,11 +305,6 @@ func (mb *mutationBuilder) buildInputForUpdate(
 			mb.outScope = mb.b.buildDistinctOn(
 				pkCols, mb.outScope, false /* nullsAreDistinct */, "" /* errorOnDup */)
 		}
-	}
-
-	// Set list of columns that will be fetched by the input expression.
-	for i := 0; i < numCols; i++ {
-		mb.fetchOrds[i] = scopeOrdinal(i)
 	}
 }
 
@@ -390,7 +365,7 @@ func (mb *mutationBuilder) buildInputForDelete(
 
 	// Set list of columns that will be fetched by the input expression.
 	for i := range mb.outScope.cols {
-		mb.fetchOrds[i] = scopeOrdinal(i)
+		mb.fetchColIDs[i] = mb.outScope.cols[i].id
 	}
 }
 
@@ -541,9 +516,9 @@ func (mb *mutationBuilder) replaceDefaultExprs(inRows *tree.Select) (outRows *tr
 //      that the existing "fetched" value returned by the scan cannot be used,
 //      since it may not have been initialized yet by the backfiller.
 //
-func (mb *mutationBuilder) addSynthesizedCols(
-	scopeOrds []scopeOrdinal, addCol func(colOrd int) bool,
-) {
+// NOTE: colIDs is updated with the column IDs of any synthesized columns which
+// are added to outScope.
+func (mb *mutationBuilder) addSynthesizedCols(colIDs opt.ColList, addCol func(colOrd int) bool) {
 	var projectionsScope *scope
 
 	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
@@ -553,7 +528,7 @@ func (mb *mutationBuilder) addSynthesizedCols(
 			continue
 		}
 		// Skip columns that are already specified.
-		if scopeOrds[i] != -1 {
+		if colIDs[i] != 0 {
 			continue
 		}
 
@@ -579,8 +554,8 @@ func (mb *mutationBuilder) addSynthesizedCols(
 		// columns in the table by name.
 		scopeCol.name = tabCol.ColName()
 
-		// Remember ordinal position of the new scope column.
-		scopeOrds[i] = scopeOrdinal(len(projectionsScope.cols) - 1)
+		// Remember id of newly synthesized column.
+		colIDs[i] = scopeCol.id
 
 		// Add corresponding target column.
 		mb.targetColList = append(mb.targetColList, tabColID)
@@ -612,16 +587,20 @@ func (mb *mutationBuilder) addSynthesizedCols(
 // there, since it needs to happen before check constraints are computed, and
 // before UPSERT joins.
 //
-// if roundComputedCols is false, then don't wrap computed columns. If true,
+// If roundComputedCols is false, then don't wrap computed columns. If true,
 // then only wrap computed columns. This is necessary because computed columns
 // can depend on other columns mutated by the operation; it is necessary to
 // first round those values, then evaluated the computed expression, and then
 // round the result of the computation.
-func (mb *mutationBuilder) roundDecimalValues(scopeOrds []scopeOrdinal, roundComputedCols bool) {
+//
+// roundDecimalValues will only round decimal columns that are part of the
+// colIDs list (i.e. are not 0). If a column is rounded, then the list will be
+// updated with the column ID of the new synthesized column.
+func (mb *mutationBuilder) roundDecimalValues(colIDs opt.ColList, roundComputedCols bool) {
 	var projectionsScope *scope
 
-	for i, ord := range scopeOrds {
-		if ord == -1 {
+	for i, id := range colIDs {
+		if id == 0 {
 			// Column not mutated, so nothing to do.
 			continue
 		}
@@ -639,13 +618,19 @@ func (mb *mutationBuilder) roundDecimalValues(scopeOrds []scopeOrdinal, roundCom
 		if props == nil {
 			continue
 		}
+
+		// If column has already been rounded, then skip it.
+		if mb.roundedDecimalCols.Contains(id) {
+			continue
+		}
+
 		private := &memo.FunctionPrivate{
 			Name:       "crdb_internal.round_decimal_values",
-			Typ:        mb.outScope.cols[ord].typ,
+			Typ:        col.DatumType(),
 			Properties: props,
 			Overload:   overload,
 		}
-		variable := mb.b.factory.ConstructVariable(mb.scopeOrdToColID(ord))
+		variable := mb.b.factory.ConstructVariable(id)
 		scale := mb.b.factory.ConstructConstVal(tree.NewDInt(tree.DInt(col.ColTypeWidth())), types.Int)
 		fn := mb.b.factory.ConstructFunction(memo.ScalarListExpr{variable, scale}, private)
 
@@ -654,7 +639,12 @@ func (mb *mutationBuilder) roundDecimalValues(scopeOrds []scopeOrdinal, roundCom
 			projectionsScope = mb.outScope.replace()
 			projectionsScope.appendColumnsFromScope(mb.outScope)
 		}
-		mb.b.populateSynthesizedColumn(&projectionsScope.cols[ord], fn)
+		scopeCol := projectionsScope.getColumn(id)
+		mb.b.populateSynthesizedColumn(scopeCol, fn)
+
+		// Overwrite the input column ID with the new synthesized column ID.
+		colIDs[i] = scopeCol.id
+		mb.roundedDecimalCols.Add(scopeCol.id)
 	}
 
 	if projectionsScope != nil {
@@ -715,7 +705,7 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 			// TODO(ridwanmsharif): Maybe we can avoid building constraints here
 			// and instead use the constraints stored in the table metadata.
 			mb.b.buildScalar(texpr, mb.outScope, projectionsScope, scopeCol, nil)
-			mb.checkOrds[i] = scopeOrdinal(len(projectionsScope.cols) - 1)
+			mb.checkColIDs[i] = scopeCol.id
 		}
 
 		mb.b.constructProjectForScope(mb.outScope, projectionsScope)
@@ -727,20 +717,20 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 // defined on the target table. The execution code uses these booleans to
 // determine whether or not to add a row in the partial index.
 func (mb *mutationBuilder) addPartialIndexPutCols() {
-	mb.addPartialIndexCols("partial_index_put", mb.partialIndexPutOrds)
+	mb.addPartialIndexCols("partial_index_put", mb.partialIndexPutColIDs)
 }
 
 // addPartialIndexPutCols synthesizes a boolean output column for each partial
 // index defined on the target table. The execution code uses these booleans to
 // determine whether or not to delete a row in the partial index.
 func (mb *mutationBuilder) addPartialIndexDelCols() {
-	mb.addPartialIndexCols("partial_index_del", mb.partialIndexDelOrds)
+	mb.addPartialIndexCols("partial_index_del", mb.partialIndexDelColIDs)
 }
 
 // addPartialIndexCols synthesizes a boolean output column for each partial
 // index defined on the target table. Each synthesized column is prefixed with
 // aliasPrefix and added to the ords list.
-func (mb *mutationBuilder) addPartialIndexCols(aliasPrefix string, ords []scopeOrdinal) {
+func (mb *mutationBuilder) addPartialIndexCols(aliasPrefix string, colIDs opt.ColList) {
 	if partialIndexCount(mb.tab) > 0 {
 		projectionsScope := mb.outScope.replace()
 		projectionsScope.appendColumnsFromScope(mb.outScope)
@@ -763,7 +753,7 @@ func (mb *mutationBuilder) addPartialIndexCols(aliasPrefix string, ords []scopeO
 			scopeCol := mb.b.addColumn(projectionsScope, alias, texpr)
 
 			mb.b.buildScalar(texpr, mb.outScope, projectionsScope, scopeCol, nil)
-			ords[ord] = scopeOrdinal(len(projectionsScope.cols) - 1)
+			colIDs[ord] = scopeCol.id
 
 			ord++
 		}
@@ -777,18 +767,17 @@ func (mb *mutationBuilder) addPartialIndexCols(aliasPrefix string, ords []scopeO
 // has each table column name, and that name refers to the column with the final
 // value that the mutation applies.
 func (mb *mutationBuilder) disambiguateColumns() {
-	// Determine the set of scope columns that will have their names preserved.
-	var preserve util.FastIntSet
+	// Determine the set of input columns that will have their names preserved.
+	var preserve opt.ColSet
 	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
-		scopeOrd := mb.mapToReturnScopeOrd(i)
-		if scopeOrd != -1 {
-			preserve.Add(int(scopeOrd))
+		if colID := mb.mapToReturnColID(i); colID != 0 {
+			preserve.Add(colID)
 		}
 	}
 
 	// Clear names of all non-preserved columns.
 	for i := range mb.outScope.cols {
-		if !preserve.Contains(i) {
+		if !preserve.Contains(mb.outScope.cols[i].id) {
 			mb.outScope.cols[i].clearName()
 		}
 	}
@@ -797,29 +786,27 @@ func (mb *mutationBuilder) disambiguateColumns() {
 // makeMutationPrivate builds a MutationPrivate struct containing the table and
 // column metadata needed for the mutation operator.
 func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationPrivate {
-	// Helper function to create a column list in the MutationPrivate.
-	makeColList := func(scopeOrds []scopeOrdinal) opt.ColList {
-		var colList opt.ColList
-		for i := range scopeOrds {
-			if scopeOrds[i] != -1 {
-				if colList == nil {
-					colList = make(opt.ColList, len(scopeOrds))
-				}
-				colList[i] = mb.scopeOrdToColID(scopeOrds[i])
+	// Helper function that returns nil if there are no non-zero column IDs in a
+	// given list. A zero column ID indicates that column does not participate
+	// in this mutation operation.
+	checkEmptyList := func(colIDs opt.ColList) opt.ColList {
+		for _, id := range colIDs {
+			if id != 0 {
+				return colIDs
 			}
 		}
-		return colList
+		return nil
 	}
 
 	private := &memo.MutationPrivate{
 		Table:               mb.tabID,
-		InsertCols:          makeColList(mb.insertOrds),
-		FetchCols:           makeColList(mb.fetchOrds),
-		UpdateCols:          makeColList(mb.updateOrds),
+		InsertCols:          checkEmptyList(mb.insertColIDs),
+		FetchCols:           checkEmptyList(mb.fetchColIDs),
+		UpdateCols:          checkEmptyList(mb.updateColIDs),
 		CanaryCol:           mb.canaryColID,
-		CheckCols:           makeColList(mb.checkOrds),
-		PartialIndexPutCols: makeColList(mb.partialIndexPutOrds),
-		PartialIndexDelCols: makeColList(mb.partialIndexDelOrds),
+		CheckCols:           checkEmptyList(mb.checkColIDs),
+		PartialIndexPutCols: checkEmptyList(mb.partialIndexPutColIDs),
+		PartialIndexDelCols: checkEmptyList(mb.partialIndexDelColIDs),
 		FKCascades:          mb.cascades,
 	}
 
@@ -835,22 +822,21 @@ func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationP
 				// Only non-mutation columns are output columns.
 				continue
 			}
-			scopeOrd := mb.mapToReturnScopeOrd(i)
-			if scopeOrd == -1 {
+			retColID := mb.mapToReturnColID(i)
+			if retColID == 0 {
 				panic(errors.AssertionFailedf("column %d is not available in the mutation input", i))
 			}
-			private.ReturnCols[i] = mb.outScope.cols[scopeOrd].id
+			private.ReturnCols[i] = retColID
 		}
 	}
 
 	return private
 }
 
-// mapToReturnScopeOrd returns the ordinal of the scope column that provides the
-// final value for the column at the given ordinal position in the table. This
-// value might mutate the column, or it might be returned by the mutation
-// statement, or it might not be used at all. Columns take priority in this
-// order:
+// mapToReturnColID returns the ID of the input column that provides the final
+// value for the column at the given ordinal position in the table. This value
+// might mutate the column, or it might be returned by the mutation statement,
+// or it might not be used at all. Columns take priority in this order:
 //
 //   upsert, update, fetch, insert
 //
@@ -860,26 +846,26 @@ func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationP
 // of fetch and insert columns doesn't matter, since they're only used together
 // in the upsert case where an upsert column would be available.
 //
-// If the column is never referenced by the statement, then mapToReturnScopeOrd
+// If the column is never referenced by the statement, then mapToReturnColID
 // returns 0. This would be the case for delete-only columns in an Insert
 // statement, because they're neither fetched nor mutated.
-func (mb *mutationBuilder) mapToReturnScopeOrd(tabOrd int) scopeOrdinal {
+func (mb *mutationBuilder) mapToReturnColID(tabOrd int) opt.ColumnID {
 	switch {
-	case mb.upsertOrds[tabOrd] != -1:
-		return mb.upsertOrds[tabOrd]
+	case mb.upsertColIDs[tabOrd] != 0:
+		return mb.upsertColIDs[tabOrd]
 
-	case mb.updateOrds[tabOrd] != -1:
-		return mb.updateOrds[tabOrd]
+	case mb.updateColIDs[tabOrd] != 0:
+		return mb.updateColIDs[tabOrd]
 
-	case mb.fetchOrds[tabOrd] != -1:
-		return mb.fetchOrds[tabOrd]
+	case mb.fetchColIDs[tabOrd] != 0:
+		return mb.fetchColIDs[tabOrd]
 
-	case mb.insertOrds[tabOrd] != -1:
-		return mb.insertOrds[tabOrd]
+	case mb.insertColIDs[tabOrd] != 0:
+		return mb.insertColIDs[tabOrd]
 
 	default:
 		// Column is never referenced by the statement.
-		return -1
+		return 0
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -30,9 +30,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// scopeOrdinal identifies an ordinal position with a list of scope columns.
-type scopeOrdinal int
-
 // scope is used for the build process and maintains the variables that have
 // been bound within the current scope as columnProps. Variables bound in the
 // parent scope are also visible in this scope.

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1635,76 +1635,72 @@ upsert decimals
  ├── fetch columns: decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16
  ├── insert-mapping:
  │    ├── a:8 => decimals.a:1
- │    ├── b:17 => decimals.b:2
+ │    ├── b:9 => decimals.b:2
  │    ├── c:10 => decimals.c:3
  │    └── d:12 => decimals.d:4
  ├── update-mapping:
- │    ├── b:17 => decimals.b:2
- │    └── upsert_d:22 => decimals.d:4
- ├── check columns: check1:23 check2:24
+ │    ├── b:9 => decimals.b:2
+ │    └── upsert_d:21 => decimals.d:4
+ ├── check columns: check1:22 check2:23
  └── project
-      ├── columns: check1:23 check2:24 a:8 c:10 d:12 decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16 b:17 d:19 upsert_a:20 upsert_c:21 upsert_d:22
+      ├── columns: check1:22 check2:23 a:8 b:9 c:10 d:12 decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16 d:18 upsert_a:19 upsert_c:20 upsert_d:21
       ├── project
-      │    ├── columns: upsert_a:20 upsert_c:21 upsert_d:22 a:8 c:10 d:12 decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16 b:17 d:19
+      │    ├── columns: upsert_a:19 upsert_c:20 upsert_d:21 a:8 b:9 c:10 d:12 decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16 d:18
       │    ├── project
-      │    │    ├── columns: d:19 a:8 c:10 d:12 decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16 b:17
+      │    │    ├── columns: d:18 a:8 b:9 c:10 d:12 decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16
       │    │    ├── project
-      │    │    │    ├── columns: column18:18 a:8 c:10 d:12 decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16 b:17
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: b:17 a:8 c:10 d:12 decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16
-      │    │    │    │    ├── left-join (hash)
-      │    │    │    │    │    ├── columns: a:8 b:9 c:10 d:12 decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16
-      │    │    │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    │    │    ├── columns: a:8 b:9 c:10 d:12
-      │    │    │    │    │    │    ├── grouping columns: a:8
+      │    │    │    ├── columns: column17:17 a:8 b:9 c:10 d:12 decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16
+      │    │    │    ├── left-join (hash)
+      │    │    │    │    ├── columns: a:8 b:9 c:10 d:12 decimals.a:13 decimals.b:14 decimals.c:15 decimals.d:16
+      │    │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    │    ├── columns: a:8 b:9 c:10 d:12
+      │    │    │    │    │    ├── grouping columns: a:8
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: d:12 a:8 b:9 c:10
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: d:12 a:8 b:9 c:10
+      │    │    │    │    │    │    │    ├── columns: column11:11 a:8 b:9 c:10
       │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    ├── columns: column11:11 a:8 b:9 c:10
+      │    │    │    │    │    │    │    │    ├── columns: a:8 b:9 c:10
       │    │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    │    ├── columns: a:8 b:9 c:10
-      │    │    │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    │    │    ├── columns: column7:7!null column1:5!null column2:6
-      │    │    │    │    │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    │    │    │    │    ├── columns: column1:5!null column2:6
-      │    │    │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
-      │    │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │    │         └── 1.23 [as=column7:7]
+      │    │    │    │    │    │    │    │    │    ├── columns: column7:7!null column1:5!null column2:6
+      │    │    │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    │    │    ├── columns: column1:5!null column2:6
+      │    │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
       │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:5, 0) [as=a:8]
-      │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:6, 1) [as=b:9]
-      │    │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column7:7, 1) [as=c:10]
+      │    │    │    │    │    │    │    │    │         └── 1.23 [as=column7:7]
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── a:8 + c:10 [as=column11:11]
+      │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:5, 0) [as=a:8]
+      │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:6, 1) [as=b:9]
+      │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column7:7, 1) [as=c:10]
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column11:11, 1) [as=d:12]
-      │    │    │    │    │    │    └── aggregations
-      │    │    │    │    │    │         ├── first-agg [as=b:9]
-      │    │    │    │    │    │         │    └── b:9
-      │    │    │    │    │    │         ├── first-agg [as=c:10]
-      │    │    │    │    │    │         │    └── c:10
-      │    │    │    │    │    │         └── first-agg [as=d:12]
-      │    │    │    │    │    │              └── d:12
-      │    │    │    │    │    ├── scan decimals
-      │    │    │    │    │    │    ├── columns: decimals.a:13!null decimals.b:14 decimals.c:15 decimals.d:16
-      │    │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │    │         └── decimals.d:16
-      │    │    │    │    │    │              └── decimals.a:13::DECIMAL + decimals.c:15::DECIMAL
-      │    │    │    │    │    └── filters
-      │    │    │    │    │         └── a:8 = decimals.a:13
-      │    │    │    │    └── projections
-      │    │    │    │         └── crdb_internal.round_decimal_values(b:9, 1) [as=b:17]
+      │    │    │    │    │    │    │         └── a:8 + c:10 [as=column11:11]
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column11:11, 1) [as=d:12]
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── first-agg [as=b:9]
+      │    │    │    │    │         │    └── b:9
+      │    │    │    │    │         ├── first-agg [as=c:10]
+      │    │    │    │    │         │    └── c:10
+      │    │    │    │    │         └── first-agg [as=d:12]
+      │    │    │    │    │              └── d:12
+      │    │    │    │    ├── scan decimals
+      │    │    │    │    │    ├── columns: decimals.a:13!null decimals.b:14 decimals.c:15 decimals.d:16
+      │    │    │    │    │    └── computed column expressions
+      │    │    │    │    │         └── decimals.d:16
+      │    │    │    │    │              └── decimals.a:13::DECIMAL + decimals.c:15::DECIMAL
+      │    │    │    │    └── filters
+      │    │    │    │         └── a:8 = decimals.a:13
       │    │    │    └── projections
-      │    │    │         └── decimals.a:13::DECIMAL + decimals.c:15::DECIMAL [as=column18:18]
+      │    │    │         └── decimals.a:13::DECIMAL + decimals.c:15::DECIMAL [as=column17:17]
       │    │    └── projections
-      │    │         └── crdb_internal.round_decimal_values(column18:18, 1) [as=d:19]
+      │    │         └── crdb_internal.round_decimal_values(column17:17, 1) [as=d:18]
       │    └── projections
-      │         ├── CASE WHEN decimals.a:13 IS NULL THEN a:8 ELSE decimals.a:13 END [as=upsert_a:20]
-      │         ├── CASE WHEN decimals.a:13 IS NULL THEN c:10 ELSE decimals.c:15 END [as=upsert_c:21]
-      │         └── CASE WHEN decimals.a:13 IS NULL THEN d:12 ELSE d:19 END [as=upsert_d:22]
+      │         ├── CASE WHEN decimals.a:13 IS NULL THEN a:8 ELSE decimals.a:13 END [as=upsert_a:19]
+      │         ├── CASE WHEN decimals.a:13 IS NULL THEN c:10 ELSE decimals.c:15 END [as=upsert_c:20]
+      │         └── CASE WHEN decimals.a:13 IS NULL THEN d:12 ELSE d:18 END [as=upsert_d:21]
       └── projections
-           ├── round(upsert_a:20) = upsert_a:20 [as=check1:23]
-           └── b:17[0] > 1 [as=check2:24]
+           ├── round(upsert_a:19) = upsert_a:19 [as=check1:22]
+           └── b:9[0] > 1 [as=check2:23]
 
 # Regular UPSERT case.
 build

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -194,13 +194,13 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 	projectionsScope := mb.outScope.replace()
 	projectionsScope.appendColumnsFromScope(mb.outScope)
 
-	checkCol := func(sourceCol *scopeColumn, scopeOrd scopeOrdinal, targetColID opt.ColumnID) {
+	checkCol := func(sourceCol *scopeColumn, targetColID opt.ColumnID) {
 		// Type check the input expression against the corresponding table column.
 		ord := mb.tabID.ColumnOrdinal(targetColID)
 		checkDatumTypeFitsColumnType(mb.tab.Column(ord), sourceCol.typ)
 
-		// Add ordinal of new scope column to the list of columns to update.
-		mb.updateOrds[ord] = scopeOrd
+		// Add source column ID to the list of columns to update.
+		mb.updateColIDs[ord] = sourceCol.id
 
 		// Rename the column to match the target column being updated.
 		sourceCol.name = mb.tab.Column(ord).ColName()
@@ -217,10 +217,9 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 		desiredType := targetColMeta.Type
 		texpr := inScope.resolveType(expr, desiredType)
 		scopeCol := mb.b.addColumn(projectionsScope, targetColMeta.Alias+"_new", texpr)
-		scopeColOrd := scopeOrdinal(len(projectionsScope.cols) - 1)
 		mb.b.buildScalar(texpr, inScope, projectionsScope, scopeCol, nil)
 
-		checkCol(scopeCol, scopeColOrd, targetColID)
+		checkCol(scopeCol, targetColID)
 	}
 
 	n := 0
@@ -235,8 +234,7 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 
 				// Type check and rename columns.
 				for i := range subqueryScope.cols {
-					scopeColOrd := scopeOrdinal(len(projectionsScope.cols) + i)
-					checkCol(&subqueryScope.cols[i], scopeColOrd, mb.targetColList[n])
+					checkCol(&subqueryScope.cols[i], mb.targetColList[n])
 					n++
 				}
 
@@ -296,7 +294,7 @@ func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 	// their default values. This is necessary because they may not yet have been
 	// set by the backfiller.
 	mb.addSynthesizedCols(
-		mb.updateOrds,
+		mb.updateColIDs,
 		func(colOrd int) bool {
 			return !mb.tab.Column(colOrd).IsComputed() && cat.IsMutationColumn(mb.tab, colOrd)
 		},
@@ -305,7 +303,7 @@ func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 	// Possibly round DECIMAL-related columns containing update values. Do
 	// this before evaluating computed expressions, since those may depend on
 	// the inserted columns.
-	mb.roundDecimalValues(mb.updateOrds, false /* roundComputedCols */)
+	mb.roundDecimalValues(mb.updateColIDs, false /* roundComputedCols */)
 
 	// Disambiguate names so that references in the computed expression refer to
 	// the correct columns.
@@ -313,12 +311,12 @@ func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 
 	// Add all computed columns in case their values have changed.
 	mb.addSynthesizedCols(
-		mb.updateOrds,
+		mb.updateColIDs,
 		func(colOrd int) bool { return mb.tab.Column(colOrd).IsComputed() },
 	)
 
 	// Possibly round DECIMAL-related computed columns.
-	mb.roundDecimalValues(mb.updateOrds, true /* roundComputedCols */)
+	mb.roundDecimalValues(mb.updateColIDs, true /* roundComputedCols */)
 }
 
 // buildUpdate constructs an Update operator, possibly wrapped by a Project

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1314,21 +1314,21 @@ upsert transactiondetails
  │    ├── current_timestamp:13 => transactiondate:4
  │    ├── int8:14 => cardid:5
  │    ├── int8:15 => quantity:6
- │    ├── sellprice:29 => transactiondetails.sellprice:7
- │    ├── buyprice:30 => transactiondetails.buyprice:8
+ │    ├── sellprice:19 => transactiondetails.sellprice:7
+ │    ├── buyprice:20 => transactiondetails.buyprice:8
  │    └── column18:18 => transactiondetails.version:9
  ├── update-mapping:
- │    ├── sellprice:29 => transactiondetails.sellprice:7
- │    └── buyprice:30 => transactiondetails.buyprice:8
+ │    ├── sellprice:19 => transactiondetails.sellprice:7
+ │    └── buyprice:20 => transactiondetails.buyprice:8
  ├── input binding: &2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: upsert_dealerid:31 upsert_isbuy:32 upsert_transactiondate:33 upsert_cardid:34 sellprice:29 buyprice:30 "?column?":11!null bool:12!null current_timestamp:13!null int8:14!null int8:15!null column18:18 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
+ │    ├── columns: upsert_dealerid:29 upsert_isbuy:30 upsert_transactiondate:31 upsert_cardid:32 "?column?":11!null bool:12!null current_timestamp:13!null int8:14!null int8:15!null column18:18 sellprice:19 buyprice:20 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
  │    ├── cardinality: [1 - 2]
  │    ├── volatile
  │    ├── key: (14,15)
- │    ├── fd: ()-->(11-13), (14,15)-->(18,21-33), (21-25)-->(26-28), (21)-->(31), (21,22)-->(32), (21,23)-->(33), (14,21,24)-->(34)
+ │    ├── fd: ()-->(11-13), (14,15)-->(18-28), (21-25)-->(26-28), (21)-->(29), (21,22)-->(30), (21,23)-->(31), (14,21,24)-->(32)
  │    ├── left-join (lookup transactiondetails)
  │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13!null int8:14!null int8:15!null column18:18 sellprice:19 buyprice:20 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
  │    │    ├── key columns: [11 12 13 14 15] = [21 22 23 24 25]
@@ -1351,19 +1351,19 @@ upsert transactiondetails
  │    │    │    │    ├── volatile
  │    │    │    │    ├── fd: ()-->(11-13)
  │    │    │    │    ├── values
- │    │    │    │    │    ├── columns: detail_b:54!null detail_c:55!null detail_q:56!null detail_s:57!null
+ │    │    │    │    │    ├── columns: detail_b:52!null detail_c:53!null detail_q:54!null detail_s:55!null
  │    │    │    │    │    ├── cardinality: [2 - 2]
  │    │    │    │    │    ├── ('2.29', '49833', '4', '2.89')
  │    │    │    │    │    └── ('17.59', '29483', '2', '18.93')
  │    │    │    │    └── projections
- │    │    │    │         ├── crdb_internal.round_decimal_values(detail_s:57::STRING::DECIMAL(10,4), 4) [as=sellprice:19, outer=(57), immutable]
- │    │    │    │         ├── crdb_internal.round_decimal_values(detail_b:54::STRING::DECIMAL(10,4), 4) [as=buyprice:20, outer=(54), immutable]
+ │    │    │    │         ├── crdb_internal.round_decimal_values(detail_s:55::STRING::DECIMAL(10,4), 4) [as=sellprice:19, outer=(55), immutable]
+ │    │    │    │         ├── crdb_internal.round_decimal_values(detail_b:52::STRING::DECIMAL(10,4), 4) [as=buyprice:20, outer=(52), immutable]
  │    │    │    │         ├── cluster_logical_timestamp() [as=column18:18, volatile]
  │    │    │    │         ├── 1 [as="?column?":11]
  │    │    │    │         ├── false [as=bool:12]
  │    │    │    │         ├── '2017-05-10 13:00:00+00:00' [as=current_timestamp:13]
- │    │    │    │         ├── detail_c:55::STRING::INT8 [as=int8:14, outer=(55), immutable]
- │    │    │    │         └── detail_q:56::STRING::INT8 [as=int8:15, outer=(56), immutable]
+ │    │    │    │         ├── detail_c:53::STRING::INT8 [as=int8:14, outer=(53), immutable]
+ │    │    │    │         └── detail_q:54::STRING::INT8 [as=int8:15, outer=(54), immutable]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=sellprice:19, outer=(19)]
  │    │    │         │    └── sellprice:19
@@ -1379,37 +1379,35 @@ upsert transactiondetails
  │    │    │              └── current_timestamp:13
  │    │    └── filters (true)
  │    └── projections
- │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN "?column?":11 ELSE transactiondetails.dealerid:21 END [as=upsert_dealerid:31, outer=(11,21)]
- │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN bool:12 ELSE transactiondetails.isbuy:22 END [as=upsert_isbuy:32, outer=(12,21,22)]
- │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN current_timestamp:13 ELSE transactiondate:23 END [as=upsert_transactiondate:33, outer=(13,21,23)]
- │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN int8:14 ELSE cardid:24 END [as=upsert_cardid:34, outer=(14,21,24)]
- │         ├── crdb_internal.round_decimal_values(sellprice:19, 4) [as=sellprice:29, outer=(19), immutable]
- │         └── crdb_internal.round_decimal_values(buyprice:20, 4) [as=buyprice:30, outer=(20), immutable]
+ │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN "?column?":11 ELSE transactiondetails.dealerid:21 END [as=upsert_dealerid:29, outer=(11,21)]
+ │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN bool:12 ELSE transactiondetails.isbuy:22 END [as=upsert_isbuy:30, outer=(12,21,22)]
+ │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN current_timestamp:13 ELSE transactiondate:23 END [as=upsert_transactiondate:31, outer=(13,21,23)]
+ │         └── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN int8:14 ELSE cardid:24 END [as=upsert_cardid:32, outer=(14,21,24)]
  └── f-k-checks
       ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
       │    └── anti-join (lookup transactions)
-      │         ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39
-      │         ├── key columns: [37 38 39] = [40 41 42]
+      │         ├── columns: upsert_dealerid:35 upsert_isbuy:36 upsert_transactiondate:37
+      │         ├── key columns: [35 36 37] = [38 39 40]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 2]
       │         ├── with-scan &2
-      │         │    ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39
+      │         │    ├── columns: upsert_dealerid:35 upsert_isbuy:36 upsert_transactiondate:37
       │         │    ├── mapping:
-      │         │    │    ├──  upsert_dealerid:31 => upsert_dealerid:37
-      │         │    │    ├──  upsert_isbuy:32 => upsert_isbuy:38
-      │         │    │    └──  upsert_transactiondate:33 => upsert_transactiondate:39
+      │         │    │    ├──  upsert_dealerid:29 => upsert_dealerid:35
+      │         │    │    ├──  upsert_isbuy:30 => upsert_isbuy:36
+      │         │    │    └──  upsert_transactiondate:31 => upsert_transactiondate:37
       │         │    └── cardinality: [1 - 2]
       │         └── filters (true)
       └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
            └── anti-join (lookup cards)
-                ├── columns: upsert_cardid:47
-                ├── key columns: [47] = [48]
+                ├── columns: upsert_cardid:45
+                ├── key columns: [45] = [46]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 2]
                 ├── with-scan &2
-                │    ├── columns: upsert_cardid:47
+                │    ├── columns: upsert_cardid:45
                 │    ├── mapping:
-                │    │    └──  upsert_cardid:34 => upsert_cardid:47
+                │    │    └──  upsert_cardid:32 => upsert_cardid:45
                 │    └── cardinality: [1 - 2]
                 └── filters (true)
 

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1321,23 +1321,23 @@ upsert transactiondetails
  │    ├── current_timestamp:15 => transactiondate:4
  │    ├── int8:16 => cardid:5
  │    ├── int8:17 => quantity:6
- │    ├── sellprice:35 => transactiondetails.sellprice:7
- │    ├── buyprice:36 => transactiondetails.buyprice:8
+ │    ├── sellprice:22 => transactiondetails.sellprice:7
+ │    ├── buyprice:23 => transactiondetails.buyprice:8
  │    ├── column20:20 => transactiondetails.version:9
  │    └── discount:24 => transactiondetails.discount:10
  ├── update-mapping:
- │    ├── sellprice:35 => transactiondetails.sellprice:7
- │    ├── buyprice:36 => transactiondetails.buyprice:8
- │    └── upsert_discount:44 => transactiondetails.discount:10
+ │    ├── sellprice:22 => transactiondetails.sellprice:7
+ │    ├── buyprice:23 => transactiondetails.buyprice:8
+ │    └── discount:24 => transactiondetails.discount:10
  ├── input binding: &2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: upsert_dealerid:38 upsert_isbuy:39 upsert_transactiondate:40 upsert_cardid:41 upsert_discount:44 sellprice:35 buyprice:36 "?column?":13!null bool:14!null current_timestamp:15!null int8:16!null int8:17!null column20:20 discount:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
+ │    ├── columns: upsert_dealerid:35 upsert_isbuy:36 upsert_transactiondate:37 upsert_cardid:38 "?column?":13!null bool:14!null current_timestamp:15!null int8:16!null int8:17!null column20:20 sellprice:22 buyprice:23 discount:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
  │    ├── cardinality: [1 - 2]
  │    ├── volatile
  │    ├── key: (16,17)
- │    ├── fd: ()-->(13-15,24), (16,17)-->(20,25-36,38-40,44), (25-29)-->(30-34), (25)-->(38), (25,26)-->(39), (25,27)-->(40), (16,25,28)-->(41)
+ │    ├── fd: ()-->(13-15,24), (16,17)-->(20,22,23,25-34), (25-29)-->(30-34), (25)-->(35), (25,26)-->(36), (25,27)-->(37), (16,25,28)-->(38)
  │    ├── left-join (lookup transactiondetails)
  │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15!null int8:16!null int8:17!null column20:20 sellprice:22 buyprice:23 discount:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
  │    │    ├── key columns: [13 14 15 16 17] = [25 26 27 28 29]
@@ -1360,20 +1360,20 @@ upsert transactiondetails
  │    │    │    │    ├── volatile
  │    │    │    │    ├── fd: ()-->(13-15,24)
  │    │    │    │    ├── values
- │    │    │    │    │    ├── columns: detail_b:64!null detail_c:65!null detail_q:66!null detail_s:67!null
+ │    │    │    │    │    ├── columns: detail_b:60!null detail_c:61!null detail_q:62!null detail_s:63!null
  │    │    │    │    │    ├── cardinality: [2 - 2]
  │    │    │    │    │    ├── ('2.29', '49833', '4', '2.89')
  │    │    │    │    │    └── ('17.59', '29483', '2', '18.93')
  │    │    │    │    └── projections
- │    │    │    │         ├── crdb_internal.round_decimal_values(detail_s:67::STRING::DECIMAL(10,4), 4) [as=sellprice:22, outer=(67), immutable]
- │    │    │    │         ├── crdb_internal.round_decimal_values(detail_b:64::STRING::DECIMAL(10,4), 4) [as=buyprice:23, outer=(64), immutable]
+ │    │    │    │         ├── crdb_internal.round_decimal_values(detail_s:63::STRING::DECIMAL(10,4), 4) [as=sellprice:22, outer=(63), immutable]
+ │    │    │    │         ├── crdb_internal.round_decimal_values(detail_b:60::STRING::DECIMAL(10,4), 4) [as=buyprice:23, outer=(60), immutable]
  │    │    │    │         ├── 0.0000 [as=discount:24]
  │    │    │    │         ├── cluster_logical_timestamp() [as=column20:20, volatile]
  │    │    │    │         ├── 1 [as="?column?":13]
  │    │    │    │         ├── false [as=bool:14]
  │    │    │    │         ├── '2017-05-10 13:00:00+00:00' [as=current_timestamp:15]
- │    │    │    │         ├── detail_c:65::STRING::INT8 [as=int8:16, outer=(65), immutable]
- │    │    │    │         └── detail_q:66::STRING::INT8 [as=int8:17, outer=(66), immutable]
+ │    │    │    │         ├── detail_c:61::STRING::INT8 [as=int8:16, outer=(61), immutable]
+ │    │    │    │         └── detail_q:62::STRING::INT8 [as=int8:17, outer=(62), immutable]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=sellprice:22, outer=(22)]
  │    │    │         │    └── sellprice:22
@@ -1391,38 +1391,35 @@ upsert transactiondetails
  │    │    │              └── current_timestamp:15
  │    │    └── filters (true)
  │    └── projections
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN "?column?":13 ELSE transactiondetails.dealerid:25 END [as=upsert_dealerid:38, outer=(13,25)]
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN bool:14 ELSE transactiondetails.isbuy:26 END [as=upsert_isbuy:39, outer=(14,25,26)]
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN current_timestamp:15 ELSE transactiondate:27 END [as=upsert_transactiondate:40, outer=(15,25,27)]
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN int8:16 ELSE cardid:28 END [as=upsert_cardid:41, outer=(16,25,28)]
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN discount:24 ELSE crdb_internal.round_decimal_values(discount:24, 4) END [as=upsert_discount:44, outer=(24,25), immutable]
- │         ├── crdb_internal.round_decimal_values(sellprice:22, 4) [as=sellprice:35, outer=(22), immutable]
- │         └── crdb_internal.round_decimal_values(buyprice:23, 4) [as=buyprice:36, outer=(23), immutable]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN "?column?":13 ELSE transactiondetails.dealerid:25 END [as=upsert_dealerid:35, outer=(13,25)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN bool:14 ELSE transactiondetails.isbuy:26 END [as=upsert_isbuy:36, outer=(14,25,26)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN current_timestamp:15 ELSE transactiondate:27 END [as=upsert_transactiondate:37, outer=(15,25,27)]
+ │         └── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN int8:16 ELSE cardid:28 END [as=upsert_cardid:38, outer=(16,25,28)]
  └── f-k-checks
       ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
       │    └── anti-join (lookup transactions)
-      │         ├── columns: upsert_dealerid:45 upsert_isbuy:46 upsert_transactiondate:47
-      │         ├── key columns: [45 46 47] = [48 49 50]
+      │         ├── columns: upsert_dealerid:41 upsert_isbuy:42 upsert_transactiondate:43
+      │         ├── key columns: [41 42 43] = [44 45 46]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 2]
       │         ├── with-scan &2
-      │         │    ├── columns: upsert_dealerid:45 upsert_isbuy:46 upsert_transactiondate:47
+      │         │    ├── columns: upsert_dealerid:41 upsert_isbuy:42 upsert_transactiondate:43
       │         │    ├── mapping:
-      │         │    │    ├──  upsert_dealerid:38 => upsert_dealerid:45
-      │         │    │    ├──  upsert_isbuy:39 => upsert_isbuy:46
-      │         │    │    └──  upsert_transactiondate:40 => upsert_transactiondate:47
+      │         │    │    ├──  upsert_dealerid:35 => upsert_dealerid:41
+      │         │    │    ├──  upsert_isbuy:36 => upsert_isbuy:42
+      │         │    │    └──  upsert_transactiondate:37 => upsert_transactiondate:43
       │         │    └── cardinality: [1 - 2]
       │         └── filters (true)
       └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
            └── anti-join (lookup cards)
-                ├── columns: upsert_cardid:57
-                ├── key columns: [57] = [58]
+                ├── columns: upsert_cardid:53
+                ├── key columns: [53] = [54]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 2]
                 ├── with-scan &2
-                │    ├── columns: upsert_cardid:57
+                │    ├── columns: upsert_cardid:53
                 │    ├── mapping:
-                │    │    └──  upsert_cardid:41 => upsert_cardid:57
+                │    │    └──  upsert_cardid:38 => upsert_cardid:53
                 │    └── cardinality: [1 - 2]
                 └── filters (true)
 


### PR DESCRIPTION
Previously, the mutation builder constructed mutation operation lists consisting
of scope column ordinals. For example, it kept an `updateOrds` list that tracked
all columns that need to be updated. This mechanism turned out to be hard to use
because it required the output scope to be kept in a strict order.

This commit switches to use column IDs rather than scope ordinals. This allows
scope columns to be added in any order. Also, this commit adds a small
optimization that avoids rounding the same column twice, and more importantly
avoids the necessity of updating multiple mutation operation lists when we
round a column.

Release note: None