### PR TITLE
kvserver: use raft.BasicStatus in maybeCampaignOnWakeLocked

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1442,7 +1442,7 @@ func shouldCampaignOnWake(
 	leaseStatus kvserverpb.LeaseStatus,
 	lease roachpb.Lease,
 	storeID roachpb.StoreID,
-	raftStatus raft.Status,
+	raftStatus raft.BasicStatus,
 ) bool {
 	// When waking up a range, campaign unless we know that another
 	// node holds a valid lease (this is most important after a split,
@@ -1470,7 +1470,7 @@ func (r *Replica) maybeCampaignOnWakeLocked(ctx context.Context) {
 	}
 
 	leaseStatus := r.leaseStatus(ctx, *r.mu.state.Lease, r.store.Clock().Now(), r.mu.minLeaseProposedTS)
-	raftStatus := r.mu.internalRaftGroup.Status()
+	raftStatus := r.mu.internalRaftGroup.BasicStatus()
 	if shouldCampaignOnWake(leaseStatus, *r.mu.state.Lease, r.store.StoreID(), raftStatus) {
 		log.VEventf(ctx, 3, "campaigning")
 		if err := r.mu.internalRaftGroup.Campaign(); err != nil {

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -138,7 +138,7 @@ func (r *Replica) unquiesceAndWakeLeaderLocked() {
 // replicas if the remaining live replicas all meet the quiesce
 // requirements. When a node considered non-live becomes live, the
 // node liveness instance invokes a callback which causes all nodes to
-// wakes up any ranges containing replicas owned by the newly-live
+// wake up any ranges containing replicas owned by the newly-live
 // node, allowing the out-of-date replicas to be brought back up to date.
 // If livenessMap is nil, liveness data will not be used, meaning no range
 // will quiesce if any replicas are behind, whether or not they are live.

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10404,35 +10404,35 @@ func TestReplicaShouldCampaignOnWake(t *testing.T) {
 		},
 	}
 
-	followerWithoutLeader := raft.Status{BasicStatus: raft.BasicStatus{
+	followerWithoutLeader := raft.BasicStatus{
 		SoftState: raft.SoftState{
 			RaftState: raft.StateFollower,
 			Lead:      0,
 		},
-	}}
-	followerWithLeader := raft.Status{BasicStatus: raft.BasicStatus{
+	}
+	followerWithLeader := raft.BasicStatus{
 		SoftState: raft.SoftState{
 			RaftState: raft.StateFollower,
 			Lead:      1,
 		},
-	}}
-	candidate := raft.Status{BasicStatus: raft.BasicStatus{
+	}
+	candidate := raft.BasicStatus{
 		SoftState: raft.SoftState{
 			RaftState: raft.StateCandidate,
 			Lead:      0,
 		},
-	}}
-	leader := raft.Status{BasicStatus: raft.BasicStatus{
+	}
+	leader := raft.BasicStatus{
 		SoftState: raft.SoftState{
 			RaftState: raft.StateLeader,
 			Lead:      1,
 		},
-	}}
+	}
 
 	tests := []struct {
 		leaseStatus kvserverpb.LeaseStatus
 		lease       roachpb.Lease
-		raftStatus  raft.Status
+		raftStatus  raft.BasicStatus
 		exp         bool
 	}{
 		{kvserverpb.LeaseStatus{State: kvserverpb.LeaseState_VALID}, myLease, followerWithoutLeader, true},


### PR DESCRIPTION
Small improvement that avoids a few heap allocations.