### PR TITLE
descs: push descriptor type hydration into the desc.Collection

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -655,21 +654,6 @@ func (sc *SchemaChanger) truncateIndexes(
 				if err != nil {
 					return err
 				}
-
-				// Hydrate types used in the retrieved table.
-				// TODO (rohany): This can be removed once table access from the
-				//  desc.Collection returns tables with hydrated types.
-				typLookup := func(ctx context.Context, id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
-					return resolver.ResolveTypeDescByID(ctx, txn, sc.execCfg.Codec, id, tree.ObjectLookupFlags{})
-				}
-				if err := sqlbase.HydrateTypesInTableDescriptor(
-					ctx,
-					tableDesc.TableDesc(),
-					sqlbase.TypeLookupFunc(typLookup),
-				); err != nil {
-					return err
-				}
-
 				rd, err := row.MakeDeleter(
 					ctx,
 					txn,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -490,13 +490,7 @@ func (p *planner) LookupTableByID(
 		}
 		return catalog.TableEntry{}, err
 	}
-	// TODO (rohany): This shouldn't be needed once the descs.Collection always
-	//  returns descriptors with hydrated types.
-	hydratedDesc, err := p.maybeHydrateTypesInDescriptor(ctx, table)
-	if err != nil {
-		return catalog.TableEntry{}, err
-	}
-	return catalog.TableEntry{Desc: hydratedDesc.(*sqlbase.ImmutableTableDescriptor)}, nil
+	return catalog.TableEntry{Desc: table}, nil
 }
 
 // TypeAsString enforces (not hints) that the given expression typechecks as a

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -25,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -129,14 +127,6 @@ func (p *planner) LookupObject(
 	lookupFlags.CommonLookupFlags = p.CommonLookupFlags(false /* required */)
 	objDesc, err := sc.GetObjectDesc(ctx, p.txn, p.ExecCfg().Settings, p.ExecCfg().Codec, dbName, scName, tbName, lookupFlags)
 
-	// The returned object may contain types.T that need hydrating.
-	if objDesc != nil {
-		objDesc, err = p.maybeHydrateTypesInDescriptor(ctx, objDesc)
-		if err != nil {
-			return false, nil, err
-		}
-	}
-
 	return objDesc != nil, objDesc, err
 }
 
@@ -203,38 +193,6 @@ func (p *planner) ResolveTypeByID(ctx context.Context, id uint32) (*types.T, err
 		return nil, err
 	}
 	return desc.MakeTypesT(ctx, name, p)
-}
-
-// maybeHydrateTypesInDescriptor hydrates any types.T's in the input descriptor.
-// TODO (rohany): Once we lease types, this should be pushed down into the
-//  leased object collection.
-func (p *planner) maybeHydrateTypesInDescriptor(
-	ctx context.Context, objDesc catalog.Descriptor,
-) (catalog.Descriptor, error) {
-	// As of now, only {Mutable,Immutable}TableDescriptor have types.T that
-	// need to be hydrated.
-	switch t := objDesc.(type) {
-	case *sqlbase.MutableTableDescriptor:
-		// MutableTableDescriptors are safe to modify in place.
-		if err := sqlbase.HydrateTypesInTableDescriptor(ctx, t.TableDesc(), p); err != nil {
-			return nil, err
-		}
-		return objDesc, nil
-	case *sqlbase.ImmutableTableDescriptor:
-		// ImmutableTableDescriptors need to be copied before hydration. If there
-		// aren't any user defined types in the descriptor, then just return.
-		if !t.ContainsUserDefinedTypes() {
-			return objDesc, nil
-		}
-		// Make a copy of the underlying TableDescriptor.
-		desc := protoutil.Clone(t.TableDesc()).(*sqlbase.TableDescriptor)
-		if err := sqlbase.HydrateTypesInTableDescriptor(ctx, desc, p); err != nil {
-			return nil, err
-		}
-		return sqlbase.NewImmutableTableDescriptor(*desc), nil
-	default:
-		return objDesc, nil
-	}
 }
 
 // ObjectLookupFlags is part of the resolver.SchemaResolver interface.


### PR DESCRIPTION
Fixes #49484.
Preparation for #51385.

Up until now, the `planner` was responsible for installing user defined
type metadata in tables that contained user defined types. This was
slightly messy and caused leakage of responsibility regarding when
descriptors had user defined types vs when they didn't. This commit
pushes that responsibility into the `descs.Collection`. It also paves
the way for work to avoid copying `ImmutableTableDescriptor`s that
contain user defined types every time that they need hydration.

Release note: None