### PR TITLE
release-20.1: combined fixes for ownership related bugs

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3470,6 +3470,260 @@ func TestBackupRestoreSequence(t *testing.T) {
 	})
 }
 
+func TestBackupRestoreSequenceOwnership(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	const numAccounts = 1
+	_, _, origDB, dir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
+	defer cleanupFn()
+	args := base.TestServerArgs{ExternalIODir: dir}
+
+	// Setup for sequence ownership backup/restore tests in the same database.
+	backupLoc := LocalFoo + `/d`
+	origDB.Exec(t, `CREATE DATABASE d`)
+	origDB.Exec(t, `CREATE TABLE d.t(a int)`)
+	origDB.Exec(t, `CREATE SEQUENCE d.seq OWNED BY d.t.a`)
+	origDB.Exec(t, `BACKUP DATABASE d TO $1`, backupLoc)
+
+	// When restoring a database which has a owning table and an owned sequence,
+	// the ownership relationship should be preserved and remapped post restore.
+	t.Run("test restoring database should preserve ownership dependency", func(t *testing.T) {
+		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{ServerArgs: args})
+		defer tc.Stopper().Stop(context.Background())
+
+		newDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+		kvDB := tc.Server(0).DB()
+
+		newDB.Exec(t, `RESTORE DATABASE d FROM $1`, backupLoc)
+
+		tableDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d", "t")
+		seqDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d", "seq")
+
+		require.True(t, seqDesc.SequenceOpts.HasOwner(), "no sequence owner after restore")
+		require.Equal(t, tableDesc.ID, seqDesc.SequenceOpts.SequenceOwner.OwnerTableID,
+			"unexpected table is sequence owner after restore",
+		)
+		require.Equal(t, tableDesc.GetColumns()[0].ID, seqDesc.SequenceOpts.SequenceOwner.OwnerColumnID,
+			"unexpected column is sequence owner after restore",
+		)
+		require.Equal(t, 1, len(tableDesc.GetColumns()[0].OwnsSequenceIds),
+			"unexpected number of sequences owned by d.t after restore",
+		)
+		require.Equal(t, seqDesc.ID, tableDesc.GetColumns()[0].OwnsSequenceIds[0],
+			"unexpected ID of sequence owned by table d.t after restore",
+		)
+	})
+
+	// When restoring a sequence that is owned by a table, but the owning table
+	// does not exist, the user must specify the `skip_missing_sequence_owners`
+	// flag. When supplied, the sequence should be restored without an owner.
+	t.Run("test restoring sequence when table does not exist", func(t *testing.T) {
+		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{ServerArgs: args})
+		defer tc.Stopper().Stop(context.Background())
+
+		newDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+		kvDB := tc.Server(0).DB()
+		newDB.Exec(t, `CREATE DATABASE d`)
+		newDB.Exec(t, `USE d`)
+		newDB.ExpectErr(t, `pq: cannot restore sequence "seq" without referenced owner`,
+			`RESTORE TABLE seq FROM $1`, backupLoc)
+
+		newDB.Exec(t, `RESTORE TABLE seq FROM $1 WITH skip_missing_sequence_owners`, backupLoc)
+		seqDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d", "seq")
+		require.False(t, seqDesc.SequenceOpts.HasOwner(), "unexpected owner of restored sequence.")
+	})
+
+	// When just the table is restored by itself, the ownership dependency is
+	// removed as the sequence doesn't exist. When the sequence is restored
+	// after that, it requires the `skip_missing_sequence_owners` flag as
+	// the table isn't being restored with it, and when provided, the sequence
+	// shouldn't have an owner.
+	t.Run("test restoring table then sequence should remove ownership dependency",
+		func(t *testing.T) {
+			tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{ServerArgs: args})
+			defer tc.Stopper().Stop(context.Background())
+
+			newDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+			kvDB := tc.Server(0).DB()
+			newDB.Exec(t, `CREATE DATABASE d`)
+			newDB.Exec(t, `USE d`)
+			newDB.ExpectErr(t, `pq: cannot restore sequence "seq" without referenced owner table`,
+				`RESTORE TABLE seq FROM $1`, backupLoc)
+
+			newDB.ExpectErr(t, `pq: cannot restore table "t" without referenced sequence`,
+				`RESTORE TABLE t FROM $1`, backupLoc)
+			newDB.Exec(t, `RESTORE TABLE t FROM $1 WITH skip_missing_sequence_owners`, backupLoc)
+
+			tableDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d", "t")
+
+			require.Equal(t, 0, len(tableDesc.GetColumns()[0].OwnsSequenceIds),
+				"expected restored table to own 0 sequences",
+			)
+
+			newDB.ExpectErr(t, `pq: cannot restore sequence "seq" without referenced owner table`,
+				`RESTORE TABLE seq FROM $1`, backupLoc)
+			newDB.Exec(t, `RESTORE TABLE seq FROM $1 WITH skip_missing_sequence_owners`, backupLoc)
+
+			seqDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d", "seq")
+			require.False(t, seqDesc.SequenceOpts.HasOwner(), "unexpected sequence owner after restore")
+		})
+
+	// Ownership dependencies should be preserved and remapped when restoring
+	// both the owned sequence and owning table into a different database.
+	t.Run("test restoring all tables into a different database", func(t *testing.T) {
+		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{ServerArgs: args})
+		defer tc.Stopper().Stop(context.Background())
+
+		newDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+		kvDB := tc.Server(0).DB()
+
+		newDB.Exec(t, `CREATE DATABASE restore_db`)
+		newDB.Exec(t, `RESTORE d.* FROM $1 WITH into_db='restore_db'`, backupLoc)
+
+		tableDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "restore_db", "t")
+		seqDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "restore_db", "seq")
+
+		require.True(t, seqDesc.SequenceOpts.HasOwner(), "no sequence owner after restore")
+		require.Equal(t, tableDesc.ID, seqDesc.SequenceOpts.SequenceOwner.OwnerTableID,
+			"unexpected table is sequence owner after restore",
+		)
+		require.Equal(t, tableDesc.GetColumns()[0].ID, seqDesc.SequenceOpts.SequenceOwner.OwnerColumnID,
+			"unexpected column is sequence owner after restore",
+		)
+		require.Equal(t, 1, len(tableDesc.GetColumns()[0].OwnsSequenceIds),
+			"unexpected number of sequences owned by d.t after restore",
+		)
+		require.Equal(t, seqDesc.ID, tableDesc.GetColumns()[0].OwnsSequenceIds[0],
+			"unexpected ID of sequence owned by table d.t after restore",
+		)
+	})
+
+	// Setup for cross-database ownership backup-restore tests.
+	backupLocD2D3 := LocalFoo + `/d2d3`
+
+	origDB.Exec(t, `CREATE DATABASE d2`)
+	origDB.Exec(t, `CREATE TABLE d2.t(a int)`)
+
+	origDB.Exec(t, `CREATE DATABASE d3`)
+	origDB.Exec(t, `CREATE TABLE d3.t(a int)`)
+
+	origDB.Exec(t, `CREATE SEQUENCE d2.seq OWNED BY d3.t.a`)
+
+	origDB.Exec(t, `CREATE SEQUENCE d3.seq OWNED BY d2.t.a`)
+	origDB.Exec(t, `CREATE SEQUENCE d3.seq2 OWNED BY d3.t.a`)
+
+	origDB.Exec(t, `BACKUP DATABASE d2, d3 TO $1`, backupLocD2D3)
+
+	// When restoring a database that has a sequence which is owned by a table
+	// in another database, the user must supply the
+	// `skip_missing_sequence_owners` flag. When supplied, the cross-database
+	// ownership dependency should be removed.
+	t.Run("test restoring two databases removes cross-database ownership dependency",
+		func(t *testing.T) {
+			tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{ServerArgs: args})
+			defer tc.Stopper().Stop(context.Background())
+
+			newDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+			kvDB := tc.Server(0).DB()
+
+			newDB.ExpectErr(t, "pq: cannot restore sequence \"seq\" without referenced owner|"+
+				"pq: cannot restore table \"t\" without referenced sequence",
+				`RESTORE DATABASE d2 FROM $1`, backupLocD2D3)
+			newDB.Exec(t, `RESTORE DATABASE d2 FROM $1 WITH skip_missing_sequence_owners`, backupLocD2D3)
+
+			tableDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d2", "t")
+			require.Equal(t, 0, len(tableDesc.GetColumns()[0].OwnsSequenceIds),
+				"expected restored table to own no sequences.",
+			)
+
+			newDB.ExpectErr(t, "pq: cannot restore sequence \"seq\" without referenced owner|"+
+				"pq: cannot restore table \"t\" without referenced sequence",
+				`RESTORE DATABASE d3 FROM $1`, backupLocD2D3)
+			newDB.Exec(t, `RESTORE DATABASE d3 FROM $1 WITH skip_missing_sequence_owners`, backupLocD2D3)
+
+			seqDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d3", "seq")
+			require.False(t, seqDesc.SequenceOpts.HasOwner(), "unexpected sequence owner after restore")
+
+			// Sequence dependencies inside the database should still be preserved.
+			sd := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d3", "seq2")
+			td := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d3", "t")
+
+			require.True(t, sd.SequenceOpts.HasOwner(), "no owner found for seq2")
+			require.Equal(t, td.ID, sd.SequenceOpts.SequenceOwner.OwnerTableID,
+				"unexpected table owner for sequence seq2 after restore",
+			)
+			require.Equal(t, td.GetColumns()[0].ID, sd.SequenceOpts.SequenceOwner.OwnerColumnID,
+				"unexpected column owner for sequence seq2 after restore")
+			require.Equal(t, 1, len(td.GetColumns()[0].OwnsSequenceIds),
+				"unexpected number of sequences owned by d3.t after restore",
+			)
+			require.Equal(t, sd.ID, td.GetColumns()[0].OwnsSequenceIds[0],
+				"unexpected ID of sequences owned by d3.t",
+			)
+		})
+
+	// When restoring both the databases that contain a cross database ownership
+	// dependency, we should preserve and remap the ownership dependencies.
+	t.Run("test restoring both databases at the same time", func(t *testing.T) {
+		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{ServerArgs: args})
+		defer tc.Stopper().Stop(context.Background())
+
+		newDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+		kvDB := tc.Server(0).DB()
+
+		newDB.Exec(t, `RESTORE DATABASE d2, d3 FROM $1`, backupLocD2D3)
+
+		// d2.t owns d3.seq should be preserved.
+		tableDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d2", "t")
+		seqDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d3", "seq")
+
+		require.True(t, seqDesc.SequenceOpts.HasOwner(), "no sequence owner after restore")
+		require.Equal(t, tableDesc.ID, seqDesc.SequenceOpts.SequenceOwner.OwnerTableID,
+			"unexpected table is sequence owner after restore",
+		)
+		require.Equal(t, tableDesc.GetColumns()[0].ID, seqDesc.SequenceOpts.SequenceOwner.OwnerColumnID,
+			"unexpected column is sequence owner after restore",
+		)
+		require.Equal(t, 1, len(tableDesc.GetColumns()[0].OwnsSequenceIds),
+			"unexpected number of sequences owned by d.t after restore",
+		)
+		require.Equal(t, seqDesc.ID, tableDesc.GetColumns()[0].OwnsSequenceIds[0],
+			"unexpected ID of sequence owned by table d.t after restore",
+		)
+
+		// d3.t owns d2.seq and d3.seq2 should be preserved.
+		td := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d3", "t")
+		sd := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d2", "seq")
+		sdSeq2 := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d3", "seq2")
+
+		require.True(t, sd.SequenceOpts.HasOwner(), "no sequence owner after restore")
+		require.True(t, sdSeq2.SequenceOpts.HasOwner(), "no sequence owner after restore")
+
+		require.Equal(t, td.ID, sd.SequenceOpts.SequenceOwner.OwnerTableID,
+			"unexpected table is sequence owner of d3.seq after restore",
+		)
+		require.Equal(t, td.ID, sdSeq2.SequenceOpts.SequenceOwner.OwnerTableID,
+			"unexpected table is sequence owner of d3.seq2 after restore",
+		)
+
+		require.Equal(t, td.GetColumns()[0].ID, sd.SequenceOpts.SequenceOwner.OwnerColumnID,
+			"unexpected column is sequence owner of d2.seq after restore",
+		)
+		require.Equal(t, td.GetColumns()[0].ID, sdSeq2.SequenceOpts.SequenceOwner.OwnerColumnID,
+			"unexpected column is sequence owner of d3.seq2 after restore",
+		)
+
+		require.Equal(t, 2, len(td.GetColumns()[0].OwnsSequenceIds),
+			"unexpected number of sequences owned by d3.t after restore",
+		)
+		require.Equal(t, sd.ID, td.GetColumns()[0].OwnsSequenceIds[0],
+			"unexpected ID of sequence owned by table d3.t after restore",
+		)
+		require.Equal(t, sdSeq2.ID, td.GetColumns()[0].OwnsSequenceIds[1],
+			"unexpected ID of sequence owned by table d3.t after restore",
+		)
+	})
+}
+
 func TestBackupRestoreShowJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -418,7 +418,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				return err
 			}
 
