### PR TITLE
sql: fix pagination in UPSERT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1213,3 +1213,24 @@ DROP TABLE source
 
 statement ok
 DROP TABLE target
+
+# Regression test for UPSERT batching logic (#51391).
+statement ok
+SET CLUSTER SETTING kv.raft.command.max_size='4MiB';
+CREATE TABLE src (s STRING);
+CREATE TABLE dest (s STRING);
+INSERT INTO src
+SELECT
+	'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+FROM
+	generate_series(1, 50000)
+
+# This statement produces a raft command of about 6.6 MiB in size, so if the
+# batching logic is incorrect, we'll encounter "command is too large" error.
+statement ok
+UPSERT INTO dest (s) (SELECT s FROM src)
+
+statement ok
+RESET CLUSTER SETTING kv.raft.command.max_size;
+DROP TABLE src;
+DROP TABLE dest

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1436,7 +1436,6 @@ func (ef *execFactory) ConstructUpsert(
 			insertCols: ri.InsertCols,
 			tw: optTableUpserter{
 				ri:            ri,
-				alloc:         ef.planner.alloc,
 				canaryOrdinal: int(canaryCol),
 				fetchCols:     fetchColDescs,
 				updateCols:    updateColDescs,

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -178,7 +178,7 @@ func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) err
 // BatchedCount implements the batchedPlanNode interface.
 func (n *upsertNode) BatchedCount() int { return n.run.tw.batchedCount() }
 
-// BatchedCount implements the batchedPlanNode interface.
+// BatchedValues implements the batchedPlanNode interface.
 func (n *upsertNode) BatchedValues(rowIdx int) tree.Datums { return n.run.tw.batchedValues(rowIdx) }
 
 func (n *upsertNode) Close(ctx context.Context) {


### PR DESCRIPTION
**sql: minor cleanup around upsert**

This commit removes a couple of duplicated "init" calls as well as some
unused parameters around upsert code.

Release note: None

**sql: fix pagination in UPSERT**

`optTableUpserter` was incorrectly overriding `curBatchSize` method by
returning `insertRows.Len`, but that container is not actually used
anywhere. As a result, `curBatchSize` was always considered 0, and we
didn't perform the pagination on the UPSERTs. The bug was introduced in
#33339 (in 19.1.0).

Fixes: #51391.

Release note (bug fix): Previously, CockroachDB could hit a "command is
too large" error when performing UPSERT operation with many values.
Internally, we attempt to perform such operation by splitting it into
"batches", but the batching mechanism was broken.