### PR TITLE
stats: don't delete stale cache entries, update them asynchronously instead

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1057,6 +1057,7 @@ func injectTableStats(
 	// update is handled asynchronously).
 	params.extendedEvalCtx.ExecCfg.TableStatsCache.InvalidateTableStats(params.ctx, desc.ID)
 
+	// Use Gossip to refresh the caches on other nodes.
 	if g, ok := params.extendedEvalCtx.ExecCfg.Gossip.Optional(47925); ok {
 		return stats.GossipTableStatAdded(g, desc.ID)
 	}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -470,10 +470,10 @@ func (r *createStatsResumer) Resume(
 		return err
 	}
 
-	// Invalidate the local cache synchronously; this guarantees that the next
-	// statement in the same session won't use a stale cache (whereas the gossip
-	// update is handled asynchronously).
-	evalCtx.ExecCfg.TableStatsCache.InvalidateTableStats(ctx, r.tableID)
+	// Refresh the local cache if Gossip is not available.
+	if _, ok := evalCtx.ExecCfg.Gossip.Optional(47925); !ok {
+		evalCtx.ExecCfg.TableStatsCache.RefreshTableStats(ctx, r.tableID)
+	}
 
 	// Record this statistics creation in the event log.
 	if !createStatsPostEvents.Get(&evalCtx.Settings.SV) {

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -488,7 +488,7 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 	}
 
 	if g, ok := s.FlowCtx.Cfg.Gossip.Optional(47925); ok {
-		// Gossip invalidation of the stat caches for this table.
+		// Gossip refresh of the stat caches for this table.
 		return stats.GossipTableStatAdded(g, s.tableID)
 	}
 	return nil

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -114,7 +114,7 @@ func (sc *TableStatisticsCache) tableStatAddedGossipUpdate(key string, value roa
 		log.Errorf(context.Background(), "tableStatAddedGossipUpdate(%s) error: %v", key, err)
 		return
 	}
-	sc.InvalidateTableStats(context.Background(), sqlbase.ID(tableID))
+	sc.RefreshTableStats(context.Background(), sqlbase.ID(tableID))
 }
 
 // GetTableStats looks up statistics for the requested table ID in the cache,
