### PR TITLE
colexec: add optimized support of "contains" LIKE match

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
@@ -110,6 +110,9 @@ func genLikeOps(inputFileContents string, wr io.Writer) error {
 		makeOverload("Suffix", bytesRepresentation, func(targetElem, leftElem, rightElem string) string {
 			return fmt.Sprintf("%s = bytes.HasSuffix(%s, %s)", targetElem, leftElem, rightElem)
 		}),
+		makeOverload("Contains", bytesRepresentation, func(targetElem, leftElem, rightElem string) string {
+			return fmt.Sprintf("%s = bytes.Contains(%s, %s)", targetElem, leftElem, rightElem)
+		}),
 		makeOverload("Regexp", "*regexp.Regexp", func(targetElem, leftElem, rightElem string) string {
 			return fmt.Sprintf("%s = %s.Match(%s)", targetElem, rightElem, leftElem)
 		}),
@@ -118,6 +121,9 @@ func genLikeOps(inputFileContents string, wr io.Writer) error {
 		}),
 		makeOverload("NotSuffix", bytesRepresentation, func(targetElem, leftElem, rightElem string) string {
 			return fmt.Sprintf("%s = !bytes.HasSuffix(%s, %s)", targetElem, leftElem, rightElem)
+		}),
+		makeOverload("NotContains", bytesRepresentation, func(targetElem, leftElem, rightElem string) string {
+			return fmt.Sprintf("%s = !bytes.Contains(%s, %s)", targetElem, leftElem, rightElem)
 		}),
 		makeOverload("NotRegexp", "*regexp.Regexp", func(targetElem, leftElem, rightElem string) string {
 			return fmt.Sprintf("%s = !%s.Match(%s)", targetElem, rightElem, leftElem)

--- a/pkg/sql/colexec/like_ops.eg.go
+++ b/pkg/sql/colexec/like_ops.eg.go
@@ -356,6 +356,179 @@ func (p projSuffixBytesBytesConstOp) Init() {
 	p.input.Init()
 }
 
+type selContainsBytesBytesConstOp struct {
+	selConstOpBase
+	constArg []byte
+}
+
+func (p *selContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+	// In order to inline the templated code of overloads, we need to have a
+	// `_overloadHelper` local variable of type `overloadHelper`.
+	_overloadHelper := p.overloadHelper
+	// However, the scratch is not used in all of the selection operators, so
+	// we add this to go around "unused" error.
+	_ = _overloadHelper
+	var isNull bool
+	for {
+		batch := p.input.Next(ctx)
+		if batch.Length() == 0 {
+			return batch
+		}
+
+		vec := batch.ColVec(p.colIdx)
+		col := vec.Bytes()
+		var idx int
+		n := batch.Length()
+		if vec.MaybeHasNulls() {
+			nulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					var cmp bool
+					arg := col.Get(i)
+					cmp = bytes.Contains(arg, p.constArg)
+					isNull = nulls.NullAt(i)
+					if cmp && !isNull {
+						sel[idx] = i
+						idx++
+					}
+				}
+			} else {
+				batch.SetSelection(true)
+				sel := batch.Selection()
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					var cmp bool
+					arg := col.Get(i)
+					cmp = bytes.Contains(arg, p.constArg)
+					isNull = nulls.NullAt(i)
+					if cmp && !isNull {
+						sel[idx] = i
+						idx++
+					}
+				}
+			}
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					var cmp bool
+					arg := col.Get(i)
+					cmp = bytes.Contains(arg, p.constArg)
+					isNull = false
+					if cmp && !isNull {
+						sel[idx] = i
+						idx++
+					}
+				}
+			} else {
+				batch.SetSelection(true)
+				sel := batch.Selection()
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					var cmp bool
+					arg := col.Get(i)
+					cmp = bytes.Contains(arg, p.constArg)
+					isNull = false
+					if cmp && !isNull {
+						sel[idx] = i
+						idx++
+					}
+				}
+			}
+		}
+		if idx > 0 {
+			batch.SetLength(idx)
+			return batch
+		}
+	}
+}
+
+func (p *selContainsBytesBytesConstOp) Init() {
+	p.input.Init()
+}
+
+type projContainsBytesBytesConstOp struct {
+	projConstOpBase
+	constArg []byte
+}
+
+func (p projContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+	// In order to inline the templated code of overloads, we need to have a
+	// `_overloadHelper` local variable of type `overloadHelper`.
+	_overloadHelper := p.overloadHelper
+	// However, the scratch is not used in all of the projection operators, so
+	// we add this to go around "unused" error.
+	_ = _overloadHelper
+	batch := p.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col *coldata.Bytes
+	col = vec.Bytes()
+	projVec := batch.ColVec(p.outputIdx)
+	if projVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		projVec.Nulls().UnsetNulls()
+	}
+	projCol := projVec.Bool()
+	if vec.Nulls().MaybeHasNulls() {
+		colNulls := vec.Nulls()
+		if sel := batch.Selection(); sel != nil {
+			sel = sel[:n]
+			for _, i := range sel {
+				if !colNulls.NullAt(i) {
+					// We only want to perform the projection operation if the value is not null.
+					arg := col.Get(i)
+					projCol[i] = bytes.Contains(arg, p.constArg)
+				}
+			}
+		} else {
+			col = col
+			_ = 0
+			_ = n
+			_ = projCol.Get(n - 1)
+			for i := 0; i < n; i++ {
+				if !colNulls.NullAt(i) {
+					// We only want to perform the projection operation if the value is not null.
+					arg := col.Get(i)
+					projCol[i] = bytes.Contains(arg, p.constArg)
+				}
+			}
+		}
+		colNullsCopy := colNulls.Copy()
+		projVec.SetNulls(&colNullsCopy)
+	} else {
+		if sel := batch.Selection(); sel != nil {
+			sel = sel[:n]
+			for _, i := range sel {
+				arg := col.Get(i)
+				projCol[i] = bytes.Contains(arg, p.constArg)
+			}
+		} else {
+			col = col
+			_ = 0
+			_ = n
+			_ = projCol.Get(n - 1)
+			for i := 0; i < n; i++ {
+				arg := col.Get(i)
+				projCol[i] = bytes.Contains(arg, p.constArg)
+			}
+		}
+	}
+	// Although we didn't change the length of the batch, it is necessary to set
+	// the length anyway (this helps maintaining the invariant of flat bytes).
+	batch.SetLength(n)
+	return batch
+}
+
+func (p projContainsBytesBytesConstOp) Init() {
+	p.input.Init()
+}
+
 type selRegexpBytesBytesConstOp struct {
 	selConstOpBase
 	constArg *regexp.Regexp
@@ -872,6 +1045,179 @@ func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 }
 
 func (p projNotSuffixBytesBytesConstOp) Init() {
+	p.input.Init()
+}
+
+type selNotContainsBytesBytesConstOp struct {
+	selConstOpBase
+	constArg []byte
+}
+
+func (p *selNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+	// In order to inline the templated code of overloads, we need to have a
+	// `_overloadHelper` local variable of type `overloadHelper`.
+	_overloadHelper := p.overloadHelper
+	// However, the scratch is not used in all of the selection operators, so
+	// we add this to go around "unused" error.
+	_ = _overloadHelper
+	var isNull bool
+	for {
+		batch := p.input.Next(ctx)
+		if batch.Length() == 0 {
+			return batch
+		}
+
+		vec := batch.ColVec(p.colIdx)
+		col := vec.Bytes()
+		var idx int
+		n := batch.Length()
+		if vec.MaybeHasNulls() {
+			nulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					var cmp bool
+					arg := col.Get(i)
+					cmp = !bytes.Contains(arg, p.constArg)
+					isNull = nulls.NullAt(i)
+					if cmp && !isNull {
+						sel[idx] = i
+						idx++
+					}
+				}
+			} else {
+				batch.SetSelection(true)
+				sel := batch.Selection()
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					var cmp bool
+					arg := col.Get(i)
+					cmp = !bytes.Contains(arg, p.constArg)
+					isNull = nulls.NullAt(i)
+					if cmp && !isNull {
+						sel[idx] = i
+						idx++
+					}
+				}
+			}
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					var cmp bool
+					arg := col.Get(i)
+					cmp = !bytes.Contains(arg, p.constArg)
+					isNull = false
+					if cmp && !isNull {
+						sel[idx] = i
+						idx++
+					}
+				}
+			} else {
+				batch.SetSelection(true)
+				sel := batch.Selection()
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					var cmp bool
+					arg := col.Get(i)
+					cmp = !bytes.Contains(arg, p.constArg)
+					isNull = false
+					if cmp && !isNull {
+						sel[idx] = i
+						idx++
+					}
+				}
+			}
+		}
+		if idx > 0 {
+			batch.SetLength(idx)
+			return batch
+		}
+	}
+}
+
+func (p *selNotContainsBytesBytesConstOp) Init() {
+	p.input.Init()
+}
+
+type projNotContainsBytesBytesConstOp struct {
+	projConstOpBase
+	constArg []byte
+}
+
+func (p projNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+	// In order to inline the templated code of overloads, we need to have a
+	// `_overloadHelper` local variable of type `overloadHelper`.
+	_overloadHelper := p.overloadHelper
+	// However, the scratch is not used in all of the projection operators, so
+	// we add this to go around "unused" error.
+	_ = _overloadHelper
+	batch := p.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col *coldata.Bytes
+	col = vec.Bytes()
+	projVec := batch.ColVec(p.outputIdx)
+	if projVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		projVec.Nulls().UnsetNulls()
+	}
+	projCol := projVec.Bool()
+	if vec.Nulls().MaybeHasNulls() {
+		colNulls := vec.Nulls()
+		if sel := batch.Selection(); sel != nil {
+			sel = sel[:n]
+			for _, i := range sel {
+				if !colNulls.NullAt(i) {
+					// We only want to perform the projection operation if the value is not null.
+					arg := col.Get(i)
+					projCol[i] = !bytes.Contains(arg, p.constArg)
+				}
+			}
+		} else {
+			col = col
+			_ = 0
+			_ = n
+			_ = projCol.Get(n - 1)
+			for i := 0; i < n; i++ {
+				if !colNulls.NullAt(i) {
+					// We only want to perform the projection operation if the value is not null.
+					arg := col.Get(i)
+					projCol[i] = !bytes.Contains(arg, p.constArg)
+				}
+			}
+		}
+		colNullsCopy := colNulls.Copy()
+		projVec.SetNulls(&colNullsCopy)
+	} else {
+		if sel := batch.Selection(); sel != nil {
+			sel = sel[:n]
+			for _, i := range sel {
+				arg := col.Get(i)
+				projCol[i] = !bytes.Contains(arg, p.constArg)
+			}
+		} else {
+			col = col
+			_ = 0
+			_ = n
+			_ = projCol.Get(n - 1)
+			for i := 0; i < n; i++ {
+				arg := col.Get(i)
+				projCol[i] = !bytes.Contains(arg, p.constArg)
+			}
+		}
+	}
+	// Although we didn't change the length of the batch, it is necessary to set
+	// the length anyway (this helps maintaining the invariant of flat bytes).
+	batch.SetLength(n)
+	return batch
+}
+
+func (p projNotContainsBytesBytesConstOp) Init() {
 	p.input.Init()
 }
 

