### PR TITLE
sql: drop partial indexes with predicates that reference drop columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -178,6 +178,31 @@ t7  CREATE TABLE public.t7 (
     FAMILY "primary" (b, rowid)
 )
 
+#### Dropping a column referenced in the predicate drops the index.
+
+statement ok
+CREATE TABLE t8 (
+    a INT,
+    b INT,
+    c STRING,
+    INDEX (a) WHERE b > 0,
+    INDEX (a) WHERE c = 'foo',
+    FAMILY (a, b, c)
+)
+
+statement ok
+ALTER TABLE t8 DROP COLUMN c
+
+query TT
+SHOW CREATE TABLE t8
+----
+t8  CREATE TABLE public.t8 (
+    a INT8 NULL,
+    b INT8 NULL,
+    INDEX t8_a_idx (a ASC) WHERE b > 0:::INT8,
+    FAMILY fam_0_a_b_c_rowid (a, b, rowid)
+)
+
 #### CREATE TABLE LIKE ... INCLUDING INDEXES copies partial index predicate
 #### expressions to the new table.
 

--- a/pkg/sql/schemaexpr/testutils.go
+++ b/pkg/sql/schemaexpr/testutils.go
@@ -32,7 +32,8 @@ func testTableDesc(
 		cols[i] = sqlbase.ColumnDescriptor{
 			Name: columns[i].name,
 			Type: columns[i].typ,
-			ID:   sqlbase.ColumnID(i),
+			// Column IDs start at 1 to mimic "real" table descriptors.
+			ID: sqlbase.ColumnID(i + 1),
 		}
 	}
 
@@ -43,7 +44,7 @@ func testTableDesc(
 				Column: &sqlbase.ColumnDescriptor{
 					Name: mutationColumns[i].name,
 					Type: mutationColumns[i].typ,
-					ID:   sqlbase.ColumnID(len(columns) + i),
+					ID:   sqlbase.ColumnID(len(columns) + i + 1),
 				},
 			},
 			Direction: sqlbase.DescriptorMutation_ADD,


### PR DESCRIPTION
This commit updates the behavior of `ALTER TABLE ... DROP COLUMN` to
drop partial indexes with predicates that reference the column being
dropped.

For example:

    CREATE TABLE t (a INT, b INT, INDEX i (a) WHERE b > 1)
    ALTER TABLE t DROP COLUMN b

Index `i` will no longer exist on table `t`.

Fixes #51082

Release note: None