### PR TITLE
opt: disable zigzag joins when system columns are requested

### DIFF
--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -202,6 +202,18 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 		if len(t.LeftEqCols) != len(t.RightEqCols) {
 			panic(errors.AssertionFailedf("zigzag join with mismatching eq columns"))
 		}
+		meta := m.Metadata()
+		left, right := meta.Table(t.LeftTable), meta.Table(t.RightTable)
+		for i := 0; i < left.ColumnCount(); i++ {
+			if cat.IsSystemColumn(left, i) && t.Cols.Contains(t.LeftTable.ColumnID(i)) {
+				panic(errors.AssertionFailedf("zigzag join should not contain system column"))
+			}
+		}
+		for i := 0; i < right.ColumnCount(); i++ {
+			if cat.IsSystemColumn(right, i) && t.Cols.Contains(t.RightTable.ColumnID(i)) {
+				panic(errors.AssertionFailedf("zigzag join should not contain system column"))
+			}
+		}
 
 	case *AggDistinctExpr:
 		if t.Input.Op() == opt.AggFilterOp {

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -2181,6 +2181,18 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 		return
 	}
 
+	// Zigzag joins aren't currently equipped to produce system columns, so
+	// don't generate any if some system columns are requested.
+	foundSystemCol := false
+	scanPrivate.Cols.ForEach(func(colID opt.ColumnID) {
+		if cat.IsSystemColumn(tab, scanPrivate.Table.ColumnOrdinal(colID)) {
+			foundSystemCol = true
+		}
+	})
+	if foundSystemCol {
+		return
+	}
+
 	// Iterate through indexes, looking for those prefixed with fixedEq cols.
 	// Efficiently finding a set of indexes that make the most efficient zigzag
 	// join, with no limit on the number of indexes selected, is an instance of


### PR DESCRIPTION
Fixes #51664.

The zigzagjoiner isn't currently equipped to produce system columns, so
disable generation of zigzagjoin memo entries if any system columns are
requested.

Release note: None