--- a/pkg/sql/colexec/like_ops.go
+++ b/pkg/sql/colexec/like_ops.go
@@ -33,6 +33,8 @@ const (
 	likeSuffixNegate
 	likePrefix
 	likePrefixNegate
+	likeContains
+	likeContainsNegate
 	likeRegexp
 	likeRegexpNegate
 )
@@ -76,6 +78,13 @@ func getLikeOperatorType(pattern string, negate bool) (likeOpType, string, error
 				return likePrefixNegate, prefix, nil
 			}
 			return likePrefix, prefix, nil
+		}
+		if firstChar == '%' && lastChar == '%' {
+			contains := pattern[1 : len(pattern)-1]
+			if negate {
+				return likeContainsNegate, contains, nil
+			}
+			return likeContains, contains, nil
 		}
 	}
 	// Default (slow) case: execute as a regular expression match.
@@ -140,6 +149,16 @@ func GetLikeOperator(
 		}, nil
 	case likePrefixNegate:
 		return &selNotPrefixBytesBytesConstOp{
+			selConstOpBase: base,
+			constArg:       pat,
+		}, nil
+	case likeContains:
+		return &selContainsBytesBytesConstOp{
+			selConstOpBase: base,
+			constArg:       pat,
+		}, nil
+	case likeContainsNegate:
+		return &selNotContainsBytesBytesConstOp{
 			selConstOpBase: base,
 			constArg:       pat,
 		}, nil
