### PR TITLE
test: prefer NoError/Error over Nil/NotNil

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -3517,7 +3517,7 @@ func TestConnectionClass(t *testing.T) {
 	// Verify that the request carries the class we expect it to for its span.
 	verifyClass := func(class rpc.ConnectionClass, args roachpb.BatchRequest) {
 		span, err := keys.Range(args.Requests)
-		if assert.Nil(t, err) {
+		if assert.NoError(t, err) {
 			assert.Equalf(t, rpc.ConnectionClassForKey(span.Key), class,
 				"unexpected class for span key %v", span.Key)
 		}
@@ -3566,7 +3566,7 @@ func TestConnectionClass(t *testing.T) {
 				},
 			})
 			_, err := ds.Send(context.Background(), ba)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -4457,7 +4457,7 @@ func TestTracingDoesNotRaceWithCancelation(t *testing.T) {
 	// Make the transport flaky for the range in question to encourage proposals
 	// to be sent more times and ultimately traced more.
 	ri, err := getRangeInfo(ctx, db, roachpb.Key("foo"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {
 		mtc.transport.Listen(mtc.stores[i].Ident.StoreID, &unreliableRaftHandler{
@@ -4577,7 +4577,7 @@ func TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic(t *testing
 		mtc.waitForValues(keyA, []int64{1, 1, 1})
 		disabled.Store(true)
 		repl1, err := mtc.stores[0].GetReplica(1)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		// Transfer the lease on range 1. Make sure there's no pending transfer.
 		var lease roachpb.Lease
 		testutils.SucceedsSoon(t, func() error {
@@ -4925,7 +4925,7 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 
 		split(t, db, scratchTableKey)
 		ri, err := getRangeInfo(ctx, db, scratchTableKey)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		lhsID = ri.Desc.RangeID
 		// First put the range on all three nodes.
 		mtc.replicateRange(lhsID, 1, 2)

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2052,7 +2052,7 @@ func TestConcurrentAdminChangeReplicasRequests(t *testing.T) {
 	key := roachpb.Key("a")
 	db := tc.Servers[0].DB()
 	rangeInfo, err := getRangeInfo(ctx, db, key)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, rangeInfo.Desc.InternalReplicas, 1)
 	targets1, targets2 := makeReplicationTargets(2, 3, 4), makeReplicationTargets(4, 5)
 	expects1 := rangeInfo.Desc
@@ -2080,7 +2080,7 @@ func TestConcurrentAdminChangeReplicasRequests(t *testing.T) {
 	wg.Wait()
 
 	infoAfter, err := getRangeInfo(ctx, db, key)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	assert.Falsef(t, err1 == nil && err2 == nil,
 		"expected one of racing AdminChangeReplicasRequests to fail but neither did")
@@ -2146,7 +2146,7 @@ func TestRandomConcurrentAdminChangeReplicasRequests(t *testing.T) {
 	// and then allowing multiple writes to overlap and validate that the state
 	// corresponds to a valid history of events.
 	rangeInfo, err := getRangeInfo(ctx, db, key)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	addReplicas := func() error {
 		_, err := db.AdminChangeReplicas(
 			ctx, key, rangeInfo.Desc, roachpb.MakeReplicationChanges(
@@ -2647,7 +2647,7 @@ func TestAdminRelocateRangeSafety(t *testing.T) {
 	key := roachpb.Key("a")
 	assert.Nil(t, db.AdminRelocateRange(ctx, key, makeReplicationTargets(1, 2, 3)))
 	rangeInfo, err := getRangeInfo(ctx, db, key)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, rangeInfo.Desc.InternalReplicas, 3)
 	assert.Equal(t, rangeInfo.Lease.Replica.NodeID, roachpb.NodeID(1))
 	for id := roachpb.StoreID(1); id <= 3; id++ {
@@ -2664,7 +2664,7 @@ func TestAdminRelocateRangeSafety(t *testing.T) {
 
 	// Code above verified r1 is the leaseholder, so use it to ChangeReplicas.
 	r1, _, err := tc.Servers[0].Stores().GetReplicaForRangeID(rangeInfo.Desc.RangeID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	expDescAfterAdd := rangeInfo.Desc // for use with ChangeReplicas
 	expDescAfterAdd.NextReplicaID++
 	expDescAfterAdd.InternalReplicas = append(expDescAfterAdd.InternalReplicas, roachpb.ReplicaDescriptor{
@@ -2689,7 +2689,7 @@ func TestAdminRelocateRangeSafety(t *testing.T) {
 	go func() { change(); wg.Done() }()
 	wg.Wait()
 	rangeInfo, err = getRangeInfo(ctx, db, key)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, len(rangeInfo.Desc.InternalReplicas) >= 3)
 	assert.Falsef(t, relocateErr == nil && changeErr == nil,
 		"expected one of racing AdminRelocateReplicas and ChangeReplicas "+

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -321,7 +321,7 @@ func TestClosedTimestampCanServeAfterSplitAndMerges(t *testing.T) {
 	// Now merge the ranges back together and ensure that there's two values in
 	// the merged range.
 	merged, err := tc.Server(0).MergeRanges(lr.StartKey.AsRawKey())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	mergedRepls := replsForRange(ctx, t, tc, merged)
 	// The hazard here is that a follower is not yet aware of the merge and will
 	// return an error. We'll accept that because a client wouldn't see that error
@@ -606,7 +606,7 @@ RESET statement_timeout;
 	})
 
 	desc, err := tc.LookupRange(startKey)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// First, we perform an arbitrary lease transfer because that will turn the
 	// lease into an epoch based one (the initial lease is likely expiration based

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -147,7 +147,7 @@ func TestLockTableWaiterWithTxn(t *testing.T) {
 			g.notify()
 
 			err := w.WaitOn(ctx, makeReq(), g)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		})
 	})
 
@@ -159,7 +159,7 @@ func TestLockTableWaiterWithTxn(t *testing.T) {
 		go cancel()
 
 		err := w.WaitOn(ctxWithCancel, makeReq(), g)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Equal(t, context.Canceled.Error(), err.GoError().Error())
 	})
 
@@ -172,7 +172,7 @@ func TestLockTableWaiterWithTxn(t *testing.T) {
 		}()
 
 		err := w.WaitOn(ctx, makeReq(), g)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.IsType(t, &roachpb.NodeUnavailableError{}, err.GetDetail())
 	})
 }
@@ -218,7 +218,7 @@ func TestLockTableWaiterWithNonTxn(t *testing.T) {
 			g.notify()
 
 			err := w.WaitOn(ctx, makeReq(), g)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		})
 	})
 
@@ -230,7 +230,7 @@ func TestLockTableWaiterWithNonTxn(t *testing.T) {
 		go cancel()
 
 		err := w.WaitOn(ctxWithCancel, makeReq(), g)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Equal(t, context.Canceled.Error(), err.GoError().Error())
 	})
 
@@ -243,7 +243,7 @@ func TestLockTableWaiterWithNonTxn(t *testing.T) {
 		}()
 
 		err := w.WaitOn(ctx, makeReq(), g)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.IsType(t, &roachpb.NodeUnavailableError{}, err.GetDetail())
 	})
 }
@@ -274,7 +274,7 @@ func testWaitPush(t *testing.T, k waitKind, makeReq func() Request, expPushTS hl
 			// It returns immediately.
 			if k == waitElsewhere && !lockHeld {
 				err := w.WaitOn(ctx, req, g)
-				require.Nil(t, err)
+				require.NoError(t, err)
 				return
 			}
 
@@ -283,7 +283,7 @@ func testWaitPush(t *testing.T, k waitKind, makeReq func() Request, expPushTS hl
 			if req.Txn == nil && !lockHeld {
 				defer notifyUntilDone(t, g)()
 				err := w.WaitOn(ctx, req, g)
-				require.Nil(t, err)
+				require.NoError(t, err)
 				return
 			}
 
@@ -324,7 +324,7 @@ func testWaitPush(t *testing.T, k waitKind, makeReq func() Request, expPushTS hl
 			}
 
 			err := w.WaitOn(ctx, req, g)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		})
 	})
 }
@@ -339,7 +339,7 @@ func testWaitNoopUntilDone(t *testing.T, k waitKind, makeReq func() Request) {
 	defer notifyUntilDone(t, g)()
 
 	err := w.WaitOn(ctx, makeReq(), g)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func notifyUntilDone(t *testing.T, g *mockLockTableGuard) func() {

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
@@ -282,7 +282,7 @@ func TestCleanupIntentsAsyncThrottled(t *testing.T) {
 	// processing of the intents resulting in no error and the consumption of the
 	// sendFuncs.
 	err = ir.CleanupIntentsAsync(context.Background(), testIntents, true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, sf.len(), 0)
 }
 
@@ -398,7 +398,7 @@ func TestCleanupMultipleIntentsAsync(t *testing.T) {
 	err := ir.CleanupIntentsAsync(ctx, testIntents, false)
 	sf.drain(t)
 	stopper.Stop(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Both txns should be pushed and all four intents should be resolved.
 	sort.Strings(reqs.pushed)
@@ -579,7 +579,7 @@ func TestCleanupTxnIntentsAsync(t *testing.T) {
 				return nil
 			})
 			stopper.Stop(context.Background())
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -669,7 +669,7 @@ func TestCleanupMultipleTxnIntentsAsync(t *testing.T) {
 	err := ir.CleanupTxnIntentsAsync(ctx, 1, testEndTxnIntents, false)
 	sf.drain(t)
 	stopper.Stop(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// All four intents should be resolved and both txn records should be GCed.
 	sort.Strings(reqs.resolved)

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -98,7 +98,7 @@ func TestProposalBuffer(t *testing.T) {
 		leaseReq := i == 3
 		pd, data := newPropData(leaseReq)
 		mlai, err := b.Insert(pd, data)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		if leaseReq {
 			expMlai := uint64(i)
 			require.Equal(t, uint64(0), mlai)
@@ -120,7 +120,7 @@ func TestProposalBuffer(t *testing.T) {
 	// Remember that the lease request above did not receive a lease index.
 	pd, data := newPropData(false)
 	mlai, err := b.Insert(pd, data)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	expMlai := uint64(num + 1)
 	require.Equal(t, expMlai, mlai)
 	require.Equal(t, expMlai, pd.command.MaxLeaseIndex)
@@ -143,7 +143,7 @@ func TestProposalBuffer(t *testing.T) {
 	// Insert one more proposal. The lease applied index should adjust to
 	// the increase accordingly.
 	mlai, err = b.Insert(pd, data)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	expMlai = p.lai + 1
 	require.Equal(t, expMlai, mlai)
 	require.Equal(t, expMlai, pd.command.MaxLeaseIndex)
@@ -245,7 +245,7 @@ func TestProposalBufferRegistersAllOnProposalError(t *testing.T) {
 	for i := 0; i < num; i++ {
 		pd, data := newPropData(false)
 		_, err := b.Insert(pd, data)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 	require.Equal(t, num, b.Len())
 
@@ -279,7 +279,7 @@ func TestProposalBufferRegistrationWithInsertionErrors(t *testing.T) {
 	for i := 0; i < num; i++ {
 		pd, data := newPropData(i%2 == 0)
 		_, err := b.Insert(pd, data)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	var insertErr = errors.New("failed insertion")

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2757,7 +2757,7 @@ func TestReplicaLatchingSplitDeclaresWrites(t *testing.T) {
 		if tc.expectAccess {
 			require.NoError(t, err)
 		} else {
-			require.NotNil(t, err)
+			require.Error(t, err)
 			require.Regexp(t, "undeclared span", err)
 		}
 	}

--- a/pkg/kv/kvserver/txnrecovery/manager_test.go
+++ b/pkg/kv/kvserver/txnrecovery/manager_test.go
@@ -142,7 +142,7 @@ func TestResolveIndeterminateCommit(t *testing.T) {
 		iceErr := roachpb.NewIndeterminateCommitError(txn)
 		resTxn, err := m.ResolveIndeterminateCommit(context.Background(), iceErr)
 		assert.NotNil(t, resTxn)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		if !prevent {
 			assert.Equal(t, roachpb.COMMITTED, resTxn.Status)
@@ -318,7 +318,7 @@ func TestResolveIndeterminateCommitTxnChanges(t *testing.T) {
 			resTxn, err := m.ResolveIndeterminateCommit(context.Background(), iceErr)
 			assert.NotNil(t, resTxn)
 			assert.Equal(t, c.changedTxn, *resTxn)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expMetrics = expMetrics.merge(c.metricImpact)
 			assertMetrics(t, m, expMetrics)
@@ -365,5 +365,5 @@ func TestResolveIndeterminateCommitTxnWithoutInFlightWrites(t *testing.T) {
 	resTxn, err := m.ResolveIndeterminateCommit(context.Background(), iceErr)
 	assert.NotNil(t, resTxn)
 	assert.Equal(t, roachpb.COMMITTED, resTxn.Status)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/pkg/kv/kvserver/txnwait/queue_test.go
+++ b/pkg/kv/kvserver/txnwait/queue_test.go
@@ -269,7 +269,7 @@ func TestPushersReleasedAfterAnyQueryTxnFindsAbortedTxn(t *testing.T) {
 			ctx := context.Background()
 			req := roachpb.PushTxnRequest{PusheeTxn: txn.TxnMeta, PushType: roachpb.PUSH_ABORT}
 			res, err := q.MaybeWaitForPush(ctx, &req)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, res)
 			require.Equal(t, roachpb.ABORTED, res.PusheeTxn.Status)
 		}()

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -1501,7 +1501,7 @@ func TestGRPCDialClass(t *testing.T) {
 	})
 
 	ln, err := netutil.ListenAndServeGRPC(serverCtx.Stopper, s, util.TestAddr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	remoteAddr := ln.Addr().String()
 	clientCtx := newTestContext(serverCtx.ClusterID.Get(), clock, stopper)
 
@@ -1620,12 +1620,12 @@ func TestTestingKnobs(t *testing.T) {
 	})
 
 	ln, err := netutil.ListenAndServeGRPC(serverCtx.Stopper, s, util.TestAddr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	remoteAddr := ln.Addr().String()
 	sysConn, err := clientCtx.GRPCDialNode(remoteAddr, 1, SystemClass).Connect(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defConn, err := clientCtx.GRPCDialNode(remoteAddr, 1, DefaultClass).Connect(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	const unaryMethod = "/cockroach.rpc.Testing/Foo"
 	const streamMethod = "/cockroach.rpc.Testing/Bar"
 	const numSysUnary = 3
@@ -1633,7 +1633,7 @@ func TestTestingKnobs(t *testing.T) {
 		ba := roachpb.BatchRequest{}
 		br := roachpb.BatchResponse{}
 		err := sysConn.Invoke(context.Background(), unaryMethod, &ba, &br)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 	const numDefStream = 4
 	for i := 0; i < numDefStream; i++ {
@@ -1642,7 +1642,7 @@ func TestTestingKnobs(t *testing.T) {
 			ClientStreams: true,
 		}
 		cs, err := defConn.NewStream(context.Background(), &desc, streamMethod)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Nil(t, cs.SendMsg(&roachpb.BatchRequest{}))
 		var br roachpb.BatchResponse
 		require.Nil(t, cs.RecvMsg(&br))

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -698,7 +698,7 @@ func TestConnCloseReleasesLocks(t *testing.T) {
 
 		if !open {
 			_, err = tx.Exec("bogus")
-			require.NotNil(t, err)
+			require.Error(t, err)
 		}
 		err = conn.Close()
 		require.NoError(t, err)

--- a/pkg/util/fsm/fsm_test.go
+++ b/pkg/util/fsm/fsm_test.go
@@ -55,12 +55,12 @@ func noErr(f func(Args)) func(Args) error {
 
 func (tr Transitions) applyWithoutErr(t *testing.T, a Args) State {
 	s, err := tr.apply(a)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	return s
 }
 func (tr Transitions) applyWithErr(t *testing.T, a Args) error {
 	_, err := tr.apply(a)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	return err
 }
 

--- a/pkg/util/quotapool/intpool_test.go
+++ b/pkg/util/quotapool/intpool_test.go
@@ -346,7 +346,7 @@ func TestOnAcquisition(t *testing.T) {
 		}))
 	ctx := context.Background()
 	alloc, err := qp.Acquire(ctx, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, called)
 	alloc.Release()
 }
@@ -601,7 +601,7 @@ func TestLen(t *testing.T) {
 	allocCh := make(chan *quotapool.IntAlloc)
 	doAcquire := func(ctx context.Context) {
 		alloc, err := qp.Acquire(ctx, 1)
-		if ctx.Err() == nil && assert.Nil(t, err) {
+		if ctx.Err() == nil && assert.NoError(t, err) {
 			allocCh <- alloc
 		}
 	}
@@ -617,7 +617,7 @@ func TestLen(t *testing.T) {
 	assert.Equal(t, 0, qp.Len())
 	// Acquire all of the quota from the pool.
 	alloc, err := qp.Acquire(ctx, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// The length should still be 0.
 	assert.Equal(t, 0, qp.Len())
 	// Launch a goroutine to acquire quota, ensure that the length increases.

--- a/pkg/util/search/search_test.go
+++ b/pkg/util/search/search_test.go
@@ -216,7 +216,7 @@ func TestBinarySearcher(t *testing.T) {
 	res, err := bs.Search(func(i int) (bool, error) {
 		return i <= 25, nil
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, res, 26)
 
 	// Looking for 25. Should result in 25 because of precision.
@@ -224,7 +224,7 @@ func TestBinarySearcher(t *testing.T) {
 	res, err = bs.Search(func(i int) (bool, error) {
 		return i <= 25, nil
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, res, 25)
 }
 
@@ -302,7 +302,7 @@ func TestLineSearcher(t *testing.T) {
 	res, err := ls.Search(func(i int) (bool, error) {
 		return i <= 25, nil
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, res, 26)
 
 	// Looking for 25. Should result in 25 because of precision.
@@ -310,7 +310,7 @@ func TestLineSearcher(t *testing.T) {
 	res, err = ls.Search(func(i int) (bool, error) {
 		return i <= 25, nil
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, res, 25)
 }
 
@@ -342,7 +342,7 @@ func TestIdenticalSearchers(t *testing.T) {
 		for _, fn := range searcherFns {
 			s := fn(min, max)
 			val, err := s.Search(pred)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, val, toFind, "searching with %T in range [%d,%d)", s, min, max)
 		}
 


### PR DESCRIPTION
replaces calls to require/assert Nil/NotNil to NoError/Error

[NoError](https://godoc.org/github.com/stretchr/testify/require#NoError) is for asserting no error was return
[Error](https://godoc.org/github.com/stretchr/testify/require#Error) is for asserting an error was returned

## Why is it important?

```golang
return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
```
```golang
return Fail(t, "An error is expected but got nil.", msgAndArgs...)
```
When these fail their message explicitly calls out that we were or were not expecting an error. This communicates the intent of the assertion.