### PR TITLE
sql,descs: use the desc.Collection to access types during planning

### DIFF
--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -114,14 +114,13 @@ func (p *planner) renameType(params runParams, n *alterTypeNode, newName string)
 	if err != nil {
 		return err
 	}
-	// TODO (rohany): This should use a method on the desc collection instead.
-	arrayDesc, err := sqlbase.GetTypeDescFromID(params.ctx, p.txn, p.ExecCfg().Codec, n.desc.ArrayTypeID)
+	arrayDesc, err := p.Descriptors().GetMutableTypeVersionByID(params.ctx, p.txn, n.desc.ArrayTypeID)
 	if err != nil {
 		return err
 	}
 	if err := p.performRenameTypeDesc(
 		params.ctx,
-		sqlbase.NewMutableExistingTypeDescriptor(*arrayDesc.TypeDesc()),
+		arrayDesc,
 		newArrayName,
 		tree.AsStringWithFQNames(n.n, params.Ann()),
 	); err != nil {

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -25,6 +25,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/database"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -538,14 +540,25 @@ func (tc *Collection) getMutableDescriptorByID(
 func (tc *Collection) hydrateTypesInTableDesc(
 	ctx context.Context, txn *kv.Txn, desc sqlbase.TableDescriptorInterface,
 ) (sqlbase.TableDescriptorInterface, error) {
-	getType := func(ctx context.Context, id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
-		// TODO (rohany): Use the collection API's here.
-		return resolver.ResolveTypeDescByID(ctx, txn, tc.codec(), id, tree.ObjectLookupFlags{})
-	}
 	switch t := desc.(type) {
 	case *sqlbase.MutableTableDescriptor:
 		// It is safe to hydrate directly into MutableTableDescriptor since it is
-		// not shared.
+		// not shared. When hydrating mutable descriptors, use the mutable access
+		// method to access types.
+		getType := func(ctx context.Context, id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
+			desc, err := tc.GetMutableTypeVersionByID(ctx, txn, id)
+			if err != nil {
+				return nil, nil, err
+			}
+			// TODO (lucy): This database access should go through the collection.
+			dbDesc, err := sqlbase.GetDatabaseDescFromID(ctx, txn, tc.codec(), desc.ParentID)
+			if err != nil {
+				return nil, nil, err
+			}
+			name := tree.MakeNewQualifiedTypeName(dbDesc.Name, tree.PublicSchema, desc.Name)
+			return &name, desc, nil
+		}
+
 		return desc, sqlbase.HydrateTypesInTableDescriptor(ctx, t.TableDesc(), sqlbase.TypeLookupFunc(getType))
 	case *sqlbase.ImmutableTableDescriptor:
 		// ImmutableTableDescriptors need to be copied before hydration, because
@@ -559,6 +572,20 @@ func (tc *Collection) hydrateTypesInTableDesc(
 		//  hydrated table descriptors and potentially return without having to
 		//  make a copy. However, we could avoid hitting the cache if any of the
 		//  user defined types have been modified in this transaction.
+
+		getType := func(ctx context.Context, id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
+			desc, err := tc.GetTypeVersionByID(ctx, txn, id, tree.ObjectLookupFlagsWithRequired())
+			if err != nil {
+				return nil, nil, err
+			}
+			// TODO (lucy): This database access should go through the collection.
+			dbDesc, err := sqlbase.GetDatabaseDescFromID(ctx, txn, tc.codec(), desc.ParentID)
+			if err != nil {
+				return nil, nil, err
+			}
+			name := tree.MakeNewQualifiedTypeName(dbDesc.Name, tree.PublicSchema, desc.Name)
+			return &name, desc, nil
+		}
 
 		// Make a copy of the underlying descriptor before hydration.
 		descBase := protoutil.Clone(t.TableDesc()).(*sqlbase.TableDescriptor)
@@ -584,12 +611,12 @@ func (tc *Collection) ReleaseSpecifiedLeases(ctx context.Context, descs []lease.
 	})
 
 	filteredLeases := leasedDescs[:0] // will store the remaining leases
-	tablesToConsider := descs
+	descsToConsider := descs
 	shouldRelease := func(id sqlbase.ID) (found bool) {
-		for len(tablesToConsider) > 0 && tablesToConsider[0].ID < id {
-			tablesToConsider = tablesToConsider[1:]
+		for len(descsToConsider) > 0 && descsToConsider[0].ID < id {
+			descsToConsider = descsToConsider[1:]
 		}
-		return len(tablesToConsider) > 0 && tablesToConsider[0].ID == id
+		return len(descsToConsider) > 0 && descsToConsider[0].ID == id
 	}
 	for _, l := range leasedDescs {
 		if !shouldRelease(l.GetID()) {
@@ -727,6 +754,78 @@ func (tc *Collection) GetUncommittedTables() (tables []*sqlbase.ImmutableTableDe
 		}
 	}
 	return tables
+}
+
+// User defined type accessors.
+
+// GetMutableTypeDescriptor is the equivalent of GetMutableTableDescriptor but
+// for accessing types.
+func (tc *Collection) GetMutableTypeDescriptor(
+	ctx context.Context, txn *kv.Txn, tn *tree.TypeName, flags tree.ObjectLookupFlags,
+) (*sqlbase.MutableTypeDescriptor, error) {
+	desc, err := tc.getMutableObjectDescriptor(ctx, txn, tn, flags)
+	if err != nil {
+		return nil, err
+	}
+	mutDesc, ok := desc.(*sqlbase.MutableTypeDescriptor)
+	if !ok {
+		if flags.Required {
+			return nil, sqlbase.NewUndefinedTypeError(tn)
+		}
+		return nil, nil
+	}
+	return mutDesc, nil
+}
+
+// GetMutableTypeVersionByID is the equivalent of GetMutableTableDescriptorByID
+// but for accessing types.
+func (tc *Collection) GetMutableTypeVersionByID(
+	ctx context.Context, txn *kv.Txn, typeID sqlbase.ID,
+) (*sqlbase.MutableTypeDescriptor, error) {
+	desc, err := tc.getMutableDescriptorByID(ctx, typeID, txn)
+	if err != nil {
+		return nil, err
+	}
+	return desc.(*sqlbase.MutableTypeDescriptor), nil
+}
+
+// GetTypeVersion is the equivalent of GetTableVersion but for accessing types.
+func (tc *Collection) GetTypeVersion(
+	ctx context.Context, txn *kv.Txn, tn *tree.TypeName, flags tree.ObjectLookupFlags,
+) (*sqlbase.ImmutableTypeDescriptor, error) {
+	desc, err := tc.getObjectVersion(ctx, txn, tn, flags)
+	if err != nil {
+		return nil, err
+	}
+	typ, ok := desc.(*sqlbase.ImmutableTypeDescriptor)
+	if !ok {
+		if flags.Required {
+			return nil, sqlbase.NewUndefinedTypeError(tn)
+		}
+		return nil, nil
+	}
+	return typ, nil
+}
+
+// GetTypeVersionByID is the equivalent of GetTableVersionByID but for accessing
+// types.
+func (tc *Collection) GetTypeVersionByID(
+	ctx context.Context, txn *kv.Txn, typeID sqlbase.ID, flags tree.ObjectLookupFlags,
+) (*sqlbase.ImmutableTypeDescriptor, error) {
+	desc, err := tc.getDescriptorVersionByID(ctx, txn, typeID, flags)
+	if err != nil {
+		if errors.Is(err, sqlbase.ErrDescriptorNotFound) {
+			return nil, pgerror.Newf(
+				pgcode.UndefinedObject, "type with ID %d does not exist", typeID)
+		}
+		return nil, err
+	}
+	typ, ok := desc.(*sqlbase.ImmutableTypeDescriptor)
+	if !ok {
+		return nil, pgerror.Newf(
+			pgcode.UndefinedObject, "type with ID %d does not exist", typeID)
+	}
+	return typ, nil
 }
 
 // DBAction is an operation to an uncommitted database.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -148,8 +148,19 @@ func (p *planner) CommonLookupFlags(required bool) tree.CommonLookupFlags {
 func (p *planner) GetTypeDescriptor(
 	ctx context.Context, id sqlbase.ID,
 ) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
-	// TODO (rohany): This should go through the descs.Collection.
-	return resolver.ResolveTypeDescByID(ctx, p.txn, p.ExecCfg().Codec, id, tree.ObjectLookupFlags{})
+	desc, err := p.Descriptors().GetTypeVersionByID(ctx, p.txn, id, tree.ObjectLookupFlagsWithRequired())
+	if err != nil {
+		return nil, nil, err
+	}
+	// TODO (lucy): This database access should go through the collection.
+	//  When I try to use the DatabaseCache() here, a nil pointer deref occurs.
+	dbDesc, err := sqlbase.GetDatabaseDescFromID(ctx, p.txn, p.ExecCfg().Codec, desc.ParentID)
+	if err != nil {
+		return nil, nil, err
+	}
+	// TODO (rohany): Update this once user defined schemas exist.
+	name := tree.MakeNewQualifiedTypeName(dbDesc.Name, tree.PublicSchema, desc.Name)
+	return &name, desc, nil
 }
 
 // ResolveType implements the TypeReferenceResolver interface.
@@ -186,15 +197,7 @@ func (p *planner) ResolveType(
 
 // ResolveTypeByID implements the tree.TypeResolver interface.
 func (p *planner) ResolveTypeByID(ctx context.Context, id uint32) (*types.T, error) {
-	name, desc, err := resolver.ResolveTypeDescByID(
-		ctx,
-		p.txn,
-		p.ExecCfg().Codec,
-		sqlbase.ID(id),
-		tree.ObjectLookupFlags{
-			CommonLookupFlags: tree.CommonLookupFlags{Required: true},
-		},
-	)
+	name, desc, err := p.GetTypeDescriptor(ctx, sqlbase.ID(id))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Work for #49261.
Prerequisite for using leased types on remote nodes during a flow.

This commit adds the necessary methods to the desc.Collection for access
of `TypeDescriptor`s and uses those methods in the process of name
resolution during planning.

Release note: None