### PR TITLE
cli: add userfile delete command to remove uploaded user files

### DIFF
--- a/pkg/cli/userfile.go
+++ b/pkg/cli/userfile.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ const (
 
 var userFileUploadCmd = &cobra.Command{
 	Use:   "upload <source> <destination>",
-	Short: "Upload file from source to destination",
+	Short: "upload file from source to destination",
 	Long: `
 Uploads a file to the user scoped file storage using a SQL connection.
 `,
@@ -43,12 +44,38 @@ Uploads a file to the user scoped file storage using a SQL connection.
 
 var userFileListCmd = &cobra.Command{
 	Use:   "ls <file|dir glob>",
-	Short: "List files matching the provided glob",
+	Short: "list files matching the provided pattern",
 	Long: `
-Lists the files stored in the user scoped file storage which match the glob, using a SQL connection.
+Lists the files stored in the user scoped file storage which match the provided pattern,
+using a SQL connection. If no pattern is provided, all files in the specified
+(or default, if unspecified) user scoped file storage will be listed.
 `,
 	Args: cobra.MinimumNArgs(0),
 	RunE: maybeShoutError(runUserFileList),
+}
+
+var userFileDeleteCmd = &cobra.Command{
+	Use:   "delete <file|dir glob>",
+	Short: "delete files matching the provided pattern",
+	Long: `
+Deletes the files stored in the user scoped file storage which match the provided pattern,
+using a SQL connection. If passed pattern '*', all files in the specified
+(or default, if unspecified) user scoped file storage will be deleted. Deletions are not
+atomic, and all deletions prior to the first failure will occur. 
+`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: maybeShoutError(runUserFileDelete),
+}
+
+func runUserFileDelete(cmd *cobra.Command, args []string) error {
+	conn, err := makeSQLClient("cockroach userfile", useDefaultDb)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	glob := args[0]
+	return deleteUserFile(context.Background(), conn, glob)
 }
 
 func runUserFileList(cmd *cobra.Command, args []string) error {
@@ -142,7 +169,7 @@ func constructUserfileDestinationURI(source, destination, user string) string {
 func constructUserfileListURI(glob, user string) string {
 	// User has not specified a glob pattern and so we construct a URI which will
 	// list all the files stored in the UserFileTableStorage.
-	if glob == "" {
+	if glob == "" || glob == "*" {
 		userFileURL := url.URL{
 			Scheme: defaultUserfileScheme,
 			Host:   defaultQualifiedNamePrefix + user,
@@ -196,7 +223,8 @@ func listUserFile(ctx context.Context, conn *sqlConn, glob string) error {
 		QualifiedTableName: userfileParsedURL.Host,
 		Path:               userfileParsedURL.Path,
 	}
-	f, err := cloudimpl.MakeSQLConnFileTableStorage(ctx, userFileTableConf, conn.conn.(driver.QueryerContext))
+	f, err := cloudimpl.MakeSQLConnFileTableStorage(ctx, userFileTableConf,
+		conn.conn.(cloud.SQLConnI))
 	if err != nil {
 		return err
 	}
@@ -210,6 +238,66 @@ func listUserFile(ctx context.Context, conn *sqlConn, glob string) error {
 		fmt.Println(file)
 	}
 
+	return nil
+}
+
+func deleteUserFile(ctx context.Context, conn *sqlConn, glob string) error {
+	if err := conn.ensureConn(); err != nil {
+		return err
+	}
+
+	connURL, err := url.Parse(conn.url)
+	if err != nil {
+		return err
+	}
+
+	userfileListURI := constructUserfileListURI(glob, connURL.User.Username())
+	unescapedUserfileListURI, err := url.PathUnescape(userfileListURI)
+	if err != nil {
+		return err
+	}
+
+	userfileParsedURL, err := url.ParseRequestURI(unescapedUserfileListURI)
+	if err != nil {
+		return err
+	}
+	userFileTableConf := roachpb.ExternalStorage_FileTable{
+		User:               connURL.User.Username(),
+		QualifiedTableName: userfileParsedURL.Host,
+	}
+	f, err := cloudimpl.MakeSQLConnFileTableStorage(ctx, userFileTableConf,
+		conn.conn.(cloud.SQLConnI))
+	if err != nil {
+		return err
+	}
+
+	files, err := f.ListFiles(ctx, userfileParsedURL.Path)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		var deleteFileBasename string
+		if userfileParsedURL.Path == "" {
+			// ListFiles will return absolute userfile URIs which will require
+			// parsing.
+			parsedFile, err := url.ParseRequestURI(file)
+			if err != nil {
+				return errors.WithDetailf(err, "deletion failed at %s", file)
+			}
+			deleteFileBasename = parsedFile.Path
+		} else {
+			// ListFiles returns relative filepaths without a leading /. All files are
+			// stored with a prefix / in the underlying user scoped tables.
+			deleteFileBasename = path.Join("/", file)
+		}
+		err = f.Delete(ctx, deleteFileBasename)
+		if err != nil {
+			return errors.WithDetail(err, fmt.Sprintf("deletion failed at %s", file))
+		}
+
+		fmt.Printf("deleted userfile://%s%s\n", userfileParsedURL.Host, deleteFileBasename)
+	}
 	return nil
 }
 
@@ -286,6 +374,7 @@ func uploadUserFile(
 var userFileCmds = []*cobra.Command{
 	userFileUploadCmd,
 	userFileListCmd,
+	userFileDeleteCmd,
 }
 
 var userFileCmd = &cobra.Command{

--- a/pkg/cli/userfiletable_test.go
+++ b/pkg/cli/userfiletable_test.go
@@ -14,7 +14,11 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/url"
+	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -148,4 +152,291 @@ func TestUserFileUpload(t *testing.T) {
 				destination, tc.fileContent)
 		})
 	}
+}
+
+func checkListedFiles(t *testing.T, c cliTest, uri string, expectedFiles []string) {
+	cliOutput, err := c.RunWithCaptureArgs([]string{"userfile", "ls", uri})
+	require.NoError(t, err)
+	cliOutput = strings.TrimSpace(cliOutput)
+
+	var listedFiles []string
+	// Split returns a slice of len 1 if output is empty but sep is \n.
+	if cliOutput != "" {
+		listedFiles = strings.Split(cliOutput, "\n")
+	}
+
+	require.Equal(t, expectedFiles, listedFiles)
+}
+
+func checkDeletedFiles(t *testing.T, c cliTest, uri string, expectedFiles []string) {
+	cliOutput, err := c.RunWithCaptureArgs([]string{"userfile", "delete", uri})
+	require.NoError(t, err)
+	cliOutput = strings.TrimSpace(cliOutput)
+
+	var deletedFiles []string
+	// Split returns a slice of len 1 if output is empty but sep is \n.
+	if cliOutput != "" {
+		deletedFiles = strings.Split(cliOutput, "\n")
+		for i, file := range deletedFiles {
+			deletedFiles[i] = strings.TrimPrefix(file, "deleted ")
+		}
+	}
+
+	require.Equal(t, expectedFiles, deletedFiles)
+}
+
+func TestUserFileList(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c := newCLITest(cliTestParams{t: t})
+	c.omitArgs = true
+	defer c.cleanup()
+
+	dir, cleanFn := testutils.TempDir(t)
+	defer cleanFn()
+
+	dataLetterFiles := []string{"file/letters/dataA.csv", "file/letters/dataB.csv"}
+	dataNumberFiles := []string{"file/numbers/data1.csv", "file/numbers/data2.csv"}
+	unicodeFile := []string{"file/unicode/á.csv"}
+	fileNames := append(dataLetterFiles, dataNumberFiles...)
+	fileNames = append(fileNames, unicodeFile...)
+	sort.Strings(fileNames)
+
+	localFilePath := filepath.Join(dir, "test.csv")
+	err := ioutil.WriteFile(localFilePath, []byte("a"), 0666)
+	require.NoError(t, err)
+
+	defaultUserfileURLSchemeAndHost := url.URL{
+		Scheme: defaultUserfileScheme,
+		Host:   defaultQualifiedNamePrefix + security.RootUser,
+	}
+
+	abs := func(in []string) []string {
+		out := make([]string, len(in))
+		for i := range in {
+			out[i] = defaultUserfileURLSchemeAndHost.String() + "/" + in[i]
+		}
+		return out
+	}
+
+	t.Run("ListFiles", func(t *testing.T) {
+		// Upload files to default userfile URI.
+		for _, file := range fileNames {
+			_, err = c.RunWithCapture(fmt.Sprintf("userfile upload %s %s", localFilePath, file))
+			require.NoError(t, err)
+		}
+
+		for _, tc := range []struct {
+			name       string
+			URI        string
+			resultList []string
+		}{
+			{
+				"list-all-in-default-using-star",
+				"*",
+				abs(fileNames),
+			},
+			{
+				"no-uri-list-all-in-default",
+				"",
+				abs(fileNames),
+			},
+			{
+				"no-glob-path-list-all-in-default",
+				defaultUserfileURLSchemeAndHost.String(),
+				abs(fileNames),
+			},
+			{
+				"well-formed-userfile-uri",
+				defaultUserfileURLSchemeAndHost.String() + "/file/letters/*.csv",
+				abs(dataLetterFiles),
+			},
+			{
+				"only-glob",
+				"file/letters/*.csv",
+				abs(dataLetterFiles),
+			},
+			{
+				"list-data-num-csv",
+				"file/numbers/data[0-9].csv",
+				abs(dataNumberFiles),
+			},
+			{
+				"wildcard-bucket-and-filename",
+				"*/numbers/*.csv",
+				abs(dataNumberFiles),
+			},
+			{
+				"list-all-csv-skip-dir",
+				// filepath.Glob() assumes that / is the separator, and enforces that it's there.
+				// So this pattern would not actually match anything.
+				"file/*.csv",
+				nil,
+			},
+			{
+				"list-no-matches",
+				"file/letters/dataD.csv",
+				nil,
+			},
+			{
+				"list-escaped-star",
+				"file/*/\\*.csv",
+				nil,
+			},
+			{
+				"list-escaped-range",
+				"file/*/data\\[0-9\\].csv",
+				nil,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				checkListedFiles(t, c, tc.URI, tc.resultList)
+			})
+		}
+	})
+	require.NoError(t, os.RemoveAll(dir))
+}
+
+func TestUserFileDelete(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c := newCLITest(cliTestParams{t: t})
+	c.omitArgs = true
+	defer c.cleanup()
+
+	dir, cleanFn := testutils.TempDir(t)
+	defer cleanFn()
+
+	dataLetterFiles := []string{"file/letters/dataA.csv", "file/letters/dataB.csv"}
+	dataNumberFiles := []string{"file/numbers/data1.csv", "file/numbers/data2.csv"}
+	unicodeFile := []string{"file/unicode/á.csv"}
+	fileNames := append(dataLetterFiles, dataNumberFiles...)
+	fileNames = append(fileNames, unicodeFile...)
+	sort.Strings(fileNames)
+
+	localFilePath := filepath.Join(dir, "test.csv")
+	err := ioutil.WriteFile(localFilePath, []byte("a"), 0666)
+	require.NoError(t, err)
+
+	defaultUserfileURLSchemeAndHost := url.URL{
+		Scheme: defaultUserfileScheme,
+		Host:   defaultQualifiedNamePrefix + security.RootUser,
+	}
+
+	abs := func(in []string) []string {
+		if in == nil {
+			return nil
+		}
+
+		out := make([]string, len(in))
+		for i := range in {
+			out[i] = defaultUserfileURLSchemeAndHost.String() + "/" + in[i]
+		}
+		return out
+	}
+
+	t.Run("DeleteFiles", func(t *testing.T) {
+		for _, tc := range []struct {
+			name               string
+			URI                string
+			writeList          []string
+			expectedDeleteList []string
+			postDeleteList     []string
+		}{
+			{
+				"delete-all-in-default",
+				"*",
+				fileNames,
+				abs(fileNames),
+				nil,
+			},
+			{
+				"no-glob-path-delete-all-in-default",
+				defaultUserfileURLSchemeAndHost.String(),
+				fileNames,
+				abs(fileNames),
+				nil,
+			},
+			{
+				"well-formed-userfile-uri",
+				defaultUserfileURLSchemeAndHost.String() + "/file/letters/*.csv",
+				fileNames,
+				abs(dataLetterFiles),
+				append(dataNumberFiles, unicodeFile...),
+			},
+			{
+				"delete-unicode-file",
+				defaultUserfileURLSchemeAndHost.String() + "/file/unicode/á.csv",
+				fileNames,
+				abs(unicodeFile),
+				append(dataLetterFiles, dataNumberFiles...),
+			},
+			{
+				"delete-data-num-csv",
+				"file/numbers/data[0-9].csv",
+				fileNames,
+				abs(dataNumberFiles),
+				append(dataLetterFiles, unicodeFile...),
+			},
+			{
+				"wildcard-bucket-and-filename",
+				"*/numbers/*.csv",
+				fileNames,
+				abs(dataNumberFiles),
+				append(dataLetterFiles, unicodeFile...),
+			},
+			{
+				"delete-all-csv-skip-dir",
+				// filepath.Glob() assumes that / is the separator, and enforces that it's there.
+				// So this pattern would not actually match anything.
+				"file/*.csv",
+				fileNames,
+				nil,
+				fileNames,
+			},
+			{
+				"delete-no-matches",
+				"file/letters/dataD.csv",
+				fileNames,
+				nil,
+				fileNames,
+			},
+			{
+				"delete-escaped-star",
+				"file/*/\\*.csv",
+				fileNames,
+				nil,
+				fileNames,
+			},
+			{
+				"delete-escaped-range",
+				"file/*/data\\[0-9\\].csv",
+				fileNames,
+				nil,
+				fileNames,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				// Upload files to default userfile URI.
+				for _, file := range tc.writeList {
+					_, err = c.RunWithCapture(fmt.Sprintf("userfile upload %s %s", localFilePath, file))
+					require.NoError(t, err)
+				}
+
+				// List files prior to deletion.
+				checkListedFiles(t, c, "", abs(tc.writeList))
+
+				// Delete files.
+				checkDeletedFiles(t, c, tc.URI, tc.expectedDeleteList)
+
+				// List files after deletion.
+				checkListedFiles(t, c, "", abs(tc.postDeleteList))
+
+				// Cleanup all files for next test run.
+				_, err = c.RunWithCaptureArgs([]string{"userfile", "delete", "*"})
+				require.NoError(t, err)
+			})
+		}
+	})
+	require.NoError(t, os.RemoveAll(dir))
 }

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -12,6 +12,7 @@ package cloud
 
 import (
 	"context"
+	"database/sql/driver"
 	"io"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -82,3 +83,10 @@ type ExternalStorageFactory func(ctx context.Context, dest roachpb.ExternalStora
 // ExternalStorageFromURIFactory describes a factory function for ExternalStorage given a URI.
 type ExternalStorageFromURIFactory func(ctx context.Context, uri string,
 	user string) (ExternalStorage, error)
+
+// SQLConnI encapsulates the interfaces which will be implemented by the network
+// backed SQLConn which is used to interact with the userfile tables.
+type SQLConnI interface {
+	driver.QueryerContext
+	driver.ExecerContext
+}

--- a/pkg/storage/cloudimpl/file_table_storage.go
+++ b/pkg/storage/cloudimpl/file_table_storage.go
@@ -12,7 +12,6 @@ package cloudimpl
 
 import (
 	"context"
-	"database/sql/driver"
 	"fmt"
 	"io"
 	"net/url"
@@ -93,7 +92,7 @@ func makeFileTableStorage(
 // interact with the underlying FileToTableSystem. It only supports a subset of
 // methods compared to the internal SQL connection backed FileTableStorage.
 func MakeSQLConnFileTableStorage(
-	ctx context.Context, cfg roachpb.ExternalStorage_FileTable, conn driver.QueryerContext,
+	ctx context.Context, cfg roachpb.ExternalStorage_FileTable, conn cloud.SQLConnI,
 ) (cloud.ExternalStorage, error) {
 	executor := filetable.MakeSQLConnFileToTableExecutor(conn)
 	fileToTableSystem, err := filetable.NewFileToTableSystem(ctx, cfg.QualifiedTableName, executor,
@@ -244,7 +243,7 @@ func (f *fileTableStorage) ListFiles(ctx context.Context, patternSuffix string) 
 	for _, match := range matches {
 		// If there is no glob pattern, then the user wishes to list all the uploaded
 		// files stored in the userfile table storage.
-		if f.prefix == "" {
+		if pattern == "" {
 			match = strings.TrimPrefix(match, "/")
 			unescapedURI, err := url.PathUnescape(makeUserFileURIWithQualifiedName(f.cfg.
 				QualifiedTableName, match))

--- a/pkg/storage/cloudimpl/filetable/file_table_read_writer.go
+++ b/pkg/storage/cloudimpl/filetable/file_table_read_writer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/errors"
 )
 
@@ -47,6 +48,8 @@ type FileToTableExecutorRows struct {
 type FileToTableSystemExecutor interface {
 	Query(ctx context.Context, opName, query, username string,
 		qargs ...interface{}) (*FileToTableExecutorRows, error)
+	Exec(ctx context.Context, opName, query, username string,
+		qargs ...interface{}) error
 }
 
 // InternalFileToTableExecutor is the SQL query executor which uses an internal
@@ -80,18 +83,27 @@ func (i *InternalFileToTableExecutor) Query(
 	return &result, nil
 }
 
+// Exec implements the FileToTableSystemExecutor interface.
+func (i *InternalFileToTableExecutor) Exec(
+	ctx context.Context, opName, query, username string, qargs ...interface{},
+) error {
+	_, err := i.ie.ExecEx(ctx, opName, nil,
+		sqlbase.InternalExecutorSessionDataOverride{User: username}, query, qargs...)
+	return err
+}
+
 // SQLConnFileToTableExecutor is the SQL query executor which uses a network
 // backed SQL connection to interact with the database.
 type SQLConnFileToTableExecutor struct {
-	conn driver.QueryerContext
+	executor cloud.SQLConnI
 }
 
 var _ FileToTableSystemExecutor = &SQLConnFileToTableExecutor{}
 
 // MakeSQLConnFileToTableExecutor returns an instance of a
 // SQLConnFileToTableExecutor.
-func MakeSQLConnFileToTableExecutor(conn driver.QueryerContext) *SQLConnFileToTableExecutor {
-	return &SQLConnFileToTableExecutor{conn: conn}
+func MakeSQLConnFileToTableExecutor(executor cloud.SQLConnI) *SQLConnFileToTableExecutor {
+	return &SQLConnFileToTableExecutor{executor: executor}
 }
 
 // Query implements the FileToTableSystemExecutor interface.
@@ -111,11 +123,28 @@ func (i *SQLConnFileToTableExecutor) Query(
 	}
 
 	var err error
-	result.sqlConnExecResults, err = i.conn.QueryContext(ctx, query, argVals)
+	result.sqlConnExecResults, err = i.executor.QueryContext(ctx, query, argVals)
 	if err != nil {
 		return nil, err
 	}
 	return &result, nil
+}
+
+// Exec implements the FileToTableSystemExecutor interface.
+func (i *SQLConnFileToTableExecutor) Exec(
+	ctx context.Context, _, query, _ string, qargs ...interface{},
+) error {
+	argVals := make([]driver.NamedValue, len(qargs))
+	for i, qarg := range qargs {
+		namedVal := driver.NamedValue{
+			// Ordinal position is 1 indexed.
+			Ordinal: i + 1,
+			Value:   qarg,
+		}
+		argVals[i] = namedVal
+	}
+	_, err := i.executor.ExecContext(ctx, query, argVals)
+	return err
 }
 
 // FileToTableSystem can be used to store, retrieve and delete the
@@ -308,6 +337,10 @@ filename`, f.GetFQFileTableName())
 			filename := vals[0].(string)
 			files = append(files, filename)
 		}
+
+		if err = rows.sqlConnExecResults.Close(); err != nil {
+			return nil, err
+		}
 	default:
 		return []string{}, errors.New("unsupported executor type in FileSize")
 	}
@@ -353,33 +386,31 @@ func DestroyUserFileSystem(ctx context.Context, f *FileToTableSystem) error {
 // DeleteFile deletes the blobs and metadata of filename from the user scoped
 // tables.
 func (f *FileToTableSystem) DeleteFile(ctx context.Context, filename string) error {
-	e, err := resolveInternalFileToTableExecutor(f.executor)
-	if err != nil {
-		return err
+	defer func() {
+		_ = f.executor.Exec(ctx, "commit", `COMMIT`, f.username)
+	}()
+
+	txnErr := f.executor.Exec(ctx, "delete-file", `BEGIN`, f.username)
+	if txnErr != nil {
+		return txnErr
 	}
 
-	if err := e.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		deleteFileQuery := fmt.Sprintf(`DELETE FROM %s WHERE filename=$1`, f.GetFQFileTableName())
-		_, err := e.ie.QueryEx(ctx, "delete-file-table", txn,
-			sqlbase.InternalExecutorSessionDataOverride{User: f.username},
-			deleteFileQuery, filename)
-		if err != nil {
-			return errors.Wrap(err, "failed to delete from the file table")
-		}
-
-		deletePayloadQuery := fmt.Sprintf(`DELETE FROM %s WHERE filename=$1`,
-			f.GetFQPayloadTableName())
-		_, err = e.ie.QueryEx(ctx, "delete-payload-table", txn,
-			sqlbase.InternalExecutorSessionDataOverride{User: f.username},
-			deletePayloadQuery, filename)
-		if err != nil {
-			return errors.Wrap(err, "failed to delete from the payload table")
-		}
-
-		return nil
-	}); err != nil {
-		return err
+	deleteFileQuery := fmt.Sprintf(`DELETE FROM %s WHERE filename=$1`, f.GetFQFileTableName())
+	txnErr = f.executor.Exec(ctx, "delete-file-table", deleteFileQuery,
+		f.username, filename)
+	if txnErr != nil {
+		return errors.Wrap(txnErr, "failed to delete from the file table")
 	}
+
+	deletePayloadQuery := fmt.Sprintf(`DELETE FROM %s WHERE filename=$1`,
+		f.GetFQPayloadTableName())
+
+	txnErr = f.executor.Exec(ctx, "delete-payload-table", deletePayloadQuery, f.username,
+		filename)
+	if txnErr != nil {
+		return errors.Wrap(txnErr, "failed to delete from the payload table")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This change adds support for a `userfile delete` command which allows
users to remove file(s) which have been uploaded to the user-scoped
FileTableStorage.

The delete command accepts one CLI arg which can either be a well-formed
userfile URI or a glob pattern.

The semantics of `userfile delete` are as follows: 
`userfile delete "*"`: Delete all files in the default user FileTableStorage tables
`defaultdb.public.userfiles_$USERNAME`

`userfile delete userfile://db.schema.tableprefix/glob/pattern` : Delete
all files which match the glob pattern and are in the
db.schema.tableprefix tables.

`userfile delete glob/pattern` : Delete files which match the glob
pattern in the default user FileTableStorage tables
`defaultdb.public.userfiles_$USERNAME`

Informs: #51222

Release note (cli change): userfile now supports delete command which
allows users to delete the files they have uploaded to the user-scoped
FileTableStorage. `userfile delete` accepts one CLI arg which can either
be a well-formed userfile URI or a glob pattern.  The latter defaults to
searching in the default FileTableStorage tables
defaultdb.public.userfiles_$USRENAME.