### PR TITLE
sql: disable distribution of plans when transaction has modified a type

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -789,7 +789,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 
 	ex.sessionTracing.TracePlanCheckStart(ctx)
 	distributePlan := getPlanDistribution(
-		ctx, planner.execCfg.NodeID, ex.sessionData.DistSQLMode, planner.curPlan.main,
+		ctx, planner, planner.execCfg.NodeID, ex.sessionData.DistSQLMode, planner.curPlan.main,
 	).WillDistribute()
 	ex.sessionTracing.TracePlanCheckEnd(ctx, nil, distributePlan)
 

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -186,6 +186,7 @@ func (p *planner) createArrayType(
 		ParentSchemaID: keys.PublicSchemaID,
 		Kind:           sqlbase.TypeDescriptor_ALIAS,
 		Alias:          types.MakeArray(elemTyp),
+		Version:        1,
 	})
 
 	jobStr := fmt.Sprintf("implicit array type creation for %s", tree.AsStringWithFQNames(n, params.Ann()))
@@ -260,6 +261,7 @@ func (p *planner) createEnum(params runParams, n *tree.CreateType) error {
 		ParentSchemaID: keys.PublicSchemaID,
 		Kind:           sqlbase.TypeDescriptor_ENUM,
 		EnumMembers:    members,
+		Version:        1,
 	})
 
 	// Create the implicit array type for this type before finishing the type.

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -145,6 +145,9 @@ func (p *planner) createDescriptorWithID(
 		if err := mutType.Validate(ctx, p.txn, p.ExecCfg().Codec); err != nil {
 			return err
 		}
+		if err := p.Descriptors().AddUncommittedDescriptor(mutType); err != nil {
+			return err
+		}
 	}
 
 	mutDesc, isTable := descriptor.(*sqlbase.MutableTableDescriptor)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -852,7 +852,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	var distributeSubquery bool
 	if maybeDistribute {
 		distributeSubquery = getPlanDistribution(
-			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, subqueryPlan.plan,
+			ctx, planner, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, subqueryPlan.plan,
 		).WillDistribute()
 	}
 	subqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distributeSubquery)
@@ -1145,7 +1145,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	var distributePostquery bool
 	if maybeDistribute {
 		distributePostquery = getPlanDistribution(
-			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, postqueryPlan,
+			ctx, planner, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, postqueryPlan,
 		).WillDistribute()
 	}
 	postqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distributePostquery)

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -71,6 +71,7 @@ type distSQLExplainable interface {
 // *only* be used in EXPLAIN variants.
 func getPlanDistributionForExplainPurposes(
 	ctx context.Context,
+	p *planner,
 	nodeID *base.SQLIDContainer,
 	distSQLMode sessiondata.DistSQLExecMode,
 	plan planMaybePhysical,
@@ -99,13 +100,13 @@ func getPlanDistributionForExplainPurposes(
 		// for setting up the correct DistSQL infrastructure).
 		return physicalplan.FullyDistributedPlan
 	}
-	return getPlanDistribution(ctx, nodeID, distSQLMode, plan)
+	return getPlanDistribution(ctx, p, nodeID, distSQLMode, plan)
 }
 
 func (n *explainDistSQLNode) startExec(params runParams) error {
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
 	distribution := getPlanDistributionForExplainPurposes(
-		params.ctx, params.extendedEvalCtx.ExecCfg.NodeID,
+		params.ctx, params.p, params.extendedEvalCtx.ExecCfg.NodeID,
 		params.extendedEvalCtx.SessionData.DistSQLMode, n.plan.main,
 	)
 	willDistribute := distribution.WillDistribute()

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -345,7 +345,7 @@ func explainGetDistributedAndVectorized(
 	// special rows.
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
 	distribution = getPlanDistributionForExplainPurposes(
-		params.ctx, params.extendedEvalCtx.ExecCfg.NodeID,
+		params.ctx, params.p, params.extendedEvalCtx.ExecCfg.NodeID,
 		params.extendedEvalCtx.SessionData.DistSQLMode, plan.main,
 	)
 	willDistribute := distribution.WillDistribute()

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -54,7 +54,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	n.run.values = make(tree.Datums, 1)
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
 	distribution := getPlanDistributionForExplainPurposes(
-		params.ctx, params.extendedEvalCtx.ExecCfg.NodeID,
+		params.ctx, params.p, params.extendedEvalCtx.ExecCfg.NodeID,
 		params.extendedEvalCtx.SessionData.DistSQLMode, n.plan,
 	)
 	willDistribute := distribution.WillDistribute()

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1070,3 +1070,33 @@ SELECT * FROM t51474 INTERSECT ALL SELECT * FROM t51474
 ----
 hello
 howdy
+
+# Transactions which create or modify types must not distribute their
+# plans to remote nodes.
+statement ok
+BEGIN;
+CREATE TYPE local_type AS ENUM ('local');
+CREATE TABLE local_table (x INT);
+INSERT INTO local_table VALUES (1), (2)
+
+query TTT
+SELECT * FROM [EXPLAIN SELECT * FROM local_table] LIMIT 1
+----
+·     distribution  local
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN;
+ALTER TYPE greeting RENAME TO greeting_local;
+CREATE TABLE local_table (x INT);
+INSERT INTO local_table VALUES (1), (2)
+
+query TTT
+SELECT * FROM [EXPLAIN SELECT * FROM local_table] LIMIT 1
+----
+·     distribution  local
+
+statement ok
+ROLLBACK

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -266,7 +266,7 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 		defer recv.Release()
 
 		willDistribute := getPlanDistribution(
-			ctx, localPlanner.execCfg.NodeID,
+			ctx, localPlanner, localPlanner.execCfg.NodeID,
 			localPlanner.extendedEvalCtx.SessionData.DistSQLMode,
 			localPlanner.curPlan.main,
 		).WillDistribute()


### PR DESCRIPTION
Fixes #50897.

Release note (sql change): Transactions that have modified or created a
type will execute queries on the local node, rather than distributing
the queries to other nodes in the cluster.