### PR TITLE
sql: add support for COMMENT ON VIEW, COMMENT ON SEQUENCE

### DIFF
--- a/docs/generated/sql/bnf/comment.bnf
+++ b/docs/generated/sql/bnf/comment.bnf
@@ -3,3 +3,5 @@ comment_stmt ::=
 	| 'COMMENT' 'ON' 'TABLE' table_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'COLUMN' column_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'INDEX' table_index_name 'IS' comment_text
+	| 'COMMENT' 'ON' 'VIEW' view_name 'IS' comment_text
+	| 'COMMENT' 'ON' 'SEQUENCE' sequence_name 'IS' comment_text

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -55,6 +55,8 @@ comment_stmt ::=
 	| 'COMMENT' 'ON' 'TABLE' table_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'COLUMN' column_path 'IS' comment_text
 	| 'COMMENT' 'ON' 'INDEX' table_index_name 'IS' comment_text
+	| 'COMMENT' 'ON' 'VIEW' view_name 'IS' comment_text
+	| 'COMMENT' 'ON' 'SEQUENCE' sequence_name 'IS' comment_text
 
 execute_stmt ::=
 	'EXECUTE' table_alias_name execute_param_clause
@@ -240,6 +242,12 @@ column_path ::=
 table_index_name ::=
 	table_name '@' index_name
 	| standalone_index_name
+
+view_name ::=
+	table_name
+
+sequence_name ::=
+	db_object_name
 
 table_alias_name ::=
 	name
@@ -1534,12 +1542,6 @@ opt_temp ::=
 	'TEMPORARY'
 	| 'TEMP'
 	| 
