### PR TITLE
colflow,colexec: fixes around cancellation

### DIFF
--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -12,7 +12,6 @@ package colexec
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -21,7 +20,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -222,8 +223,14 @@ func (s *ParallelUnorderedSynchronizer) init(ctx context.Context) {
 				s.externalWaitGroup.Done()
 			}()
 			sendErr := func(err error) {
-				if strings.Contains(err.Error(), context.Canceled.Error()) && atomic.LoadInt32(&internalCancellation) == 1 {
-					// Don't propagate an internal cancellation error.
+				ctxCanceled := errors.Is(err, context.Canceled)
+				grpcCtxCanceled := grpcutil.IsContextCanceled(err)
+				queryCanceled := errors.Is(err, sqlbase.QueryCanceledError)
+				if atomic.LoadInt32(&internalCancellation) == 1 && (ctxCanceled || grpcCtxCanceled || queryCanceled) {
+					// If the synchronizer performed the internal cancellation,
+					// we need to swallow context cancellation and "query
+					// canceled" errors since they could occur as part of
+					// "graceful" shutdown of synchronizer's inputs.
 					return
 				}
 				select {

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -266,6 +266,12 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 				i.close()
 				return coldata.ZeroBatch
 			}
+			// Note that here err can be stream's context cancellation. If it
+			// was caused by the internal cancellation of the parallel
+			// unordered synchronizer, it'll get swallowed by the synchronizer
+			// goroutine. Regardless of the cause we want to propagate such
+			// error in all cases so that the caller could decide on how to
+			// handle it.
 			i.errCh <- err
 			colexecerror.ExpectedError(err)
 		}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -647,8 +647,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 	diskMon, diskAccounts := s.createDiskAccounts(ctx, flowCtx, mmName, len(output.Streams))
 	router, outputs := colexec.NewHashRouter(allocators, input, outputTyps, output.HashColumns, limit, s.diskQueueCfg, s.fdSemaphore, diskAccounts, metadataSourcesQueue, toClose)
 	runRouter := func(ctx context.Context, _ context.CancelFunc) {
-		logtags.AddTag(ctx, "hashRouterID", mmName)
-		router.Run(ctx)
+		router.Run(logtags.AddTag(ctx, "hashRouterID", strings.Join(streamIDs, ",")))
 	}
 	s.accumulateAsyncComponent(runRouter)
 

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -860,11 +860,6 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 				if testCase.skip != "" {
 					skip.IgnoreLint(t, testCase.skip)
 				}
-				if vectorize {
-					// TODO(asubiotto): figure out why this race occurs.
-					skip.WithIssue(t, 51647, "vectorize option is temporarily skipped because there appears to be "+
-						"a race between the expected error and the context cancellation error")
-				}
 				func() {
 					_, err := defaultConn.Exec(fmt.Sprintf("set vectorize=%s", vectorizeOpt))
 					require.NoError(t, err)

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -54,6 +54,15 @@ func IsTimeout(err error) bool {
 	return false
 }
 
+// IsContextCanceled returns true if err's Cause is an error produced by gRPC
+// on context cancellation.
+func IsContextCanceled(err error) bool {
+	if s, ok := status.FromError(errors.UnwrapAll(err)); ok {
+		return s.Code() == codes.Canceled && s.Message() == context.Canceled.Error()
+	}
+	return false
+}
+
 // IsClosedConnection returns true if err's Cause is an error produced by gRPC
 // on closed connections.
 func IsClosedConnection(err error) bool {


### PR DESCRIPTION
**colflow: fix cancellation of the outbox**

Previously, we were passing in the cancellation function of the flow's
context to each outbox which would result in too early of a cancellation
whenever any outboxes encounters a stream error. This is now fixed by
deriving a separate child context with separate cancellation function
for each outbox and only canceling the flow's context when the last
outbox exits.

Release note (bug fix): CockroachDB could previously encounter benign
internal "context canceled" errors when queries were executed by the
vectorized engine.

**colexec: swallow "query canceled" in synchronizer with internal cancellation**

Parallel unordered synchronizer shuts down all of its input subtrees by
canceling the context which those inputs are listening on. This results
in an "internal cancellation", and the error handling is different in
such case in the synchronizer - it needs to swallow "context canceled"
errors because, well, it was the one that canceled it, so such error is
expected part of the "graceful" shutdown. However, we also need to
swallow "query canceled" errors because `CancelChecker` operator might
be listening on `ctx.Done` channel and will emit query cancellation
error when it sees that the context is canceled (so "query canceled"
error is also expected as part of the graceful shutdown). Previously, we
weren't swallowing it, and we do.

Addresses: #51647.

Release note: None