### PR TITLE
sql: fix panic when evaluating check constraint during insert fast path

### DIFF
--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -355,6 +355,12 @@ func (n *insertFastPathNode) enableAutoCommit() {
 func interceptAlterColumnTypeParseError(
 	insertCols []sqlbase.ColumnDescriptor, colNum int, err error,
 ) error {
+	// Only intercept the error if the column being inserted into
+	// is an actual column. This is to avoid checking on values that don't
+	// correspond to an actual column, for example a check constraint.
+	if colNum >= len(insertCols) {
+		return err
+	}
 	var insertCol sqlbase.ColumnDescriptor
 
 	// wrapParseError is a helper function that checks if an insertCol has the

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -337,3 +337,11 @@ CREATE TABLE t46675isnotnull (k int, a int, CHECK ((k, a) IS NOT NULL))
 # value.
 statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(\(k, a\) IS NOT NULL\)
 INSERT INTO t46675isnotnull VALUES (1, NULL)
+
+# Regression test for #51690. Make sure we don't panic when a check constraint
+# errors during an insert using the fast path.
+statement ok
+CREATE TABLE t51690(x INT, y INT, CHECK(x / y = 1));
+
+statement error pq: division by zero
+INSERT INTO t51690 VALUES (1, 0)


### PR DESCRIPTION
Fix panic due to out of bounds error when intercepting error message in
insert_fast_path.go.

No release note since the panic is not in prod.

Release note: None