### PR TITLE
roachtest: bump MinVersion for decommission/mixed-versions

### DIFF
--- a/pkg/cmd/roachtest/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/mixed_version_decommission.go
@@ -278,7 +278,7 @@ func registerDecommissionMixedVersion(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       "decommission/mixed-versions",
 		Owner:      OwnerKV,
-		MinVersion: "v20.1.0",
+		MinVersion: "v20.2.0",
 		Cluster:    makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runDecommissionMixedVersions(ctx, t, c, r.buildVersion)


### PR DESCRIPTION
Noticed it debugging #51535, it was written to target 20.2 code so
should reflect as much.

Release note: None