### PR TITLE
sql: remove gossip dependency from SpanResolver and replicaoracle

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1695,25 +1695,6 @@ func (dg DeprecatedGossip) DeprecatedSystemConfig(issueNo int) *config.SystemCon
 	return g.GetSystemConfig()
 }
 
-// DeprecatedOracleGossip trims down *gossip.Gossip for use in the Oracle.
-//
-// NB: we're trying to get rid of this dep altogether, see:
-// https://github.com/cockroachdb/cockroach/issues/48432
-type DeprecatedOracleGossip interface {
-	// GetNodeDescriptor is used by oracles to order replicas by distance from the
-	// current locality.
-	GetNodeDescriptor(roachpb.NodeID) (*roachpb.NodeDescriptor, error)
-}
-
-// DeprecatedOracleGossip returns an DeprecatedOracleGossip (a Gossip for use with the
-// replicaoracle package).
-//
-// Use of Gossip from within the SQL layer is **deprecated**. Please do not
-// introduce new uses of it.
-func (dg DeprecatedGossip) DeprecatedOracleGossip(issueNo int) DeprecatedOracleGossip {
-	return dg.deprecated(issueNo)
-}
-
 // DeprecatedRegisterSystemConfigChannel calls RegisterSystemConfigChannel on
 // the wrapped Gossip instance.
 //

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -613,6 +613,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		clock:                    clock,
 		runtime:                  runtimeSampler,
 		rpcContext:               rpcContext,
