### PR TITLE
sql: validate partial index predicates in TableDescriptor.Validate

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -55,7 +55,7 @@ func parseTableDesc(createTableStmt string) (*sqlbase.TableDescriptor, error) {
 	if err != nil {
 		return nil, err
 	}
-	return mutDesc.TableDesc(), mutDesc.TableDesc().ValidateTable()
+	return mutDesc.TableDesc(), mutDesc.TableDesc().ValidateTable(ctx)
 }
 
 func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.EncDatumRow, error) {

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -950,7 +950,7 @@ func prepareNewTableDescsForIngestion(
 	// imported data.
 	if err := backupccl.WriteDescriptors(ctx, txn, nil, /* databases */
 		newMutableTableDescriptors, nil, tree.RequestedDescriptors,
-		p.ExecCfg().Settings, seqValKVs); err != nil {
+		p.ExecCfg().Settings, seqValKVs, p.SemaCtx()); err != nil {
 		return nil, errors.Wrapf(err, "creating importTables")
 	}
 

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -557,7 +557,7 @@ func addDelayedFKs(
 		if err := fixDescriptorFKState(def.tbl.TableDesc()); err != nil {
 			return err
 		}
-		if err := def.tbl.AllocateIDs(); err != nil {
+		if err := def.tbl.AllocateIDs(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -137,7 +137,7 @@ func (pt *partitioningTest) parse() error {
 			return err
 		}
 		pt.parsed.tableDesc = mutDesc
-		if err := pt.parsed.tableDesc.ValidateTable(); err != nil {
+		if err := pt.parsed.tableDesc.ValidateTable(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -237,16 +237,21 @@ func alterColumnTypeGeneral(
 	// will fail until the old column is dropped.
 	var inverseExpr string
 	if using != nil {
+		// Dequalify the columns in the expression.
+		expr, err := schemaexpr.DequalifyExpr(ctx, tableDesc, using, tn)
+		if err != nil {
+			return err
+		}
+
 		// Validate the provided using expr and ensure it has the correct type.
-		typedExpr, _, err := schemaexpr.DequalifyAndValidateExpr(
+		typedExpr, _, err := schemaexpr.ValidateExprTypeAndVolatility(
 			ctx,
 			tableDesc,
-			using,
+			expr,
 			toType,
 			"ALTER COLUMN TYPE USING EXPRESSION",
 			&params.p.semaCtx,
 			tree.VolatilityVolatile,
-			tn,
 		)
 
 		if err != nil {
@@ -351,7 +356,7 @@ func alterColumnTypeGeneral(
 
 	tableDesc.AddColumnMutation(&newCol, sqlbase.DescriptorMutation_ADD)
 
-	if err := tableDesc.AllocateIDs(); err != nil {
+	if err := tableDesc.AllocateIDs(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -356,7 +356,7 @@ func alterColumnTypeGeneral(
 
 	tableDesc.AddColumnMutation(&newCol, sqlbase.DescriptorMutation_ADD)
 
-	if err := tableDesc.AllocateIDs(ctx); err != nil {
+	if err := tableDesc.AllocateIDs(ctx, &params.p.semaCtx); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -89,7 +89,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 		}
 	}
 
-	if err := n.tableDesc.AllocateIDs(); err != nil {
+	if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -89,7 +89,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 		}
 	}
 
-	if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
+	if err := n.tableDesc.AllocateIDs(params.ctx, &params.p.semaCtx); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -175,7 +175,7 @@ func (p *planner) AlterPrimaryKey(
 	if err := tableDesc.AddIndexMutation(newPrimaryIndexDesc, sqlbase.DescriptorMutation_ADD); err != nil {
 		return err
 	}
-	if err := tableDesc.AllocateIDs(); err != nil {
+	if err := tableDesc.AllocateIDs(ctx); err != nil {
 		return err
 	}
 
@@ -224,7 +224,7 @@ func (p *planner) AlterPrimaryKey(
 		// Make the copy of the old primary index not-interleaved. This decision
 		// can be revisited based on user experience.
 		oldPrimaryIndexCopy.Interleave = sqlbase.InterleaveDescriptor{}
-		if err := addIndexMutationWithSpecificPrimaryKey(tableDesc, oldPrimaryIndexCopy, newPrimaryIndexDesc); err != nil {
+		if err := addIndexMutationWithSpecificPrimaryKey(ctx, tableDesc, oldPrimaryIndexCopy, newPrimaryIndexDesc); err != nil {
 			return err
 		}
 	}
@@ -282,7 +282,7 @@ func (p *planner) AlterPrimaryKey(
 		newIndex := protoutil.Clone(idx).(*sqlbase.IndexDescriptor)
 		basename := newIndex.Name + "_rewrite_for_primary_key_change"
 		newIndex.Name = sqlbase.GenerateUniqueConstraintName(basename, nameExists)
-		if err := addIndexMutationWithSpecificPrimaryKey(tableDesc, newIndex, newPrimaryIndexDesc); err != nil {
+		if err := addIndexMutationWithSpecificPrimaryKey(ctx, tableDesc, newIndex, newPrimaryIndexDesc); err != nil {
 			return err
 		}
 		// If the index that we are rewriting is interleaved, we need to setup the rewritten

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -175,7 +175,7 @@ func (p *planner) AlterPrimaryKey(
 	if err := tableDesc.AddIndexMutation(newPrimaryIndexDesc, sqlbase.DescriptorMutation_ADD); err != nil {
 		return err
 	}
-	if err := tableDesc.AllocateIDs(ctx); err != nil {
+	if err := tableDesc.AllocateIDs(ctx, &p.semaCtx); err != nil {
 		return err
 	}
 
@@ -224,7 +224,7 @@ func (p *planner) AlterPrimaryKey(
 		// Make the copy of the old primary index not-interleaved. This decision
 		// can be revisited based on user experience.
 		oldPrimaryIndexCopy.Interleave = sqlbase.InterleaveDescriptor{}
-		if err := addIndexMutationWithSpecificPrimaryKey(ctx, tableDesc, oldPrimaryIndexCopy, newPrimaryIndexDesc); err != nil {
+		if err := addIndexMutationWithSpecificPrimaryKey(ctx, tableDesc, oldPrimaryIndexCopy, newPrimaryIndexDesc, &p.semaCtx); err != nil {
 			return err
 		}
 	}
@@ -282,7 +282,7 @@ func (p *planner) AlterPrimaryKey(
 		newIndex := protoutil.Clone(idx).(*sqlbase.IndexDescriptor)
 		basename := newIndex.Name + "_rewrite_for_primary_key_change"
 		newIndex.Name = sqlbase.GenerateUniqueConstraintName(basename, nameExists)
-		if err := addIndexMutationWithSpecificPrimaryKey(ctx, tableDesc, newIndex, newPrimaryIndexDesc); err != nil {
+		if err := addIndexMutationWithSpecificPrimaryKey(ctx, tableDesc, newIndex, newPrimaryIndexDesc, &p.semaCtx); err != nil {
 			return err
 		}
 		// If the index that we are rewriting is interleaved, we need to setup the rewritten

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -712,7 +712,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 		}
 
 		// Allocate IDs now, so new IDs are available to subsequent commands
-		if err := n.tableDesc.AllocateIDs(); err != nil {
+		if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
 			return err
 		}
 	}
@@ -789,6 +789,7 @@ func (n *alterTableNode) Close(context.Context)        {}
 // addIndexMutationWithSpecificPrimaryKey adds an index mutation into the given table descriptor, but sets up
 // the index with ExtraColumnIDs from the given index, rather than the table's primary key.
 func addIndexMutationWithSpecificPrimaryKey(
+	ctx context.Context,
 	table *sqlbase.MutableTableDescriptor,
 	toAdd *sqlbase.IndexDescriptor,
 	primary *sqlbase.IndexDescriptor,
@@ -798,7 +799,7 @@ func addIndexMutationWithSpecificPrimaryKey(
 	if err := table.AddIndexMutation(toAdd, sqlbase.DescriptorMutation_ADD); err != nil {
 		return err
 	}
-	if err := table.AllocateIDs(); err != nil {
+	if err := table.AllocateIDs(ctx); err != nil {
 		return err
 	}
 	// Use the columns in the given primary index to construct this indexes ExtraColumnIDs list.

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -160,7 +160,7 @@ func unwrapDescriptorMutable(
 		if err := table.MaybeFillInDescriptor(ctx, txn, codec); err != nil {
 			return nil, err
 		}
-		if err := table.ValidateTable(); err != nil {
+		if err := table.ValidateTable(ctx); err != nil {
 			return nil, err
 		}
 		return sqlbase.NewMutableExistingTableDescriptor(*table), nil

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -76,7 +76,7 @@ func (p *planner) setupFamilyAndConstraintForShard(
 	}
 	// Assign an ID to the newly-added shard column, which is needed for the creation
 	// of a valid check constraint.
-	if err := tableDesc.AllocateIDs(ctx); err != nil {
+	if err := tableDesc.AllocateIDs(ctx, &p.semaCtx); err != nil {
 		return err
 	}
 
@@ -402,7 +402,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 	if err := n.tableDesc.AddIndexMutation(indexDesc, sqlbase.DescriptorMutation_ADD); err != nil {
 		return err
 	}
-	if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
+	if err := n.tableDesc.AllocateIDs(params.ctx, &params.p.semaCtx); err != nil {
 		return err
 	}
 	// The index name may have changed as a result of

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -225,5 +225,10 @@ func MakeSequenceTableDesc(
 	// immediately.
 	desc.State = sqlbase.TableDescriptor_PUBLIC
 
-	return desc, desc.ValidateTable()
+	ctx := context.Background()
+	if params != nil {
+		ctx = params.ctx
+	}
+
+	return desc, desc.ValidateTable(ctx)
 }

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -140,7 +140,7 @@ func doCreateSequence(
 		return err
 	}
 
-	if err := desc.Validate(params.ctx, params.p.txn, params.ExecCfg().Codec); err != nil {
+	if err := desc.Validate(params.ctx, params.p.txn, params.ExecCfg().Codec, &params.p.semaCtx); err != nil {
 		return err
 	}
 

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -367,7 +367,7 @@ func addResultColumns(
 		}
 		desc.AddColumn(col)
 	}
-	if err := desc.AllocateIDs(); err != nil {
+	if err := desc.AllocateIDs(ctx); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -208,7 +208,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		return err
 	}
 
-	if err := newDesc.Validate(params.ctx, params.p.txn, params.ExecCfg().Codec); err != nil {
+	if err := newDesc.Validate(params.ctx, params.p.txn, params.ExecCfg().Codec, &params.p.semaCtx); err != nil {
 		return err
 	}
 
@@ -367,7 +367,7 @@ func addResultColumns(
 		}
 		desc.AddColumn(col)
 	}
-	if err := desc.AllocateIDs(ctx); err != nil {
+	if err := desc.AllocateIDs(ctx, semaCtx); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -152,7 +152,7 @@ func (p *planner) createDescriptorWithID(
 
 	mutDesc, isTable := descriptor.(*sqlbase.MutableTableDescriptor)
 	if isTable {
-		if err := mutDesc.ValidateTable(); err != nil {
+		if err := mutDesc.ValidateTable(ctx); err != nil {
 			return err
 		}
 		if err := p.Descriptors().AddUncommittedDescriptor(mutDesc); err != nil {

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -82,7 +82,7 @@ func (mt mutationTest) makeMutationsActive() {
 	}
 	mt.tableDesc.Mutations = nil
 	mt.tableDesc.Version++
-	if err := mt.tableDesc.ValidateTable(); err != nil {
+	if err := mt.tableDesc.ValidateTable(context.Background()); err != nil {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
@@ -140,7 +140,7 @@ func (mt mutationTest) writeMutation(m sqlbase.DescriptorMutation) {
 	}
 	mt.tableDesc.Mutations = append(mt.tableDesc.Mutations, m)
 	mt.tableDesc.Version++
-	if err := mt.tableDesc.ValidateTable(); err != nil {
+	if err := mt.tableDesc.ValidateTable(context.Background()); err != nil {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
@@ -441,21 +441,21 @@ CREATE INDEX allidx ON t.test (k, v);
 	// Check that a mutation can only be inserted with an explicit mutation state, and direction.
 	tableDesc = mTest.tableDesc
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{}}
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, and no column/index descriptor") {
+	if err := tableDesc.ValidateTable(context.Background()); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, and no column/index descriptor") {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{Descriptor_: &sqlbase.DescriptorMutation_Column{Column: &tableDesc.Columns[len(tableDesc.Columns)-1]}}}
 	tableDesc.Columns = tableDesc.Columns[:len(tableDesc.Columns)-1]
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state UNKNOWN, direction NONE, col "i", id 3`) {
+	if err := tableDesc.ValidateTable(context.Background()); !testutils.IsError(err, `mutation in state UNKNOWN, direction NONE, col "i", id 3`) {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = sqlbase.DescriptorMutation_DELETE_ONLY
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state DELETE_ONLY, direction NONE, col "i", id 3`) {
+	if err := tableDesc.ValidateTable(context.Background()); !testutils.IsError(err, `mutation in state DELETE_ONLY, direction NONE, col "i", id 3`) {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = sqlbase.DescriptorMutation_UNKNOWN
 	tableDesc.Mutations[0].Direction = sqlbase.DescriptorMutation_DROP
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state UNKNOWN, direction DROP, col "i", id 3`) {
+	if err := tableDesc.ValidateTable(context.Background()); !testutils.IsError(err, `mutation in state UNKNOWN, direction DROP, col "i", id 3`) {
 		t.Fatal(err)
 	}
 }
@@ -626,7 +626,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo (v));
 	tableDesc = mTest.tableDesc
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{Descriptor_: &sqlbase.DescriptorMutation_Index{Index: &tableDesc.Indexes[len(tableDesc.Indexes)-1]}}}
 	tableDesc.Indexes = tableDesc.Indexes[:len(tableDesc.Indexes)-1]
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, index foo, id 2") {
+	if err := tableDesc.ValidateTable(context.Background()); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, index foo, id 2") {
 		t.Fatal(err)
 	}
 }

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -165,7 +165,7 @@ func (n *dropIndexNode) dropShardColumnAndConstraint(
 		}
 	}
 
-	if err := tableDesc.AllocateIDs(); err != nil {
+	if err := tableDesc.AllocateIDs(params.ctx); err != nil {
 		return err
 	}
 	mutationID := tableDesc.ClusterVersion.NextMutationID

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -165,7 +165,7 @@ func (n *dropIndexNode) dropShardColumnAndConstraint(
 		}
 	}
 
-	if err := tableDesc.AllocateIDs(params.ctx); err != nil {
+	if err := tableDesc.AllocateIDs(params.ctx, &params.p.semaCtx); err != nil {
 		return err
 	}
 	mutationID := tableDesc.ClusterVersion.NextMutationID
@@ -496,7 +496,7 @@ func (p *planner) dropIndexByName(
 		return err
 	}
 
-	if err := tableDesc.Validate(ctx, p.txn, p.ExecCfg().Codec); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, p.ExecCfg().Codec, &p.semaCtx); err != nil {
 		return err
 	}
 	mutationID := tableDesc.ClusterVersion.NextMutationID

--- a/pkg/sql/namespace_test.go
+++ b/pkg/sql/namespace_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -37,6 +38,7 @@ func TestNamespaceTableSemantics(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 	ctx := context.Background()
+	semaCtx := tree.MakeSemaContext()
 	codec := keys.SystemSQLCodec
 
 	// IDs to map (parentID, name) to. Actual ID value is irrelevant to the test.
@@ -138,7 +140,7 @@ func TestNamespaceTableSemantics(t *testing.T) {
 		&sqlbase.PrivilegeDescriptor{},
 		false,
 	)
-	if err := desc.AllocateIDs(ctx); err != nil {
+	if err := desc.AllocateIDs(ctx, &semaCtx); err != nil {
 		t.Fatal(err)
 	}
 	if err := kvDB.Put(ctx, mKey, desc.DescriptorProto()); err != nil {

--- a/pkg/sql/namespace_test.go
+++ b/pkg/sql/namespace_test.go
@@ -138,7 +138,7 @@ func TestNamespaceTableSemantics(t *testing.T) {
 		&sqlbase.PrivilegeDescriptor{},
 		false,
 	)
-	if err := desc.AllocateIDs(); err != nil {
+	if err := desc.AllocateIDs(ctx); err != nil {
 		t.Fatal(err)
 	}
 	if err := kvDB.Put(ctx, mKey, desc.DescriptorProto()); err != nil {

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -71,7 +71,7 @@ func (n *renameColumnNode) startExec(params runParams) error {
 		return nil
 	}
 
-	if err := tableDesc.Validate(ctx, p.txn, p.ExecCfg().Codec); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, p.ExecCfg().Codec, &p.semaCtx); err != nil {
 		return err
 	}
 

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -96,7 +96,7 @@ func (n *renameIndexNode) startExec(params runParams) error {
 		return err
 	}
 
-	if err := tableDesc.Validate(ctx, p.txn, p.ExecCfg().Codec); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, p.ExecCfg().Codec, &p.semaCtx); err != nil {
 		return err
 	}
 

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -148,7 +148,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 	newTbKey := sqlbase.MakeObjectNameKey(ctx, params.ExecCfg().Settings,
 		targetDbDesc.GetID(), tableDesc.GetParentSchemaID(), newTn.Table()).Key(p.ExecCfg().Codec)
 
-	if err := tableDesc.Validate(ctx, p.txn, p.ExecCfg().Codec); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, p.ExecCfg().Codec, &p.semaCtx); err != nil {
 		return err
 	}
 

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -179,7 +179,7 @@ func (p *planner) ResolveType(
 	tn := tree.MakeTypeNameFromPrefix(prefix, tree.Name(name.Object()))
 	tdesc := desc.(*sqlbase.ImmutableTypeDescriptor)
 
-	// Disllow cross-database type resolution. Note that we check
+	// Disallow cross-database type resolution. Note that we check
 	// p.contextDatabaseID != sqlbase.InvalidID when we have been restricted to
 	// accessing types in the database with ID = p.contextDatabaseID by
 	// p.runWithOptions. So, check to see if the resolved descriptor's parentID

--- a/pkg/sql/schemaexpr/check_constraint.go
+++ b/pkg/sql/schemaexpr/check_constraint.go
@@ -86,17 +86,22 @@ func (b *CheckConstraintBuilder) Build(
 		}
 	}
 
+	// Dequalify the columns in the expression.
+	expr, err := DequalifyExpr(b.ctx, b.desc, c.Expr, &b.tableName)
+	if err != nil {
+		return nil, err
+	}
+
 	// Verify that the expression results in a boolean and does not use
 	// invalid functions.
-	typedExpr, colIDs, err := DequalifyAndValidateExpr(
+	typedExpr, colIDs, err := ValidateExprTypeAndVolatility(
 		b.ctx,
 		b.desc,
-		c.Expr,
+		expr,
 		types.Bool,
 		"CHECK",
 		b.semaCtx,
 		tree.VolatilityVolatile,
-		&b.tableName,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/schemaexpr/computed_column.go
+++ b/pkg/sql/schemaexpr/computed_column.go
@@ -113,18 +113,23 @@ func (v *ComputedColumnValidator) Validate(d *tree.ColumnTableDef) error {
 		return err
 	}
 
+	// Dequalify the columns in the expression.
+	expr, err := DequalifyExpr(v.ctx, v.desc, d.Computed.Expr, v.tableName)
+	if err != nil {
+		return err
+	}
+
 	// Check that the type of the expression is of type defType and that there
 	// are no variable expressions (besides dummyColumnItems) and no impure
 	// functions.
-	typedExpr, _, err := DequalifyAndValidateExpr(
+	typedExpr, _, err := ValidateExprTypeAndVolatility(
 		v.ctx,
 		v.desc,
-		d.Computed.Expr,
+		expr,
 		defType,
 		"computed column",
 		v.semaCtx,
 		tree.VolatilityImmutable,
-		v.tableName,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/schemaexpr/expr.go
+++ b/pkg/sql/schemaexpr/expr.go
@@ -49,11 +49,26 @@ func DeserializeTableDescExpr(
 	return typed, nil
 }
 
-// DequalifyAndValidateExpr takes an expr de-qualifies the column names and
-// validates that expression is valid, has the correct type and
-// has no impure functions if allowImpure is false.
-// Returns the type-checked and constant-folded expression.
-func DequalifyAndValidateExpr(
+// DequalifyExpr dequalifies the column names in the given expression, removing
+// database and table prefixes.
+func DequalifyExpr(
+	ctx context.Context, desc sqlbase.TableDescriptorInterface, expr tree.Expr, tn *tree.TableName,
+) (tree.Expr, error) {
+	sourceInfo := sqlbase.NewSourceInfoForSingleTable(
+		*tn, sqlbase.ResultColumnsFromColDescs(
+			desc.GetID(),
+			desc.TableDesc().AllNonDropColumns(),
+		),
+	)
+
+	return DequalifyColumnRefs(ctx, sourceInfo, expr)
+}
+
+// ValidateExprTypeAndVolatility validates that an expression has the given type
+// and contains no functions with a volatility greater than maxVolatility. The
+// type-checked and constant-folded expression and the set of column IDs within
+// the expression are returned, if valid.
+func ValidateExprTypeAndVolatility(
 	ctx context.Context,
 	desc sqlbase.TableDescriptorInterface,
 	expr tree.Expr,
@@ -61,19 +76,8 @@ func DequalifyAndValidateExpr(
 	op string,
 	semaCtx *tree.SemaContext,
 	maxVolatility tree.Volatility,
-	tn *tree.TableName,
 ) (tree.TypedExpr, sqlbase.TableColSet, error) {
 	var colIDs sqlbase.TableColSet
-	sourceInfo := sqlbase.NewSourceInfoForSingleTable(
-		*tn, sqlbase.ResultColumnsFromColDescs(
-			desc.GetID(),
-			desc.TableDesc().AllNonDropColumns(),
-		),
-	)
-	expr, err := DequalifyColumnRefs(ctx, sourceInfo, expr)
-	if err != nil {
-		return nil, colIDs, err
-	}
 
 	// Replace the column variables with dummyColumns so that they can be
 	// type-checked.

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1390,7 +1390,7 @@ func (desc *MutableTableDescriptor) MaybeFillColumnID(
 
 // AllocateIDs allocates column, family, and index ids for any column, family,
 // or index which has an ID of 0.
-func (desc *MutableTableDescriptor) AllocateIDs() error {
+func (desc *MutableTableDescriptor) AllocateIDs(ctx context.Context) error {
 	// Only physical tables can have / need a primary key.
 	if desc.IsPhysicalTable() {
 		if err := desc.ensurePrimaryKey(); err != nil {
@@ -1427,7 +1427,7 @@ func (desc *MutableTableDescriptor) AllocateIDs() error {
 	if desc.ID == 0 {
 		desc.ID = keys.MinUserDescID
 	}
-	err := desc.ValidateTable()
+	err := desc.ValidateTable(ctx)
 	desc.ID = savedID
 	return err
 }
@@ -1757,7 +1757,7 @@ func (desc *MutableTableDescriptor) OriginalVersion() DescriptorVersion {
 // Validate validates that the table descriptor is well formed. Checks include
 // both single table and cross table invariants.
 func (desc *TableDescriptor) Validate(ctx context.Context, txn *kv.Txn, codec keys.SQLCodec) error {
-	err := desc.ValidateTable()
+	err := desc.ValidateTable(ctx)
 	if err != nil {
 		return err
 	}
@@ -1952,7 +1952,7 @@ func (desc *TableDescriptor) ValidateIndexNameIsUnique(indexName string) error {
 // are consistent. Use Validate to validate that cross-table references are
 // correct.
 // If version is supplied, the descriptor is checked for version incompatibilities.
-func (desc *TableDescriptor) ValidateTable() error {
+func (desc *TableDescriptor) ValidateTable(ctx context.Context) error {
 	if err := validateName(desc.Name, "table"); err != nil {
 		return err
 	}
@@ -2088,7 +2088,7 @@ func (desc *TableDescriptor) ValidateTable() error {
 			return err
 		}
 
-		if err := desc.validateTableIndexes(columnNames); err != nil {
+		if err := desc.validateTableIndexes(ctx, columnNames); err != nil {
 			return err
 		}
 		if err := desc.validatePartitioning(); err != nil {
@@ -2223,12 +2223,18 @@ func (desc *TableDescriptor) validateColumnFamilies(columnIDs map[ColumnID]strin
 	return nil
 }
 
+// SchemaExprPartialIndexPredicateValidateHook is a work-around for an import
+// cycle between sqlbase and schemaexpr.
+var SchemaExprPartialIndexPredicateValidateHook func(context.Context, TableDescriptorInterface, tree.Expr, *tree.SemaContext) (tree.Expr, error)
+
 // validateTableIndexes validates that indexes are well formed. Checks include
 // validating the columns involved in the index, verifying the index names and
 // IDs are unique, and the family of the primary key is 0. This does not check
 // if indexes are unique (i.e. same set of columns, direction, and uniqueness)
 // as there are practical uses for them.
-func (desc *TableDescriptor) validateTableIndexes(columnNames map[string]ColumnID) error {
+func (desc *TableDescriptor) validateTableIndexes(
+	ctx context.Context, columnNames map[string]ColumnID,
+) error {
 	if len(desc.PrimaryIndex.ColumnIDs) == 0 {
 		return ErrMissingPrimaryKey
 	}
@@ -2302,6 +2308,23 @@ func (desc *TableDescriptor) validateTableIndexes(columnNames map[string]ColumnI
 			if _, exists := columnNames[index.Sharded.Name]; !exists {
 				return fmt.Errorf("index %q refers to non-existent shard column %q",
 					index.Name, index.Sharded.Name)
+			}
+		}
+
+		if index.IsPartial() && SchemaExprPartialIndexPredicateValidateHook != nil {
+			expr, err := parser.ParseExpr(index.Predicate)
+			if err != nil {
+				return err
+			}
+
+			immutableDesc := NewImmutableTableDescriptor(*desc)
+			// TODO(mgartner): Set a TypeResolver in semaCtx to support user
+			// defined types in partial index predicates.
+			semaCtx := tree.MakeSemaContext()
+
+			_, err = SchemaExprPartialIndexPredicateValidateHook(ctx, immutableDesc, expr, &semaCtx)
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -48,6 +48,7 @@ func makeIndexDescriptor(name string, columnNames []string) IndexDescriptor {
 func TestAllocateIDs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	semaCtx := tree.MakeSemaContext()
 	desc := NewMutableCreatedTableDescriptor(TableDescriptor{
 		ParentID: keys.MinUserDescID,
 		ID:       keys.MinUserDescID + 1,
@@ -70,7 +71,7 @@ func TestAllocateIDs(t *testing.T) {
 		Privileges:    NewDefaultPrivilegeDescriptor(),
 		FormatVersion: FamilyFormatVersion,
 	})
-	if err := desc.AllocateIDs(context.Background()); err != nil {
+	if err := desc.AllocateIDs(context.Background(), &semaCtx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -121,7 +122,7 @@ func TestAllocateIDs(t *testing.T) {
 		t.Fatalf("expected %s, but found %s", a, b)
 	}
 
-	if err := desc.AllocateIDs(context.Background()); err != nil {
+	if err := desc.AllocateIDs(context.Background(), &semaCtx); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(expected, desc) {
@@ -1346,6 +1347,7 @@ func TestMaybeUpgradeFormatVersion(t *testing.T) {
 }
 
 func TestUnvalidateConstraints(t *testing.T) {
+	semaCtx := tree.MakeSemaContext()
 	desc := NewMutableCreatedTableDescriptor(TableDescriptor{
 		Name:     "test",
 		ParentID: ID(1),
@@ -1364,7 +1366,7 @@ func TestUnvalidateConstraints(t *testing.T) {
 			},
 		},
 	})
-	if err := desc.AllocateIDs(context.Background()); err != nil {
+	if err := desc.AllocateIDs(context.Background(), &semaCtx); err != nil {
 		t.Fatal(err)
 	}
 	lookup := func(_ ID) (*TableDescriptor, error) {

--- a/pkg/sql/sqlbase/validate_test.go
+++ b/pkg/sql/sqlbase/validate_test.go
@@ -145,9 +145,7 @@ var validationMap = []struct {
 			"Sharded":           {status: iSolemnlySwearThisFieldIsValidated},
 			"Disabled":          {status: thisFieldReferencesNoObjects},
 			"GeoConfig":         {status: thisFieldReferencesNoObjects},
-			"Predicate": {
-				status: todoIAmKnowinglyAddingTechDebt,
-				reason: "initial import: TODO(mgartner): add validation"},
+			"Predicate":         {status: iSolemnlySwearThisFieldIsValidated},
 		},
 	},
 	{

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -259,7 +259,7 @@ func (p *planner) writeTableDescToBatch(
 		tableDesc.MaybeIncrementVersion()
 	}
 
-	if err := tableDesc.ValidateTable(); err != nil {
+	if err := tableDesc.ValidateTable(ctx); err != nil {
 		return errors.AssertionFailedf("table descriptor is not valid: %s\n%v", err, tableDesc)
 	}
 

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -307,14 +307,15 @@ func TestMakeTableDescIndexes(t *testing.T) {
 func TestPrimaryKeyUnspecified(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	ctx := context.Background()
 	s := "CREATE TABLE foo.test (a INT, b INT, CONSTRAINT c UNIQUE (b))"
-	desc, err := CreateTestTableDescriptor(context.Background(), 1, 100, s, sqlbase.NewDefaultPrivilegeDescriptor())
+	desc, err := CreateTestTableDescriptor(ctx, 1, 100, s, sqlbase.NewDefaultPrivilegeDescriptor())
 	if err != nil {
 		t.Fatal(err)
 	}
 	desc.PrimaryIndex = sqlbase.IndexDescriptor{}
 
-	err = desc.ValidateTable()
+	err = desc.ValidateTable(ctx)
 	if !testutils.IsError(err, sqlbase.ErrMissingPrimaryKey.Error()) {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -198,7 +198,7 @@ func TestSystemTableLiterals(t *testing.T) {
 		if err != nil {
 			t.Fatalf("test: %+v, err: %v", test, err)
 		}
-		require.NoError(t, gen.ValidateTable())
+		require.NoError(t, gen.ValidateTable(context.Background()))
 
 		if !proto.Equal(test.pkg.TableDesc(), gen.TableDesc()) {
 			diff := strings.Join(pretty.Diff(&test.pkg, &gen), "\n")

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -39,6 +39,7 @@ func CreateTestTableDescriptor(
 	}
 	semaCtx := tree.MakeSemaContext()
 	evalCtx := tree.MakeTestingEvalContext(st)
+	params := runParams{ctx: ctx}
 	switch n := stmt.AST.(type) {
 	case *tree.CreateTable:
 		desc, err := MakeTableDesc(
@@ -65,7 +66,7 @@ func CreateTestTableDescriptor(
 			hlc.Timestamp{}, /* creationTime */
 			privileges,
 			false, /* temporary */
-			nil,   /* params */
+			&params,
 		)
 		return &desc, err
 	default:


### PR DESCRIPTION
This commit adds validation of partial index predicates when
`TableDescriptor.Validate` is called. This prevents corruption in
partial index predicates, such as references to columns that do not
exist in the table.

The validator responsible for validating partial index predicates on
creation, `schemaexpr.IndexPredicateValidator` is used here. Some minor
tweaks were made. Most notably, the validator now supports validation
with and without dequalifying the columns in the expression.

Fixes #51083
Informs #50854

Release note: None