@@ -138,8 +138,8 @@ func (sc *TableStatisticsCache) GetTableStats(
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
-	if found, stats, err := sc.lookupStatsLocked(ctx, tableID); found {
-		return stats, err
+	if found, e := sc.lookupStatsLocked(ctx, tableID); found {
+		return e.stats, e.err
 	}
 
 	return sc.addCacheEntryLocked(ctx, tableID)
@@ -154,12 +154,12 @@ func (sc *TableStatisticsCache) GetTableStats(
 // locked again if we need to wait (this can only happen when found=true).
 func (sc *TableStatisticsCache) lookupStatsLocked(
 	ctx context.Context, tableID sqlbase.ID,
-) (found bool, _ []*TableStatistic, _ error) {
+) (found bool, e *cacheEntry) {
 	eUntyped, ok := sc.mu.cache.Get(tableID)
 	if !ok {
-		return false, nil, nil
+		return false, nil
 	}
-	e := eUntyped.(*cacheEntry)
+	e = eUntyped.(*cacheEntry)
 
 	if e.mustWait {
 		// We are in the process of grabbing stats for this table. Wait until
@@ -173,7 +173,7 @@ func (sc *TableStatisticsCache) lookupStatsLocked(
 			log.Infof(ctx, "statistics for table %d found in cache", tableID)
 		}
 	}
-	return true, e.stats, e.err
+	return true, e
 }
 
 // addCacheEntryLocked creates a new cache entry and retrieves table statistics
@@ -221,7 +221,65 @@ func (sc *TableStatisticsCache) addCacheEntryLocked(
 	return stats, err
 }
 
+// refreshCacheEntry retrieves table statistics from the database and updates
+// an existing cache entry. It does this in a way so that the other goroutines
+// can continue using the stale stats from the existing entry until the new
+// stats are added:
+//  - the existing cache entry is retrieved;
+//  - mutex is unlocked;
+//  - stats are retrieved from database:
+//  - mutex is locked again and the entry is updated.
+//
+func (sc *TableStatisticsCache) refreshCacheEntry(ctx context.Context, tableID sqlbase.ID) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	if log.V(1) {
+		log.Infof(ctx, "reading statistics for table %d", tableID)
+	}
+
+	// If the stats don't already exist in the cache, don't bother performing
+	// the refresh. If e.err is not nil, the stats are in the process of being
+	// removed from the cache (see addCacheEntryLocked), so don't refresh in this
+	// case either.
+	found, e := sc.lookupStatsLocked(ctx, tableID)
+	if !found || e.err != nil {
+		return
+	}
+	sc.mu.numInternalQueries++
+
+	var stats []*TableStatistic
+	var err error
+	func() {
+		sc.mu.Unlock()
+		defer sc.mu.Lock()
+
+		stats, err = sc.getTableStatsFromDB(ctx, tableID)
+	}()
+
+	e.stats, e.err = stats, err
+
+	if err != nil {
+		// Don't keep the cache entry around, so that we retry the query.
+		sc.mu.cache.Del(tableID)
+	}
+}
+
+// RefreshTableStats refreshes the cached statistics for the given table ID
+// by fetching the new stats from the database.
+func (sc *TableStatisticsCache) RefreshTableStats(ctx context.Context, tableID sqlbase.ID) {
+	if log.V(1) {
+		log.Infof(ctx, "refreshing statistics for table %d", tableID)
+	}
+	// Perform an asynchronous refresh of the cache.
+	go sc.refreshCacheEntry(ctx, tableID)
+}
+
 // InvalidateTableStats invalidates the cached statistics for the given table ID.
+//
+// Note that RefreshTableStats should normally be used instead of this function.
+// This function is used only when we want to guarantee that the next query
+// uses updated stats.
 func (sc *TableStatisticsCache) InvalidateTableStats(ctx context.Context, tableID sqlbase.ID) {
 	if log.V(1) {
 		log.Infof(ctx, "evicting statistics for table %d", tableID)

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -257,8 +258,43 @@ func TestCacheBasic(t *testing.T) {
 		}
 	}
 
-	// After invalidation Table ID 2 should be gone.
+	// Insert a new stat for Table ID 2.
 	tableID := sqlbase.ID(102)
+	stat := TableStatisticProto{
+		TableID:       tableID,
+		StatisticID:   35,
+		Name:          "table2",
+		ColumnIDs:     []sqlbase.ColumnID{1, 2, 3},
+		CreatedAt:     time.Date(2001, 1, 10, 5, 26, 34, 0, time.UTC),
+		RowCount:      10,
+		DistinctCount: 10,
+		NullCount:     0,
+	}
+	if err := insertTableStat(ctx, db, ex, &stat); err != nil {
+		t.Fatal(err)
+	}
+
+	// After refreshing, Table ID 2 should be available immediately in the cache
+	// for querying, and eventually should contain the updated stat.
+	sc.RefreshTableStats(ctx, tableID)
+	if _, ok := lookupTableStats(ctx, sc, tableID); !ok {
+		t.Fatalf("expected lookup of refreshed key %d to succeed", tableID)
+	}
+	expected := append([]*TableStatisticProto{&stat}, expectedStats[tableID]...)
+	testutils.SucceedsSoon(t, func() error {
+		statsList, ok := lookupTableStats(ctx, sc, tableID)
+		if !ok {
+			return errors.Errorf("expected lookup of refreshed key %d to succeed", tableID)
+		}
+		if !checkStats(statsList, expected) {
+			return errors.Errorf(
+				"for lookup of key %d, expected stats %s but found %s", tableID, expected, statsList,
+			)
+		}
+		return nil
+	})
+
+	// After invalidation Table ID 2 should be gone.
 	sc.InvalidateTableStats(ctx, tableID)
 	if statsList, ok := lookupTableStats(ctx, sc, tableID); ok {
 		t.Fatalf("lookup of invalidated key %d returned: %s", tableID, statsList)
@@ -341,7 +377,7 @@ func TestCacheWait(t *testing.T) {
 		before := sc.mu.numInternalQueries
 
 		id := tableIDs[rand.Intn(len(tableIDs))]
-		sc.InvalidateTableStats(ctx, id)
+		sc.RefreshTableStats(ctx, id)
 		// Run GetTableStats multiple times in parallel.
 		var wg sync.WaitGroup
 		for n := 0; n < 10; n++ {


### PR DESCRIPTION
Prior to this commit, any time new statistics were added for a table, the
cache entry for that table was deleted so that the new statistics would be
fetched by the next query. This had the effect of forcing queries to wait
unnecessarily to get the freshest stats, even if slightly stale stats would
have produced the same query plan. For workloads with frequent stats updates,
contention on the `system.table_statistics` table could result in latency spikes.

This commit fixes the problem by performing a "refresh" rather than an
"invalidation" of the cache. Any time new stats are available, the freshest
stats are fetched asynchronously from the database and added to the cache when
they are available in memory. In the mean time, other queries can continue
using the stale stats without blocking.

Fixes #36365

Release note (performance improvement): Queries no longer block during planning
if cached table statistics have become stale and the new statistics have not
yet been loaded. Instead, the stale statistics are used for planning until the
new statistics have been loaded. This improves performance because it prevents
latency spikes that may occur if there is a delay in loading the new
statistics.