-			if err := params.p.dropSequencesOwnedByCol(params.ctx, colToDrop); err != nil {
+			if err := params.p.dropSequencesOwnedByCol(params.ctx, colToDrop, true /* queueJob */); err != nil {
 				return err
 			}
 

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 type dropSequenceNode struct {
@@ -159,6 +160,13 @@ func (p *planner) canRemoveOwnedSequencesImpl(
 	for _, sequenceID := range col.OwnsSequenceIds {
 		seqLookup, err := p.LookupTableByID(ctx, sequenceID)
 		if err != nil {
+			// Special case error swallowing for #50711 and #50781, which can cause a
+			// column to own sequences that have been dropped/do not exist.
+			if err.Error() == errTableDropped.Error() ||
+				pgerror.GetPGCode(err) == pgcode.UndefinedTable {
+				log.Eventf(ctx, "swallowing error ensuring owned sequences can be removed: %s", err.Error())
+				continue
+			}
 			return err
 		}
 		seqDesc := seqLookup.Desc

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -106,6 +106,9 @@ func (p *planner) dropSequenceImpl(
 	jobDesc string,
 	behavior tree.DropBehavior,
 ) error {
+	if err := removeSequenceOwnerIfExists(ctx, p, seqDesc.ID, seqDesc.GetSequenceOpts()); err != nil {
+		return err
+	}
 	return p.initiateDropTable(ctx, seqDesc, queueJob, jobDesc, true /* drainName */)
 }
 

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -288,7 +288,7 @@ func (p *planner) dropTableImpl(
 
 	// Drop sequences that the columns of the table own
 	for _, col := range tableDesc.Columns {
-		if err := p.dropSequencesOwnedByCol(ctx, &col); err != nil {
+		if err := p.dropSequencesOwnedByCol(ctx, &col, queueJob); err != nil {
 			return droppedViews, err
 		}
 	}
@@ -336,7 +336,7 @@ func (p *planner) initiateDropTable(
 	drainName bool,
 ) error {
 	if tableDesc.Dropped() {
-		return fmt.Errorf("table %q is being dropped", tableDesc.Name)
+		return errors.Errorf("table %q is already being dropped", tableDesc.Name)
 	}
 
 	// If the table is not interleaved , use the delayed GC mechanism to

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1170,7 +1170,6 @@ DROP DATABASE db_50712 CASCADE
 
 statement ok
 DROP TABLE t_50712
-<<<<<<< HEAD
 
 # previously, changing ownership of a sequence between columns of the same table
 # was causing the sequenceID to appear in multiple column's ownedSequences list.

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1084,3 +1084,135 @@ DROP SEQUENCE seq_50649
 
 statement ok
 DROP TABLE t_50649
+
+subtest regression_50712
+
+statement ok
+CREATE DATABASE db_50712
+
+statement ok
+CREATE TABLE db_50712.t_50712(a INT PRIMARY KEY)
+
+statement ok
+CREATE SEQUENCE db_50712.seq_50712 OWNED BY db_50712.t_50712.a
+
+statement ok
+DROP DATABASE db_50712 CASCADE
+
+# Same test like above, except the table is lexicographically less than the
+# sequence, which results in drop database dropping the table before the
+# sequence.
+statement ok
+CREATE DATABASE db_50712
+
+statement ok
+CREATE TABLE db_50712.a_50712(a INT PRIMARY KEY)
+
+statement ok
+CREATE SEQUENCE db_50712.seq_50712 OWNED BY db_50712.a_50712.a
+
+statement ok
+DROP DATABASE db_50712 CASCADE
+
+# Same test like above, except the db is switched as the current db
+statement ok
+CREATE DATABASE db_50712
+
+statement ok
+SET DATABASE = db_50712
+
+statement ok
+CREATE TABLE a_50712(a INT PRIMARY KEY)
+
+statement ok
+CREATE SEQUENCE seq_50712 OWNED BY a_50712.a
+
+statement ok
+DROP DATABASE db_50712
+
+statement ok
+SET DATABASE = test
+
+# Tests db drop.
+# Sequence: outside db.
+# Owner: inside db.
+# The sequence should be automatically dropped.
+statement ok
+CREATE DATABASE db_50712
+
+statement ok
+CREATE TABLE db_50712.t_50712(a INT PRIMARY KEY)
+
+statement ok
+CREATE SEQUENCE seq_50712 OWNED BY db_50712.t_50712.a
+
+statement ok
+DROP DATABASE db_50712 CASCADE
+
+statement error pq: relation "seq_50712" does not exist
+SELECT * FROM seq_50712
+
+# Tests db drop.
+# Sequence: inside db
+# Owner: outside db
+# It should be possible to drop the table later.
+statement ok
+CREATE DATABASE db_50712
+
+statement ok
+CREATE TABLE t_50712(a INT PRIMARY KEY)
+
+statement ok
+CREATE SEQUENCE db_50712.seq_50712 OWNED BY t_50712.a
+
+statement ok
+DROP DATABASE db_50712 CASCADE
+
+statement ok
+DROP TABLE t_50712
+
+# previously, changing ownership of a sequence between columns of the same table
+# was causing the sequenceID to appear in multiple column's ownedSequences list.
+# This makes it impossible to drop the affected columns/table once the sequence
+# has been dropped. This tests for these scenarios and ensures the table/columns
+# remain drop-able.
+subtest regression_50711
+
+statement ok
+CREATE TABLE t_50711(a int, b int)
+
+statement ok
+CREATE SEQUENCE seq_50711 owned by t_50711.a
+
+statement ok
+ALTER SEQUENCE seq_50711 owned by t_50711.b
+
+statement ok
+ALTER SEQUENCE seq_50711 owned by t_50711.a
+
+statement ok
+DROP SEQUENCE seq_50711
+
+statement ok
+DROP TABLE t_50711
+
+statement ok
+CREATE TABLE t_50711(a int, b int)
+
+statement ok
+CREATE SEQUENCE seq_50711 owned by t_50711.a
+
+statement ok
+ALTER SEQUENCE seq_50711 owned by t_50711.b
+
+statement ok
+ALTER SEQUENCE seq_50711 owned by t_50711.a
+
+statement ok
+DROP SEQUENCE seq_50711
+
+statement ok
+ALTER TABLE t_50711 DROP COLUMN a
+
+statement ok
+ALTER TABLE t_50711 DROP COLUMN b

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1071,3 +1071,16 @@ DROP TABLE b;
 
 statement ok
 DROP TABLE a;
+subtest regression_50649
+
+statement ok
+CREATE TABLE t_50649(a INT PRIMARY KEY)
+
+statement ok
+CREATE SEQUENCE seq_50649 OWNED BY t_50649.a
+
+statement ok
+DROP SEQUENCE seq_50649
+
+statement ok
+DROP TABLE t_50649

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1170,6 +1170,7 @@ DROP DATABASE db_50712 CASCADE
 
 statement ok
 DROP TABLE t_50712
+<<<<<<< HEAD
 
 # previously, changing ownership of a sequence between columns of the same table
 # was causing the sequenceID to appear in multiple column's ownedSequences list.

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -290,7 +290,7 @@ func assignSequenceOptions(
 					if err := removeSequenceOwnerIfExists(params.ctx, params.p, sequenceID, opts); err != nil {
 						return err
 					}
-					err := addSequenceOwner(params.ctx, params.p, tableDesc, col, sequenceID, opts)
+					err := addSequenceOwner(params.ctx, params.p, option.ColumnItemVal, sequenceID, opts)
 					if err != nil {
 						return err
 					}
@@ -384,11 +384,15 @@ func resolveColumnItemToDescriptors(
 func addSequenceOwner(
 	ctx context.Context,
 	p *planner,
-	tableDesc *MutableTableDescriptor,
-	col *sqlbase.ColumnDescriptor,
+	columnItemVal *tree.ColumnItem,
 	sequenceID sqlbase.ID,
 	opts *sqlbase.TableDescriptor_SequenceOpts,
 ) error {
+	tableDesc, col, err := resolveColumnItemToDescriptors(ctx, p, columnItemVal)
+	if err != nil {
+		return err
+	}
+
 	col.OwnsSequenceIds = append(col.OwnsSequenceIds, sequenceID)
 
 	opts.SequenceOwner.OwnerColumnID = col.ID

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -336,6 +336,11 @@ func removeSequenceOwnerIfExists(
 	if err != nil {
 		return err
 	}
+	// If the table descriptor has already been dropped, there is no need to
+	// remove the reference.
+	if tableDesc.Dropped() {
+		return nil
+	}
 	col, err := tableDesc.FindColumnByID(opts.SequenceOwner.OwnerColumnID)
 	if err != nil {
 		return err
@@ -471,17 +476,21 @@ func maybeAddSequenceDependencies(
 // dropSequencesOwnedByCol drops all the sequences from col.OwnsSequenceIDs.
 // Called when the respective column (or the whole table) is being dropped.
 func (p *planner) dropSequencesOwnedByCol(
-	ctx context.Context, col *sqlbase.ColumnDescriptor,
+	ctx context.Context, col *sqlbase.ColumnDescriptor, queueJob bool,
 ) error {
 	for _, sequenceID := range col.OwnsSequenceIds {
 		seqDesc, err := p.Tables().getMutableTableVersionByID(ctx, sequenceID, p.txn)
 		if err != nil {
 			return err
 		}
+		// This sequence is already getting dropped. Don't do it twice.
+		if seqDesc.Dropped() {
+			continue
+		}
 		jobDesc := fmt.Sprintf("removing sequence %q dependent on column %q which is being dropped",
 			seqDesc.Name, col.ColName())
 		if err := p.dropSequenceImpl(
-			ctx, seqDesc, true /* queueJob */, jobDesc, tree.DropRestrict,
+			ctx, seqDesc, queueJob, jobDesc, tree.DropRestrict,
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -329,7 +329,7 @@ func removeSequenceOwnerIfExists(
 	sequenceID sqlbase.ID,
 	opts *sqlbase.TableDescriptor_SequenceOpts,
 ) error {
-	if opts.SequenceOwner.Equal(sqlbase.TableDescriptor_SequenceOpts_SequenceOwner{}) {
+	if !opts.HasOwner() {
 		return nil
 	}
 	tableDesc, err := p.Tables().getMutableTableVersionByID(ctx, opts.SequenceOwner.OwnerTableID, p.txn)

--- a/pkg/sql/sequence_test.go
+++ b/pkg/sql/sequence_test.go
@@ -15,7 +15,11 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func BenchmarkSequenceIncrement(b *testing.B) {
@@ -69,4 +73,119 @@ func BenchmarkUniqueRowID(b *testing.B) {
 		}
 	}
 	b.StopTimer()
+}
+
+// Regression test for #50711. The root cause of #50711 was the fact that a
+// sequenceID popped up in multiple columns' column descriptor. This test
+// inspects the table descriptor to ascertain that sequence ownership integrity
+// is preserved in various scenarios.
+// Scenarios tested:
+// - ownership swaps between table columns
+// - two sequences being owned simultaneously
+// - sequence drops
+// - ownership removal
+func TestSequenceOwnershipDependencies(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	params := base.TestServerArgs{}
+	s, sqlConn, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	if _, err := sqlConn.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test(a INT PRIMARY KEY, b INT)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Switch ownership between columns of the same table.
+	if _, err := sqlConn.Exec("CREATE SEQUENCE t.seq1 OWNED BY t.test.a"); err != nil {
+		t.Fatal(err)
+	}
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 0 /* colIdx */, []string{"seq1"})
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 1 /* colIdx */, nil /* seqNames */)
+
+	if _, err := sqlConn.Exec("ALTER SEQUENCE t.seq1 OWNED BY t.test.b"); err != nil {
+		t.Fatal(err)
+	}
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 0 /* colIdx */, nil /* seqNames */)
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 1 /* colIdx */, []string{"seq1"})
+
+	if _, err := sqlConn.Exec("ALTER SEQUENCE t.seq1 OWNED BY t.test.a"); err != nil {
+		t.Fatal(err)
+	}
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 0 /* colIdx */, []string{"seq1"})
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 1 /* colIdx */, nil /* seqNames */)
+
+	// Add a second sequence in the mix and switch its ownership.
+	if _, err := sqlConn.Exec("CREATE SEQUENCE t.seq2 OWNED BY t.test.a"); err != nil {
+		t.Fatal(err)
+	}
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 0 /* colIdx */, []string{"seq1", "seq2"})
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 1 /* colIdx */, nil /* seqNames */)
+
+	if _, err := sqlConn.Exec("ALTER SEQUENCE t.seq2 OWNED BY t.test.b"); err != nil {
+		t.Fatal(err)
+	}
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 0 /* colIdx */, []string{"seq1"})
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 1 /* colIdx */, []string{"seq2"})
+
+	if _, err := sqlConn.Exec("ALTER SEQUENCE t.seq2 OWNED BY t.test.a"); err != nil {
+		t.Fatal(err)
+	}
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 0 /* colIdx */, []string{"seq1", "seq2"})
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 1 /* colIdx */, nil /* seqNames */)
+
+	// Ensure dropping sequences removes the ownership dependencies.
+	if _, err := sqlConn.Exec("DROP SEQUENCE t.seq1"); err != nil {
+		t.Fatal(err)
+	}
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 0 /* colIdx */, []string{"seq2"})
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 1 /* colIdx */, nil /* seqNames */)
+
+	// Ensure removing an owner removes the ownership dependency.
+	if _, err := sqlConn.Exec("ALTER SEQUENCE t.seq2 OWNED BY NONE"); err != nil {
+		t.Fatal(err)
+	}
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 0 /* colIdx */, nil /* seqNames */)
+	assertColumnOwnsSequences(t, kvDB, "t", "test", 1 /* colIdx */, nil /* seqNames */)
+}
+
+// assertColumnOwnsSequences ensures that the column at (DbName, tbName, colIdx)
+// owns all the sequences passed to it (in order) by looking up descriptors in
+// kvDB.
+func assertColumnOwnsSequences(
+	t *testing.T, kvDB *kv.DB, dbName string, tbName string, colIdx int, seqNames []string,
+) {
+	tableDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, dbName, tbName)
+	col := tableDesc.GetColumns()[colIdx]
+	var seqDescs []*SequenceDescriptor
+	for _, seqName := range seqNames {
+		seqDescs = append(
+			seqDescs,
+			sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, dbName, seqName),
+		)
+	}
+
+	if len(col.OwnsSequenceIds) != len(seqDescs) {
+		t.Fatalf(
+			"unexpected number of sequence ownership dependencies. expected: %d, got:%d",
+			len(seqDescs), len(col.OwnsSequenceIds),
+		)
+	}
+
+	for i, seqID := range col.OwnsSequenceIds {
+		if seqID != seqDescs[i].GetID() {
+			t.Fatalf("unexpected sequence id. expected %d got %d", seqDescs[i].GetID(), seqID)
+		}
+
+		ownerTableID := seqDescs[i].SequenceOpts.SequenceOwner.OwnerTableID
+		ownerColID := seqDescs[i].SequenceOpts.SequenceOwner.OwnerColumnID
+		if ownerTableID != tableDesc.GetID() || ownerColID != col.ID {
+			t.Fatalf(
+				"unexpected sequence owner. expected table id %d, got: %d; expected column id %d, got :%d",
+				tableDesc.GetID(), ownerTableID, col.ID, ownerColID,
+			)
+		}
+	}
 }

