### PR TITLE
kvserver: don't panic on wto after committed txn

### DIFF
--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -13,6 +13,7 @@ package kvserver
 import (
 	"bytes"
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
@@ -217,6 +218,14 @@ func evaluateBatch(
 		// cantDeferWTOE is set when a WriteTooOldError cannot be deferred past the
 		// end of the current batch.
 		cantDeferWTOE bool
+
+		// The following fields help with debugging #50317.
+		msg              string
+		initialTxnStatus roachpb.TransactionStatus
+	}
+
+	if baHeader.Txn != nil {
+		writeTooOldState.initialTxnStatus = baHeader.Txn.Status
 	}
 
 	for index, union := range baReqs {
@@ -275,6 +284,7 @@ func evaluateBatch(
 				// other concurrent overlapping transactions are forced
 				// through intent resolution and the chances of this batch
 				// succeeding when it will be retried are increased.
+				writeTooOldState.msg += fmt.Sprintf("request %d (%s) got WriteTooOldErr; ", index, args.Method())
 				if writeTooOldState.err != nil {
 					writeTooOldState.err.ActualTimestamp.Forward(
 						tErr.ActualTimestamp)
@@ -393,7 +403,15 @@ func evaluateBatch(
 
 	if writeTooOldState.err != nil {
 		if baHeader.Txn != nil && baHeader.Txn.Status.IsCommittedOrStaging() {
-			log.Fatalf(ctx, "committed txn with writeTooOld err: %s", writeTooOldState.err)
+			err := errorutil.UnexpectedWithIssueErrorf(
+				50317,
+				"committed txn with writeTooOld; "+
+					"requests: %s, msg: %s, txn: %s, initial txn status: %s, cantDeferErr: %t, err: %s",
+				ba.RequestsSafe(), log.Safe(writeTooOldState.msg), baHeader.Txn,
+				log.Safe(writeTooOldState.initialTxnStatus.String()),
+				writeTooOldState.cantDeferWTOE, writeTooOldState.err)
+			log.Errorf(ctx, "%v", err)
+			errorutil.SendReport(ctx, &rec.ClusterSettings().SV, err)
 		}
 	}
 

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 //go:generate go run -tags gen-batch gen_batch.go
@@ -569,6 +570,16 @@ func (ba BatchRequest) Split(canSplitET bool) [][]RequestUnion {
 		ba.Requests = ba.Requests[len(part):]
 	}
 	return parts
+}
+
+// RequestsSafe lists all the request types in the batch. Also see Summary().
+func (ba BatchRequest) RequestsSafe() redact.SafeString {
+	var sb strings.Builder
+	for _, arg := range ba.Requests {
+		req := arg.GetInner()
+		sb.WriteString(req.Method().String() + " ")
+	}
+	return redact.SafeString(sb.String())
 }
 
 // String gives a brief summary of the contained requests and keys in the batch.


### PR DESCRIPTION
In #50317 we're getting reports of an assertion firing telling us that a
transaction has moved to the STAGING or COMMITTED state but there's also
a WriteTooOldError to return to the client. This seems bad, and I can't
figure out how it happens. EndTxn, which moves the txn to these states,
is supposed to notice the WriteTooOld field on the baHeader.Txn and not
do that transition. All the reports seem to be in the context of
UPSERTs.

This patch changes the assertion from a Fatal to just a sentry report,
and includes more info in the report. The hope is that this turns out to
be benign, related to the STAGING state.

Touches #50317

Release note: An unknown condition previously crash with the message
"committed txn with writeTooOld err" now no longer crashes a node;
instead an error message is printed to the logs asking for help in the
investigation.