### PR TITLE
colexec: simplify tracking of operator cpu time

### DIFF
--- a/pkg/sql/colexec/execpb/stats.pb.go
+++ b/pkg/sql/colexec/execpb/stats.pb.go
@@ -27,10 +27,14 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
 // VectorizedStats represents the stats collected from an operator.
 type VectorizedStats struct {
-	ID         int32         `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	NumBatches int64         `protobuf:"varint,2,opt,name=num_batches,json=numBatches,proto3" json:"num_batches,omitempty"`
-	NumTuples  int64         `protobuf:"varint,3,opt,name=num_tuples,json=numTuples,proto3" json:"num_tuples,omitempty"`
-	Time       time.Duration `protobuf:"bytes,4,opt,name=time,proto3,stdduration" json:"time"`
+	ID int32 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	// num_batches is the number of batches that this stats collector observed its
+	// operator to output.
+	NumBatches int64 `protobuf:"varint,2,opt,name=num_batches,json=numBatches,proto3" json:"num_batches,omitempty"`
+	// num_tuples is the number of tuples that this stats collector received
+	// from its input.
+	NumTuples int64         `protobuf:"varint,3,opt,name=num_tuples,json=numTuples,proto3" json:"num_tuples,omitempty"`
+	Time      time.Duration `protobuf:"bytes,4,opt,name=time,proto3,stdduration" json:"time"`
 	// stall indicates whether stall time or execution time is being tracked.
 	Stall            bool  `protobuf:"varint,5,opt,name=stall,proto3" json:"stall,omitempty"`
 	MaxAllocatedMem  int64 `protobuf:"varint,6,opt,name=max_allocated_mem,json=maxAllocatedMem,proto3" json:"max_allocated_mem,omitempty"`
@@ -41,7 +45,7 @@ func (m *VectorizedStats) Reset()         { *m = VectorizedStats{} }
 func (m *VectorizedStats) String() string { return proto.CompactTextString(m) }
 func (*VectorizedStats) ProtoMessage()    {}
 func (*VectorizedStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_stats_fe732b30c56248d9, []int{0}
+	return fileDescriptor_stats_74d7c56ee15c9a92, []int{0}
 }
 func (m *VectorizedStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -482,10 +486,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/colexec/execpb/stats.proto", fileDescriptor_stats_fe732b30c56248d9)
+	proto.RegisterFile("sql/colexec/execpb/stats.proto", fileDescriptor_stats_74d7c56ee15c9a92)
 }
 
-var fileDescriptor_stats_fe732b30c56248d9 = []byte{
+var fileDescriptor_stats_74d7c56ee15c9a92 = []byte{
 	// 349 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x54, 0x90, 0x41, 0x6b, 0xdb, 0x30,
 	0x18, 0x86, 0x2d, 0x27, 0xf1, 0x32, 0xe5, 0x90, 0x4d, 0x84, 0xe1, 0x05, 0x26, 0x9b, 0x9d, 0xcc,

--- a/pkg/sql/colexec/execpb/stats.proto
+++ b/pkg/sql/colexec/execpb/stats.proto
@@ -18,7 +18,11 @@ import "google/protobuf/duration.proto";
 // VectorizedStats represents the stats collected from an operator.
 message VectorizedStats {
   int32 id = 1 [(gogoproto.customname) = "ID"];
+  // num_batches is the number of batches that this stats collector observed its
+  // operator to output.
   int64 num_batches = 2;
+  // num_tuples is the number of tuples that this stats collector received
+  // from its input.
   int64 num_tuples = 3;
   google.protobuf.Duration time = 4 [(gogoproto.nullable) = false,
                                   (gogoproto.stdduration) = true];

--- a/pkg/sql/colexec/stats.go
+++ b/pkg/sql/colexec/stats.go
@@ -35,15 +35,15 @@ type VectorizedStatsCollector struct {
 	execpb.VectorizedStats
 	idTagKey string
 
-	// inputWatch is a single stop watch that is shared with all the input
-	// Operators. If the Operator doesn't have any inputs (like colBatchScan),
-	// it is not shared with anyone. It is used by the wrapped Operator to
-	// measure its stall or execution time.
-	inputWatch *timeutil.StopWatch
-	// outputWatch is a stop watch that is shared with the Operator that the
-	// wrapped Operator is feeding into. It must be started right before
-	// returning a batch when Nexted. It is used by the "output" Operator.
-	outputWatch *timeutil.StopWatch
+	// stopwatch keeps track of the amount of time the wrapped operator spent
+	// doing work. Note that this will include all of the time that the operator's
+	// inputs spent doing work - this will be corrected when stats are reported
+	// in finalizeStats.
+	stopwatch *timeutil.StopWatch
+
+	// childStatsCollectors contains the stats collectors for all of the inputs
+	// to the wrapped operator.
+	childStatsCollectors []*VectorizedStatsCollector
 
 	memMonitors  []*mon.BytesMonitor
 	diskMonitors []*mon.BytesMonitor
@@ -54,7 +54,7 @@ var _ colexecbase.Operator = &VectorizedStatsCollector{}
 // NewVectorizedStatsCollector creates a new VectorizedStatsCollector which
 // wraps 'op' that corresponds to a component with either ProcessorID or
 // StreamID 'id' (with 'idTagKey' distinguishing between the two). 'isStall'
-// indicates whether stall or execution time is being measured. 'inputWatch'
+// indicates whether stall or execution time is being measured. 'stopwatch'
 // must be non-nil.
 func NewVectorizedStatsCollector(
 	op colexecbase.Operator,
@@ -64,62 +64,45 @@ func NewVectorizedStatsCollector(
 	inputWatch *timeutil.StopWatch,
 	memMonitors []*mon.BytesMonitor,
 	diskMonitors []*mon.BytesMonitor,
+	inputStatsCollectors []*VectorizedStatsCollector,
 ) *VectorizedStatsCollector {
 	if inputWatch == nil {
 		colexecerror.InternalError("input watch for VectorizedStatsCollector is nil")
 	}
 	return &VectorizedStatsCollector{
-		Operator:        op,
-		VectorizedStats: execpb.VectorizedStats{ID: id, Stall: isStall},
-		idTagKey:        idTagKey,
-		inputWatch:      inputWatch,
-		memMonitors:     memMonitors,
-		diskMonitors:    diskMonitors,
+		Operator:             op,
+		VectorizedStats:      execpb.VectorizedStats{ID: id, Stall: isStall},
+		idTagKey:             idTagKey,
+		stopwatch:            inputWatch,
+		memMonitors:          memMonitors,
+		diskMonitors:         diskMonitors,
+		childStatsCollectors: inputStatsCollectors,
 	}
 }
 
-// SetOutputWatch sets vsc.outputWatch to outputWatch. It is used to "connect"
-// this VectorizedStatsCollector to the next one in the chain.
-func (vsc *VectorizedStatsCollector) SetOutputWatch(outputWatch *timeutil.StopWatch) {
-	vsc.outputWatch = outputWatch
-}
-
-// Next is part of Operator interface.
+// Next is part of the Operator interface.
 func (vsc *VectorizedStatsCollector) Next(ctx context.Context) coldata.Batch {
-	if vsc.outputWatch != nil {
-		// vsc.outputWatch is non-nil which means that this Operator is outputting
-		// the batches into another one. In order to avoid double counting the time
-		// actually spent in the current "input" Operator, we're stopping the stop
-		// watch of the other "output" Operator before doing any computations here.
-		vsc.outputWatch.Stop()
-	}
-
 	var batch coldata.Batch
-	if vsc.VectorizedStats.Stall {
-		// We're measuring stall time, so there are no inputs into the wrapped
-		// Operator, and we need to start the stop watch ourselves.
-		vsc.inputWatch.Start()
-	}
+	vsc.stopwatch.Start()
 	batch = vsc.Operator.Next(ctx)
 	if batch.Length() > 0 {
 		vsc.NumBatches++
 		vsc.NumTuples += int64(batch.Length())
 	}
-	vsc.inputWatch.Stop()
-	if vsc.outputWatch != nil {
-		// vsc.outputWatch is non-nil which means that this Operator is outputting
-		// the batches into another one. To allow for measuring the execution time
-		// of that other Operator, we're starting the stop watch right before
-		// returning batch.
-		vsc.outputWatch.Start()
-	}
+	vsc.stopwatch.Stop()
 	return batch
 }
 
 // finalizeStats records the time measured by the stop watch into the stats as
 // well as the memory and disk usage.
 func (vsc *VectorizedStatsCollector) finalizeStats() {
-	vsc.Time = vsc.inputWatch.Elapsed()
+	vsc.Time = vsc.stopwatch.Elapsed()
+	// Subtract the time spent in each of the child stats collectors, to produce
+	// the amount of time that the wrapped operator spent doing work itself, not
+	// including time spent waiting on its inputs.
+	for _, statsCollectors := range vsc.childStatsCollectors {
+		vsc.Time -= statsCollectors.stopwatch.Elapsed()
+	}
 	for _, memMon := range vsc.memMonitors {
 		vsc.MaxAllocatedMem += memMon.MaximumBytes()
 	}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -348,16 +348,18 @@ func (s *vectorizedFlowCreator) wrapWithVectorizedStatsCollector(
 			memMonitors = append(memMonitors, m)
 		}
 	}
-	vsc := colexec.NewVectorizedStatsCollector(
-		op, id, idTagKey, len(inputs) == 0, inputWatch, memMonitors, diskMonitors,
-	)
-	for _, input := range inputs {
+	inputStatsCollectors := make([]*colexec.VectorizedStatsCollector, len(inputs))
+	for i, input := range inputs {
 		sc, ok := input.(*colexec.VectorizedStatsCollector)
 		if !ok {
 			return nil, errors.New("unexpectedly an input is not collecting stats")
 		}
-		sc.SetOutputWatch(inputWatch)
+		inputStatsCollectors[i] = sc
 	}
+	vsc := colexec.NewVectorizedStatsCollector(
+		op, id, idTagKey, len(inputs) == 0, inputWatch, memMonitors, diskMonitors,
+		inputStatsCollectors,
+	)
 	s.vectorizedStatsCollectorsQueue = append(s.vectorizedStatsCollectorsQueue, vsc)
 	return vsc, nil
 }


### PR DESCRIPTION
Previously, operator stats collectors would collaboratively start and
stop each other's stopwatches to track how long they each took to run.
Now, each stats collector just starts and stops itself, and subtracts
the elapsed time of all of its inputs at the end to get an accurate
statistic.

Release note: None