### PR TITLE
backupccl: avoid hanging forever on intents

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -84,12 +83,6 @@ var fullClusterSystemTables = []string{
 	sqlbase.JobsTable.Name,
 	// Table statistics are backed up in the backup descriptor for now.
 }
-
-var useTBI = settings.RegisterBoolSetting(
-	"kv.bulk_io_write.experimental_incremental_export_enabled",
-	"use experimental time-bound file filter when exporting in BACKUP",
-	true,
-)
 
 type tableAndIndex struct {
 	tableID descpb.ID

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -10,10 +10,13 @@ package backupccl
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
@@ -22,12 +25,31 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	hlc "github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	gogotypes "github.com/gogo/protobuf/types"
 )
 
 var backupOutputTypes = []*types.T{}
+
+var (
+	useTBI = settings.RegisterBoolSetting(
+		"kv.bulk_io_write.experimental_incremental_export_enabled",
+		"use experimental time-bound file filter when exporting in BACKUP",
+		true,
+	)
+	priorityAfter = settings.RegisterNonNegativeDurationSetting(
+		"bulkio.backup.read_with_priority_after",
+		"age of read-as-of time above which a BACKUP should read with priority",
+		time.Minute,
+	)
+	delayPerAttmpt = settings.RegisterNonNegativeDurationSetting(
+		"bulkio.backup.read_retry_delay",
+		"amount of time since the read-as-of time, per-prior attempt, to wait before making another attempt",
+		time.Second*5,
+	)
+)
 
 // TODO(pbardea): It would be nice if we could add some DistSQL processor tests
 // we would probably want to have a mock cloudStorage object that we could
