### PR TITLE
sqlbase: refactor of type metadata installation API

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -659,10 +659,14 @@ func (sc *SchemaChanger) truncateIndexes(
 				// Hydrate types used in the retrieved table.
 				// TODO (rohany): This can be removed once table access from the
 				//  desc.Collection returns tables with hydrated types.
-				typLookup := func(id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
+				typLookup := func(ctx context.Context, id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
 					return resolver.ResolveTypeDescByID(ctx, txn, sc.execCfg.Codec, id, tree.ObjectLookupFlags{})
 				}
-				if err := sqlbase.HydrateTypesInTableDescriptor(tableDesc.TableDesc(), typLookup); err != nil {
+				if err := sqlbase.HydrateTypesInTableDescriptor(
+					ctx,
+					tableDesc.TableDesc(),
+					sqlbase.TypeLookupFunc(typLookup),
+				); err != nil {
 					return err
 				}
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2775,10 +2775,7 @@ CREATE TABLE pg_catalog.pg_type (
 
 				// Now generate rows for user defined types in this database.
 				return forEachTypeDesc(ctx, p, dbContext, func(_ *sqlbase.ImmutableDatabaseDescriptor, _ string, typDesc *sqlbase.ImmutableTypeDescriptor) error {
-					typ, err := typDesc.MakeTypesT(
-						tree.NewUnqualifiedTypeName(tree.Name(typDesc.GetName())),
-						p.makeTypeLookupFn(ctx),
-					)
+					typ, err := typDesc.MakeTypesT(ctx, tree.NewUnqualifiedTypeName(tree.Name(typDesc.GetName())), p)
 					if err != nil {
 						return err
 					}
@@ -2816,10 +2813,7 @@ CREATE TABLE pg_catalog.pg_type (
 					}
 					return false, err
 				}
-				typ, err = typDesc.MakeTypesT(
-					tree.NewUnqualifiedTypeName(tree.Name(typDesc.GetName())),
-					p.makeTypeLookupFn(ctx),
-				)
+				typ, err = typDesc.MakeTypesT(ctx, tree.NewUnqualifiedTypeName(tree.Name(typDesc.GetName())), p)
 				if err != nil {
 					return false, err
 				}

--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -96,7 +96,9 @@ func MakeNewQualifiedTypeName(db, schema, typ string) TypeName {
 
 // TypeReferenceResolver is the interface that will provide the ability
 // to actually look up type metadata and transform references into
-// *types.T's.
+// *types.T's. Implementers of TypeReferenceResolver should also implement
+// sqlbase.TypeDescriptorResolver is sqlbase.TypeDescriptorInterface is the
+// underlying representation of a user defined type.
 type TypeReferenceResolver interface {
 	ResolveType(ctx context.Context, name *UnresolvedObjectName) (*types.T, error)
 	ResolveTypeByID(ctx context.Context, id uint32) (*types.T, error)

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -327,14 +327,14 @@ func parseStats(
 			// collecting the stats. Changes to types are backwards compatible across
 			// versions, so using a newer version of the type metadata here is safe.
 			err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-				typeLookup := func(id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
+				typeLookup := func(ctx context.Context, id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
 					return resolver.ResolveTypeDescByID(ctx, txn, codec, id, tree.ObjectLookupFlags{})
 				}
-				name, typeDesc, err := typeLookup(sqlbase.ID(typ.StableTypeID()))
+				name, typeDesc, err := typeLookup(ctx, sqlbase.ID(typ.StableTypeID()))
 				if err != nil {
 					return err
 				}
-				return typeDesc.HydrateTypeInfoWithName(typ, name, typeLookup)
+				return typeDesc.HydrateTypeInfoWithName(ctx, typ, name, sqlbase.TypeLookupFunc(typeLookup))
 			})
 			if err != nil {
 				return nil, err

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -337,14 +337,14 @@ CREATE TABLE test.tt (x test.t);
 		t.Fatal(err)
 	}
 	desc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "tt")
-	typLookup := func(id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
+	typLookup := func(ctx context.Context, id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
 		typDesc, err := sqlbase.GetTypeDescFromID(ctx, kvDB, keys.SystemSQLCodec, id)
 		if err != nil {
 			return nil, nil, err
 		}
 		return &tree.TypeName{}, typDesc, nil
 	}
-	if err := sqlbase.HydrateTypesInTableDescriptor(desc, typLookup); err != nil {
+	if err := sqlbase.HydrateTypesInTableDescriptor(ctx, desc, sqlbase.TypeLookupFunc(typLookup)); err != nil {
 		t.Fatal(err)
 	}
 	// Ensure that we can clone this table.


### PR DESCRIPTION
This PR pulls a refactor out of #50942 that isn't important for that PR
but adds much more flexibility to the process of type metadata
hydration. In particular, we move away from passing in a closure to the
metadata installation methods to passing in an interface.

Release note: None