### PR TITLE
release-19.1: sql: fix pagination in UPSERT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -987,3 +987,24 @@ query III
 SELECT * from table38627
 ----
 1  1  5
+
+# Regression test for UPSERT batching logic (#51391).
+statement ok
+SET CLUSTER SETTING kv.raft.command.max_size='4MiB';
+CREATE TABLE src (s STRING);
+CREATE TABLE dest (s STRING);
+INSERT INTO src
+SELECT
+	'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+FROM
+	generate_series(1, 50000)
+
+# This statement produces a raft command of about 6.6 MiB in size, so if the
+# batching logic is incorrect, we'll encounter "command is too large" error.
+statement ok
+UPSERT INTO dest (s) (SELECT s FROM src)
+
+statement ok
+RESET CLUSTER SETTING kv.raft.command.max_size;
+DROP TABLE src;
+DROP TABLE dest

--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -147,8 +147,6 @@ func (tu *tableUpserterBase) batchedValues(rowIdx int) tree.Datums {
 	return tu.rowsUpserted.At(rowIdx)
 }
 
-func (tu *tableUpserterBase) curBatchSize() int { return tu.insertRows.Len() }
-
 // close is part of the tableWriter interface.
 func (tu *tableUpserterBase) close(ctx context.Context) {
 	tu.insertRows.Close(ctx)
@@ -492,6 +490,11 @@ func (tu *tableUpserter) atBatchEnd(ctx context.Context, traceKV bool) error {
 
 	return nil
 }
+
+// curBatchSize is part of the extendedTableWriter interface. Note that we need
+// to override tableWriterBase.curBatchSize because tableUpserter stores the
+// insert rows not in the batch but in insertRows row container.
+func (tu *tableUpserter) curBatchSize() int { return tu.insertRows.Len() }
 
 // updateConflictingRow updates the existing row in the table, when there was a
 // conflict. existingRows contains the previously seen rows, and is modified

--- a/pkg/sql/tablewriter_upsert_strict.go
+++ b/pkg/sql/tablewriter_upsert_strict.go
@@ -101,6 +101,11 @@ func (tu *strictTableUpserter) atBatchEnd(ctx context.Context, traceKV bool) err
 	return nil
 }
 
+// curBatchSize is part of the extendedTableWriter interface. Note that we need
+// to override tableWriterBase.curBatchSize because strictTableUpserter stores
+// the insert rows not in the batch but in insertRows row container.
+func (tu *strictTableUpserter) curBatchSize() int { return tu.insertRows.Len() }
+
 // Get all unique indexes and store them in tu.ConflictIndexes.
 func (tu *strictTableUpserter) getUniqueIndexes() (err error) {
 	tableDesc := tu.tableDesc()


### PR DESCRIPTION
Backport 1/1 commits from #51612.

/cc @cockroachdb/release

---

`optTableUpserter` and `fastTableUpserter` were incorrectly using
`curBatchSize` method implementation of `tableUpserterBase` which
returns the number of rows in `insertRows` row container, but that \
container is not actually used by those two upserters. As a result,
`curBatchSize` was always considered 0, and we didn't perform the
pagination on the UPSERTs when driven by the optimizer. This is now
fixed by keeping `tableWriterBase` implementation of `curBatchSize`
method and overriding it by `tableUpserter` and `strictTableUpserter`
since those two actually use a row container.
The bug was introduced in #33339 (in 19.1.0).

Fixes: #51391.

Release note (bug fix): Previously, CockroachDB could hit a "command is
too large" error when performing UPSERT operation with many values.
Internally, we attempt to perform such operation by splitting it into
"batches", but the batching mechanism was broken.