@@ -93,6 +115,8 @@ func (cp *backupDataProcessor) Run(ctx context.Context) {
 type spanAndTime struct {
 	span       roachpb.Span
 	start, end hlc.Timestamp
+	attempts   int
+	lastTried  time.Time
 }
 
 func runBackupProcessor(
@@ -131,6 +155,14 @@ func runBackupProcessor(
 	}
 
 	return ctxgroup.GroupWorkers(ctx, numSenders, func(ctx context.Context, _ int) error {
+		readTime := spec.BackupEndTime.GoTime()
+
+		// priority becomes true when we're sending re-attempts of reads far enough
+		// in the past that we want to run them with priority.
+		var priority bool
+		timer := timeutil.NewTimer()
+		defer timer.Stop()
+
 		done := ctx.Done()
 		for {
 			select {
@@ -149,9 +181,54 @@ func runBackupProcessor(
 					MVCCFilter:                          spec.MVCCFilter,
 					Encryption:                          spec.Encryption,
 				}
-				log.Infof(ctx, "sending ExportRequest for span %s", span.span)
+
+				// If we're doing re-attempts but are not yet in the priority regime,
+				// check to see if it is time to switch to priority.
+				if !priority && span.attempts > 0 {
+					// Check if this is starting a new pass and we should delay first.
+					// We're okay with delaying this worker until then since we assume any
+					// other work it could pull off the queue will likely want to delay to
+					// a similar or later time anyway.
+					if delay := delayPerAttmpt.Get(&settings.SV) - timeutil.Since(span.lastTried); delay > 0 {
+						timer.Reset(delay)
+						log.Infof(ctx, "waiting %s to start attempt %d of remaining spans", delay, span.attempts+1)
+						select {
+						case <-done:
+							return ctx.Err()
+						case <-timer.C:
+							timer.Read = true
+						}
+					}
+
+					priority = timeutil.Since(readTime) > priorityAfter.Get(&settings.SV)
+				}
+
+				if priority {
+					// This re-attempt is reading far enough in the past that we just want
+					// to abort any transactions it hits.
+					header.UserPriority = roachpb.MaxUserPriority
+				} else {
+					// On the initial attempt to export this span and re-attempts that are
+					// done while it is still less than the configured time above the read
+					// time, we set WaitPolicy to Error, so that the export will return an
+					// error to us instead of instead doing blocking wait if it hits any
+					// other txns. This lets us move on to other ranges we have to export,
+					// provide an indication of why we're blocked, etc instead and come
+					// back to this range later.
+					header.WaitPolicy = lock.WaitPolicy_Error
+				}
+				log.Infof(ctx, "sending ExportRequest for span %s (attempt %d, priority %s)",
+					span.span, span.attempts+1, header.UserPriority.String())
 				rawRes, pErr := kv.SendWrappedWith(ctx, flowCtx.Cfg.DB.NonTransactionalSender(), header, req)
 				if pErr != nil {
+					if err := pErr.Detail.GetWriteIntent(); err != nil {
+						span.lastTried = timeutil.Now()
+						span.attempts++
+						todo <- span
+						// TODO(dt): send a progress update to update job progress to note
+						// the intents being hit.
+						continue
+					}
 					return errors.Wrapf(pErr.GoError(), "exporting %s", span.span)
 				}
 				res := rawRes.(*roachpb.ExportResponse)

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -4953,3 +4953,39 @@ func TestClientDisconnect(t *testing.T) {
 		})
 	}
 }
+
+func TestBackupDoesNotHangOnIntent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 10
+	ctx, _, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, "SET CLUSTER SETTING bulkio.backup.read_with_priority_after = '100ms'")
+	sqlDB.Exec(t, "SET CLUSTER SETTING bulkio.backup.read_retry_delay = '10ms'")
+
+	// start a txn that we'll hold open while we try to backup.
+	tx, err := sqlDB.DB.(*gosql.DB).BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// observe commit time to ensure it sees the client restart error below when
+	// the backup aborts it.
+	if _, err := tx.Exec("SELECT cluster_logical_timestamp()"); err != nil {
+		t.Fatal(err)
+	}
+
+	// lay down an intent that out backup will hit.
+	if _, err := tx.Exec("UPDATE data.bank SET balance = 0 WHERE id = 5 OR id = 8"); err != nil {
+		t.Fatal(err)
+	}
+
+	// backup the table in which we have our intent.
+	_, err = sqlDB.DB.ExecContext(ctx, "BACKUP data.bank TO 'nodelocal://0/intent'")
+	require.NoError(t, err)
+
+	// observe that the backup aborted our txn.
+	require.Error(t, tx.Commit())
+}


### PR DESCRIPTION
BACKUP, like any read, cannot export a range if it contains an unresolved intent.
If we hit an intent during iteration, we typically return a WriteIntentError like
any scan and let the store resolve it and retry the request before replying to the
sender.

However blocking intent resolution can mean a single txn left open can cause backups
to hang, sometimes for hours or even days in some observed cases. While operators
typically want bulk, background jobs like BACKUP to have as little impact on their
foreground traffic as possible, even more importantly they want their BACKUPs to
actually complete to maintain their RPO SLA. So while you typically would not want
a BACKUP to immeidately run at high priority and abort any transactions from OLTP
foreground traffic as soon as it starts, you do, eventually, want it to do whatever
it needs to do to finish.

Backdating BACKUPs with AS OF SYSTEM TIME '-30s' is a good best practice to reduce
the number of still-running transactions they may encounter, but an abandoned or very
long-running transaction can still hang such a backup. This change extends BACKUP to
initially start asking individual ranges to backup but bail out if they encounter an
intent, rather than attempting to resolve it and holding up the whole BACKUP while
doing so. If any range replies that it bailed out, it is put at the back of the queue
to come back to later, and BACKUP continues to work on other ranges, in the hopes that
by the time it is done with them, the intent may have already resolved itself.

When it comes back to a range that it has already attempted to backup up to the limit
(default 3), it instead asks the range to backup but not bail out if it hits an intent
and instead do the usual behavior of trying to resolve it. It addtionally sets the
priority to high, so that during that resolution, other transactions will be aborted
so that the backup can finish.

Release note (enterprise change): BACKUP takes priority over other transactions if its initial attempts to export a range fail.