-
-view_name ::=
-	table_name
-
-sequence_name ::=
-	db_object_name
 
 opt_sequence_option_list ::=
 	sequence_option_list

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -385,6 +385,8 @@ const (
 	TableCommentType    = 1
 	ColumnCommentType   = 2
 	IndexCommentType    = 3
+	ViewCommentType     = 4
+	SequenceCommentType = 5
 )
 
 const (

--- a/pkg/sql/comment_on_sequence.go
+++ b/pkg/sql/comment_on_sequence.go
@@ -1,0 +1,99 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+type commentOnSequenceNode struct {
+	n            *tree.CommentOnSequence
+	sequenceDesc *ImmutableTableDescriptor
+}
+
+// CommentOnSequence adds comment on a sequence.
+// Privileges: CREATE on sequence.
+func (p *planner) CommentOnSequence(
+	ctx context.Context, n *tree.CommentOnSequence,
+) (planNode, error) {
+	sequenceDesc, err := p.ResolveUncachedTableDescriptorEx(ctx, n.Sequence, true, tree.ResolveRequireSequenceDesc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Require that the current user can create a sequence to begin with.
+	if err := p.CheckPrivilege(ctx, sequenceDesc, privilege.CREATE); err != nil {
+		return nil, err
+	}
+
+	return &commentOnSequenceNode{
+		n:            n,
+		sequenceDesc: sequenceDesc,
+	}, nil
+}
+
+func (n *commentOnSequenceNode) startExec(params runParams) error {
+	if n.n.Comment != nil {
+		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+			params.ctx,
+			"set-sequence-comment",
+			params.p.Txn(),
+			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+			"UPSERT INTO system.comments VALUES ($1, $2, 0, $3)",
+			keys.SequenceCommentType,
+			n.sequenceDesc.ID,
+			*n.n.Comment)
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+			params.ctx,
+			"delete-sequence-comment",
+			params.p.Txn(),
+			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+			"DELETE FROM system.comments WHERE type=$1 AND object_id=$2 AND sub_id=0",
+			keys.SequenceCommentType,
+			n.sequenceDesc.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
+		params.ctx,
+		params.p.txn,
+		EventLogCommentOnSequence,
+		int32(n.sequenceDesc.ID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
+		struct {
+			SequenceName string
+			Statement    string
+			User         string
+			Comment      *string
+		}{
+			params.p.ResolvedName(n.n.Sequence).FQString(),
+			n.n.String(),
+			params.SessionData().User,
+			n.n.Comment,
+		},
+	)
+}
+
+func (n *commentOnSequenceNode) Next(runParams) (bool, error) { return false, nil }
+func (n *commentOnSequenceNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *commentOnSequenceNode) Close(context.Context)        {}

--- a/pkg/sql/comment_on_sequence_test.go
+++ b/pkg/sql/comment_on_sequence_test.go
@@ -1,0 +1,108 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	gosql "database/sql"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+func TestCommentOnSequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := tests.CreateTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.Background())
+
+	if _, err := db.Exec(`
+		CREATE DATABASE d;
+		SET DATABASE = d;
+		CREATE SEQUENCE s;
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		exec   string
+		query  string
+		expect gosql.NullString
+	}{
+		{
+			`COMMENT ON SEQUENCE s IS 'foo'`,
+			`SELECT obj_description('s'::regclass)`,
+			gosql.NullString{String: `foo`, Valid: true},
+		},
+		{
+			`COMMENT ON SEQUENCE s IS NULL`,
+			`SELECT obj_description('s'::regclass)`,
+			gosql.NullString{Valid: false},
+		},
+	}
+
+	for _, tc := range testCases {
+		if _, err := db.Exec(tc.exec); err != nil {
+			t.Fatal(err)
+		}
+
+		row := db.QueryRow(tc.query)
+		var comment gosql.NullString
+		if err := row.Scan(&comment); err != nil {
+			t.Fatal(err)
+		}
+		if tc.expect != comment {
+			t.Fatalf("expected comment %v, got %v", tc.expect, comment)
+		}
+	}
+}
+
+func TestCommentOnSequenceWhenDrop(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := tests.CreateTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.Background())
+
+	if _, err := db.Exec(`
+		CREATE DATABASE d;
+		SET DATABASE = d;
+		CREATE SEQUENCE s;
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Exec(`COMMENT ON SEQUENCE s IS 'foo'`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Exec(`DROP SEQUENCE s`); err != nil {
+		t.Fatal(err)
+	}
+
+	row := db.QueryRow(`SELECT comment FROM system.comments LIMIT 1`)
+	var comment string
+	err := row.Scan(&comment)
+	if !errors.Is(err, gosql.ErrNoRows) {
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Fatal("dropped comment remain comment")
+	}
+}

--- a/pkg/sql/comment_on_view.go
+++ b/pkg/sql/comment_on_view.go
@@ -1,0 +1,96 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+type commentOnViewNode struct {
+	n        *tree.CommentOnView
+	viewDesc *ImmutableTableDescriptor
+}
+
+// CommentOnView adds comment on a view.
+// Privileges: CREATE on view.
+func (p *planner) CommentOnView(ctx context.Context, n *tree.CommentOnView) (planNode, error) {
+	viewDesc, err := p.ResolveUncachedTableDescriptorEx(ctx, n.View, true, tree.ResolveRequireViewDesc)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.CheckPrivilege(ctx, viewDesc, privilege.CREATE); err != nil {
+		return nil, err
+	}
+
+	return &commentOnViewNode{
+		n:        n,
+		viewDesc: viewDesc,
+	}, nil
+}
+
+func (n *commentOnViewNode) startExec(params runParams) error {
+	if n.n.Comment != nil {
+		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+			params.ctx,
+			"set-view-comment",
+			params.p.Txn(),
+			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+			"UPSERT INTO system.comments VALUES ($1, $2, 0, $3)",
+			keys.ViewCommentType,
+			n.viewDesc.ID,
+			*n.n.Comment)
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+			params.ctx,
+			"delete-view-comment",
+			params.p.Txn(),
+			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+			"DELETE FROM system.comments WHERE type=$1 AND object_id=$2 AND sub_id=0",
+			keys.ViewCommentType,
+			n.viewDesc.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
+		params.ctx,
+		params.p.txn,
+		EventLogCommentOnView,
+		int32(n.viewDesc.ID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
+		struct {
+			ViewName  string
+			Statement string
+			User      string
+			Comment   *string
+		}{
+			params.p.ResolvedName(n.n.View).FQString(),
+			n.n.String(),
+			params.SessionData().User,
+			n.n.Comment,
+		},
+	)
+}
+
+func (n *commentOnViewNode) Next(runParams) (bool, error) { return false, nil }
+func (n *commentOnViewNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *commentOnViewNode) Close(context.Context)        {}

--- a/pkg/sql/comment_on_view_test.go
+++ b/pkg/sql/comment_on_view_test.go
@@ -1,0 +1,108 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	gosql "database/sql"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+func TestCommentOnView(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := tests.CreateTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.Background())
+
+	if _, err := db.Exec(`
+		CREATE DATABASE d;
+		SET DATABASE = d;
+		CREATE VIEW v AS SELECT 1;
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		exec   string
+		query  string
+		expect gosql.NullString
+	}{
+		{
+			`COMMENT ON VIEW v IS 'foo'`,
+			`SELECT obj_description('v'::regclass)`,
+			gosql.NullString{String: `foo`, Valid: true},
+		},
+		{
+			`COMMENT ON VIEW v IS NULL`,
+			`SELECT obj_description('v'::regclass)`,
+			gosql.NullString{Valid: false},
+		},
+	}
+
+	for _, tc := range testCases {
+		if _, err := db.Exec(tc.exec); err != nil {
+			t.Fatal(err)
+		}
+
+		row := db.QueryRow(tc.query)
+		var comment gosql.NullString
+		if err := row.Scan(&comment); err != nil {
+			t.Fatal(err)
+		}
+		if tc.expect != comment {
+			t.Fatalf("expected comment %v, got %v", tc.expect, comment)
+		}
+	}
+}
+
+func TestCommentOnViewWhenDrop(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := tests.CreateTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.Background())
+
+	if _, err := db.Exec(`
+		CREATE DATABASE d;
+		SET DATABASE = d;
+		CREATE VIEW v AS SELECT 1;
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Exec(`COMMENT ON VIEW v IS 'foo'`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Exec(`DROP VIEW v`); err != nil {
+		t.Fatal(err)
+	}
+
+	row := db.QueryRow(`SELECT comment FROM system.comments LIMIT 1`)
+	var comment string
+	err := row.Scan(&comment)
+	if !errors.Is(err, gosql.ErrNoRows) {
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Fatal("dropped comment remain comment")
+	}
+}

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -111,6 +111,12 @@ func (p *planner) dropSequenceImpl(
 	if err := removeSequenceOwnerIfExists(ctx, p, seqDesc.ID, seqDesc.GetSequenceOpts()); err != nil {
 		return err
 	}
+
+	// Drop any comments for the sequence.
+	if err := p.removeTableComments(ctx, seqDesc); err != nil {
+		return err
+	}
+
 	return p.initiateDropTable(ctx, seqDesc, queueJob, jobDesc, true /* drainName */)
 }
 

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -225,6 +225,11 @@ func (p *planner) dropViewImpl(
 		}
 	}
 
+	// Drop any comments for the view.
+	if err := p.removeTableComments(ctx, viewDesc); err != nil {
+		return cascadeDroppedViews, err
+	}
+
 	if err := p.initiateDropTable(ctx, viewDesc, queueJob, jobDesc, true /* drainName */); err != nil {
 		return cascadeDroppedViews, err
 	}

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -46,6 +46,10 @@ const (
 	EventLogCommentOnTable EventLogType = "comment_on_table"
 	// EventLogCommentOnIndex is recorded when a index is commented.
 	EventLogCommentOnIndex EventLogType = "comment_on_index"
+	// EventLogCommentOnView is recorded when a view is commented.
+	EventLogCommentOnView EventLogType = "comment_on_view"
+	// EventLogCommentOnSequence is recorded when a sequence is commented.
+	EventLogCommentOnSequence EventLogType = "comment_on_sequence"
 
 	// EventLogCreateIndex is recorded when an index is created.
 	EventLogCreateIndex EventLogType = "create_index"

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2186,18 +2186,25 @@ statement ok
 CREATE TABLE t(x INT);
 
 statement ok
+CREATE VIEW v AS SELECT x FROM t;
+
+statement ok
 COMMENT ON TABLE t IS 'waa'
 
 statement ok
 COMMENT ON COLUMN t.x IS 'woo'
 
-query TTTT
+statement ok
+COMMENT ON VIEW v IS 'woo'
+
+query TTTTT
 SELECT obj_description('t'::regclass::oid),
        obj_description('t'::regclass::oid, 'pg_class'),
        obj_description('t'::regclass::oid, 'notexist'),
-       col_description('t'::regclass, 1)
+       col_description('t'::regclass, 1),
+       obj_description('v'::regclass::oid)
 ----
-waa  waa  NULL  woo
+waa  waa  NULL  woo  woo
 
 statement ok
 COMMENT ON DATABASE test is 'foo'
@@ -2543,12 +2550,12 @@ NULL
 query I
 SELECT crdb_internal.get_namespace_id(0, 'root_test')
 ----
-61
+62
 
 query I
 SELECT crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't')
 ----
-62
+63
 
 query T
 SELECT crdb_internal.get_zone_config(-1)::string
@@ -2598,12 +2605,12 @@ user testuser
 query I
 SELECT crdb_internal.get_namespace_id(0, 'root_test')
 ----
-61
+62
 
 query I
 SELECT crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't')
 ----
-62
+63
 
 query T
 SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(0, 'root_test'))::string

