### PR TITLE
backupccl: make basic BACKUP and RESTORE free to use

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -877,12 +876,6 @@ func restorePlanHook(
 		// TODO(dan): Move this span into sql.
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
-
-		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "RESTORE",
-		); err != nil {
-			return err
-		}
 
 		if err := p.RequireAdminRole(ctx, "RESTORE"); err != nil {
 			return err


### PR DESCRIPTION
The removes the enterprise license check from RESTORE as well as
from the basic form of BACKUP, making these free to use without
an enterprise licsense.

Advanced BACKUP options like incremental backups, backups to
partitioned storage destinations, or backups that capture
revision history or use file-level encryption all continue
to require an enterprise license, but basic backups can now
be run without a license. RESTORE now never requires a license
regardless of the options passed to it or to the backup it
is restoring.

Release note (enterprise change): Basic BACKUP and RESTORE no longer require an enterprise license.