### PR TITLE
opt: do not prune mutation fetch columns indexed by partial index

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -171,3 +171,27 @@ t7  CREATE TABLE t7 (
     INDEX t6i3 (b DESC) WHERE b > 8:::INT8,
     FAMILY "primary" (b, rowid)
 )
+
+#### Update a non-indexed column referenced by the predicate.
+
+statement ok
+CREATE TABLE a (
+    a INT,
+    b INT,
+    c INT,
+    INDEX idx_c_b_gt_1 (c) WHERE b > 1,
+    FAMILY (a),
+    FAMILY (b),
+    FAMILY (c)
+)
+
+statement ok
+INSERT INTO a VALUES (1, 1, 1);
+
+statement ok
+UPDATE a SET b = b + 1 WHERE a = 1
+
+query III
+SELECT * FROM a@idx_c_b_gt_1 WHERE b > 1
+----
+1  2  1

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -585,8 +585,8 @@ func (s *ScanPrivate) IsLocking() bool {
 // UsesPartialIndex returns true if the ScanPrivate indicates a scan over a
 // partial index.
 func (s *ScanPrivate) UsesPartialIndex(md *opt.Metadata) bool {
-	tabMeta := md.TableMeta(s.Table)
-	return IsPartialIndex(tabMeta, s.Index)
+	_, isPartialIndex := md.Table(s.Table).Index(s.Index).Predicate()
+	return isPartialIndex
 }
 
 // PartialIndexPredicate returns the FiltersExpr representing the predicate of
@@ -831,17 +831,13 @@ func OutputColumnIsAlwaysNull(e RelExpr, col opt.ColumnID) bool {
 	return false
 }
 
-// IsPartialIndex returns true if the table's index at the given ordinal is
-// a partial index.
-func IsPartialIndex(tabMeta *opt.TableMeta, ord cat.IndexOrdinal) bool {
-	_, isPartial := tabMeta.PartialIndexPredicates[ord]
-	return isPartial
-}
-
 // PartialIndexPredicate returns the FiltersExpr representing the partial index
 // predicate at the given index ordinal. If the index at the ordinal is not a
-// partial index, this function panics. IsPartialIndex should be used first to
-// determine if the index is a partial index.
+// partial index, this function panics. cat.Index.Predicate should be used first
+// to determine if the index is a partial index.
+//
+// Note that TableMeta.PartialIndexPredicates is not initialized for mutation
+// queries. This function will panic in the context of a mutation.
 func PartialIndexPredicate(tabMeta *opt.TableMeta, ord cat.IndexOrdinal) FiltersExpr {
 	p := tabMeta.PartialIndexPredicates[ord]
 	return *p.(*FiltersExpr)

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1224,7 +1224,6 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 	case *ScanPrivate:
 		// Don't output name of index if it's the primary index.
 		tab := f.Memo.metadata.Table(t.Table)
-		tabMeta := f.Memo.metadata.TableMeta(t.Table)
 		if t.Index == cat.PrimaryIndex {
 			fmt.Fprintf(f.Buffer, " %s", tableAlias(f, t.Table))
 		} else {
@@ -1233,7 +1232,7 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		if ScanIsReverseFn(f.Memo.Metadata(), t, &physProps.Ordering) {
 			f.Buffer.WriteString(",rev")
 		}
-		if IsPartialIndex(tabMeta, t.Index) {
+		if t.UsesPartialIndex(f.Memo.Metadata()) {
 			f.Buffer.WriteString(",partial")
 		}
 

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -48,8 +48,10 @@ CREATE TABLE partial_indexes (
     a INT PRIMARY KEY,
     b INT,
     c STRING,
-    INDEX (b) WHERE c = 'foo',
-    INDEX (c) WHERE a > b AND c = 'bar'
+    FAMILY (a),
+    FAMILY (b),
+    FAMILY (c),
+    INDEX (c) WHERE b > 1
 )
 ----
 
@@ -1938,38 +1940,49 @@ delete a
 
 # Do not prune columns that are required for evaluating partial index
 # predicates.
-norm expect-not=(PruneMutationFetchCols)
-UPDATE partial_indexes SET c = 'bar' RETURNING a
+norm expect-not=PruneMutationFetchCols
+UPDATE partial_indexes SET b = b + 1 WHERE a = 1
 ----
 update partial_indexes
- ├── columns: a:1!null
+ ├── columns: <none>
  ├── fetch columns: a:5 b:6 c:7
  ├── update-mapping:
- │    └── c_new:11 => c:3
- ├── partial index put columns: column12:12 column13:13
- ├── partial index del columns: column9:9 column10:10
+ │    └── b_new:10 => b:2
+ ├── partial index put columns: column11:11
+ ├── partial index del columns: column9:9
+ ├── cardinality: [0 - 0]
  ├── volatile, mutations
- ├── key: (1)
  └── project
-      ├── columns: column12:12!null column13:13 c_new:11!null column9:9 column10:10 a:5!null b:6 c:7
-      ├── key: (5)
-      ├── fd: ()-->(11,12), (5)-->(6,7,10,13), (7)-->(9)
-      ├── scan partial_indexes
-      │    ├── columns: a:5!null b:6 c:7
-      │    ├── partial index predicates
-      │    │    ├── secondary: filters
-      │    │    │    └── c:7 = 'foo' [outer=(7), constraints=(/7: [/'foo' - /'foo']; tight), fd=()-->(7)]
-      │    │    └── secondary: filters
-      │    │         ├── a:5 > b:6 [outer=(5,6), constraints=(/5: (/NULL - ]; /6: (/NULL - ])]
-      │    │         └── c:7 = 'bar' [outer=(7), constraints=(/7: [/'bar' - /'bar']; tight), fd=()-->(7)]
-      │    ├── key: (5)
-      │    └── fd: (5)-->(6,7)
+      ├── columns: column11:11 a:5!null b:6 c:7 column9:9 b_new:10
+      ├── cardinality: [0 - 1]
+      ├── immutable
+      ├── key: ()
+      ├── fd: ()-->(5-7,9-11)
+      ├── project
+      │    ├── columns: b_new:10 column9:9 a:5!null b:6 c:7
+      │    ├── cardinality: [0 - 1]
+      │    ├── immutable
+      │    ├── key: ()
+      │    ├── fd: ()-->(5-7,9,10)
+      │    ├── select
+      │    │    ├── columns: a:5!null b:6 c:7
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(5-7)
+      │    │    ├── scan partial_indexes
+      │    │    │    ├── columns: a:5!null b:6 c:7
+      │    │    │    ├── partial index predicates
+      │    │    │    │    └── secondary: filters
+      │    │    │    │         └── b:6 > 1 [outer=(6), constraints=(/6: [/2 - ]; tight)]
+      │    │    │    ├── key: (5)
+      │    │    │    └── fd: (5)-->(6,7)
+      │    │    └── filters
+      │    │         └── a:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+      │    └── projections
+      │         ├── b:6 + 1 [as=b_new:10, outer=(6), immutable]
+      │         └── b:6 > 1 [as=column9:9, outer=(6)]
       └── projections
-           ├── false [as=column12:12]
-           ├── a:5 > b:6 [as=column13:13, outer=(5,6)]
-           ├── 'bar' [as=c_new:11]
-           ├── c:7 = 'foo' [as=column9:9, outer=(7)]
-           └── (a:5 > b:6) AND (c:7 = 'bar') [as=column10:10, outer=(5-7)]
+           └── b_new:10 > 1 [as=column11:11, outer=(10)]
 
 # Prune secondary family column not needed for the update.
 norm expect=(PruneMutationFetchCols,PruneMutationInputCols)

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -720,17 +720,10 @@ func (b *Builder) addPartialIndexPredicatesForTable(tabMeta *opt.TableMeta) {
 		filter := b.factory.ConstructFiltersItem(scalar)
 
 		// Expressions with non-immutable operators are not supported as partial
-		// index predicates, so add a replacement expression of False. This is
-		// done for two reasons:
-		//
-		//   1. TableMeta.PartialIndexPredicates is a source of truth within the
-		//      optimizer for determining which indexes are partial. It is safer
-		//      to use a False predicate than no predicate so that the optimizer
-		//      won't incorrectly assume that the index is a full index.
-		//   2. A partial index with a False predicate will never be used to
-		//      satisfy a query, effectively making these non-immutable partial
-		//      index predicates not possible to use.
-		//
+		// index predicates, so add a replacement expression of False. A partial
+		// index with a False predicate will never be used to satisfy a query.
+		// It is safer to use a False predicate than no predicate so that the
+		// optimizer won't incorrectly assume that the index is a full index.
 		if filter.ScalarProps().VolatilitySet.HasStable() || filter.ScalarProps().VolatilitySet.HasVolatile() {
 			fals := memo.FiltersExpr{b.factory.ConstructFiltersItem(memo.FalseSingleton)}
 			tabMeta.AddPartialIndexPredicate(indexOrd, &fals)

--- a/pkg/sql/opt/xform/scan_index_iter.go
+++ b/pkg/sql/opt/xform/scan_index_iter.go
@@ -144,7 +144,7 @@ func (it *scanIndexIter) Next() bool {
 		}
 
 		if it.hasRejectFlag(rejectPartialIndexes | rejectNonPartialIndexes) {
-			isPartialIndex := memo.IsPartialIndex(it.tabMeta, it.indexOrd)
+			_, isPartialIndex := it.currIndex.Predicate()
 
 			// Skip over partial indexes if rejectPartialIndexes is set.
 			if it.hasRejectFlag(rejectPartialIndexes) && isPartialIndex {


### PR DESCRIPTION
This commit prevents the optimizer from pruning mutation fetch columns
that are required to encode partial index entries.

Previously, for the query below, column `c` would be pruned from the
mutation fetch columns because it is not being mutated.

    CREATE TABLE abc (
      a INT,
      b INT,
      c INT,
      INDEX (c) WHERE b > 1,
      FAMILY(a), FAMILY(b), FAMILY(c)
    )

    UPDATE abc SET b = b + 1 WHERE a = 1

However, it is necessary to fetch `c` in the event that `UPDATE` mutates
a row to now be included in the partial index. In order to add the row
to the partial index, the value of `c` is required to encode the index
entry.

Fixes #51527

Release note: None