### PR TITLE
release-19.2: sql: follow-up to UPSERT batching behavior fix

### DIFF
--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -144,8 +144,6 @@ func (tu *tableUpserterBase) batchedValues(rowIdx int) tree.Datums {
 	return tu.rowsUpserted.At(rowIdx)
 }
 
-func (tu *tableUpserterBase) curBatchSize() int { return tu.insertRows.Len() }
-
 // close is part of the tableWriter interface.
 func (tu *tableUpserterBase) close(ctx context.Context) {
 	tu.insertRows.Close(ctx)
@@ -486,6 +484,11 @@ func (tu *tableUpserter) atBatchEnd(ctx context.Context, traceKV bool) error {
 
 	return nil
 }
+
+// curBatchSize is part of the extendedTableWriter interface. Note that we need
+// to override tableWriterBase.curBatchSize because tableUpserter stores the
+// insert rows not in the batch but in insertRows row container.
+func (tu *tableUpserter) curBatchSize() int { return tu.insertRows.Len() }
 
 // updateConflictingRow updates the existing row in the table, when there was a
 // conflict. existingRows contains the previously seen rows, and is modified

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -160,11 +160,6 @@ func (tu *optTableUpserter) atBatchEnd(ctx context.Context, traceKV bool) error 
 	return nil
 }
 
-// curBatchSize is part of the extendedTableWriter interface. Note that we need
-// to override tableUpserterBase.curBatchSize because the optimizer-driven
-// UPSERTs do not store the insert rows in insertRows row container.
-func (tu *optTableUpserter) curBatchSize() int { return tu.batchSize }
-
 // insertNonConflictingRow inserts the given source row into the table when
 // there was no conflict. If the RETURNING clause was specified, then the
 // inserted row is stored in the rowsUpserted collection.

--- a/pkg/sql/tablewriter_upsert_strict.go
+++ b/pkg/sql/tablewriter_upsert_strict.go
@@ -97,6 +97,11 @@ func (tu *strictTableUpserter) atBatchEnd(ctx context.Context, traceKV bool) err
 	return nil
 }
 
+// curBatchSize is part of the extendedTableWriter interface. Note that we need
+// to override tableWriterBase.curBatchSize because tableUpserter stores the
+// insert rows not in the batch but in insertRows row container.
+func (tu *strictTableUpserter) curBatchSize() int { return tu.insertRows.Len() }
+
 // Get all unique indexes and store them in tu.ConflictIndexes.
 func (tu *strictTableUpserter) getUniqueIndexes() (err error) {
 	tableDesc := tu.tableDesc()


### PR DESCRIPTION
In #51612 we fixed batching behavior of `optTableUpserter`. However,
`fastTableUpserter` has the same problem. This is now fixed by
keeping `tableWriterBase` implementation of `curBatchSize` method
and overriding it by `tableUpserter` and `strictTableUpserter` since
those two actually use a row container.

I noticed that `fastTableUpserter` also has the bug only because CI
failed on 19.1 backport.

Release note: None