### PR TITLE
sql: drop indexes that reference dropped columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -339,7 +339,7 @@ statement ok
 ALTER TABLE t ADD COLUMN g INT UNIQUE
 
 statement ok
-CREATE TABLE o (gf INT REFERENCES t (g), h INT, i INT, INDEX ii (i) STORING(h))
+CREATE TABLE o (gf INT REFERENCES t (g), h INT, i INT, INDEX oi (i), INDEX oh (h), INDEX oih (i) STORING (h))
 
 statement error "t_g_key" is referenced by foreign key from table "o"
 ALTER TABLE t DROP COLUMN g
@@ -347,11 +347,18 @@ ALTER TABLE t DROP COLUMN g
 statement ok
 ALTER TABLE t DROP COLUMN g CASCADE
 
-statement error column "h" is referenced by existing index "ii"
+# Dropping columns that are indexed or stored in indexes drops those indexes
+# too.
+statement ok
 ALTER TABLE o DROP COLUMN h
 
-statement ok
-ALTER TABLE o DROP COLUMN h CASCADE
+query TTBITTBB colnames
+SHOW INDEXES FROM o
+----
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
+o           primary     false       1             rowid        ASC        false    false
+o           oi          true        1             i            ASC        false    false
+o           oi          true        2             rowid        ASC        false    true
 
 statement ok
 ALTER TABLE t ADD f INT CHECK (f > 1)


### PR DESCRIPTION
Previously, dropping a column would fail if an index included the
dropped column alongside other columns. It would only succeed and remove
the dependent indexes if the `CASCADE` option was provided.

This commit disregards the `CASCADE` option when considering columns
referenced in table indexes. This matches Postgres's behavior. The
`CASCADE` option is only used signifying cascading removal of objects
outside the table, such as foreign key references or views.

From Postgres's [ALTER TABLE
docs](https://www.postgresql.org/docs/12/sql-altertable.html):

> DROP COLUMN [ IF EXISTS ]
>
> This form drops a column from a table. Indexes and table constraints
> involving the column will be automatically dropped as well.
> [...]
> You will need to say CASCADE if anything outside the table depends on
> the column, for example, foreign key references or views.

Release note (sql change): Dropping a column always drops all indexes
that index the column. It is no longer necessary to provide the CASCADE
option.