### PR TITLE
roachprod: rewrite `roachprod start`

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -102,7 +102,13 @@ func (c *SyncedCluster) IsLocal() bool {
 	return c.Name == config.Local
 }
 
-// ServerNodes TODO(peter): document
+// ServerNodes is the fully expanded, ordered list of nodes that any given
+// roachprod command is intending to target.
+//
+//  $ roachprod create local -n 4
+//  $ roachprod start local          # [1, 2, 3, 4]
+//  $ roachprod start local:2-4      # [2, 3, 4]
+//  $ roachprod start local:2,1,4    # [1, 2, 4]
 func (c *SyncedCluster) ServerNodes() []int {
 	return append([]int{}, c.Nodes...)
 }

--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -128,43 +128,12 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 		}
 	}
 
-	if c.Secure && bootstrap {
-		c.DistributeCerts()
-	}
+	h := &crdbStartHelper{c: c, r: r}
+	h.distributeCerts()
 
 	display := fmt.Sprintf("%s: starting", c.Name)
 	host1 := c.host(1)
 	nodes := c.ServerNodes()
-
-	// If we're creating nodes that span VPC (e.g. AWS multi-region or
-	// multi-cloud), we'll tell the nodes to advertise their public IPs
-	// so that attaching nodes to the cluster Just Works.
-	var advertisePublicIP bool
-	for i, vpc := range c.VPCs {
-		if i > 0 && vpc != c.VPCs[0] {
-			advertisePublicIP = true
-			break
-		}
-	}
-
-	env := func() string {
-		var buf strings.Builder
-		for _, v := range os.Environ() {
-			if strings.HasPrefix(v, "COCKROACH_") {
-				if buf.Len() > 0 {
-					buf.WriteString(" ")
-				}
-				buf.WriteString(v)
-			}
-		}
-		if len(c.Env) > 0 {
-			if buf.Len() > 0 {
-				buf.WriteString(" ")
-			}
-			buf.WriteString(c.Env)
-		}
-		return buf.String()
-	}()
 
 	p := 0
 	if StartOpts.Sequential {
@@ -227,7 +196,7 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 		// For a one-node cluster, use `start-single-node` to disable replication.
 		// For everything else we'll fall back to using `cockroach start`.
 		var startCmd string
-		if len(c.VMs) == 1 && vers.AtLeast(version.MustParse("v19.2.0")) {
+		if h.useStartSingleNode(vers) {
 			startCmd = "start-single-node"
 			bootstrap = false // `cockroach start-single-node` auto-bootstraps, so we skip doing so ourselves.
 		} else {
@@ -239,7 +208,7 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 			}
 		}
 
-		if advertisePublicIP {
+		if h.shouldAdvertisePublicIP() {
 			args = append(args, fmt.Sprintf("--advertise-host=%s", c.host(nodeIdx+1)))
 		} else if !c.IsLocal() {
 			// Explicitly advertise by IP address so that we don't need to
@@ -301,7 +270,7 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 			// https://github.com/cockroachdb/cockroach/issues/37815#issuecomment-545650087
 			//
 			// "COCKROACH_ENFORCE_CONSISTENT_STATS=true " +
-			env + " " + binary + " " + startCmd + " " + strings.Join(args, " ") +
+			h.getEnvVars() + " " + binary + " " + startCmd + " " + strings.Join(args, " ") +
 			" >> " + logDir + "/cockroach.stdout.log 2>> " + logDir + "/cockroach.stderr.log" +
 			" || (x=$?; cat " + logDir + "/cockroach.stderr.log; exit $x)"
 		if out, err := sess.CombinedOutput(cmd); err != nil {
@@ -519,4 +488,55 @@ func (r Cockroach) SQL(c *SyncedCluster, args []string) error {
 	}
 
 	return nil
+}
+
+type crdbStartHelper struct {
+	c *SyncedCluster
+	r Cockroach
+}
+
+func (h *crdbStartHelper) useStartSingleNode(vers *version.Version) bool {
+	return len(h.c.VMs) == 1 && vers.AtLeast(version.MustParse("v19.2.0"))
+}
+
+// distributeCerts, like the name suggests, distributes certs if it's a secure
+// cluster and we're starting n1.
+func (h *crdbStartHelper) distributeCerts() {
+	for _, node := range h.c.ServerNodes() {
+		if node == 1 && h.c.Secure {
+			h.c.DistributeCerts()
+			break
+		}
+	}
+}
+
+func (h *crdbStartHelper) shouldAdvertisePublicIP() bool {
+	// If we're creating nodes that span VPC (e.g. AWS multi-region or
+	// multi-cloud), we'll tell the nodes to advertise their public IPs
+	// so that attaching nodes to the cluster Just Works.
+	for i, vpc := range h.c.VPCs {
+		if i > 0 && vpc != h.c.VPCs[0] {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *crdbStartHelper) getEnvVars() string {
+	var buf strings.Builder
+	for _, v := range os.Environ() {
+		if strings.HasPrefix(v, "COCKROACH_") {
+			if buf.Len() > 0 {
+				buf.WriteString(" ")
+			}
+			buf.WriteString(v)
+		}
+	}
+	if len(h.c.Env) > 0 {
+		if buf.Len() > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString(h.c.Env)
+	}
+	return buf.String()
 }

--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -146,7 +146,25 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 		}
 
 		if h.useStartSingleNode(vers) {
-			bootstrap = false // `cockroach start-single-node` auto-bootstraps, so we skip doing so ourselves.
+			// `cockroach start-single-node` auto-bootstraps, so we skip doing
+			// so ourselves.
+			//
+			// TODO(irfansharif): We don't seem to be setting cluster settings
+			// for clusters started using `start-single-node`, we should.
+			//
+			// TODO(irfansharif): We shouldn't explicitly bootstrap clusters
+			// running versions <20.1, as the join flags are constructed in a
+			// way such that node 1 is started with an empty join flag, and thus
+			// auto-bootstraps.
+			//
+			// TODO(irfansharif): `roachprod start --sequential` is broken.
+			// Given we bootstrap the cluster after having started all the
+			// servers in parallel, there's no longer any guarantee that node
+			// IDs will have been allocated in sequential order. What we should
+			// do here instead is initialize the cluster as soon as we start
+			// node 1, that way subsequent node additions will be allocated the
+			// right node IDs.
+			bootstrap = false
 		}
 
 		if _, err := h.startNode(nodeIdx, extraArgs, vers); err != nil {

--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -110,7 +110,13 @@ func argExists(args []string, target string) int {
 	return -1
 }
 
-// Start implements the ClusterImpl.NodeDir interface.
+// Start implements the ClusterImpl.NodeDir interface, and powers `roachprod
+// start`. Starting the first node is special-cased quite a bit, it's used to
+// distribute certs, set cluster settings, and initialize the cluster. Also,
+// if we're only starting a single node in the cluster and it happens to be the
+// "first" node (node 1, as understood by SyncedCluster.ServerNodes), we use
+// `start-single-node` (this was written to provide a short hand to start a
+// single node cluster with a replication factor of one).
 func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 	// Check to see if node 1 was started, indicating the cluster is to be
 	// bootstrapped.


### PR DESCRIPTION
This is quite the workhorse, and does a lot and has to be compatible
with a lot of existing CRDB versions. It's grown organically as a result
and I'm finding it a bit difficult to maintain, breaking it down a bit
makes it clearer what the structure of it all is and would've perhaps
prevented me introducing bugs like #51497.

Do scrutinize the PR closely, we use `roachprod start` everywhere. It's
mostly mindless code movement but it's pretty fragile code.

Release note: None