--- a/pkg/sql/logictest/testdata/logic_test/comments
+++ b/pkg/sql/logictest/testdata/logic_test/comments
@@ -1,0 +1,122 @@
+##########################
+# Comments on Databases  #
+##########################
+
+subtest comment_on_databases
+
+statement ok
+CREATE DATABASE d;
+
+statement ok
+COMMENT ON DATABASE d IS 'foo';
+
+query T
+SELECT shobj_description((select oid from pg_database where datname = 'd')::oid, 'pg_database');
+----
+foo
+
+statement ok
+COMMENT ON DATABASE d IS NULL;
+
+query T
+SELECT shobj_description((select oid from pg_database where datname = 'd')::oid, 'pg_database');
+----
+NULL
+
+##########################
+# Comments on Tables     #
+##########################
+
+subtest comment_on_tables
+
+statement ok
+CREATE TABLE T (i INT);
+
+statement ok
+COMMENT ON TABLE t IS 'foo';
+
+query T
+SELECT obj_description('t'::regclass);
+----
+foo
+
+statement ok
+COMMENT ON TABLE t IS NULL;
+
+query T
+SELECT obj_description('t'::regclass);
+----
+NULL
+
+##########################
+# Comments on Columns    #
+##########################
+
+subtest comment_on_columns
+
+statement ok
+COMMENT ON COLUMN t.i IS 'foo';
+
+query T
+SELECT col_description('t'::regclass, 1);
+----
+foo
+
+statement ok
+COMMENT ON COLUMN t.i IS NULL;
+
+query T
+SELECT col_description('t'::regclass, 1);
+----
+NULL
+
+##########################
+# Comments on Views      #
+##########################
+
+subtest comment_on_views
+
+statement ok
+CREATE VIEW v AS SELECT i FROM t;
+
+statement ok
+COMMENT ON VIEW v IS 'foo';
+
+query T
+SELECT obj_description('v'::regclass);
+----
+foo
+
+statement ok
+COMMENT ON VIEW v IS NULL;
+
+query T
+SELECT obj_description('v'::regclass);
+----
+NULL
+
+##########################
+# Comments on Sequences  #
+##########################
+
+subtest comment_on_sequences
+
+statement ok
+CREATE SEQUENCE s;
+
+statement ok
+COMMENT ON SEQUENCE s IS 'foo';
+
+query T
+SELECT obj_description('s'::regclass);
+----
+foo
+
+statement ok
+COMMENT ON SEQUENCE s IS NULL;
+
+query T
+SELECT obj_description('s'::regclass);
+----
+NULL
+

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -67,6 +67,10 @@ func buildOpaque(
 		plan, err = p.CommentOnIndex(ctx, n)
 	case *tree.CommentOnTable:
 		plan, err = p.CommentOnTable(ctx, n)
+	case *tree.CommentOnView:
+		plan, err = p.CommentOnView(ctx, n)
+	case *tree.CommentOnSequence:
+		plan, err = p.CommentOnSequence(ctx, n)
 	case *tree.CreateDatabase:
 		plan, err = p.CreateDatabase(ctx, n)
 	case *tree.CreateIndex:
@@ -176,6 +180,8 @@ func init() {
 		&tree.CommentOnDatabase{},
 		&tree.CommentOnIndex{},
 		&tree.CommentOnTable{},
+		&tree.CommentOnView{},
+		&tree.CommentOnSequence{},
 		&tree.CreateDatabase{},
 		&tree.CreateIndex{},
 		&tree.CreateSchema{},

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1405,6 +1405,10 @@ func TestParse(t *testing.T) {
 		{`COMMENT ON INDEX foo IS NULL`},
 		{`COMMENT ON TABLE foo IS 'a'`},
 		{`COMMENT ON TABLE foo IS NULL`},
+		{`COMMENT ON VIEW foo IS 'a'`},
+		{`COMMENT ON VIEW foo IS NULL`},
+		{`COMMENT ON SEQUENCE foo IS 'a'`},
+		{`COMMENT ON SEQUENCE food IS NULL`},
 
 		{`ALTER SEQUENCE a RENAME TO b`},
 		{`EXPLAIN ALTER SEQUENCE a RENAME TO b`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2627,6 +2627,14 @@ comment_stmt:
   {
     $$.val = &tree.CommentOnIndex{Index: $4.tableIndexName(), Comment: $6.strPtr()}
   }
+| COMMENT ON VIEW view_name IS comment_text
+  {
+    $$.val = &tree.CommentOnView{View: $4.unresolvedObjectName(), Comment: $6.strPtr()}
+  }
+| COMMENT ON SEQUENCE sequence_name IS comment_text
+  {
+    $$.val = &tree.CommentOnSequence{Sequence: $4.unresolvedObjectName(), Comment: $6.strPtr()}
+  }
 
 comment_text:
   SCONST

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1402,7 +1402,7 @@ CREATE TABLE pg_catalog.pg_description (
 			case keys.DatabaseCommentType:
 				// Database comments are exported in pg_shdescription.
 				continue
-			case keys.ColumnCommentType, keys.TableCommentType:
+			case keys.ColumnCommentType, keys.TableCommentType, keys.ViewCommentType, keys.SequenceCommentType:
 				objID = tree.NewDOid(tree.MustBeDInt(objID))
 				classOid = tree.NewDOid(sqlbase.PgCatalogClassTableID)
 			case keys.IndexCommentType:

--- a/pkg/sql/sem/tree/comment_on_sequence.go
+++ b/pkg/sql/sem/tree/comment_on_sequence.go
@@ -1,0 +1,31 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+import "github.com/cockroachdb/cockroach/pkg/sql/lex"
+
+// CommentOnSequence represents a COMMENT ON SEQUENCE statement.
+type CommentOnSequence struct {
+	Sequence *UnresolvedObjectName
+	Comment  *string
+}
+
+// Format implements the NodeFormatter interface.
+func (n *CommentOnSequence) Format(ctx *FmtCtx) {
+	ctx.WriteString("COMMENT ON SEQUENCE ")
+	ctx.FormatNode(n.Sequence)
+	ctx.WriteString(" IS ")
+	if n.Comment != nil {
+		lex.EncodeSQLStringWithFlags(&ctx.Buffer, *n.Comment, ctx.flags.EncodeFlags())
+	} else {
+		ctx.WriteString("NULL")
+	}
+}

--- a/pkg/sql/sem/tree/comment_on_view.go
+++ b/pkg/sql/sem/tree/comment_on_view.go
@@ -1,0 +1,31 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+import "github.com/cockroachdb/cockroach/pkg/sql/lex"
+
+// CommentOnView represents a COMMENT ON VIEW statement.
+type CommentOnView struct {
+	View    *UnresolvedObjectName
+	Comment *string
+}
+
+// Format implements the NodeFormatter interface.
+func (n *CommentOnView) Format(ctx *FmtCtx) {
+	ctx.WriteString("COMMENT ON VIEW ")
+	ctx.FormatNode(n.View)
+	ctx.WriteString(" IS ")
+	if n.Comment != nil {
+		lex.EncodeSQLStringWithFlags(&ctx.Buffer, *n.Comment, ctx.flags.EncodeFlags())
+	} else {
+		ctx.WriteString("NULL")
+	}
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -292,6 +292,18 @@ func (*CommentOnTable) StatementType() StatementType { return DDL }
 func (*CommentOnTable) StatementTag() string { return "COMMENT ON TABLE" }
 
 // StatementType implements the Statement interface.
+func (*CommentOnView) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*CommentOnView) StatementTag() string { return "COMMENT ON VIEW" }
+
+// StatementType implements the Statement interface.
+func (*CommentOnSequence) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*CommentOnSequence) StatementTag() string { return "COMMENT ON SEQUENCE" }
+
+// StatementType implements the Statement interface.
 func (*CommitTransaction) StatementType() StatementType { return Ack }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -945,6 +957,8 @@ func (n *CommentOnColumn) String() string                { return AsString(n) }
 func (n *CommentOnDatabase) String() string              { return AsString(n) }
 func (n *CommentOnIndex) String() string                 { return AsString(n) }
 func (n *CommentOnTable) String() string                 { return AsString(n) }
+func (n *CommentOnView) String() string                  { return AsString(n) }
+func (n *CommentOnSequence) String() string              { return AsString(n) }
 func (n *CommitTransaction) String() string              { return AsString(n) }
 func (n *CopyFrom) String() string                       { return AsString(n) }
 func (n *CreateChangefeed) String() string               { return AsString(n) }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -922,6 +922,8 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&commentOnDatabaseNode{}): "comment on database",
 	reflect.TypeOf(&commentOnIndexNode{}):    "comment on index",
 	reflect.TypeOf(&commentOnTableNode{}):    "comment on table",
+	reflect.TypeOf(&commentOnViewNode{}):     "comment on view",
+	reflect.TypeOf(&commentOnSequenceNode{}): "comment on sequence",
 	reflect.TypeOf(&controlJobsNode{}):       "control jobs",
 	reflect.TypeOf(&createDatabaseNode{}):    "create database",
 	reflect.TypeOf(&createIndexNode{}):       "create index",


### PR DESCRIPTION
Added the CommentOnView and CommentOnSequence tree node and plan node.
These will each append a new type to the system.comments table for views
and sequences respectively.

This would resolve #44135

Release note (sql change): implemented COMMENT ON VIEW/SEQUENCE

I think it might be possible to handle the comment on view/sequence code all within a single plan node. Something like the commentOnTable as they are all considered table objects anyway underneath (as far as I understand it). But this might also bloat the commentOnTableNode. So albeit a bit repetitive, this implements the comment on view and comment on sequence as separate tree items and plan nodes.

I wasn't sure what would be the best place to put the logic tests for comments. But given that more support for comments is being added I added a dedicated comments logic test file that covers all the currently supported comment statements.

- [x] Parsing COMMENT ON VIEW
- [x] Executing COMMENT ON VIEW
- [x] Parsing COMMENT ON SEQUENCE
- [x] Executing COMMENT ON SEQUENCE
- [x] Delete comments for view when view is dropped
- [x] Delete comments for sequence when sequence is dropped
- [x] Tests for COMMENT ON VIEW
- [x] Tests for COMMENT ON SEQUENCE
- [x] Logic tests