### PR TITLE
sql: ensure that no NULL gets written to system.users.hashedPassword

### DIFF
--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -145,6 +145,15 @@ func (n *alterRoleNode) startExec(params runParams) error {
 			}
 		}
 
+		if hashedPassword == nil {
+			// v20.1 and below crash during authentication if they find a NULL value
+			// in system.users.hashedPassword. v20.2 and above handle this correctly,
+			// but we need to maintain mixed version compatibility for at least one
+			// release.
+			// TODO(nvanbenschoten): remove this for v21.1.
+			hashedPassword = []byte{}
+		}
+
 		// Updating PASSWORD is a special case since PASSWORD lives in system.users
 		// while the rest of the role options lives in system.role_options.
 		_, err = params.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(


### PR DESCRIPTION
My latest change in this area broke Nathan's previous fix.
This commit reverts it.

Release note: None