### PR TITLE
opt: improve error message for failing to force a partial index

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -457,6 +457,10 @@ func (b *Builder) scanParams(
 		var err error
 		if idx.IsInverted() {
 			err = fmt.Errorf("index \"%s\" is inverted and cannot be used for this query", idx.Name())
+		} else if _, isPartial := idx.Predicate(); isPartial {
+			err = fmt.Errorf(
+				"index \"%s\" is a partial index that does not contain all the rows needed to execute this query",
+				idx.Name())
 		} else {
 			// This should never happen.
 			err = fmt.Errorf("index \"%s\" cannot be used for this query", idx.Name())

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -26,6 +26,23 @@ CREATE TABLE u (
 )
 
 # ---------------------------------------------------------
+# SELECT
+# ---------------------------------------------------------
+
+query T kvtrace
+SELECT a FROM t WHERE a > b AND c = 'foo'
+----
+Scan /Table/53/{4-5}
+
+query T kvtrace
+SELECT a FROM t@c_partial WHERE a > b AND c = 'foo'
+----
+Scan /Table/53/{4-5}
+
+statement error index "c_partial" is a partial index that does not contain all the rows needed to execute this query
+SELECT a FROM t@c_partial WHERE a > b AND c = 'bar'
+
+# ---------------------------------------------------------
 # INSERT
 # ---------------------------------------------------------
 


### PR DESCRIPTION
This commit expands the error message when a user tries to force a
partial index that cannot satisfy the query. This error is emitted when
the query filter does not imply the partial index predicate.

Release note: None