### PR TITLE
colfetcher: emit rows/bytes read statistics

### DIFF
--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -53,6 +53,11 @@ func newKVFetcher(batchFetcher kvBatchFetcher) *KVFetcher {
 	}
 }
 
+// GetBytesRead returns the number of bytes read by this fetcher.
+func (f *KVFetcher) GetBytesRead() int64 {
+	return f.bytesRead
+}
+
 // NextKV returns the next kv from this fetcher. Returns false if there are no
 // more kvs to fetch, the kv that was fetched, and any errors that may have
 // occurred.


### PR DESCRIPTION
Previously, the vectorized engine wasn't emitting the same rows/bytes
read statistics that the row at a time engine was. This commit corrects
the issue.

Release note (bug fix): show statistics for rows/bytes read in the
vectorized engine, which were missing before.