+		nodeDescs:                g,
 		nodeDialer:               nodeDialer,
 		distSender:               distSender,
 		db:                       db,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -596,7 +596,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	sqlServer, err := newSQLServer(ctx, sqlServerArgs{
-		sqlServerOptionalArgs: sqlServerOptionalArgs{
+		sqlServerOptionalKVArgs: sqlServerOptionalKVArgs{
 			statusServer:           serverpb.MakeOptionalStatusServer(sStatus),
 			nodeLiveness:           sqlbase.MakeOptionalNodeLiveness(nodeLiveness),
 			gossip:                 gossip.MakeExposedGossip(g),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -597,12 +597,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	sqlServer, err := newSQLServer(ctx, sqlServerArgs{
 		sqlServerOptionalArgs: sqlServerOptionalArgs{
-			rpcContext:             rpcContext,
-			distSender:             distSender,
 			statusServer:           serverpb.MakeOptionalStatusServer(sStatus),
 			nodeLiveness:           sqlbase.MakeOptionalNodeLiveness(nodeLiveness),
 			gossip:                 gossip.MakeExposedGossip(g),
-			nodeDialer:             nodeDialer,
 			grpcServer:             grpc.Server,
 			recorder:               recorder,
 			nodeIDContainer:        idContainer,
@@ -615,6 +612,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		stopper:                  stopper,
 		clock:                    clock,
 		runtime:                  runtimeSampler,
+		rpcContext:               rpcContext,
+		nodeDialer:               nodeDialer,
+		distSender:               distSender,
 		db:                       db,
 		registry:                 registry,
 		sessionRegistry:          sessionRegistry,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -94,17 +94,6 @@ type sqlServer struct {
 // respective object is available. When it is not, return
 // UnsupportedWithMultiTenancy.
 type sqlServerOptionalArgs struct {
-	// DistSQL uses rpcContext to set up flows. Less centrally, the executor
-	// also uses rpcContext in a number of places to learn whether the server
-	// is running insecure, and to read the cluster name.
-	// TODO(nvanbenschoten): move off this struct.
-	rpcContext *rpc.Context
-
-	// SQL mostly uses the DistSender "wrapped" under a *kv.DB, but SQL also
-	// uses range descriptors and leaseholders, which DistSender maintains,
-	// for debugging and DistSQL planning purposes.
-	// TODO(nvanbenschoten): move off this struct.
-	distSender *kvcoord.DistSender
 	// statusServer gives access to the Status service.
 	statusServer serverpb.OptionalStatusServer
 	// Narrowed down version of *NodeLiveness. Used by jobs and DistSQLPlanner
@@ -113,9 +102,6 @@ type sqlServerOptionalArgs struct {
 	// config, the DistSQL planner, the table statistics cache, the statements
 	// diagnostics registry, and the lease manager.
 	gossip gossip.DeprecatedGossip
-	// Used by DistSQLConfig and DistSQLPlanner.
-	// TODO(nvanbenschoten): move off this struct.
-	nodeDialer *nodedialer.Dialer
 	// To register blob and DistSQL servers.
 	grpcServer *grpc.Server
 	// Used by executorConfig.
@@ -150,6 +136,19 @@ type sqlServerArgs struct {
 	// DistSQLCfg holds on to this to check for node CPU utilization in
 	// samplerProcessor.
 	runtime execinfra.RuntimeStats
+
+	// DistSQL uses rpcContext to set up flows. Less centrally, the executor
+	// also uses rpcContext in a number of places to learn whether the server
+	// is running insecure, and to read the cluster name.
+	rpcContext *rpc.Context
+
+	// Used by DistSQLConfig and DistSQLPlanner.
+	nodeDialer *nodedialer.Dialer
+
+	// SQL mostly uses the DistSender "wrapped" under a *kv.DB, but SQL also
+	// uses range descriptors and leaseholders, which DistSender maintains,
+	// for debugging and DistSQL planning purposes.
+	distSender *kvcoord.DistSender
 
 	// SQL uses KV, both for non-DistSQL and DistSQL execution.
 	db *kv.DB

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -87,13 +87,13 @@ type sqlServer struct {
 	stmtDiagnosticsRegistry *stmtdiagnostics.Registry
 }
 
-// sqlServerOptionalArgs are the arguments supplied to newSQLServer which
-// are only available if the SQL server runs as part of a KV node.
+// sqlServerOptionalKVArgs are the arguments supplied to newSQLServer which are
+// only available if the SQL server runs as part of a KV node.
 //
 // TODO(tbg): give all of these fields a wrapper that can signal whether the
 // respective object is available. When it is not, return
 // UnsupportedWithMultiTenancy.
-type sqlServerOptionalArgs struct {
+type sqlServerOptionalKVArgs struct {
 	// statusServer gives access to the Status service.
 	statusServer serverpb.OptionalStatusServer
 	// Narrowed down version of *NodeLiveness. Used by jobs and DistSQLPlanner
@@ -114,15 +114,17 @@ type sqlServerOptionalArgs struct {
 	// Used by backup/restore.
 	externalStorage        cloud.ExternalStorageFactory
 	externalStorageFromURI cloud.ExternalStorageFromURIFactory
+}
 
-	// TODO(nvanbenschoten): Move to a second "optional" args struct. One for
-	// dependencies that are only available if the SQL server runs NOT as part
-	// of a KV node.
+// sqlServerOptionalTenantArgs are the arguments supplied to newSQLServer which
+// are only available if the SQL server runs as part of a standalone SQL node.
+type sqlServerOptionalTenantArgs struct {
 	tenantProxy kvtenant.Proxy
 }
 
 type sqlServerArgs struct {
-	sqlServerOptionalArgs
+	sqlServerOptionalKVArgs
+	sqlServerOptionalTenantArgs
 
 	*SQLConfig
 	*BaseConfig

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -144,7 +144,10 @@ type sqlServerArgs struct {
 	// is running insecure, and to read the cluster name.
 	rpcContext *rpc.Context
 
-	// Used by DistSQLConfig and DistSQLPlanner.
+	// Used by DistSQLPlanner.
+	nodeDescs kvcoord.NodeDescStore
+
+	// Used by DistSQLPlanner.
 	nodeDialer *nodedialer.Dialer
 
 	// SQL mostly uses the DistSender "wrapped" under a *kv.DB, but SQL also
@@ -415,6 +418,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 			cfg.rpcContext,
 			distSQLServer,
 			cfg.distSender,
+			cfg.nodeDescs,
 			cfg.gossip,
 			cfg.stopper,
 			isLive,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -575,12 +575,9 @@ func makeSQLServerArgs(
 	noStatusServer := serverpb.MakeOptionalStatusServer(nil)
 	return sqlServerArgs{
 		sqlServerOptionalArgs: sqlServerOptionalArgs{
-			rpcContext:   rpcContext,
-			distSender:   ds,
 			statusServer: noStatusServer,
 			nodeLiveness: sqlbase.MakeOptionalNodeLiveness(nil),
 			gossip:       gossip.MakeUnexposedGossip(g),
-			nodeDialer:   nodeDialer,
 			grpcServer:   dummyRPCServer,
 			recorder:     dummyRecorder,
 			isMeta1Leaseholder: func(_ context.Context, timestamp hlc.Timestamp) (bool, error) {
@@ -601,6 +598,9 @@ func makeSQLServerArgs(
 		stopper:                  stopper,
 		clock:                    clock,
 		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),
+		rpcContext:               rpcContext,
+		nodeDialer:               nodeDialer,
+		distSender:               ds,
 		db:                       db,
 		registry:                 registry,
 		sessionRegistry:          sql.NewSessionRegistry(),

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -574,7 +574,7 @@ func makeSQLServerArgs(
 	dummyRPCServer := rpc.NewServer(rpcContext)
 	noStatusServer := serverpb.MakeOptionalStatusServer(nil)
 	return sqlServerArgs{
-		sqlServerOptionalArgs: sqlServerOptionalArgs{
+		sqlServerOptionalKVArgs: sqlServerOptionalKVArgs{
 			statusServer: noStatusServer,
 			nodeLiveness: sqlbase.MakeOptionalNodeLiveness(nil),
 			gossip:       gossip.MakeUnexposedGossip(g),
@@ -591,6 +591,8 @@ func makeSQLServerArgs(
 				uri, user string) (cloud.ExternalStorage, error) {
 				return nil, errors.New("external uri storage is not available to secondary tenants")
 			},
+		},
+		sqlServerOptionalTenantArgs: sqlServerOptionalTenantArgs{
 			tenantProxy: tenantProxy,
 		},
 		SQLConfig:                &sqlCfg,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -601,6 +601,7 @@ func makeSQLServerArgs(
 		clock:                    clock,
 		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),
 		rpcContext:               rpcContext,
+		nodeDescs:                tenantProxy,
 		nodeDialer:               nodeDialer,
 		distSender:               ds,
 		db:                       db,

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -273,6 +273,7 @@ func startConnExecutor(
 				NodeID:         nodeID,
 			}),
 			nil, /* distSender */
+			nil, /* nodeDescs */
 			gw,
 			stopper,
 			func(roachpb.NodeID) (bool, error) { return true, nil }, // everybody is live

--- a/pkg/sql/physicalplan/replicaoracle/oracle_test.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle_test.go
@@ -41,8 +41,8 @@ func TestClosest(t *testing.T) {
 	g, _ := makeGossip(t, stopper)
 	nd, _ := g.GetNodeDescriptor(1)
 	of := NewOracleFactory(ClosestChoice, Config{
-		Gossip:   g,
-		NodeDesc: *nd,
+		NodeDescs: g,
+		NodeDesc:  *nd,
 	})
 	of.(*closestOracle).latencyFunc = func(s string) (time.Duration, bool) {
 		if strings.HasSuffix(s, "2") {

--- a/pkg/sql/physicalplan/span_resolver_test.go
+++ b/pkg/sql/physicalplan/span_resolver_test.go
@@ -87,7 +87,7 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 	lr := physicalplan.NewSpanResolver(
 		s3.Cfg.Settings,
 		s3.DistSenderI().(*kvcoord.DistSender),
-		gossip.MakeExposedGossip(s3.Gossip()),
+		s3.Gossip(),
 		s3.GetNode().Descriptor, nil,
 		replicaoracle.BinPackingChoice)
 
@@ -196,7 +196,7 @@ func TestSpanResolver(t *testing.T) {
 	lr := physicalplan.NewSpanResolver(
 		s.(*server.TestServer).Cfg.Settings,
 		s.DistSenderI().(*kvcoord.DistSender),
-		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		s.GossipI().(*gossip.Gossip),
 		s.(*server.TestServer).GetNode().Descriptor, nil,
 		replicaoracle.BinPackingChoice)
 
@@ -292,7 +292,7 @@ func TestMixedDirections(t *testing.T) {
 	lr := physicalplan.NewSpanResolver(
 		s.(*server.TestServer).Cfg.Settings,
 		s.DistSenderI().(*kvcoord.DistSender),
-		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		s.GossipI().(*gossip.Gossip),
 		s.(*server.TestServer).GetNode().Descriptor,
 		nil,
 		replicaoracle.BinPackingChoice)


### PR DESCRIPTION
Fixes #48432.

This commit uses the new NodeDescStore abstraction to avoid the gossip dependency in DistSQL's SpanResolver and its replicaoracle.Oracle. Using this new generality, it then provides the tenant proxy (pending rename to "connector") to server as this dependencies in SQL-only processes.