### PR TITLE
sql: fix UPSERT in some cases and clean up tableWriters

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -479,9 +479,7 @@ func (n *createTableNode) startExec(params runParams) error {
 					if err != nil {
 						return err
 					}
-					_, err := tw.finalize(
-						params.ctx, params.extendedEvalCtx.Tracing.KVTracingEnabled())
-					if err != nil {
+					if err := tw.finalize(params.ctx); err != nil {
 						return err
 					}
 					break

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -43,15 +43,9 @@ type deleteRun struct {
 	td         tableDeleter
 	rowsNeeded bool
 
-	// rowCount is the number of rows in the current batch.
-	rowCount int
-
 	// done informs a new call to BatchedNext() that the previous call
 	// to BatchedNext() has completed the work already.
 	done bool
-
-	// rows contains the accumulated result rows if rowsNeeded is set.
-	rows *rowcontainer.RowContainer
 
 	// traceKV caches the current KV tracing flag.
 	traceKV bool
@@ -80,7 +74,7 @@ func (d *deleteNode) startExec(params runParams) error {
 	d.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
 
 	if d.run.rowsNeeded {
-		d.run.rows = rowcontainer.NewRowContainer(
+		d.run.td.rows = rowcontainer.NewRowContainer(
 			params.EvalContext().Mon.MakeBoundAccount(),
 			sqlbase.ColTypeInfoFromResCols(d.columns), 0)
 	}
@@ -105,11 +99,8 @@ func (d *deleteNode) BatchedNext(params runParams) (bool, error) {
 
 	tracing.AnnotateTrace()
 
-	// Advance one batch. First, clear the current batch.
-	d.run.rowCount = 0
-	if d.run.rows != nil {
-		d.run.rows.Clear(params.ctx)
-	}
+	// Advance one batch. First, clear the last batch.
+	d.run.td.clearLastBatch(params.ctx)
 	// Now consume/accumulate the rows for this batch.
 	lastBatch := false
 	for {
@@ -132,19 +123,13 @@ func (d *deleteNode) BatchedNext(params runParams) (bool, error) {
 			return false, err
 		}
 
-		d.run.rowCount++
-
 		// Are we done yet with the current batch?
-		if d.run.td.curBatchSize() >= maxDeleteBatchSize {
+		if d.run.td.currentBatchSize >= maxDeleteBatchSize {
 			break
 		}
 	}
 
-	if d.run.rowCount > 0 {
-		if err := d.run.td.atBatchEnd(params.ctx, d.run.traceKV); err != nil {
-			return false, err
-		}
-
+	if d.run.td.currentBatchSize > 0 {
 		if !lastBatch {
 			// We only run/commit the batch if there were some rows processed
 			// in this batch.
@@ -155,7 +140,7 @@ func (d *deleteNode) BatchedNext(params runParams) (bool, error) {
 	}
 
 	if lastBatch {
-		if _, err := d.run.td.finalize(params.ctx, d.run.traceKV); err != nil {
+		if err := d.run.td.finalize(params.ctx); err != nil {
 			return false, err
 		}
 		// Remember we're done for the next call to BatchedNext().
@@ -165,10 +150,10 @@ func (d *deleteNode) BatchedNext(params runParams) (bool, error) {
 	// Possibly initiate a run of CREATE STATISTICS.
 	params.ExecCfg().StatsRefresher.NotifyMutation(
 		d.run.td.tableDesc().ID,
-		d.run.rowCount,
+		d.run.td.lastBatchSize,
 	)
 
-	return d.run.rowCount > 0, nil
+	return d.run.td.lastBatchSize > 0, nil
 }
 
 // processSourceRow processes one row from the source for deletion and, if
@@ -199,7 +184,7 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	}
 
 	// If result rows need to be accumulated, do it.
-	if d.run.rows != nil {
+	if d.run.td.rows != nil {
 		// The new values can include all columns, the construction of the
 		// values has used execinfra.ScanVisibilityPublicAndNotPublic so the
 		// values may contain additional columns for every newly dropped column
@@ -207,14 +192,14 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 		//
 		// d.run.rows.NumCols() is guaranteed to only contain the requested
 		// public columns.
-		resultValues := make(tree.Datums, d.run.rows.NumCols())
+		resultValues := make(tree.Datums, d.run.td.rows.NumCols())
 		for i, retIdx := range d.run.rowIdxToRetIdx {
 			if retIdx >= 0 {
 				resultValues[retIdx] = sourceVals[i]
 			}
 		}
 
-		if _, err := d.run.rows.AddRow(params.ctx, resultValues); err != nil {
+		if _, err := d.run.td.rows.AddRow(params.ctx, resultValues); err != nil {
 			return err
 		}
 	}
@@ -223,17 +208,13 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 }
 
 // BatchedCount implements the batchedPlanNode interface.
-func (d *deleteNode) BatchedCount() int { return d.run.rowCount }
+func (d *deleteNode) BatchedCount() int { return d.run.td.lastBatchSize }
 
 // BatchedCount implements the batchedPlanNode interface.
-func (d *deleteNode) BatchedValues(rowIdx int) tree.Datums { return d.run.rows.At(rowIdx) }
+func (d *deleteNode) BatchedValues(rowIdx int) tree.Datums { return d.run.td.rows.At(rowIdx) }
 
 func (d *deleteNode) Close(ctx context.Context) {
 	d.source.Close(ctx)
-	if d.run.rows != nil {
-		d.run.rows.Close(ctx)
-		d.run.rows = nil
-	}
 	d.run.td.close(ctx)
 	*d = deleteNode{}
 	deleteNodePool.Put(d)

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -63,12 +63,13 @@ type tableWriter interface {
 	// inner loop of table accesses.
 	row(context.Context, tree.Datums, row.PartialIndexUpdateHelper, bool /* traceKV */) error
 
-	// finalize flushes out any remaining writes. It is called after all calls to
-	// row.  It returns a slice of all Datums not yet returned by calls to `row`.
-	// The traceKV parameter determines whether the individual K/V operations
-	// should be logged to the context. See the comment above for why
-	// this a separate parameter as opposed to a Value field on the context.
-	finalize(ctx context.Context, traceKV bool) (*rowcontainer.RowContainer, error)
+	// flushAndStartNewBatch is called at the end of each batch but the last.
+	// This should flush the current batch.
+	flushAndStartNewBatch(context.Context) error
+
+	// finalize flushes out any remaining writes. It is called after all calls
+	// to row.
+	finalize(context.Context) error
 
 	// tableDesc returns the TableDescriptor for the table that the tableWriter
 	// will modify.
@@ -83,23 +84,6 @@ type tableWriter interface {
 
 	// enable auto commit in call to finalize().
 	enableAutoCommit()
-
-	// atBatchEnd is called at the end of each batch, just before
-	// finalize/flush. It can utilize the current KV batch which is
-	// still open at that point. It must not run the batch itself; that
-	// task is left to tableWriter.finalize() or flushAndStartNewBatch()
-	// below.
-	atBatchEnd(context.Context, bool /* traceKV */) error
-
-	// flushAndStartNewBatch is called at the end of each batch but the last.
-	// This should flush the current batch.
-	flushAndStartNewBatch(context.Context) error
-
-	// curBatchSize returns an upper bound for the amount of KV work
-	// needed for the current batch. This cannot reflect the actual KV
-	// batch size because the actual KV batch will be constructed only
-	// during the call to atBatchEnd().
-	curBatchSize() int
 }
 
 type autoCommitOpt int
@@ -110,43 +94,47 @@ const (
 )
 
 // tableWriterBase is meant to be used to factor common code between
-// the other tableWriters.
+// the all tableWriters.
 type tableWriterBase struct {
 	// txn is the current KV transaction.
 	txn *kv.Txn
+	// desc is the descriptor of the table that we're writing.
+	desc *sqlbase.ImmutableTableDescriptor
 	// is autoCommit turned on.
 	autoCommit autoCommitOpt
 	// b is the current batch.
 	b *kv.Batch
-	// batchSize is the current batch size (when known).
-	batchSize int
+	// currentBatchSize is the size of the current batch. It is updated on
+	// every row() call and is reset once a new batch is started.
+	currentBatchSize int
+	// lastBatchSize is the size of the last batch. It is set to the value of
+	// currentBatchSize once the batch is flushed or finalized.
+	lastBatchSize int
+	// rows contains the accumulated result rows if rowsNeeded is set on the
+	// corresponding tableWriter.
+	rows *rowcontainer.RowContainer
 }
 
-func (tb *tableWriterBase) init(txn *kv.Txn) {
+func (tb *tableWriterBase) init(txn *kv.Txn, tableDesc *sqlbase.ImmutableTableDescriptor) {
 	tb.txn = txn
+	tb.desc = tableDesc
 	tb.b = txn.NewBatch()
 }
 
 // flushAndStartNewBatch shares the common flushAndStartNewBatch() code between
 // tableWriters.
-func (tb *tableWriterBase) flushAndStartNewBatch(
-	ctx context.Context, tableDesc *sqlbase.ImmutableTableDescriptor,
-) error {
+func (tb *tableWriterBase) flushAndStartNewBatch(ctx context.Context) error {
 	if err := tb.txn.Run(ctx, tb.b); err != nil {
-		return row.ConvertBatchError(ctx, tableDesc, tb.b)
+		return row.ConvertBatchError(ctx, tb.desc, tb.b)
 	}
 	tb.b = tb.txn.NewBatch()
-	tb.batchSize = 0
+	tb.lastBatchSize = tb.currentBatchSize
+	tb.currentBatchSize = 0
 	return nil
 }
 
-// curBatchSize shares the common curBatchSize() code between tableWriters.
-func (tb *tableWriterBase) curBatchSize() int { return tb.batchSize }
-
 // finalize shares the common finalize() code between tableWriters.
-func (tb *tableWriterBase) finalize(
-	ctx context.Context, tableDesc *sqlbase.ImmutableTableDescriptor,
-) (err error) {
+func (tb *tableWriterBase) finalize(ctx context.Context) (err error) {
 	if tb.autoCommit == autoCommitEnabled {
 		log.Event(ctx, "autocommit enabled")
 		// An auto-txn can commit the transaction with the batch. This is an
@@ -156,13 +144,27 @@ func (tb *tableWriterBase) finalize(
 	} else {
 		err = tb.txn.Run(ctx, tb.b)
 	}
-
+	tb.lastBatchSize = tb.currentBatchSize
 	if err != nil {
-		return row.ConvertBatchError(ctx, tableDesc, tb.b)
+		return row.ConvertBatchError(ctx, tb.desc, tb.b)
 	}
 	return nil
 }
 
 func (tb *tableWriterBase) enableAutoCommit() {
 	tb.autoCommit = autoCommitEnabled
+}
+
+func (tb *tableWriterBase) clearLastBatch(ctx context.Context) {
+	tb.lastBatchSize = 0
+	if tb.rows != nil {
+		tb.rows.Clear(ctx)
+	}
+}
+
+func (tb *tableWriterBase) close(ctx context.Context) {
+	if tb.rows != nil {
+		tb.rows.Close(ctx)
+		tb.rows = nil
+	}
 }

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
-	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -42,28 +41,15 @@ func (td *tableDeleter) walkExprs(_ func(desc string, index int, expr tree.Typed
 
 // init is part of the tableWriter interface.
 func (td *tableDeleter) init(_ context.Context, txn *kv.Txn, _ *tree.EvalContext) error {
-	td.tableWriterBase.init(txn)
+	td.tableWriterBase.init(txn, td.tableDesc())
 	return nil
 }
-
-// flushAndStartNewBatch is part of the tableWriter interface.
-func (td *tableDeleter) flushAndStartNewBatch(ctx context.Context) error {
-	return td.tableWriterBase.flushAndStartNewBatch(ctx, td.rd.Helper.TableDesc)
-}
-
-// finalize is part of the tableWriter interface.
-func (td *tableDeleter) finalize(ctx context.Context, _ bool) (*rowcontainer.RowContainer, error) {
-	return nil, td.tableWriterBase.finalize(ctx, td.rd.Helper.TableDesc)
-}
-
-// atBatchEnd is part of the tableWriter interface.
-func (td *tableDeleter) atBatchEnd(_ context.Context, _ bool) error { return nil }
 
 // row is part of the tableWriter interface.
 func (td *tableDeleter) row(
 	ctx context.Context, values tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,
 ) error {
-	td.batchSize++
+	td.currentBatchSize++
 	return td.rd.DeleteRow(ctx, td.b, values, pm, traceKV)
 }
 
@@ -79,7 +65,7 @@ func (td *tableDeleter) row(
 func (td *tableDeleter) deleteAllRows(
 	ctx context.Context, resume roachpb.Span, limit int64, traceKV bool,
 ) (roachpb.Span, error) {
-	if td.rd.Helper.TableDesc.IsInterleaved() {
+	if td.tableDesc().IsInterleaved() {
 		log.VEvent(ctx, 2, "delete forced to scan: table is interleaved")
 		return td.deleteAllRowsScan(ctx, resume, limit, traceKV)
 	}
@@ -99,7 +85,7 @@ func (td *tableDeleter) deleteAllRowsFast(
 	ctx context.Context, resume roachpb.Span, limit int64, traceKV bool,
 ) (roachpb.Span, error) {
 	if resume.Key == nil {
-		tablePrefix := td.rd.Helper.Codec.TablePrefix(uint32(td.rd.Helper.TableDesc.ID))
+		tablePrefix := td.rd.Helper.Codec.TablePrefix(uint32(td.tableDesc().ID))
 		// Delete rows and indexes starting with the table's prefix.
 		resume = roachpb.Span{
 			Key:    tablePrefix,
@@ -110,7 +96,7 @@ func (td *tableDeleter) deleteAllRowsFast(
 	log.VEventf(ctx, 2, "DelRange %s - %s", resume.Key, resume.EndKey)
 	td.b.DelRange(resume.Key, resume.EndKey, false /* returnKeys */)
 	td.b.Header.MaxSpanRequestKeys = limit
-	if _, err := td.finalize(ctx, traceKV); err != nil {
+	if err := td.finalize(ctx); err != nil {
 		return resume, err
 	}
 	if l := len(td.b.Results); l != 1 {
@@ -123,7 +109,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 	ctx context.Context, resume roachpb.Span, limit int64, traceKV bool,
 ) (roachpb.Span, error) {
 	if resume.Key == nil {
-		resume = td.rd.Helper.TableDesc.PrimaryIndexSpan(td.rd.Helper.Codec)
+		resume = td.tableDesc().PrimaryIndexSpan(td.rd.Helper.Codec)
 	}
 
 	var valNeededForCol util.FastIntSet
@@ -133,8 +119,8 @@ func (td *tableDeleter) deleteAllRowsScan(
 
 	var rf row.Fetcher
 	tableArgs := row.FetcherTableArgs{
-		Desc:            td.rd.Helper.TableDesc,
-		Index:           &td.rd.Helper.TableDesc.PrimaryIndex,
+		Desc:            td.tableDesc(),
+		Index:           &td.tableDesc().PrimaryIndex,
 		ColIdxMap:       td.rd.FetchColIDtoRowIndex,
 		Cols:            td.rd.FetchCols,
 		ValNeededForCol: valNeededForCol,
@@ -177,8 +163,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 		// Update the resume start key for the next iteration.
 		resume.Key = rf.Key()
 	}
-	_, err := td.finalize(ctx, traceKV)
-	return resume, err
+	return resume, td.finalize(ctx)
 }
 
 // deleteIndex runs the kv operations necessary to delete all kv entries in the
@@ -206,7 +191,7 @@ func (td *tableDeleter) deleteIndexFast(
 	ctx context.Context, idx *sqlbase.IndexDescriptor, resume roachpb.Span, limit int64, traceKV bool,
 ) (roachpb.Span, error) {
 	if resume.Key == nil {
-		resume = td.rd.Helper.TableDesc.IndexSpan(td.rd.Helper.Codec, idx.ID)
+		resume = td.tableDesc().IndexSpan(td.rd.Helper.Codec, idx.ID)
 	}
 
 	if traceKV {
@@ -214,7 +199,7 @@ func (td *tableDeleter) deleteIndexFast(
 	}
 	td.b.DelRange(resume.Key, resume.EndKey, false /* returnKeys */)
 	td.b.Header.MaxSpanRequestKeys = limit
-	if _, err := td.finalize(ctx, traceKV); err != nil {
+	if err := td.finalize(ctx); err != nil {
 		return resume, err
 	}
 	if l := len(td.b.Results); l != 1 {
@@ -228,7 +213,7 @@ func (td *tableDeleter) clearIndex(ctx context.Context, idx *sqlbase.IndexDescri
 		return errors.Errorf("unexpected interleaved index %d", idx.ID)
 	}
 
-	sp := td.rd.Helper.TableDesc.IndexSpan(td.rd.Helper.Codec, idx.ID)
+	sp := td.tableDesc().IndexSpan(td.rd.Helper.Codec, idx.ID)
 
 	// ClearRange cannot be run in a transaction, so create a
 	// non-transactional batch to send the request.
@@ -246,7 +231,7 @@ func (td *tableDeleter) deleteIndexScan(
 	ctx context.Context, idx *sqlbase.IndexDescriptor, resume roachpb.Span, limit int64, traceKV bool,
 ) (roachpb.Span, error) {
 	if resume.Key == nil {
-		resume = td.rd.Helper.TableDesc.PrimaryIndexSpan(td.rd.Helper.Codec)
+		resume = td.tableDesc().PrimaryIndexSpan(td.rd.Helper.Codec)
 	}
 
 	var valNeededForCol util.FastIntSet
@@ -256,8 +241,8 @@ func (td *tableDeleter) deleteIndexScan(
 
 	var rf row.Fetcher
 	tableArgs := row.FetcherTableArgs{
-		Desc:            td.rd.Helper.TableDesc,
-		Index:           &td.rd.Helper.TableDesc.PrimaryIndex,
+		Desc:            td.tableDesc(),
+		Index:           &td.tableDesc().PrimaryIndex,
 		ColIdxMap:       td.rd.FetchColIDtoRowIndex,
 		Cols:            td.rd.FetchCols,
 		ValNeededForCol: valNeededForCol,
@@ -297,12 +282,9 @@ func (td *tableDeleter) deleteIndexScan(
 		// Update the resume start key for the next iteration.
 		resume.Key = rf.Key()
 	}
-	_, err := td.finalize(ctx, traceKV)
-	return resume, err
+	return resume, td.finalize(ctx)
 }
 
 func (td *tableDeleter) tableDesc() *sqlbase.ImmutableTableDescriptor {
 	return td.rd.Helper.TableDesc
 }
-
-func (td *tableDeleter) close(_ context.Context) {}

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
-	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -33,7 +32,7 @@ func (*tableInserter) desc() string { return "inserter" }
 
 // init is part of the tableWriter interface.
 func (ti *tableInserter) init(_ context.Context, txn *kv.Txn, _ *tree.EvalContext) error {
-	ti.tableWriterBase.init(txn)
+	ti.tableWriterBase.init(txn, ti.tableDesc())
 	return nil
 }
 
@@ -41,30 +40,14 @@ func (ti *tableInserter) init(_ context.Context, txn *kv.Txn, _ *tree.EvalContex
 func (ti *tableInserter) row(
 	ctx context.Context, values tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,
 ) error {
-	ti.batchSize++
+	ti.currentBatchSize++
 	return ti.ri.InsertRow(ctx, ti.b, values, pm, false /* overwrite */, traceKV)
-}
-
-// atBatchEnd is part of the tableWriter interface.
-func (ti *tableInserter) atBatchEnd(_ context.Context, _ bool) error { return nil }
-
-// flushAndStartNewBatch is part of the tableWriter interface.
-func (ti *tableInserter) flushAndStartNewBatch(ctx context.Context) error {
-	return ti.tableWriterBase.flushAndStartNewBatch(ctx, ti.tableDesc())
-}
-
-// finalize is part of the tableWriter interface.
-func (ti *tableInserter) finalize(ctx context.Context, _ bool) (*rowcontainer.RowContainer, error) {
-	return nil, ti.tableWriterBase.finalize(ctx, ti.tableDesc())
 }
 
 // tableDesc is part of the tableWriter interface.
 func (ti *tableInserter) tableDesc() *sqlbase.ImmutableTableDescriptor {
 	return ti.ri.Helper.TableDesc
 }
-
-// close is part of the tableWriter interface.
-func (ti *tableInserter) close(_ context.Context) {}
 
 // walkExprs is part of the tableWriter interface.
 func (ti *tableInserter) walkExprs(_ func(desc string, index int, expr tree.TypedExpr)) {}

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
-	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -33,7 +32,7 @@ func (*tableUpdater) desc() string { return "updater" }
 
 // init is part of the tableWriter interface.
 func (tu *tableUpdater) init(_ context.Context, txn *kv.Txn, _ *tree.EvalContext) error {
-	tu.tableWriterBase.init(txn)
+	tu.tableWriterBase.init(txn, tu.tableDesc())
 	return nil
 }
 
@@ -54,30 +53,14 @@ func (tu *tableUpdater) rowForUpdate(
 	pm row.PartialIndexUpdateHelper,
 	traceKV bool,
 ) (tree.Datums, error) {
-	tu.batchSize++
+	tu.currentBatchSize++
 	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, pm, traceKV)
-}
-
-// atBatchEnd is part of the tableWriter interface.
-func (tu *tableUpdater) atBatchEnd(_ context.Context, _ bool) error { return nil }
-
-// flushAndStartNewBatch is part of the tableWriter interface.
-func (tu *tableUpdater) flushAndStartNewBatch(ctx context.Context) error {
-	return tu.tableWriterBase.flushAndStartNewBatch(ctx, tu.tableDesc())
-}
-
-// finalize is part of the tableWriter interface.
-func (tu *tableUpdater) finalize(ctx context.Context, _ bool) (*rowcontainer.RowContainer, error) {
-	return nil, tu.tableWriterBase.finalize(ctx, tu.tableDesc())
 }
 
 // tableDesc is part of the tableWriter interface.
 func (tu *tableUpdater) tableDesc() *sqlbase.ImmutableTableDescriptor {
 	return tu.ru.Helper.TableDesc
 }
-
-// close is part of the tableWriter interface.
-func (tu *tableUpdater) close(_ context.Context) {}
 
 // walkExprs is part of the tableWriter interface.
 func (tu *tableUpdater) walkExprs(_ func(desc string, index int, expr tree.TypedExpr)) {}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -46,15 +46,9 @@ type updateRun struct {
 
 	checkOrds checkSet
 
-	// rowCount is the number of rows in the current batch.
-	rowCount int
-
 	// done informs a new call to BatchedNext() that the previous call to
 	// BatchedNext() has completed the work already.
 	done bool
-
-	// rows contains the accumulated result rows if rowsNeeded is set.
-	rows *rowcontainer.RowContainer
 
 	// traceKV caches the current KV tracing flag.
 	traceKV bool
@@ -133,7 +127,7 @@ func (u *updateNode) startExec(params runParams) error {
 	u.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
 
 	if u.run.rowsNeeded {
-		u.run.rows = rowcontainer.NewRowContainer(
+		u.run.tu.rows = rowcontainer.NewRowContainer(
 			params.EvalContext().Mon.MakeBoundAccount(),
 			sqlbase.ColTypeInfoFromResCols(u.columns), 0)
 	}
@@ -158,11 +152,9 @@ func (u *updateNode) BatchedNext(params runParams) (bool, error) {
 
 	tracing.AnnotateTrace()
 
-	// Advance one batch. First, clear the current batch.
-	u.run.rowCount = 0
-	if u.run.rows != nil {
-		u.run.rows.Clear(params.ctx)
-	}
+	// Advance one batch. First, clear the last batch.
+	u.run.tu.clearLastBatch(params.ctx)
+
 	// Now consume/accumulate the rows for this batch.
 	lastBatch := false
 	for {
@@ -185,19 +177,13 @@ func (u *updateNode) BatchedNext(params runParams) (bool, error) {
 			return false, err
 		}
 
-		u.run.rowCount++
-
 		// Are we done yet with the current batch?
-		if u.run.tu.curBatchSize() >= maxUpdateBatchSize {
+		if u.run.tu.currentBatchSize >= maxUpdateBatchSize {
 			break
 		}
 	}
 
-	if u.run.rowCount > 0 {
-		if err := u.run.tu.atBatchEnd(params.ctx, u.run.traceKV); err != nil {
-			return false, err
-		}
-
+	if u.run.tu.currentBatchSize > 0 {
 		if !lastBatch {
 			// We only run/commit the batch if there were some rows processed
 			// in this batch.
@@ -208,7 +194,7 @@ func (u *updateNode) BatchedNext(params runParams) (bool, error) {
 	}
 
 	if lastBatch {
-		if _, err := u.run.tu.finalize(params.ctx, u.run.traceKV); err != nil {
+		if err := u.run.tu.finalize(params.ctx); err != nil {
 			return false, err
 		}
 		// Remember we're done for the next call to BatchedNext().
@@ -218,10 +204,10 @@ func (u *updateNode) BatchedNext(params runParams) (bool, error) {
 	// Possibly initiate a run of CREATE STATISTICS.
 	params.ExecCfg().StatsRefresher.NotifyMutation(
 		u.run.tu.tableDesc().ID,
-		u.run.rowCount,
+		u.run.tu.lastBatchSize,
 	)
 
-	return u.run.rowCount > 0, nil
+	return u.run.tu.lastBatchSize > 0, nil
 }
 
 // processSourceRow processes one row from the source for update and, if
@@ -301,7 +287,9 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// contain the results of evaluation.
 	if !u.run.checkOrds.Empty() {
 		checkVals := sourceVals[len(u.run.tu.ru.FetchCols)+len(u.run.tu.ru.UpdateCols)+u.run.numPassthrough:]
-		if err := checkMutationInput(params.ctx, &params.p.semaCtx, u.run.tu.tableDesc(), u.run.checkOrds, checkVals); err != nil {
+		if err := checkMutationInput(
+			params.ctx, &params.p.semaCtx, u.run.tu.tableDesc(), u.run.checkOrds, checkVals,
+		); err != nil {
 			return err
 		}
 	}
@@ -329,7 +317,7 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	}
 
 	// If result rows need to be accumulated, do it.
-	if u.run.rows != nil {
+	if u.run.tu.rows != nil {
 		// The new values can include all columns, the construction of the
 		// values has used execinfra.ScanVisibilityPublicAndNotPublic so the
 		// values may contain additional columns for every newly added column
@@ -363,7 +351,7 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 			}
 		}
 
-		if _, err := u.run.rows.AddRow(params.ctx, resultValues); err != nil {
+		if _, err := u.run.tu.rows.AddRow(params.ctx, resultValues); err != nil {
 			return err
 		}
 	}
@@ -372,17 +360,13 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 }
 
 // BatchedCount implements the batchedPlanNode interface.
-func (u *updateNode) BatchedCount() int { return u.run.rowCount }
+func (u *updateNode) BatchedCount() int { return u.run.tu.lastBatchSize }
 
 // BatchedCount implements the batchedPlanNode interface.
-func (u *updateNode) BatchedValues(rowIdx int) tree.Datums { return u.run.rows.At(rowIdx) }
+func (u *updateNode) BatchedValues(rowIdx int) tree.Datums { return u.run.tu.rows.At(rowIdx) }
 
 func (u *updateNode) Close(ctx context.Context) {
 	u.source.Close(ctx)
-	if u.run.rows != nil {
-		u.run.rows.Close(ctx)
-		u.run.rows = nil
-	}
 	u.run.tu.close(ctx)
 	*u = updateNode{}
 	updateNodePool.Put(u)

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -84,6 +84,9 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 
 	tracing.AnnotateTrace()
 
+	// Advance one batch. First, clear the last batch.
+	n.run.tw.clearLastBatch(params.ctx)
+
 	// Now consume/accumulate the rows for this batch.
 	lastBatch := false
 	for {
@@ -107,19 +110,12 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 		}
 
 		// Are we done yet with the current batch?
-		if n.run.tw.curBatchSize() >= maxUpsertBatchSize {
+		if n.run.tw.currentBatchSize >= maxUpsertBatchSize {
 			break
 		}
 	}
 
-	// In Upsert, curBatchSize indicates whether "there is still work to do in this batch".
-	batchSize := n.run.tw.curBatchSize()
-
-	if batchSize > 0 {
-		if err := n.run.tw.atBatchEnd(params.ctx, n.run.traceKV); err != nil {
-			return false, err
-		}
-
+	if n.run.tw.currentBatchSize > 0 {
 		if !lastBatch {
 			// We only run/commit the batch if there were some rows processed
 			// in this batch.
@@ -130,7 +126,7 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 	}
 
 	if lastBatch {
-		if _, err := n.run.tw.finalize(params.ctx, n.run.traceKV); err != nil {
+		if err := n.run.tw.finalize(params.ctx); err != nil {
 			return false, err
 		}
 		// Remember we're done for the next call to BatchedNext().
@@ -140,10 +136,10 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 	// Possibly initiate a run of CREATE STATISTICS.
 	params.ExecCfg().StatsRefresher.NotifyMutation(
 		n.run.tw.tableDesc().ID,
-		n.run.tw.batchedCount(),
+		n.run.tw.lastBatchSize,
 	)
 
-	return n.run.tw.batchedCount() > 0, nil
+	return n.run.tw.lastBatchSize > 0, nil
 }
 
 // processSourceRow processes one row from the source for upsertion.
@@ -195,7 +191,7 @@ func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) err
 }
 
 // BatchedCount implements the batchedPlanNode interface.
-func (n *upsertNode) BatchedCount() int { return n.run.tw.batchedCount() }
+func (n *upsertNode) BatchedCount() int { return n.run.tw.lastBatchSize }
 
 // BatchedValues implements the batchedPlanNode interface.
 func (n *upsertNode) BatchedValues(rowIdx int) tree.Datums { return n.run.tw.batchedValues(rowIdx) }


### PR DESCRIPTION
`optTableUpserter.resultCount` tracks the number of rows in the current
batch (and mirrors `rowsUpserted.Len()` if it's collecting rows).
Previously, `resultCount` was never reset although `rowsUpserted` was.
This resulted in a "unsynchronization" of `BatchedCount` and
`BatchedValues` methods which - I think - could lead to incorrect
results being returned by RETURNING clause of UPSERT statement (possibly
attempting to request a "value" that is "out of bounds").

This commit cleans up the code around `tableWriter`s by removing
leftover things and unnecessary methods and also fixes the issue
describes above by putting `rowCount` variable into `tableWriterBase`
with it being reset in `optTableUpserter` accordingly (it was already
appropriate being reset for all other table writers).

Release note: None