--- a/pkg/sql/sequence_test.go
+++ b/pkg/sql/sequence_test.go
@@ -12,14 +12,16 @@ package sql
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkSequenceIncrement(b *testing.B) {
@@ -157,13 +159,13 @@ CREATE TABLE t.test(a INT PRIMARY KEY, b INT)`); err != nil {
 func assertColumnOwnsSequences(
 	t *testing.T, kvDB *kv.DB, dbName string, tbName string, colIdx int, seqNames []string,
 ) {
-	tableDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, dbName, tbName)
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, dbName, tbName)
 	col := tableDesc.GetColumns()[colIdx]
 	var seqDescs []*SequenceDescriptor
 	for _, seqName := range seqNames {
 		seqDescs = append(
 			seqDescs,
-			sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, dbName, seqName),
+			sqlbase.GetTableDescriptor(kvDB, dbName, seqName),
 		)
 	}
 
@@ -188,4 +190,216 @@ func assertColumnOwnsSequences(
 			)
 		}
 	}
+}
+
+// Tests for allowing drops on sequence descriptors in a bad state due to
+// ownership bugs. It should be possible to drop tables/sequences that have
+// descriptors in an invalid state. See tracking issue #51770 for more details.
+// Relevant sub-issues are referenced in test names/inline comments.
+func TestInvalidOwnedDescriptorsAreDroppable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testCases := []struct {
+		name string
+		test func(*testing.T, *kv.DB, *sqlutils.SQLRunner)
+	}{
+		// Tests simulating #50711 by breaking the invariant that sequences are owned
+		// by at most one column at a time.
+
+		// Dropping the table should work when the table descriptor is in an invalid
+		// state. The owned sequence should also be dropped.
+		{
+			name: "#50711 drop table",
+			test: func(t *testing.T, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner) {
+				addOwnedSequence(t, kvDB, "t", "test", 0, "seq")
+				addOwnedSequence(t, kvDB, "t", "test", 1, "seq")
+
+				sqlDB.Exec(t, "DROP TABLE t.test")
+				// The sequence should have been dropped as well.
+				sqlDB.ExpectErr(t, `pq: relation "t.seq" does not exist`, "SELECT * FROM t.seq")
+				// The valid sequence should have also been dropped.
+				sqlDB.ExpectErr(t, `pq: relation "t.valid_seq" does not exist`, "SELECT * FROM t.valid_seq")
+			},
+		},
+		{
+			name: "#50711 drop sequence followed by drop table",
+			test: func(t *testing.T, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner) {
+				addOwnedSequence(t, kvDB, "t", "test", 0, "seq")
+				addOwnedSequence(t, kvDB, "t", "test", 1, "seq")
+
+				sqlDB.Exec(t, "DROP SEQUENCE t.seq")
+				sqlDB.Exec(t, "SELECT * FROM t.valid_seq")
+				sqlDB.Exec(t, "DROP TABLE t.test")
+
+				// The valid sequence should have also been dropped.
+				sqlDB.ExpectErr(t, `pq: relation "t.valid_seq" does not exist`, "SELECT * FROM t.valid_seq")
+			},
+		},
+		{
+			// This test invalidates both seq and useq as DROP DATABASE CASCADE operates
+			// on objects lexicographically -- owned sequences can be dropped both as a
+			// regular sequence drop and as a side effect of the owner table being dropped.
+			name: "#50711 drop database cascade",
+			test: func(t *testing.T, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner) {
+				addOwnedSequence(t, kvDB, "t", "test", 0, "seq")
+				addOwnedSequence(t, kvDB, "t", "test", 1, "seq")
+
+				addOwnedSequence(t, kvDB, "t", "test", 0, "useq")
+				addOwnedSequence(t, kvDB, "t", "test", 1, "useq")
+
+				sqlDB.Exec(t, "DROP DATABASE t CASCADE")
+			},
+		},
+
+		// Tests simulating #50781 by modifying the sequence's owner to a table that
+		// doesn't exist and column's `ownsSequenceIDs` to sequences that don't exist.
+
+		{
+			name: "#50781 drop table followed by drop sequence",
+			test: func(t *testing.T, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner) {
+				breakOwnershipMapping(t, kvDB, "t", "test", "seq")
+
+				sqlDB.Exec(t, "DROP TABLE t.test")
+				// The valid sequence should have also been dropped.
+				sqlDB.ExpectErr(t, `pq: relation "t.valid_seq" does not exist`, "SELECT * FROM t.valid_seq")
+				sqlDB.Exec(t, "DROP SEQUENCE t.seq")
+			},
+		},
+		{
+			name: "#50781 drop sequence followed by drop table",
+			test: func(t *testing.T, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner) {
+				breakOwnershipMapping(t, kvDB, "t", "test", "seq")
+
+				sqlDB.Exec(t, "DROP SEQUENCE t.seq")
+				sqlDB.Exec(t, "DROP TABLE t.test")
+				// The valid sequence should have also been dropped.
+				sqlDB.ExpectErr(t, `pq: relation "t.valid_seq" does not exist`, "SELECT * FROM t.valid_seq")
+			},
+		},
+
+		// This test invalidates both seq and useq as DROP DATABASE CASCADE operates
+		// on objects lexicographically -- owned sequences can be dropped both as a
+		// regular sequence drop and as a side effect of the owner table being dropped.
+		{
+			name: "#50781 drop database cascade",
+			test: func(t *testing.T, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner) {
+				breakOwnershipMapping(t, kvDB, "t", "test", "seq")
+				breakOwnershipMapping(t, kvDB, "t", "test", "useq")
+				sqlDB.Exec(t, "DROP DATABASE t CASCADE")
+			},
+		},
+		{
+			name: "combined #50711 #50781 drop table followed by sequence",
+			test: func(t *testing.T, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner) {
+				addOwnedSequence(t, kvDB, "t", "test", 0, "seq")
+				addOwnedSequence(t, kvDB, "t", "test", 1, "seq")
+				breakOwnershipMapping(t, kvDB, "t", "test", "seq")
+
+				sqlDB.Exec(t, "DROP TABLE t.test")
+				// The valid sequence should have also been dropped.
+				sqlDB.ExpectErr(t, `pq: relation "t.valid_seq" does not exist`, "SELECT * FROM t.valid_seq")
+				sqlDB.Exec(t, "DROP SEQUENCE t.seq")
+			},
+		},
+		{
+			name: "combined #50711 #50781 drop sequence followed by table",
+			test: func(t *testing.T, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner) {
+				addOwnedSequence(t, kvDB, "t", "test", 0, "seq")
+				addOwnedSequence(t, kvDB, "t", "test", 1, "seq")
+				breakOwnershipMapping(t, kvDB, "t", "test", "seq")
+
+				sqlDB.Exec(t, "DROP SEQUENCE t.seq")
+				sqlDB.Exec(t, "DROP TABLE t.test")
+				// The valid sequence should have also been dropped.
+				sqlDB.ExpectErr(t, `pq: relation "t.valid_seq" does not exist`, "SELECT * FROM t.valid_seq")
+			},
+		},
+		// This test invalidates both seq and useq as DROP DATABASE CASCADE operates
+		// on objects lexicographically -- owned sequences can be dropped both as a
+		// regular sequence drop and as a side effect of the owner table being dropped.
+		{
+			name: "combined #50711 #50781 drop database cascade",
+			test: func(t *testing.T, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner) {
+				addOwnedSequence(t, kvDB, "t", "test", 0, "seq")
+				addOwnedSequence(t, kvDB, "t", "test", 1, "seq")
+				breakOwnershipMapping(t, kvDB, "t", "test", "seq")
+
+				addOwnedSequence(t, kvDB, "t", "test", 0, "useq")
+				addOwnedSequence(t, kvDB, "t", "test", 1, "useq")
+				breakOwnershipMapping(t, kvDB, "t", "test", "useq")
+
+				sqlDB.Exec(t, "DROP DATABASE t CASCADE")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			params := base.TestServerArgs{}
+			s, sqlConn, kvDB := serverutils.StartServer(t, params)
+			defer s.Stopper().Stop(ctx)
+			sqlDB := sqlutils.MakeSQLRunner(sqlConn)
+			sqlDB.Exec(t, `CREATE DATABASE t;
+CREATE TABLE t.test(a INT PRIMARY KEY, b INT);
+CREATE SEQUENCE t.seq OWNED BY t.test.a;
+CREATE SEQUENCE t.useq OWNED BY t.test.a;
+CREATE SEQUENCE t.valid_seq OWNED BY t.test.a`)
+
+			tc.test(t, kvDB, sqlDB)
+		})
+	}
+}
+
+// addOwnedSequence adds the sequence referenced by seqName to the
+// ownsSequenceIDs of the column referenced by (dbName, tableName, colIdx).
+func addOwnedSequence(
+	t *testing.T, kvDB *kv.DB, dbName string, tableName string, colIdx int, seqName string,
+) {
+	seqDesc := sqlbase.GetTableDescriptor(kvDB, dbName, seqName)
+	tableDesc := sqlbase.GetTableDescriptor(
+		kvDB, dbName, tableName)
+
+	tableDesc.GetColumns()[colIdx].OwnsSequenceIds = append(
+		tableDesc.GetColumns()[colIdx].OwnsSequenceIds, seqDesc.ID)
+
+	err := kvDB.Put(
+		context.Background(),
+		sqlbase.MakeDescMetadataKey(tableDesc.GetID()),
+		sqlbase.WrapDescriptor(tableDesc),
+	)
+	require.NoError(t, err)
+}
+
+// breakOwnershipMapping simulates #50781 by setting the sequence's owner table
+// to a non-existent tableID and setting the column's `ownsSequenceID` to a
+// non-existent sequenceID.
+func breakOwnershipMapping(
+	t *testing.T, kvDB *kv.DB, dbName string, tableName string, seqName string,
+) {
+	seqDesc := sqlbase.GetTableDescriptor(kvDB, dbName, seqName)
+	tableDesc := sqlbase.GetTableDescriptor(
+		kvDB, dbName, tableName)
+
+	for colIdx := range tableDesc.GetColumns() {
+		for i := range tableDesc.GetColumns()[colIdx].OwnsSequenceIds {
+			if tableDesc.GetColumns()[colIdx].OwnsSequenceIds[i] == seqDesc.ID {
+				tableDesc.GetColumns()[colIdx].OwnsSequenceIds[i] = math.MaxInt32
+			}
+		}
+	}
+	seqDesc.SequenceOpts.SequenceOwner.OwnerTableID = math.MaxInt32
+
+	err := kvDB.Put(
+		context.Background(),
+		sqlbase.MakeDescMetadataKey(tableDesc.GetID()),
+		sqlbase.WrapDescriptor(tableDesc),
+	)
+	require.NoError(t, err)
+
+	err = kvDB.Put(
+		context.Background(),
+		sqlbase.MakeDescMetadataKey(seqDesc.GetID()),
+		sqlbase.WrapDescriptor(seqDesc),
+	)
+	require.NoError(t, err)
 }

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -4113,3 +4113,8 @@ func GenerateUniqueConstraintName(prefix string, nameExistsFunc func(name string
 	}
 	return name
 }
+
+// HasOwner returns true if the sequence options indicate an owner exists.
+func (opts *TableDescriptor_SequenceOpts) HasOwner() bool {
+	return !opts.SequenceOwner.Equal(TableDescriptor_SequenceOpts_SequenceOwner{})
+}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -57,6 +57,7 @@ func (p *planner) getVirtualTabler() VirtualTabler {
 }
 
 var errTableAdding = errors.New("table is being added")
+var errTableDropped = errors.New("table is being dropped")
 
 type inactiveTableError struct {
 	error
@@ -67,7 +68,7 @@ type inactiveTableError struct {
 func FilterTableState(tableDesc *sqlbase.TableDescriptor) error {
 	switch tableDesc.State {
 	case sqlbase.TableDescriptor_DROP:
-		return inactiveTableError{errors.New("table is being dropped")}
+		return inactiveTableError{errTableDropped}
 	case sqlbase.TableDescriptor_OFFLINE:
 		err := errors.Errorf("table %q is offline", tableDesc.Name)
 		if tableDesc.OfflineReason != "" {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -1047,7 +1047,8 @@ func (p *planner) writeSchemaChange(
 	}
 	if tableDesc.Dropped() {
 		// We don't allow schema changes on a dropped table.
-		return fmt.Errorf("table %q is being dropped", tableDesc.Name)
+		return errors.Errorf("no schema changes allowed on table %q as it is being dropped",
+			tableDesc.Name)
 	}
 	if err := p.createOrUpdateSchemaChangeJob(ctx, tableDesc, jobDesc, mutationID); err != nil {
 		return err
@@ -1063,7 +1064,8 @@ func (p *planner) writeSchemaChangeToBatch(
 	}
 	if tableDesc.Dropped() {
 		// We don't allow schema changes on a dropped table.
-		return fmt.Errorf("table %q is being dropped", tableDesc.Name)
+		return errors.Errorf("no schema changes allowed on table %q as it is being dropped",
+			tableDesc.Name)
 	}
 	return p.writeTableDescToBatch(ctx, tableDesc, b)
 }


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: remove sequence ownership dependency when dropping sequences" (#50665)
  * 1/1 commits from "sql: fix bug causing sequenceIDs to be duplicated on column descriptors" (#50720)
  * 1/1 commits from "sql: fix drop database - sequence ownership bug" (#50744)
  * 1/1 commits from "sql: fix drop database - sequence ownership bug" (#50744)
  * 1/1 commits from "backupccl: handle sequence ownership remapping logic for restore" (#50949)
  * 1/1 commits from "sql: allow drops on tables/sequences that have invalid ownership states" (#51253)

Please see individual PRs for details.

/cc @cockroachdb/release
