### PR TITLE
teamcity-trigger: stress kvnemesis for the full 1h

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -47,7 +47,7 @@ go install ./pkg/cmd/github-post
 # are test failures.
 # Use an `if` so that the `-e` option doesn't stop the script on error.
 if ! stdbuf -oL -eL \
-  make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-maxruns 100 -maxtime 1h -maxfails 1 -stderr $STRESSFLAGS" 2>&1 \
+  make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-stderr $STRESSFLAGS" 2>&1 \
   | tee artifacts/stress.log; then
   exit_status=${PIPESTATUS[0]}
   go tool test2json -t -p "${PKG}" < artifacts/stress.log | github-post

--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/abourget/teamcity"
 	"github.com/cockroachdb/cockroach/pkg/cmd/cmdutil"
@@ -57,6 +58,15 @@ var importPaths = gotool.ImportPaths([]string{baseImportPath + "..."})
 func runTC(queueBuild func(string, map[string]string)) {
 	// Queue stress builds. One per configuration per package.
 	for _, importPath := range importPaths {
+		// By default, run each package for up to 100 iterations.
+		maxRuns := 100
+
+		// By default, run each package for up to 1h.
+		maxTime := 1 * time.Hour
+
+		// By default, fail the stress run on the first test failure.
+		maxFails := 1
+
 		// The stress program by default runs as many instances in parallel as there
 		// are CPUs. Each instance itself can run tests in parallel. The amount of
 		// parallelism needs to be reduced, or we can run into OOM issues,
@@ -68,9 +78,14 @@ func runTC(queueBuild func(string, map[string]string)) {
 		// halve these values.
 		parallelism := 4
 
-		// Stress logic tests with reduced parallelism (to avoid overloading the
-		// machine, see https://github.com/cockroachdb/cockroach/pull/10966).
-		if importPath == baseImportPath+"sql/logictest" {
+		// Conditionally override stressflags.
+		switch importPath {
+		case baseImportPath + "kv/kvnemesis":
+			// Disable -maxruns for kvnemesis. Run for the full 1h.
+			maxRuns = 0
+		case baseImportPath + "sql/logictest":
+			// Stress logic tests with reduced parallelism (to avoid overloading the
+			// machine, see https://github.com/cockroachdb/cockroach/pull/10966).
 			parallelism /= 2
 		}
 
@@ -80,14 +95,15 @@ func runTC(queueBuild func(string, map[string]string)) {
 
 		// Run non-race build.
 		opts["env.GOFLAGS"] = fmt.Sprintf("-parallel=%d", parallelism)
-		opts["env.STRESSFLAGS"] = fmt.Sprintf("-p %d", parallelism)
+		opts["env.STRESSFLAGS"] = fmt.Sprintf("-maxruns %d -maxtime %s -maxfails %d -p %d",
+			maxRuns, maxTime, maxFails, parallelism)
 		queueBuild("Cockroach_Nightlies_Stress", opts)
 
 		// Run race build. Reduce the parallelism to avoid overloading the machine.
 		parallelism /= 2
 		opts["env.GOFLAGS"] = fmt.Sprintf("-race -parallel=%d", parallelism)
-		opts["env.STRESSFLAGS"] = fmt.Sprintf("-p %d", parallelism)
-
+		opts["env.STRESSFLAGS"] = fmt.Sprintf("-maxruns %d -maxtime %s -maxfails %d -p %d",
+			maxRuns, maxTime, maxFails, parallelism)
 		queueBuild("Cockroach_Nightlies_Stress", opts)
 	}
 }

--- a/pkg/cmd/teamcity-trigger/main_test.go
+++ b/pkg/cmd/teamcity-trigger/main_test.go
@@ -35,11 +35,17 @@ func TestRunTC(t *testing.T) {
 }
 
 func Example_runTC() {
-	// Shows sample output for two packages, one of which runs with reduced
-	// parallelism.
+	// Shows sample output for the following packages, some of which runs with
+	// non-default configurations.
+	pkgs := map[string]struct{}{
+		baseImportPath + "kv/kvnemesis":  {},
+		baseImportPath + "sql/logictest": {},
+		baseImportPath + "storage":       {},
+	}
+
 	runTC(func(buildID string, opts map[string]string) {
 		pkg := opts["env.PKG"]
-		if !strings.HasSuffix(pkg, "pkg/sql/logictest") && !strings.HasSuffix(pkg, "pkg/storage") {
+		if _, ok := pkgs[pkg]; !ok {
 			return
 		}
 		var keys []string
@@ -57,19 +63,27 @@ func Example_runTC() {
 	})
 
 	// Output:
+	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
+	//   env.GOFLAGS:     -parallel=4
+	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 4
+	//
+	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
+	//   env.GOFLAGS:     -race -parallel=2
+	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 2
+	//
 	// github.com/cockroachdb/cockroach/pkg/sql/logictest
 	//   env.GOFLAGS:     -parallel=2
-	//   env.STRESSFLAGS: -p 2
+	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 2
 	//
 	// github.com/cockroachdb/cockroach/pkg/sql/logictest
 	//   env.GOFLAGS:     -race -parallel=1
-	//   env.STRESSFLAGS: -p 1
+	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 1
 	//
 	// github.com/cockroachdb/cockroach/pkg/storage
 	//   env.GOFLAGS:     -parallel=4
-	//   env.STRESSFLAGS: -p 4
+	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 4
 	//
 	// github.com/cockroachdb/cockroach/pkg/storage
 	//   env.GOFLAGS:     -race -parallel=2
-	//   env.STRESSFLAGS: -p 2
+	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 2
 }


### PR DESCRIPTION
This commit reworks the stress invocation logic in teamcity-trigger to
remove the `-maxruns 100` flag when stressing `pkg/kv/kvnemesis`. This
allows the package to run for the full 1h each night.

The commit does this by pulling these flags out of teamcity-stress.sh
and into teamcity-trigger/main.go, which gives us more flexibility for
this kind of conditional invocation, which we were already using for
`pkg/sql/logictest`.