### PR TITLE
roachtest: add ability to run scaledata roachtests locally

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -115,7 +115,7 @@ func filepathAbs(path string) (string, error) {
 	return path, nil
 }
 
-func findBinary(binary, defValue string) (string, error) {
+func findBinary(binary, defValue string) (abspath string, err error) {
 	if binary == "" {
 		binary = defValue
 	}

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -13,11 +13,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
+	"github.com/cockroachdb/errors"
 )
 
 func registerScaleData(r *testRegistry) {
@@ -31,9 +31,9 @@ func registerScaleData(r *testRegistry) {
 	// The map provides a mapping between application name and command-line
 	// flags unique to that application.
 	apps := map[string]string{
-		"distributed_semaphore": "",
-		"filesystem_simulator":  "",
-		"jobcoordinator":        "--num_jobs_per_worker=8 --job_period_scale_millis=100",
+		"distributed-semaphore": "",
+		"filesystem-simulator":  "",
+		"job-coordinator":       "--num_jobs_per_worker=8 --job_period_scale_millis=100",
 	}
 
 	for app, flags := range apps {
@@ -58,21 +58,28 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 	roachNodes := c.Range(1, roachNodeCount)
 	appNode := c.Node(c.spec.NodeCount)
 
-	if local && runtime.GOOS != "linux" {
-		t.Fatalf("must run on linux os, found %s", runtime.GOOS)
-	}
-	b, err := binfetcher.Download(ctx, binfetcher.Options{
-		Component: "rubrik",
-		Binary:    app,
-		Version:   "LATEST",
-		GOOS:      "linux",
-		GOARCH:    "amd64",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	if local {
+		appBinary, err := findBinary("", app)
+		if err != nil {
+			err = errors.WithHint(err,
+				"place binaries built from cockroachdb/rksql in repo root, or add to $PATH")
+			t.Fatal(err)
+		}
+		c.Put(ctx, appBinary, app, appNode)
+	} else {
+		b, err := binfetcher.Download(ctx, binfetcher.Options{
+			Component: "rubrik",
+			Binary:    app,
+			Version:   "LATEST",
+			GOOS:      "linux",
+			GOARCH:    "amd64",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	c.Put(ctx, b, app, appNode)
+		c.Put(ctx, b, app, appNode)
+	}
 	c.Put(ctx, cockroach, "./cockroach", roachNodes)
 	c.Start(ctx, t, roachNodes)
 


### PR DESCRIPTION
And point to newly defined binaries that were added in
https://github.com/cockroachdb/rksql/pull/4.

Release note: None