### PR TITLE
cmd/internal: elide issue assignee based on authorship

### DIFF
--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -42,8 +42,7 @@ const (
 
 func main() {
 	ctx := context.Background()
-
-	f := func(ctx context.Context, title, packageName, testName, testMessage, authorEmail string) error {
+	fileIssue := func(ctx context.Context, title, packageName, testName, testMessage, authorEmail string) error {
 		log.Printf("filing issue with title: %s", title)
 		req := issues.PostRequest{
 			// TODO(tbg): actually use this as a template and not a hard-coded
@@ -59,7 +58,7 @@ func main() {
 		return issues.Post(ctx, req)
 	}
 
-	if err := listFailures(ctx, os.Stdin, f); err != nil {
+	if err := listFailures(ctx, os.Stdin, fileIssue); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -110,7 +109,9 @@ func trimPkg(pkg string) string {
 func listFailures(
 	ctx context.Context,
 	input io.Reader,
-	f func(ctx context.Context, title, packageName, testName, testMessage, authorEmail string) error,
+	fileIssue func(
+		ctx context.Context, title, packageName, testName, testMessage, authorEmail string,
+	) error,
 ) error {
 	// Tests that took less than this are not even considered for slow test
 	// reporting. This is so that we protect against large number of
@@ -315,7 +316,7 @@ func listFailures(
 		}
 		trimmedPkgName := trimPkg(packageName)
 		title := fmt.Sprintf("%s: package failed", trimmedPkgName)
-		if err := f(
+		if err := fileIssue(
 			ctx, title, packageName, unknown, packageOutput.String(), "", /* authorEmail */
 		); err != nil {
 			return errors.Wrap(err, "failed to post issue")
@@ -351,7 +352,7 @@ func listFailures(
 			}
 			message := strings.Join(outputs, "")
 			title := fmt.Sprintf("%s: %s failed", trimPkg(test.pkg), test.name)
-			if err := f(ctx, title, test.pkg, test.name, message, authorEmail); err != nil {
+			if err := fileIssue(ctx, title, test.pkg, test.name, message, authorEmail); err != nil {
 				return errors.Wrap(err, "failed to post issue")
 			}
 		}
@@ -390,7 +391,7 @@ func listFailures(
 			}
 			title := fmt.Sprintf("%s: %s timed out", trimPkg(timedOutCulprit.pkg), timedOutCulprit.name)
 			log.Printf("timeout culprit found: %s\n", timedOutCulprit.name)
-			if err := f(ctx, title, timedOutCulprit.pkg, timedOutCulprit.name, report, authorEmail); err != nil {
+			if err := fileIssue(ctx, title, timedOutCulprit.pkg, timedOutCulprit.name, report, authorEmail); err != nil {
 				return errors.Wrap(err, "failed to post issue")
 			}
 		} else {
@@ -400,13 +401,12 @@ func listFailures(
 			}
 			trimmedPkgName := trimPkg(packageName)
 			title := fmt.Sprintf("%s: package timed out", trimmedPkgName)
-			// Andrei gets these reports for now, but don't think I'll fix anything
-			// you fools.
-			// TODO(andrei): Figure out how to assign to the on-call engineer. Maybe
-			// get their name from the Slack channel?
+			// TODO(irfansharif): These are assigned to nobody given our lack of
+			// a story around #51653. It'd be nice to be able to go from pkg
+			// name to team-name, and be able to assign to a specific team.
 			log.Printf("timeout culprit not found\n")
-			if err := f(
-				ctx, title, packageName, "(unknown)" /* testName */, report, "andreimatei1@gmail.com",
+			if err := fileIssue(
+				ctx, title, packageName, "(unknown)" /* testName */, report, "",
 			); err != nil {
 				return errors.Wrap(err, "failed to post issue")
 			}

--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -508,7 +508,12 @@ type PostRequest struct {
 	// A link to the test artifacts. If empty, defaults to a link constructed
 	// from the TeamCity env vars (if available).
 	Artifacts,
-	// The email of the author, used to determine who to assign the issue to.
+	// The email of the author, used to determine which team/person to assign
+	// the issue to.
+	//
+	// TODO(irfansharif): We should re-think this, and our general approach to
+	// issue assignment, and move away from assigning individual authors.
+	// #51653.
 	AuthorEmail string
 	// Additional labels that will be added to the issue. They will be created
 	// as necessary (as a side effect of creating an issue with them). An

--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -233,6 +233,8 @@ type poster struct {
 		opts *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error)
 	listMilestones func(ctx context.Context, owner string, repo string,
 		opt *github.MilestoneListOptions) ([]*github.Milestone, *github.Response, error)
+	createProjectCard func(ctx context.Context, columnID int64,
+		opt *github.ProjectCardOptions) (*github.ProjectCard, *github.Response, error)
 	getLatestTag func() (string, error)
 }
 
@@ -248,12 +250,13 @@ func newPoster() *poster {
 	)))
 
 	return &poster{
-		createIssue:    client.Issues.Create,
-		searchIssues:   client.Search.Issues,
-		createComment:  client.Issues.CreateComment,
-		listCommits:    client.Repositories.ListCommits,
-		listMilestones: client.Issues.ListMilestones,
-		getLatestTag:   getLatestTag,
+		createIssue:       client.Issues.Create,
+		searchIssues:      client.Search.Issues,
+		createComment:     client.Issues.CreateComment,
+		listCommits:       client.Repositories.ListCommits,
+		listMilestones:    client.Issues.ListMilestones,
+		createProjectCard: client.Projects.CreateProjectCard,
+		getLatestTag:      getLatestTag,
 	}
 }
 
@@ -416,9 +419,21 @@ func (p *poster) post(ctx context.Context, req PostRequest) error {
 			Assignee:  &assignee,
 			Milestone: p.milestone,
 		}
-		if _, _, err := p.createIssue(ctx, githubUser, githubRepo, &issueRequest); err != nil {
+		issue, _, err := p.createIssue(ctx, githubUser, githubRepo, &issueRequest)
+		if err != nil {
 			return errors.Wrapf(err, "failed to create GitHub issue %s",
 				github.Stringify(issueRequest))
+		}
+
+		if req.ProjectColumnID != 0 {
+			_, _, err := p.createProjectCard(ctx, int64(req.ProjectColumnID), &github.ProjectCardOptions{
+				ContentID:   *issue.ID,
+				ContentType: "Issue",
+			})
+			if err != nil {
+				return errors.Wrapf(err, "failed to add GitHub issue %s to project column %d",
+					*issue.Title, req.ProjectColumnID)
+			}
 		}
 	} else {
 		comment := github.IssueComment{Body: &body}
@@ -519,6 +534,10 @@ type PostRequest struct {
 	// as necessary (as a side effect of creating an issue with them). An
 	// existing issue may be adopted even if it does not have these labels.
 	ExtraLabels []string
+
+	// ProjectColumnID is the id of the GitHub project column to add the issue to,
+	// or 0 if none.
+	ProjectColumnID int
 }
 
 // Post either creates a new issue for a failed test, or posts a comment to an

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -512,7 +512,7 @@ func registerCDC(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("cdc/tpcc-1000/rangefeed=%t", useRangeFeed),
-		Owner:      `cdc`,
+		Owner:      OwnerCDC,
 		MinVersion: "v2.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -528,7 +528,7 @@ func registerCDC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("cdc/initial-scan/rangefeed=%t", useRangeFeed),
-		Owner:      `cdc`,
+		Owner:      OwnerCDC,
 		MinVersion: "v2.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -545,7 +545,7 @@ func registerCDC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:  "cdc/poller/rangefeed=false",
-		Owner: `cdc`,
+		Owner: OwnerCDC,
 		// When testing a 2.1 binary, we use the poller for all the other tests
 		// and this is close enough to cdc/tpcc-1000 test to be redundant, so
 		// skip it.

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -17,8 +17,6 @@ import (
 	"io"
 	// For the debug http handlers.
 	_ "net/http/pprof"
-	"os/exec"
-	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -454,39 +452,6 @@ func teamCityEscape(s string) string {
 
 func teamCityNameEscape(name string) string {
 	return strings.Replace(name, ",", "_", -1)
-}
-
-// getAuthorEmail retrieves the author of a line of code. Returns the empty
-// string if the author cannot be determined. Some test tags override this
-// behavior and have a hardcoded author email.
-func getAuthorEmail(tags []string, file string, line int) string {
-	for _, tag := range tags {
-		if tag == `orm` || tag == `driver` {
-			return `rafi@cockroachlabs.com`
-		}
-	}
-	const repo = "github.com/cockroachdb/cockroach/"
-	i := strings.Index(file, repo)
-	if i == -1 {
-		return ""
-	}
-	file = file[i+len(repo):]
-
-	cmd := exec.Command(`/bin/bash`, `-c`,
-		fmt.Sprintf(`git blame --porcelain -L%d,+1 $(git rev-parse --show-toplevel)/%s | grep author-mail`,
-			line, file))
-	// This command returns output such as:
-	// author-mail <jordan@cockroachlabs.com>
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return ""
-	}
-	re := regexp.MustCompile("author-mail <(.*)>")
-	matches := re.FindSubmatch(out)
-	if matches == nil {
-		return ""
-	}
-	return string(matches[1])
 }
 
 type testWithCount struct {

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -44,19 +44,50 @@ const (
 type OwnerMetadata struct {
 	SlackRoom    string
 	ContactEmail string
+	// TriageColumnID is the column id of the project column the team uses to
+	// triage issues. Unfortunately, there appears to be no way to retrieve this
+	// programmatically from the API.
+	//
+	// To find the triage column for a project, run the following curl command:
+	// curl -u yourusername:githubaccesstoken -H "Accept: application/vnd.githubinertia-preview+json" \
+	// https://api.github.com/repos/cockroachdb/cockroach/projects
+	//
+	// Then, for the project you care about, curl its columns URL, which looks
+	// like this:
+	// https://api.github.com/projects/3842382/columns
+	//
+	// Find the triage column you want, and pick its ID field.
+	TriageColumnID int
 }
 
 // roachtestOwners maps an owner in code (as specified on a roachtest spec) to
 // metadata used for github issue posting/slack rooms, etc.
 var roachtestOwners = map[Owner]OwnerMetadata{
-	OwnerAppDev:       {SlackRoom: `app-dev`, ContactEmail: `rafi@cockroachlabs.com`},
-	OwnerBulkIO:       {SlackRoom: `bulk-io`, ContactEmail: `david@cockroachlabs.com`},
-	OwnerCDC:          {SlackRoom: `cdc`, ContactEmail: `ajwerner@cockroachlabs.com`},
-	OwnerKV:           {SlackRoom: `kv`, ContactEmail: `andrei@cockroachlabs.com`},
-	OwnerPartitioning: {SlackRoom: `partitioning`, ContactEmail: `andrei@cockroachlabs.com`},
-	OwnerSQLExec:      {SlackRoom: `sql-execution-team`, ContactEmail: `alfonso@cockroachlabs.com`},
-	OwnerSQLSchema:    {SlackRoom: `sql-schema`, ContactEmail: `lucy@cockroachlabs.com`},
-	OwnerStorage:      {SlackRoom: `storage`, ContactEmail: `peter@cockroachlabs.com`},
+	OwnerAppDev: {SlackRoom: `app-dev`, ContactEmail: `rafi@cockroachlabs.com`,
+		TriageColumnID: 8532151,
+	},
+	OwnerBulkIO: {SlackRoom: `bulk-io`, ContactEmail: `david@cockroachlabs.com`,
+		TriageColumnID: 3097123,
+	},
+	OwnerCDC: {SlackRoom: `cdc`, ContactEmail: `ajwerner@cockroachlabs.com`,
+		TriageColumnID: 3570120,
+	},
+	OwnerKV: {SlackRoom: `kv`, ContactEmail: `andrei@cockroachlabs.com`,
+		TriageColumnID: 3550674,
+	},
+	OwnerPartitioning: {SlackRoom: `partitioning`, ContactEmail: `andrei@cockroachlabs.com`,
+		// Partitioning issues get sent to the KV triage column for now.
+		TriageColumnID: 3550674,
+	},
+	OwnerSQLExec: {SlackRoom: `sql-execution-team`, ContactEmail: `alfonso@cockroachlabs.com`,
+		TriageColumnID: 6837155,
+	},
+	OwnerSQLSchema: {SlackRoom: `sql-schema`, ContactEmail: `lucy@cockroachlabs.com`,
+		TriageColumnID: 8946818,
+	},
+	OwnerStorage: {SlackRoom: `storage`, ContactEmail: `peter@cockroachlabs.com`,
+		TriageColumnID: 6668367,
+	},
 	// Only for use in roachtest package unittests.
 	`unittest`: {},
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -628,10 +628,10 @@ func (r *testRunner) runTest(
 			shout(ctx, l, stdout, "--- FAIL: %s (%s)\n%s", t.Name(), durationStr, output)
 			// NB: check NodeCount > 0 to avoid posting issues from this pkg's unit tests.
 			if issues.CanPost() && t.spec.Run != nil && t.spec.Cluster.NodeCount > 0 {
-				// We're eliding an assignee for roachtests and instead using
-				// the ownership tags to generate a label to be filtered through
-				// (#51653).
-				ownershipLabel := fmt.Sprintf("A-%s-roachtest", t.spec.Owner)
+				projectColumnID := 0
+				if info, ok := roachtestOwners[t.spec.Owner]; ok {
+					projectColumnID = info.TriageColumnID
+				}
 
 				branch := "<unknown branch>"
 				if b := os.Getenv("TC_BUILD_BRANCH"); b != "" {
@@ -653,7 +653,8 @@ func (r *testRunner) runTest(
 					// Issues posted from roachtest are identifiable as such and
 					// they are also release blockers (this label may be removed
 					// by a human upon closer investigation).
-					ExtraLabels: []string{"O-roachtest", "release-blocker", ownershipLabel},
+					ExtraLabels:     []string{"O-roachtest", "release-blocker"},
+					ProjectColumnID: projectColumnID,
 				}
 				if err := issues.Post(
 					context.Background(),


### PR DESCRIPTION
Touches #51653. We've been spamming Andrei because of his refactor of everything related to roach{test/prod}, which makes it difficult to disambiguate which issues should actually be assigned to him vs. not. We replace roachtest assignment with new labels instead that hopefully are a bit more useful going forward. Unit test flakes still default to using `git blame` style ownership, but that's a yak we can shave elsewhere.

Release note: None