@@ -234,6 +253,16 @@ func GetLikeProjectionOperator(
 		}, nil
 	case likePrefixNegate:
 		return &projNotPrefixBytesBytesConstOp{
+			projConstOpBase: base,
+			constArg:        pat,
+		}, nil
+	case likeContains:
+		return &projContainsBytesBytesConstOp{
+			projConstOpBase: base,
+			constArg:        pat,
+		}, nil
+	case likeContainsNegate:
+		return &projNotContainsBytesBytesConstOp{
 			projConstOpBase: base,
 			constArg:        pat,
 		}, nil

--- a/pkg/sql/colexec/like_ops_test.go
+++ b/pkg/sql/colexec/like_ops_test.go
@@ -116,9 +116,11 @@ func BenchmarkLikeOps(b *testing.B) {
 	// everything out.
 	prefix := "abc"
 	suffix := "xyz"
+	contains := "lmn"
 	for i := 0; i < coldata.BatchSize()/2; i++ {
 		copy(col.Get(i)[:3], prefix)
 		copy(col.Get(i)[width-3:], suffix)
+		copy(col.Get(i)[width/2:], contains)
 	}
 
 	batch.SetLength(coldata.BatchSize())
@@ -137,6 +139,10 @@ func BenchmarkLikeOps(b *testing.B) {
 		selConstOpBase: base,
 		constArg:       []byte(suffix),
 	}
+	containsOp := &selContainsBytesBytesConstOp{
+		selConstOpBase: base,
+		constArg:       []byte(contains),
+	}
 	pattern := fmt.Sprintf("^%s.*%s$", prefix, suffix)
 	regexpOp := &selRegexpBytesBytesConstOp{
 		selConstOpBase: base,
@@ -149,6 +155,7 @@ func BenchmarkLikeOps(b *testing.B) {
 	}{
 		{name: "selPrefixBytesBytesConstOp", op: prefixOp},
 		{name: "selSuffixBytesBytesConstOp", op: suffixOp},
+		{name: "selContainsBytesBytesConstOp", op: containsOp},
 		{name: "selRegexpBytesBytesConstOp", op: regexpOp},
 	}
 	for _, tc := range testCases {

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -727,7 +727,7 @@ EXPLAIN (VEC) SELECT nation, o_year, sum(amount) AS sum_profit FROM ( SELECT n_n
                     │   └ *rowexec.joinReader
                     │     └ *rowexec.joinReader
                     │       └ *colexec.mergeJoinInnerOp
-                    │         ├ *colexec.selRegexpBytesBytesConstOp
+                    │         ├ *colexec.selContainsBytesBytesConstOp
                     │         │ └ *colfetcher.ColBatchScan
                     │         └ *colfetcher.ColBatchScan
                     └ *colfetcher.ColBatchScan

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -429,6 +429,16 @@ SELECT * FROM e WHERE x NOT LIKE '%bc'
 xyz
 
 query T
+SELECT * FROM e WHERE x LIKE '%b%'
+----
+abc
+
+query T
+SELECT * FROM e WHERE x NOT LIKE '%b%'
+----
+xyz
+
+query T
 SELECT * FROM e WHERE x LIKE 'a%c'
 ----
 abc
@@ -438,12 +448,12 @@ SELECT * FROM e WHERE x NOT LIKE 'a%c'
 ----
 xyz
 
-query TBBBBBBBB
-SELECT x, x LIKE '%', x NOT LIKE '%', x LIKE 'ab%', x NOT LIKE 'ab%', x LIKE '%bc', x NOT LIKE '%bc', x LIKE 'a%c', x NOT LIKE 'a%c' FROM e ORDER BY x
+query TBBBBBBBBBB
+SELECT x, x LIKE '%', x NOT LIKE '%', x LIKE 'ab%', x NOT LIKE 'ab%', x LIKE '%bc', x NOT LIKE '%bc', x LIKE '%b%', x NOT LIKE '%b%', x LIKE 'a%c', x NOT LIKE 'a%c' FROM e ORDER BY x
 ----
-NULL  NULL  NULL   NULL   NULL   NULL   NULL   NULL   NULL
-abc   true  false  true   false  true   false  true   false
-xyz   true  false  false  true   false  true   false  true
+NULL  NULL  NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL   NULL
+abc   true  false  true   false  true   false  true   false  true   false
+xyz   true  false  false  true   false  true   false  true   false  true
 
 # Regression test for composite null handling
 # https://github.com/cockroachdb/cockroach/issues/37358


### PR DESCRIPTION
Previously, Like matching has "prefix" match(test%) and "suffix" match(%test).

This commit adds "contains" match (%test%) using bytest.Contains function.

Release note (sql change): Add support for "contains" match(%test%) using bytes.Contains function