### PR TITLE
*: use skip.* methods, not t.Skip

### DIFF
--- a/pkg/acceptance/cli_test.go
+++ b/pkg/acceptance/cli_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -42,7 +43,7 @@ func TestDockerCLI(t *testing.T) {
 	containerConfig.Env = []string{fmt.Sprintf("PGUSER=%s", security.RootUser)}
 	ctx := context.Background()
 	if err := testDockerOneShot(ctx, t, "cli_test", containerConfig); err != nil {
-		t.Skipf(`TODO(dt): No binary in one-shot container, see #6086: %s`, err)
+		skip.IgnoreLintf(t, `TODO(dt): No binary in one-shot container, see #6086: %s`, err)
 	}
 
 	paths, err := filepath.Glob(testGlob)
@@ -102,7 +103,7 @@ func TestDockerUnixSocket(t *testing.T) {
 	ctx := context.Background()
 
 	if err := testDockerOneShot(ctx, t, "cli_test", containerConfig); err != nil {
-		t.Skipf(`TODO(dt): No binary in one-shot container, see #6086: %s`, err)
+		skip.IgnoreLintf(t, `TODO(dt): No binary in one-shot container, see #6086: %s`, err)
 	}
 
 	containerConfig.Env = []string{fmt.Sprintf("PGUSER=%s", security.RootUser)}

--- a/pkg/acceptance/compose/gss/psql/gss_test.go
+++ b/pkg/acceptance/compose/gss/psql/gss_test.go
@@ -150,7 +150,7 @@ func TestGSSFileDescriptorCount(t *testing.T) {
 	// track the open file count in the cockroach container, but that seems
 	// brittle and probably not worth the effort. However this test is
 	// useful when doing manual tracking of file descriptor count.
-	t.Skip("skip")
+	t.Skip("#51791")
 
 	rootConnector, err := pq.NewConnector("user=root sslmode=require")
 	if err != nil {

--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -105,9 +106,7 @@ func BenchmarkSelect3(b *testing.B) {
 }
 
 func BenchmarkCount(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		defer func() {
@@ -141,9 +140,7 @@ func BenchmarkCount(b *testing.B) {
 }
 
 func BenchmarkCountTwoCF(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		defer func() {
@@ -177,9 +174,7 @@ func BenchmarkCountTwoCF(b *testing.B) {
 }
 
 func BenchmarkSort(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		defer func() {
@@ -215,9 +210,7 @@ func BenchmarkSort(b *testing.B) {
 // BenchmarkTableResolution benchmarks table name resolution
 // for a variety of different naming schemes.
 func BenchmarkTableResolution(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 
 	for _, createTempTables := range []bool{false, true} {
@@ -379,9 +372,7 @@ func runBenchmarkInsertSecondaryIndex(b *testing.B, db *sqlutils.SQLRunner, coun
 }
 
 func BenchmarkSQL(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		for _, runFn := range []func(*testing.B, *sqlutils.SQLRunner, int){
@@ -561,9 +552,7 @@ func runBenchmarkScan(b *testing.B, db *sqlutils.SQLRunner, count int, limit int
 }
 
 func BenchmarkScan(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		for _, count := range []int{1, 10, 100, 1000, 10000} {
@@ -775,9 +764,7 @@ func runBenchmarkOrderBy(
 }
 
 func BenchmarkOrderBy(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	const count = 100000
 	const limit = 10
@@ -1038,9 +1025,7 @@ CREATE TABLE bench.scan(
 }
 
 func BenchmarkWideTable(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	const count = 10
 	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
@@ -1055,9 +1040,7 @@ func BenchmarkWideTable(b *testing.B) {
 }
 
 func BenchmarkWideTableIgnoreColumns(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		db.Exec(b, wideTableSchema)
@@ -1076,9 +1059,7 @@ func BenchmarkWideTableIgnoreColumns(b *testing.B) {
 // BenchmarkPlanning runs some queries on an empty table. The purpose is to
 // benchmark (and get memory allocation statistics for) the planning process.
 func BenchmarkPlanning(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		db.Exec(b, `CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX(b), UNIQUE INDEX(c))`)
 
@@ -1182,9 +1163,7 @@ func BenchmarkSortJoinAggregation(b *testing.B) {
 }
 
 func BenchmarkNameResolution(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		db.Exec(b, `CREATE TABLE namespace (k INT PRIMARY KEY, v INT)`)

--- a/pkg/bench/foreachdb.go
+++ b/pkg/bench/foreachdb.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	_ "github.com/go-sql-driver/mysql" // registers the MySQL driver to gosql
@@ -91,7 +92,7 @@ func benchmarkPostgres(b *testing.B, f BenchmarkFn) {
 		RawQuery: "sslmode=require&dbname=postgres",
 	}
 	if conn, err := net.Dial("tcp", pgURL.Host); err != nil {
-		b.Skipf("unable to connect to postgres server on %s: %s", pgURL.Host, err)
+		skip.IgnoreLintf(b, "unable to connect to postgres server on %s: %s", pgURL.Host, err)
 	} else {
 		conn.Close()
 	}
@@ -111,7 +112,7 @@ func benchmarkPostgres(b *testing.B, f BenchmarkFn) {
 func benchmarkMySQL(b *testing.B, f BenchmarkFn) {
 	const addr = "localhost:3306"
 	if conn, err := net.Dial("tcp", addr); err != nil {
-		b.Skipf("unable to connect to mysql server on %s: %s", addr, err)
+		skip.IgnoreLintf(b, "unable to connect to mysql server on %s: %s", addr, err)
 	} else {
 		conn.Close()
 	}

--- a/pkg/bench/pgbench_test.go
+++ b/pkg/bench/pgbench_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -86,7 +87,7 @@ func BenchmarkPgbenchQueryParallel(b *testing.B) {
 
 func execPgbench(b *testing.B, pgURL url.URL) {
 	if _, err := exec.LookPath("pgbench"); err != nil {
-		b.Skip("pgbench is not available on PATH")
+		skip.IgnoreLint(b, "pgbench is not available on PATH")
 	}
 	c, err := SetupExec(pgURL, "bench", 20000, b.N)
 	if err != nil {
@@ -126,7 +127,7 @@ func BenchmarkPgbenchExec(b *testing.B) {
 			RawQuery: "sslmode=disable&dbname=postgres",
 		}
 		if conn, err := net.Dial("tcp", pgURL.Host); err != nil {
-			b.Skipf("unable to connect to postgres server on %s: %s", pgURL.Host, err)
+			skip.IgnoreLintf(b, "unable to connect to postgres server on %s: %s", pgURL.Host, err)
 		} else {
 			conn.Close()
 		}

--- a/pkg/ccl/backupccl/backup_cloud_test.go
+++ b/pkg/ccl/backupccl/backup_cloud_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -39,11 +40,11 @@ func TestCloudBackupRestoreS3(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	creds, err := credentials.NewEnvCredentials().Get()
 	if err != nil {
-		t.Skipf("No AWS env keys (%v)", err)
+		skip.IgnoreLintf(t, "No AWS env keys (%v)", err)
 	}
 	bucket := os.Getenv("AWS_S3_BUCKET")
 	if bucket == "" {
-		t.Skip("AWS_S3_BUCKET env var must be set")
+		skip.IgnoreLint(t, "AWS_S3_BUCKET env var must be set")
 	}
 
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
@@ -69,7 +70,7 @@ func TestCloudBackupRestoreGoogleCloudStorage(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	bucket := os.Getenv("GS_BUCKET")
 	if bucket == "" {
-		t.Skip("GS_BUCKET env var must be set")
+		skip.IgnoreLint(t, "GS_BUCKET env var must be set")
 	}
 
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
@@ -92,11 +93,11 @@ func TestCloudBackupRestoreAzure(t *testing.T) {
 	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
 	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
 	if accountName == "" || accountKey == "" {
-		t.Skip("AZURE_ACCOUNT_NAME and AZURE_ACCOUNT_KEY env vars must be set")
+		skip.IgnoreLint(t, "AZURE_ACCOUNT_NAME and AZURE_ACCOUNT_KEY env vars must be set")
 	}
 	bucket := os.Getenv("AZURE_CONTAINER")
 	if bucket == "" {
-		t.Skip("AZURE_CONTAINER env var must be set")
+		skip.IgnoreLint(t, "AZURE_CONTAINER env var must be set")
 	}
 
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -780,7 +781,7 @@ func TestBackupRestoreCheckpointing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/33357")
+	skip.WithIssue(t, 33357)
 
 	defer func(oldInterval time.Duration) {
 		BackupCheckpointInterval = oldInterval
@@ -1018,7 +1019,7 @@ func getHighWaterMark(jobID int64, sqlDB *gosql.DB) (roachpb.Key, error) {
 func TestBackupRestoreControlJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	t.Skip("#24136")
+	skip.WithIssue(t, 24136)
 
 	// force every call to update
 	defer jobs.TestingSetProgressThresholds()()

--- a/pkg/ccl/backupccl/bench_test.go
+++ b/pkg/ccl/backupccl/bench_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/importccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/sampledataccl"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/cockroachdb/cockroach/pkg/workload/workloadsql"
@@ -40,9 +41,7 @@ func bankBuf(numAccounts int) *bytes.Buffer {
 }
 
 func BenchmarkClusterBackup(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+	skip.UnderShort(b, "TODO: fix benchmark")
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
@@ -97,9 +96,7 @@ func BenchmarkClusterRestore(b *testing.B) {
 }
 
 func BenchmarkLoadRestore(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+	skip.UnderShort(b, "TODO: fix benchmark")
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
@@ -149,9 +146,7 @@ func BenchmarkLoadSQL(b *testing.B) {
 }
 
 func BenchmarkClusterEmptyIncrementalBackup(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+	skip.UnderShort(b, "TODO: fix benchmark")
 	const numStatements = 100000
 
 	_, _, sqlDB, _, cleanupFn := backupccl.BackupRestoreTestSetup(b, backupccl.MultiNode, 0, backupccl.InitNone)

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -54,7 +55,7 @@ func BenchmarkChangefeedTicks(b *testing.B) {
 	// work with RangeFeed without a rewrite, but it's not being used for anything
 	// right now, so the rewrite isn't worth it. We should fix this if we need to
 	// start doing changefeed perf work at some point.
-	b.Skip(`broken in #38211`)
+	skip.WithIssue(b, 51842, `broken in #38211`)
 
 	ctx := context.Background()
 	s, sqlDBRaw, _ := serverutils.StartServer(b, base.TestServerArgs{UseDatabase: "d"})

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -48,8 +48,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -982,9 +982,9 @@ func TestChangefeedStopOnSchemaChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if testing.Short() || util.RaceEnabled {
-		t.Skip("takes too long with race enabled")
-	}
+	skip.UnderRace(t)
+	skip.UnderShort(t)
+
 	schemaChangeTimestampRegexp := regexp.MustCompile(`schema change occurred at ([0-9]+\.[0-9]+)`)
 	timestampStrFromError := func(t *testing.T, err error) string {
 		require.Regexp(t, schemaChangeTimestampRegexp, err)
@@ -1128,9 +1128,8 @@ func TestChangefeedNoBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if testing.Short() || util.RaceEnabled {
-		t.Skip("takes too long with race enabled")
-	}
+	skip.UnderRace(t)
+	skip.UnderShort(t)
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		// Shorten the intervals so this test doesn't take so long. We need to wait
@@ -1494,7 +1493,7 @@ func TestChangefeedMonitoring(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, func(t *testing.T) {
-		t.Skip("https://github.com/cockroachdb/cockroach/issues/38443")
+		skip.WithIssue(t, 38443)
 		enterpriseTest(testFn)
 	})
 }
@@ -1576,7 +1575,7 @@ func TestChangefeedDataTTL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/37154")
+	skip.WithIssue(t, 37154)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		ctx := context.Background()
@@ -2552,7 +2551,7 @@ func TestUnspecifiedPrimaryKey(t *testing.T) {
 func TestChangefeedNodeShutdown(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	t.Skip("#32232")
+	skip.WithIssue(t, 32232)
 
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval
@@ -2847,9 +2846,7 @@ func TestChangefeedHandlesDrainingNodes(t *testing.T) {
 	flushCh := make(chan struct{}, 1)
 	defer close(flushCh)
 
-	if util.RaceEnabled {
-		t.Skip("takes too long with race enabled")
-	}
+	skip.UnderRace(t, "Takes too long with race enabled")
 
 	shouldDrain := true
 	knobs := base.TestingKnobs{DistSQL: &execinfra.TestingKnobs{

--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -42,10 +43,8 @@ type tableSSTable struct {
 }
 
 func BenchmarkImportWorkload(b *testing.B) {
-	b.Skip("#41932: broken due to adding keys out-of-order to an sstable")
-	if testing.Short() {
-		b.Skip("skipping long benchmark")
-	}
+	skip.WithIssue(b, 41932, "broken due to adding keys out-of-order to an sstable")
+	skip.UnderShort(b, "skipping long benchmark")
 
 	dir, cleanup := testutils.TempDir(b)
 	defer cleanup()
@@ -149,9 +148,7 @@ func benchmarkAddSSTable(b *testing.B, dir string, tables []tableSSTable) {
 }
 
 func BenchmarkConvertToKVs(b *testing.B) {
-	if testing.Short() {
-		b.Skip("skipping long benchmark")
-	}
+	skip.UnderShort(b, "skipping long benchmark")
 
 	tpccGen := tpcc.FromWarehouses(1)
 	b.Run(`tpcc/warehouses=1`, func(b *testing.B) {
@@ -196,9 +193,7 @@ func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 }
 
 func BenchmarkConvertToSSTable(b *testing.B) {
-	if testing.Short() {
-		b.Skip("skipping long benchmark")
-	}
+	skip.UnderShort(b, "skipping long benchmark")
 
 	tpccGen := tpcc.FromWarehouses(1)
 	b.Run(`tpcc/warehouses=1`, func(b *testing.B) {

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -69,7 +70,7 @@ func TestImportData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skipf("failing on teamcity with testrace")
+	skip.WithIssue(t, 51811, "failing on teamcity with testrace")
 
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	ctx := context.Background()
@@ -1227,9 +1228,7 @@ ALTER TABLE ONLY public.b
 func TestImportCSVStmt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	if testing.Short() {
-		t.Skip("short")
-	}
+	skip.UnderShort(t)
 
 	const nodes = 3
 
@@ -1515,7 +1514,7 @@ func TestImportCSVStmt(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if strings.Contains(tc.name, "bzip") && len(testFiles.bzipFiles) == 0 {
-				t.Skip("bzip2 not available on PATH?")
+				skip.IgnoreLint(t, "bzip2 not available on PATH?")
 			}
 			intodb := fmt.Sprintf(`csv%d`, i)
 			sqlDB.Exec(t, fmt.Sprintf(`CREATE DATABASE %s`, intodb))
@@ -1888,9 +1887,7 @@ func TestImportIntoCSV(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if testing.Short() {
-		t.Skip("short")
-	}
+	skip.UnderShort(t)
 
 	const nodes = 3
 
@@ -2126,7 +2123,7 @@ func TestImportIntoCSV(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if strings.Contains(tc.name, "bzip") && len(testFiles.bzipFiles) == 0 {
-				t.Skip("bzip2 not available on PATH?")
+				skip.IgnoreLint(t, "bzip2 not available on PATH?")
 			}
 			sqlDB.Exec(t, `CREATE TABLE t (a INT, b STRING)`)
 			defer sqlDB.Exec(t, `DROP TABLE t`)
@@ -2287,7 +2284,7 @@ func TestImportIntoCSV(t *testing.T) {
 		if err := g.Wait(); err != nil {
 			t.Fatal(err)
 		}
-		t.Skip()
+		skip.WithIssue(t, 51812)
 
 		// Expect it to succeed on re-attempt.
 		sqlDB.QueryRow(t, `SELECT 1 FROM t`).Scan(&unused)
@@ -3446,7 +3443,7 @@ func TestImportControlJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("TODO(dt): add knob to force faster progress checks.")
+	skip.WithIssue(t, 51792, "TODO(dt): add knob to force faster progress checks.")
 
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval
@@ -3573,7 +3570,7 @@ func TestImportWorkerFailure(t *testing.T) {
 	// TODO(mjibson): Although this test passes most of the time it still
 	// sometimes fails because not all kinds of failures caused by shutting a
 	// node down are detected and retried.
-	t.Skip("flaky due to undetected kinds of failures when the node is shutdown")
+	skip.WithIssue(t, 51793, "flaky due to undetected kinds of failures when the node is shutdown")
 
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval
@@ -3653,7 +3650,7 @@ func TestImportLivenessWithRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("TODO(dt): this relies on chunking done by prior version of IMPORT." +
+	skip.WithIssue(t, 51794, "TODO(dt): this relies on chunking done by prior version of IMPORT."+
 		"Rework this test, or replace it with resume-tests + jobs infra tests.")
 
 	defer func(oldInterval time.Duration) {
@@ -3918,7 +3915,7 @@ func TestImportMysql(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/40263")
+	skip.WithIssue(t, 40263)
 
 	const (
 		nodes = 3

--- a/pkg/ccl/importccl/load_test.go
+++ b/pkg/ccl/importccl/load_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -160,9 +161,7 @@ func TestImportOutOfOrder(t *testing.T) {
 }
 
 func BenchmarkLoad(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+	skip.UnderShort(b, "TODO: fix benchmark")
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -36,9 +36,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1176,16 +1176,12 @@ func TestInitialPartitioning(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Skipping as part of test-infra-team flaky test cleanup.
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/49909")
+	skip.WithIssue(t, 49909)
 
 	// This test configures many sub-tests and is too slow to run under nightly
 	// race stress.
-	if testutils.NightlyStress() && util.RaceEnabled {
-		t.Skip("too big for nightly stress race")
-	}
-	if testing.Short() {
-		t.Skip("short")
-	}
+	skip.UnderStressRace(t)
+	skip.UnderShort(t)
 
 	rng, _ := randutil.NewPseudoRand()
 	testCases := allPartitioningTests(rng)
@@ -1291,13 +1287,11 @@ func TestRepartitioning(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Skipping as part of test-infra-team flaky test cleanup.
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/49112")
+	skip.WithIssue(t, 49112)
 
 	// This test configures many sub-tests and is too slow to run under nightly
 	// race stress.
-	if testutils.NightlyStress() && util.RaceEnabled {
-		t.Skip()
-	}
+	skip.UnderStressRace(t)
 
 	rng, _ := randutil.NewPseudoRand()
 	testCases, err := allRepartitioningTests(allPartitioningTests(rng))

--- a/pkg/ccl/sqlproxyccl/proxy_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v4"
@@ -199,7 +200,7 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Skip("this test needs a running (secure) CockroachDB instance at the given address")
+	skip.IgnoreLint(t, "this test needs a running (secure) CockroachDB instance at the given address")
 	const crdbSQL = "127.0.0.1:52966"
 	// TODO(asubiotto): use an in-mem test server once this code lives in the CRDB
 	// repo.

--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -11,6 +11,7 @@ package allccl
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"hash"
 	"hash/fnv"
 	"math"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
@@ -79,8 +81,8 @@ func TestAllRegisteredImportFixture(t *testing.T) {
 		}
 
 		t.Run(meta.Name, func(t *testing.T) {
-			if bigInitialData(meta) && testing.Short() {
-				t.Skipf(`%s loads a lot of data`, meta.Name)
+			if bigInitialData(meta) {
+				skip.UnderShort(t, fmt.Sprintf(`%s loads a lot of data`, meta.Name))
 			}
 			defer log.Scope(t).Close(t)
 
@@ -245,9 +247,7 @@ func TestDeterministicInitialData(t *testing.T) {
 
 	// There are other tests that run initial data generation under race, so we
 	// don't get anything from running this one under race as well.
-	if util.RaceEnabled {
-		t.Skip(`uninteresting under race`)
-	}
+	skip.UnderRace(t, "uninteresting under race")
 
 	// Hardcode goldens for the fingerprint of the initial data of generators with
 	// default flags. This lets us opt in generators known to be deterministic and
@@ -285,8 +285,8 @@ func TestDeterministicInitialData(t *testing.T) {
 			continue
 		}
 		t.Run(meta.Name, func(t *testing.T) {
-			if bigInitialData(meta) && testing.Short() {
-				t.Skipf(`%s involves a lot of data`, meta.Name)
+			if bigInitialData(meta) {
+				skip.UnderShort(t, fmt.Sprintf(`%s involves a lot of data`, meta.Name))
 			}
 
 			h := fnv.New64()

--- a/pkg/ccl/workloadccl/bench_test.go
+++ b/pkg/ccl/workloadccl/bench_test.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/workloadccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpcc"
@@ -48,9 +49,7 @@ func benchmarkImportFixture(b *testing.B, gen workload.Generator) {
 }
 
 func BenchmarkImportFixture(b *testing.B) {
-	if testing.Short() {
-		b.Skip("skipping long benchmark")
-	}
+	skip.UnderShort(b, "skipping long benchmark")
 
 	b.Run(`tpcc/warehouses=1`, func(b *testing.B) {
 		benchmarkImportFixture(b, tpcc.FromWarehouses(1))

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -90,7 +91,7 @@ func TestFixture(t *testing.T) {
 	gcsBucket := os.Getenv(`GS_BUCKET`)
 	gcsKey := os.Getenv(`GS_JSONKEY`)
 	if gcsBucket == "" || gcsKey == "" {
-		t.Skip("GS_BUCKET and GS_JSONKEY env vars must be set")
+		skip.IgnoreLint(t, "GS_BUCKET and GS_JSONKEY env vars must be set")
 	}
 
 	source, err := google.JWTConfigFromJSON([]byte(gcsKey), storage.ScopeReadWrite)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -382,9 +383,7 @@ func (c cliTest) RunWithCAArgs(origArgs []string) {
 func TestQuit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	if testing.Short() {
-		t.Skip("short flag")
-	}
+	skip.UnderShort(t)
 
 	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
@@ -1553,7 +1552,7 @@ SQLSTATE: 57014
 func TestNodeStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("currently flaky: #38151")
+	skip.WithIssue(t, 38151)
 
 	start := timeutil.Now()
 	c := newCLITest(cliTestParams{})

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -32,9 +32,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -143,9 +143,7 @@ func TestRemoveDeadReplicas(t *testing.T) {
 	// This test is pretty slow under race (200+ cpu-seconds) because it
 	// uses multiple real disk-backed stores and goes through multiple
 	// cycles of rereplicating all ranges.
-	if util.RaceEnabled {
-		t.Skip("skipping under race")
-	}
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
@@ -944,9 +945,7 @@ func TestClientConnSettings(t *testing.T) {
 
 	// For some reason, when run under stress all these test cases fail due to the
 	// `--host` flag being unknown to quitCmd. Just skip this under stress.
-	if testutils.NightlyStress() {
-		t.Skip()
-	}
+	skip.UnderStress(t)
 
 	// Avoid leaking configuration changes after the tests end.
 	defer initCLIDefaults()

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -35,8 +35,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -185,14 +185,10 @@ func TestUnavailableZip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if testing.Short() {
-		t.Skip("short flag")
-	}
-	if util.RaceEnabled {
-		// Race builds make the servers so slow that they report spurious
-		// unavailability.
-		t.Skip("not running under race")
-	}
+	skip.UnderShort(t)
+	// Race builds make the servers so slow that they report spurious
+	// unavailability.
+	skip.UnderRace(t)
 
 	// unavailableCh is used by the replica command filter
 	// to conditionally block requests and simulate unavailability.
@@ -286,16 +282,12 @@ func TestPartialZip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/51538")
+	skip.WithIssue(t, 51538)
 
-	if testing.Short() {
-		t.Skip("short flag")
-	}
-	if util.RaceEnabled {
-		// We want a low timeout so that the test doesn't take forever;
-		// however low timeouts make race runs flaky with false positives.
-		t.Skip("not running under race")
-	}
+	// We want a low timeout so that the test doesn't take forever;
+	// however low timeouts make race runs flaky with false positives.
+	skip.UnderShort(t)
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 

--- a/pkg/cmd/github-pull-request-make/main_test.go
+++ b/pkg/cmd/github-pull-request-make/main_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/kr/pretty"
 )
 
@@ -60,7 +61,7 @@ func TestPkgsFromDiff(t *testing.T) {
 
 func TestPkgsFromDiffHelper(t *testing.T) {
 	// This helper can easily generate new test cases.
-	t.Skip("only for manual use")
+	skip.IgnoreLint(t, "only for manual use")
 
 	ctx := context.Background()
 	client := ghClient(ctx)

--- a/pkg/cmd/internal/issues/issues_test.go
+++ b/pkg/cmd/internal/issues/issues_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -281,7 +282,7 @@ goroutine 13:
 }
 
 func TestPostEndToEnd(t *testing.T) {
-	t.Skip("only for manual testing")
+	skip.IgnoreLint(t, "only for manual testing")
 
 	env := map[string]string{
 		// githubAPITokenEnv must be set in your actual env.

--- a/pkg/cmd/publish-artifacts/main_test.go
+++ b/pkg/cmd/publish-artifacts/main_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,7 +54,7 @@ func mockPutter(p s3putter) func() {
 
 func TestMain(t *testing.T) {
 	if !slow {
-		t.Skip("only to be run manually via `./build/builder.sh go test -tags slow -timeout 1h -v ./pkg/cmd/publish-artifacts`")
+		skip.IgnoreLint(t, "only to be run manually via `./build/builder.sh go test -tags slow -timeout 1h -v ./pkg/cmd/publish-artifacts`")
 	}
 	r := &recorder{}
 	undo := mockPutter(r)

--- a/pkg/cmd/roachtest/blocklist_test.go
+++ b/pkg/cmd/roachtest/blocklist_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
 )
@@ -28,7 +29,7 @@ const runBlocklistEnv = "RUN_BLOCKLIST_TEST"
 
 func TestBlocklists(t *testing.T) {
 	if _, ok := os.LookupEnv(runBlocklistEnv); !ok {
-		t.Skipf("Blocklist test is only run if %s is set", runBlocklistEnv)
+		skip.IgnoreLintf(t, "Blocklist test is only run if %s is set", runBlocklistEnv)
 	}
 
 	blocklists := map[string]blocklist{

--- a/pkg/gossip/convergence_test.go
+++ b/pkg/gossip/convergence_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip/simulation"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -53,9 +53,7 @@ func connectionsRefused(network *simulation.Network) int64 {
 // As of Jan 2017, this normally takes ~12 cycles and 8-12 refused connections.
 func TestConvergence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if testutils.NightlyStress() {
-		t.Skip()
-	}
+	skip.UnderStress(t)
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
@@ -86,9 +84,7 @@ func TestConvergence(t *testing.T) {
 // As of Jan 2017, this normally takes 8-9 cycles and 50-60 refused connections.
 func TestNetworkReachesEquilibrium(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if testutils.NightlyStress() {
-		t.Skip()
-	}
+	skip.UnderStress(t)
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -876,7 +877,7 @@ func TestGossipPropagation(t *testing.T) {
 //     OrigStamp is less than the highwater stamp from n2
 func TestGossipLoopbackInfoPropagation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skipf("#34494")
+	skip.WithIssue(t, 34494)
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -196,9 +197,8 @@ func TestRegistryCancelation(t *testing.T) {
 func TestRegistryGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	t.Skip("")
-	// TODO (lucy): This test probably shouldn't continue to exist in its current
-	// form if GCMutations will cease to be used. Refactor or get rid of it.
+	skip.WithIssue(t, 51796, "TODO (lucy): This test probably shouldn't continue to exist in its current"+
+		"form if GCMutations will cease to be used. Refactor or get rid of it.")
 
 	ctx := context.Background()
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -286,9 +287,7 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	if testing.Short() {
-		t.Skip("this test needs to do a larger SST to see the quadratic mem usage on retries kick in.")
-	}
+	skip.UnderShort(t, "this test needs to do a larger SST to see the quadratic mem usage on retries kick in.")
 
 	const numKeys, valueSize, splitEvery = 500, 5000, 1
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/kvclientutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1494,8 +1495,8 @@ func TestReverseScanWithSplitAndMerge(t *testing.T) {
 func TestBadRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	t.Skip("TODO(andreimatei): This last assertion in this test was broken by #33150. " +
-		"I suspect the reason is that there is no longer a single Range " +
+	skip.WithIssue(t, 51795, "TODO(andreimatei): This last assertion in this test was broken by #33150. "+
+		"I suspect the reason is that there is no longer a single Range "+
 		"that spans [KeyMin, z), so we're not hitting the error.")
 	s, db := startNoSplitMergeServer(t)
 	defer s.Stopper().Stop(context.Background())

--- a/pkg/kv/kvclient/kvcoord/txn_correctness_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_correctness_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/localtestcluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -878,9 +879,7 @@ func TestTxnDBReadSkewAnomaly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if testing.Short() {
-		t.Skip("short flag")
-	}
+	skip.UnderShort(t)
 
 	txn1 := "R(A) R(B) W(C,A+B) C"
 	txn2 := "R(A) R(B) I(A) I(B) C"

--- a/pkg/kv/kvserver/batcheval/transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/transaction_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -677,7 +678,7 @@ func TestUpdateAbortSpan(t *testing.T) {
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 			if c.run == nil {
-				t.Skip("invalid test case")
+				skip.IgnoreLint(t, "invalid test case")
 			}
 
 			db := storage.NewDefaultInMem()

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -1533,7 +1534,7 @@ func TestStoreRangeMergeConcurrentRequests(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Skipping as part of test-infra-team flaky test cleanup.
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/50795")
+	skip.WithIssue(t, 50795)
 
 	ctx := context.Background()
 	storeCfg := kvserver.TestStoreConfig(nil)

--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -48,9 +48,9 @@ func TestProtectedTimestamps(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	if util.RaceEnabled || testing.Short() {
-		t.Skip("this test is too slow to run with race")
-	}
+	// This test is too slow to run with race.
+	skip.UnderRace(t)
+	skip.UnderShort(t)
 
 	args := base.TestClusterArgs{}
 	args.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{DisableGCQueue: true}

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -343,7 +344,7 @@ func TestRestoreReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/40351")
+	skip.WithIssue(t, 40351)
 
 	sc := kvserver.TestStoreConfig(nil)
 	// Disable periodic gossip activities. The periodic gossiping of the first
@@ -1096,7 +1097,7 @@ func TestConcurrentRaftSnapshots(t *testing.T) {
 	// teeing engine is being used. See
 	// https://github.com/cockroachdb/cockroach/issues/42656 for more context.
 	if storage.DefaultStorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
-		t.Skip("disabled on teeing engine")
+		skip.IgnoreLint(t, "disabled on teeing engine")
 	}
 
 	mtc := &multiTestContext{
@@ -1746,7 +1747,7 @@ func TestProgressWithDownNode(t *testing.T) {
 	// teeing engine is being used. See
 	// https://github.com/cockroachdb/cockroach/issues/42656 for more context.
 	if storage.DefaultStorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
-		t.Skip("disabled on teeing engine")
+		skip.IgnoreLint(t, "disabled on teeing engine")
 	}
 	mtc := &multiTestContext{
 		// This test was written before the multiTestContext started creating many
@@ -1921,7 +1922,7 @@ func testReplicaAddRemove(t *testing.T, addFirst bool) {
 	// teeing engine is being used. See
 	// https://github.com/cockroachdb/cockroach/issues/42656 for more context.
 	if storage.DefaultStorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
-		t.Skip("disabled on teeing engine")
+		skip.IgnoreLint(t, "disabled on teeing engine")
 	}
 	sc := kvserver.TestStoreConfig(nil)
 	// We're gonna want to validate the state of the store before and after the
@@ -3032,11 +3033,9 @@ func TestDecommission(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if util.RaceEnabled {
-		// Five nodes is too much to reliably run under testrace with our aggressive
-		// liveness timings.
-		t.Skip("skipping under testrace: #39807 and #37811")
-	}
+	// Five nodes is too much to reliably run under testrace with our aggressive
+	// liveness timings.
+	skip.UnderRace(t, "#39807 and #37811")
 
 	// This test relies on concurrently waiting for a value to change in the
 	// underlying engine(s). Since the teeing engine does not respond well to
@@ -3044,7 +3043,7 @@ func TestDecommission(t *testing.T) {
 	// teeing engine is being used. See
 	// https://github.com/cockroachdb/cockroach/issues/42656 for more context.
 	if storage.DefaultStorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
-		t.Skip("disabled on teeing engine")
+		skip.IgnoreLint(t, "disabled on teeing engine")
 	}
 
 	ctx := context.Background()
@@ -4516,7 +4515,7 @@ func TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic(t *testing
 	// teeing engine is being used. See
 	// https://github.com/cockroachdb/cockroach/issues/42656 for more context.
 	if storage.DefaultStorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
-		t.Skip("disabled on teeing engine")
+		skip.IgnoreLint(t, "disabled on teeing engine")
 	}
 
 	stopper := stop.NewStopper()
@@ -4805,7 +4804,7 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 	// teeing engine is being used. See
 	// https://github.com/cockroachdb/cockroach/issues/42656 for more context.
 	if storage.DefaultStorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
-		t.Skip("disabled on teeing engine")
+		skip.IgnoreLint(t, "disabled on teeing engine")
 	}
 	sc := kvserver.TestStoreConfig(nil)
 	// Newly-started stores (including the "rogue" one) should not GC
@@ -5277,7 +5276,7 @@ func TestReplicaRemovalClosesProposalQuota(t *testing.T) {
 	// test to make sense. It usually is.
 	lease, pendingLease := repl.GetLease()
 	if pendingLease != (roachpb.Lease{}) || lease.OwnedBy(store.StoreID()) {
-		t.Skip("the replica is not the leaseholder, this happens rarely under stressrace")
+		skip.IgnoreLint(t, "the replica is not the leaseholder, this happens rarely under stressrace")
 	}
 	var wg sync.WaitGroup
 	const N = 100

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -40,9 +40,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/kvclientutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -1713,9 +1713,9 @@ func TestSystemZoneConfigs(t *testing.T) {
 	// This test is relatively slow and resource intensive. When run under
 	// stressrace on a loaded machine (as in the nightly tests), sometimes the
 	// SucceedsSoon conditions below take longer than the allotted time (#25273).
-	if testing.Short() || testutils.NightlyStress() || util.RaceEnabled {
-		t.Skip()
-	}
+	skip.UnderRace(t)
+	skip.UnderShort(t)
+	skip.UnderStress(t)
 
 	// This test relies on concurrently waiting for a value to change in the
 	// underlying engine(s). Since the teeing engine does not respond well to
@@ -1723,7 +1723,7 @@ func TestSystemZoneConfigs(t *testing.T) {
 	// teeing engine is being used. See
 	// https://github.com/cockroachdb/cockroach/issues/42656 for more context.
 	if storage.DefaultStorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
-		t.Skip("disabled on teeing engine")
+		skip.IgnoreLint(t, "disabled on teeing engine")
 	}
 
 	ctx := context.Background()
@@ -2196,7 +2196,7 @@ func TestReplicaTombstone(t *testing.T) {
 	// teeing engine is being used. See
 	// https://github.com/cockroachdb/cockroach/issues/42656 for more context.
 	if storage.DefaultStorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
-		t.Skip("disabled on teeing engine")
+		skip.IgnoreLint(t, "disabled on teeing engine")
 	}
 
 	t.Run("(1) ChangeReplicasTrigger", func(t *testing.T) {

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
@@ -1955,7 +1956,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Skipping as part of test-infra-team flaky test cleanup.
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/50809")
+	skip.WithIssue(t, 50809)
 
 	mtc := &multiTestContext{}
 	storeCfg := kvserver.TestStoreConfig(nil)

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -1355,7 +1356,7 @@ func (m *multiTestContext) waitForValuesT(t testing.TB, key roachpb.Key, expecte
 	// teeing engine is being used. See
 	// https://github.com/cockroachdb/cockroach/issues/42656 for more context.
 	if storage.DefaultStorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
-		t.Skip("disabled on teeing engine")
+		skip.IgnoreLint(t, "disabled on teeing engine")
 	}
 	testutils.SucceedsSoon(t, func() error {
 		actual := m.readIntFromEngines(key)

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -46,12 +47,10 @@ func TestClosedTimestampCanServe(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
+	// Limiting how long transactions can run does not work
+	// well with race unless we're extremely lenient, which
+	// drives up the test duration.
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)
@@ -108,12 +107,11 @@ func TestClosedTimestampCanServeThroughoutLeaseTransfer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
+	// Limiting how long transactions can run does not work
+	// well with race unless we're extremely lenient, which
+	// drives up the test duration.
+	skip.UnderRace(t)
+
 	ctx := context.Background()
 	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)
 	defer tc.Stopper().Stop(ctx)
@@ -262,12 +260,11 @@ func TestClosedTimestampCanServeAfterSplitAndMerges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
+	// Limiting how long transactions can run does not work
+	// well with race unless we're extremely lenient, which
+	// drives up the test duration.
+	skip.UnderRace(t)
+
 	ctx := context.Background()
 	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)
 	// Disable the automatic merging.
@@ -341,12 +338,10 @@ func TestClosedTimestampCantServeBasedOnMaxTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
+	// Limiting how long transactions can run does not work
+	// well with race unless we're extremely lenient, which
+	// drives up the test duration.
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 	// Set up the target duration to be very long and rely on lease transfers to
@@ -382,12 +377,10 @@ func TestClosedTimestampCantServeForWritingTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
+	// Limiting how long transactions can run does not work
+	// well with race unless we're extremely lenient, which
+	// drives up the test duration.
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)
@@ -417,12 +410,10 @@ func TestClosedTimestampCantServeForNonTransactionalReadRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
+	// Limiting how long transactions can run does not work
+	// well with race unless we're extremely lenient, which
+	// drives up the test duration.
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)

--- a/pkg/kv/kvserver/compactor/compactor_test.go
+++ b/pkg/kv/kvserver/compactor/compactor_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -114,7 +115,7 @@ func TestCompactorThresholds(t *testing.T) {
 	// teeing engine is being used. See
 	// https://github.com/cockroachdb/cockroach/issues/42656 for more context.
 	if storage.DefaultStorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
-		t.Skip("disabled on teeing engine")
+		skip.IgnoreLint(t, "disabled on teeing engine")
 	}
 
 	fractionUsedThresh := thresholdBytesUsedFraction.Default()*float64(thresholdBytes.Default()) + 1

--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -144,12 +145,10 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Skipping as part of test-infra-team flaky test cleanup.
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/50024")
+	skip.WithIssue(t, 50024)
 
-	if testing.Short() {
-		// As of Nov 2018 it takes 3.6s.
-		t.Skip("short")
-	}
+	// As of Nov 2018 it takes 3.6s.
+	skip.UnderShort(t)
 	ctx := context.Background()
 
 	// Shorten the raft tick interval and election timeout to make range leases

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -797,9 +798,7 @@ func verifyNodeIsDecommissioning(t *testing.T, mtc *multiTestContext, nodeID roa
 func TestNodeLivenessStatusMap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	if testing.Short() {
-		t.Skip("short")
-	}
+	skip.UnderShort(t)
 
 	serverArgs := base.TestServerArgs{
 		Knobs: base.TestingKnobs{

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -449,7 +450,7 @@ func TestNewTruncateDecision(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/38584")
+	skip.WithIssue(t, 38584)
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -729,11 +729,9 @@ func TestLearnerAndJointConfigFollowerRead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work well with race
-		// unless we're extremely lenient, which drives up the test duration.
-		t.Skip("skipping under race")
-	}
+	// Limiting how long transactions can run does not work well with race
+	// unless we're extremely lenient, which drives up the test duration.
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 	knobs, ltk := makeReplicationTestKnobs()

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -597,7 +598,7 @@ func TestRaftSSTableSideloadingProposal(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "engineInMem", func(t *testing.T, engineInMem bool) {
 		testutils.RunTrueAndFalse(t, "mockSideloaded", func(t *testing.T, mockSideloaded bool) {
 			if engineInMem && !mockSideloaded {
-				t.Skip("https://github.com/cockroachdb/cockroach/issues/31913")
+				skip.WithIssue(t, 31913)
 			}
 			testRaftSSTableSideloadingProposal(t, engineInMem, mockSideloaded)
 		})

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -28,9 +28,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -43,10 +43,8 @@ func TestReplicateQueueRebalance(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if util.RaceEnabled {
-		// This test was seen taking north of 20m under race.
-		t.Skip("too heavyweight for race")
-	}
+	// This test was seen taking north of 20m under race.
+	skip.UnderRace(t)
 
 	testutils.RunTrueAndFalse(t, "atomic", func(t *testing.T, atomic bool) {
 		testReplicateQueueRebalanceInner(t, atomic)
@@ -54,9 +52,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 }
 
 func testReplicateQueueRebalanceInner(t *testing.T, atomic bool) {
-	if testing.Short() {
-		t.Skip("short flag")
-	}
+	skip.UnderShort(t)
 
 	const numNodes = 5
 
@@ -361,9 +357,9 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if testing.Short() || testutils.NightlyStress() || util.RaceEnabled {
-		t.Skip("https://github.com/cockroachdb/cockroach/issues/38565")
-	}
+	skip.UnderStress(t, 38565)
+	skip.UnderRace(t, 38565)
+	skip.UnderShort(t, 38565)
 	ctx := context.Background()
 
 	// Create a cluster with really small ranges.

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/keysutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -38,15 +38,11 @@ import (
 func TestConstraintConformanceReportIntegration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	if testing.Short() {
-		// This test takes seconds because of replication vagaries.
-		t.Skip("short flag")
-	}
-	if testutils.NightlyStress() && util.RaceEnabled {
-		// Under stressrace, replication changes seem to hit 1m deadline errors and
-		// don't make progress.
-		t.Skip("test too slow for stressrace")
-	}
+	// This test takes seconds because of replication vagaries.
+	skip.UnderShort(t)
+	// Under stressrace, replication changes seem to hit 1m deadline errors and
+	// don't make progress.
+	skip.UnderStressRace(t)
 
 	ctx := context.Background()
 	tc := serverutils.StartTestCluster(t, 5, base.TestClusterArgs{

--- a/pkg/kv/kvserver/single_key_test.go
+++ b/pkg/kv/kvserver/single_key_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -32,9 +33,7 @@ func TestSingleKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if testing.Short() {
-		t.Skip("short flag")
-	}
+	skip.UnderShort(t)
 
 	const num = 3
 	tc := testcluster.StartTestCluster(t, 3,

--- a/pkg/kv/kvserver/txn_wait_queue_test.go
+++ b/pkg/kv/kvserver/txn_wait_queue_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -353,7 +354,7 @@ func TestTxnWaitQueueTxnSilentlyCompletes(t *testing.T) {
 	// teeing engine is being used. See
 	// https://github.com/cockroachdb/cockroach/issues/42656 for more context.
 	if storage.DefaultStorageEngine == enginepb.EngineTypeTeePebbleRocksDB {
-		t.Skip("disabled on teeing engine")
+		skip.IgnoreLint(t, "disabled on teeing engine")
 	}
 	tc := testContext{}
 	ctx := context.Background()

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -931,7 +932,7 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 // its response stream even if it doesn't get any new requests.
 func TestGRPCKeepaliveFailureFailsInflightRPCs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("Takes too long given https://github.com/grpc/grpc-go/pull/2642")
+	skip.WithIssue(t, 51800, "Takes too long given https://github.com/grpc/grpc-go/pull/2642")
 
 	sc := log.Scope(t)
 	defer sc.Close(t)
@@ -1726,9 +1727,7 @@ func TestRunHeartbeatSetsHeartbeatStateWhenExitingBeforeFirstHeartbeat(t *testin
 }
 
 func BenchmarkGRPCDial(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+	skip.UnderShort(b, "TODO: fix benchmark")
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -1804,9 +1805,7 @@ func TestAdminAPIDataDistribution(t *testing.T) {
 }
 
 func BenchmarkAdminAPIDataDistribution(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+	skip.UnderShort(b, "TODO: fix benchmark")
 	testCluster := serverutils.StartTestCluster(b, 3, base.TestClusterArgs{})
 	defer testCluster.Stopper().Stop(context.Background())
 

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/ts/catalog"
@@ -496,7 +497,7 @@ func TestStatusGetFiles(t *testing.T) {
 func TestStatusLocalLogs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	if log.V(3) {
-		t.Skip("Test only works with low verbosity levels")
+		skip.IgnoreLint(t, "Test only works with low verbosity levels")
 	}
 
 	s := log.ScopeWithoutShowLogs(t)

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/logtags"
@@ -734,7 +735,8 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("fails in the presence of migrations requiring backfill, but cannot import sqlmigrations")
+	skip.WithIssue(t, 51798, "fails in the presence of migrations requiring backfill, "+
+		"but cannot import sqlmigrations")
 
 	// Result is a struct for moving results to the main result routine.
 	type Result struct {

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -823,7 +824,7 @@ CREATE TABLE t.foo (v INT);
 func TestDescriptorRefreshOnRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/50037")
+	skip.WithIssue(t, 50037)
 
 	params, _ := tests.CreateTestServerParams()
 
@@ -1616,11 +1617,11 @@ INSERT INTO t.kv VALUES ('a', 'b');
 func TestModificationTimeTxnOrdering(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
 
-	testingT.Skip("#22479")
+	skip.WithIssue(testingT, 22479)
 
 	// Decide how long we should run this.
 	maxTime := time.Duration(5) * time.Second
-	if testutils.NightlyStress() {
+	if skip.NightlyStress() {
 		maxTime = time.Duration(2) * time.Minute
 	}
 

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -176,9 +177,7 @@ var (
 
 // BenchmarkDiskQueue benchmarks a queue with parameters provided through flags.
 func BenchmarkDiskQueue(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 
 	bufSize, err := humanizeutil.ParseBytes(*bufferSizeBytes)
 	if err != nil {

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -843,7 +844,7 @@ func benchmarkAggregateFunction(
 		false, /* isScalar */
 	)
 	if err != nil {
-		b.Skip()
+		skip.IgnoreLint(b)
 	}
 	a.Init()
 

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1821,7 +1822,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	if coldata.BatchSize() > 200 {
-		t.Skipf("this test is too slow with relatively big batch size")
+		skip.IgnoreLintf(t, "this test is too slow with relatively big batch size")
 	}
 	ctx := context.Background()
 	nTuples := 2*coldata.BatchSize() + 1

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -340,9 +341,7 @@ func benchmarkProjOp(
 }
 
 func BenchmarkProjOp(b *testing.B) {
-	if testing.Short() {
-		b.Skip()
-	}
+	skip.UnderShort(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -333,7 +334,7 @@ func TestCopyOne(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("#18352")
+	skip.WithIssue(t, 18352)
 
 	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
@@ -368,7 +369,7 @@ func TestCopyInProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("#18352")
+	skip.WithIssue(t, 18352)
 
 	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)

--- a/pkg/sql/create_stats_test.go
+++ b/pkg/sql/create_stats_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -36,11 +36,9 @@ func TestStatsWithLowTTL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if util.RaceEnabled {
-		// The test requires a bunch of data to be inserted, which is much slower in
-		// race mode.
-		t.Skip("skipping under race")
-	}
+	// The test requires a bunch of data to be inserted, which is much slower in
+	// race mode.
+	skip.UnderRace(t)
 
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -434,7 +435,7 @@ func TestDistSQLDeadHosts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("#49843. test is too slow; we need to tweak timeouts so connections die faster (see #14376)")
+	skip.WithIssue(t, 49843, "test is too slow; we need to tweak timeouts so connections die faster (see #14376)")
 
 	const n = 100
 	const numNodes = 5

--- a/pkg/sql/distsql_plan_backfill_test.go
+++ b/pkg/sql/distsql_plan_backfill_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -29,9 +30,7 @@ import (
 func TestDistBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	if testing.Short() {
-		t.Skip("short flag #13645")
-	}
+	skip.UnderShort(t, "13645")
 
 	// This test sets up various queries using these tables:
 	//  - a NumToSquare table of size N that maps integers from 1 to n to their

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -633,7 +634,7 @@ func TestEvalCtxTxnOnRemoteNodes(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "vectorize", func(t *testing.T, vectorize bool) {
 		if vectorize {
-			t.Skip("skipped because we can't yet vectorize queries using DECIMALs")
+			skip.IgnoreLint(t, "skipped because we can't yet vectorize queries using DECIMALs")
 		}
 		// We're going to use the first node as the gateway and expect everything to
 		// be planned remotely.

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/physicalplanutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -2120,7 +2121,7 @@ func (t *logicTest) processSubtest(
 			if len(fields) > 1 {
 				reason = fields[1]
 			}
-			t.t().Skip(reason)
+			skip.IgnoreLint(t.t(), reason)
 
 		case "skipif":
 			if len(fields) < 2 {
@@ -2674,12 +2675,10 @@ func RunLogicTestWithDefaultConfig(
 	// with less concurrency in the nightly stress runs. If you see problems
 	// please make adjustments there.
 	// As of 6/4/2019, the logic tests never complete under race.
-	if testutils.NightlyStress() && util.RaceEnabled {
-		t.Skip("logic tests and race detector don't mix: #37993")
-	}
+	skip.UnderStressRace(t, "logic tests and race detector don't mix: #37993")
 
 	if skipLogicTests {
-		t.Skip("COCKROACH_LOGIC_TESTS_SKIP")
+		skip.IgnoreLint(t, "COCKROACH_LOGIC_TESTS_SKIP")
 	}
 
 	// Override default glob sets if -d flag was specified.
@@ -2777,13 +2776,13 @@ func RunLogicTestWithDefaultConfig(
 		// Top-level test: one per test configuration.
 		t.Run(cfg.name, func(t *testing.T) {
 			if testing.Short() && cfg.skipShort {
-				t.Skip("config skipped by -test.short")
+				skip.IgnoreLint(t, "config skipped by -test.short")
 			}
 			if logicTestsConfigExclude != "" && cfg.name == logicTestsConfigExclude {
-				t.Skip("config excluded via env var")
+				skip.IgnoreLint(t, "config excluded via env var")
 			}
 			if logicTestsConfigFilter != "" && cfg.name != logicTestsConfigFilter {
-				t.Skip("config does not match env var")
+				skip.IgnoreLint(t, "config does not match env var")
 			}
 			for _, path := range paths {
 				path := path // Rebind range variable.

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -84,7 +85,7 @@ func TestSqlLiteLogic(t *testing.T) {
 // See the comments in logic.go for more details.
 func runSQLLiteLogicTest(t *testing.T, globs ...string) {
 	if !*bigtest {
-		t.Skip("-bigtest flag must be specified to run this test")
+		skip.IgnoreLint(t, "-bigtest flag must be specified to run this test")
 	}
 
 	logicTestPath := build.Default.GOPATH + "/src/github.com/cockroachdb/sqllogictest"

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -138,7 +139,7 @@ func (t *parallelTest) run(dir string) {
 	}
 
 	if spec.SkipReason != "" {
-		t.Skip(spec.SkipReason)
+		skip.IgnoreLint(t, spec.SkipReason)
 	}
 
 	log.Infof(t.ctx, "Running test %s", dir)

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -276,8 +277,8 @@ var profileQuery = flag.String("profile-query", "kv-read", "name of query to run
 // TestCPUProfile writes the output profile to a cpu.out file in the current
 // directory. See the profile flags for ways to configure what is profiled.
 func TestCPUProfile(t *testing.T) {
-	t.Skip(
-		"Remove this when profiling. Use profile flags above to configure. Sample command line: \n" +
+	skip.IgnoreLint(t,
+		"Remove this when profiling. Use profile flags above to configure. Sample command line: \n"+
 			"GOMAXPROCS=1 go test -run TestCPUProfile --logtostderr NONE && go tool pprof bench.test cpu.out",
 	)
 

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -187,7 +188,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 						}
 					}
 					if !allowed {
-						t.Skip("Test file not applicable at this security level.")
+						skip.IgnoreLint(t, "Test file not applicable at this security level.")
 					}
 
 				case "set_hba":

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1655,7 +1656,7 @@ func TestPGWireOverUnixSocket(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	if runtime.GOOS == "windows" {
-		t.Skip("unix sockets not support on windows")
+		skip.IgnoreLint(t, "unix sockets not support on windows")
 	}
 
 	// We need a temp directory in which we'll create the unix socket.

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -738,9 +739,7 @@ func TestJoinReaderDrain(t *testing.T) {
 // returned for a single lookup row. Some cases will cause the join reader to
 // spill to disk, in which case the benchmark logs that the join spilled.
 func BenchmarkJoinReader(b *testing.B) {
-	if testing.Short() {
-		b.Skip()
-	}
+	skip.UnderShort(b)
 
 	// Create an *on-disk* store spec for the primary store and temp engine to
 	// reflect the real costs of lookups and spilling.

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -857,11 +858,11 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.query, func(t *testing.T) {
 				if testCase.skip != "" {
-					t.Skip(testCase.skip)
+					skip.IgnoreLint(t, testCase.skip)
 				}
 				if vectorize {
 					// TODO(asubiotto): figure out why this race occurs.
-					t.Skip("vectorize option is temporarily skipped because there appears to be " +
+					skip.WithIssue(t, 51647, "vectorize option is temporarily skipped because there appears to be "+
 						"a race between the expected error and the context cancellation error")
 				}
 				func() {

--- a/pkg/sql/scatter_test.go
+++ b/pkg/sql/scatter_test.go
@@ -20,10 +20,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -32,9 +31,7 @@ func TestScatterRandomizeLeases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if testutils.NightlyStress() && util.RaceEnabled {
-		t.Skip("uses too many resources for stressrace")
-	}
+	skip.UnderStressRace(t, "uses too many resources for stressrace")
 
 	const numHosts = 3
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -1393,7 +1394,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 func TestSchemaChangePurgeFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	t.Skip("")
+	skip.WithIssue(t, 51796)
 	// TODO (lucy): This test needs more complicated schema changer knobs than
 	// currently implemented. Previously this test disabled the async schema
 	// changer so that we don't retry the cleanup of the failed schema change
@@ -1865,7 +1866,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT8);
 	}
 
 	// State of jobs table
-	t.Skip("TODO(pbardea): The following fails due to causes seemingly unrelated to GC")
+	skip.WithIssue(t, 51796, "TODO(pbardea): The following fails due to causes seemingly unrelated to GC")
 	runner := sqlutils.SQLRunner{DB: sqlDB}
 	// TODO (lucy): This test API should use an offset starting from the
 	// most recent job instead.
@@ -2320,7 +2321,7 @@ func TestPrimaryKeyChangeWithPrecedingIndexCreation(t *testing.T) {
 	}
 
 	t.Run("create-index-before", func(t *testing.T) {
-		t.Skip("unskip once #45510 is completed")
+		skip.WithIssue(t, 45510, "unskip when finished")
 		if _, err := sqlDB.Exec(`CREATE TABLE t.test (k INT NOT NULL, v INT)`); err != nil {
 			t.Fatal(err)
 		}
@@ -3779,7 +3780,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 func TestSchemaChangeCompletion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	t.Skip("")
+	skip.WithIssue(t, 51796)
 	// TODO (lucy): This test needs more complicated schema changer knobs than is
 	// currently implemented.
 	params, _ := tests.CreateTestServerParams()
@@ -4117,7 +4118,7 @@ func TestTruncateWhileColumnBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/43990")
+	skip.WithIssue(t, 43990)
 
 	backfillNotification := make(chan struct{})
 	backfillCount := int64(0)
@@ -4500,7 +4501,7 @@ ALTER TABLE t.test ADD COLUMN c INT AS (v + 4) STORED, ADD COLUMN d INT DEFAULT 
 func TestCancelSchemaChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	t.Skip("")
+	skip.WithIssue(t, 51796)
 
 	const (
 		numNodes = 3
@@ -5751,8 +5752,7 @@ ALTER TABLE t.test2 ADD FOREIGN KEY (k) REFERENCES t.test;
 func TestOrphanedGCMutationsRemoved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TODO (lucy): get rid of this test once GCMutations goes away
-	t.Skip("")
+	skip.WithIssue(t, 51796, "TODO (lucy): get rid of this test once GCMutations goes away")
 	params, _ := tests.CreateTestServerParams()
 	const chunkSize = 200
 	// Disable synchronous schema change processing so that the mutations get

--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -740,7 +741,7 @@ INSERT INTO t.test VALUES (217, 314, 1337);
 func TestScrubPhysicalUnexpectedFamilyID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	t.Skip("currently KV pairs with unexpected family IDs are not noticed by the fetcher")
+	skip.WithIssue(t, 51797, "currently KV pairs with unexpected family IDs are not noticed by the fetcher")
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
@@ -858,7 +859,7 @@ CREATE TABLE t.test (
 func TestScrubPhysicalIncorrectPrimaryIndexValueColumn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	t.Skip("the test is not failing, as it would be expected")
+	skip.WithIssue(t, 51797, "the test is not failing, as it would be expected")
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 

--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -33,7 +34,7 @@ func TestShowTraceReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/34213")
+	skip.WithIssue(t, 34213)
 
 	const numNodes = 4
 

--- a/pkg/sql/stats/automatic_stats_manual_test.go
+++ b/pkg/sql/stats/automatic_stats_manual_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -56,7 +57,7 @@ func TestAdaptiveThrottling(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	if !*runManual {
-		t.Skip("manual test with no --run-manual")
+		skip.IgnoreLint(t, "manual test with no --run-manual")
 	}
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)

--- a/pkg/sql/tests/monotonic_insert_test.go
+++ b/pkg/sql/tests/monotonic_insert_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -90,9 +91,7 @@ func testMonotonicInserts(t *testing.T, distSQLMode sessiondata.DistSQLExecMode)
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if testing.Short() {
-		t.Skip("short flag")
-	}
+	skip.UnderShort(t)
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(
 		t, 3,

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -668,7 +669,7 @@ func testRandomSyntax(
 	fn func(context.Context, *verifyFormatDB, *rsg.RSG) error,
 ) {
 	if *flagRSGTime == 0 {
-		t.Skip("enable with '-rsg <duration>'")
+		skip.IgnoreLint(t, "enable with '-rsg <duration>'")
 	}
 	ctx := context.Background()
 	defer utilccl.TestingEnableEnterprise()()

--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -45,12 +45,10 @@ func TestGetUserHashedPasswordTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if util.RaceEnabled {
-		// We want to use a low timeout below to prevent
-		// this test from taking forever, however
-		// race builds are so slow as to trigger this timeout spuriously.
-		t.Skip("not running under race")
-	}
+	// We want to use a low timeout below to prevent
+	// this test from taking forever, however
+	// race builds are so slow as to trigger this timeout spuriously.
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -64,9 +65,7 @@ func setupMVCCInMemPebble(b testing.TB, loc string) Engine {
 }
 
 func BenchmarkMVCCScan_Pebble(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+	skip.WithIssue(b, 51840, "TODO: fix benchmark")
 
 	ctx := context.Background()
 	for _, numRows := range []int{1, 10, 100, 1000, 10000} {
@@ -92,9 +91,7 @@ func BenchmarkMVCCScan_Pebble(b *testing.B) {
 }
 
 func BenchmarkMVCCReverseScan_Pebble(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+	skip.WithIssue(b, 51840, "TODO: fix benchmark")
 
 	ctx := context.Background()
 	for _, numRows := range []int{1, 10, 100, 1000, 10000} {
@@ -148,9 +145,7 @@ func BenchmarkMVCCGet_Pebble(b *testing.B) {
 }
 
 func BenchmarkMVCCComputeStats_Pebble(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	ctx := context.Background()
 	for _, valueSize := range []int{8, 32, 256} {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
@@ -279,9 +274,7 @@ func BenchmarkMVCCBatchTimeSeries_Pebble(b *testing.B) {
 // BenchmarkMVCCGetMergedTimeSeries computes performance of reading merged
 // time series data using `MVCCGet()`. Uses an in-memory engine.
 func BenchmarkMVCCGetMergedTimeSeries_Pebble(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	ctx := context.Background()
 	for _, numKeys := range []int{1, 16, 256} {
 		b.Run(fmt.Sprintf("numKeys=%d", numKeys), func(b *testing.B) {
@@ -302,9 +295,7 @@ func BenchmarkMVCCGetMergedTimeSeries_Pebble(b *testing.B) {
 // what these benchmarks are trying to measure, and fix them.
 
 func BenchmarkMVCCDeleteRange_Pebble(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	ctx := context.Background()
 	for _, valueSize := range []int{8, 32, 256} {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
@@ -314,9 +305,7 @@ func BenchmarkMVCCDeleteRange_Pebble(b *testing.B) {
 }
 
 func BenchmarkClearRange_Pebble(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	ctx := context.Background()
 	runClearRange(ctx, b, setupMVCCPebble, func(eng Engine, batch Batch, start, end MVCCKey) error {
 		return batch.ClearRange(start, end)
@@ -333,9 +322,7 @@ func BenchmarkClearIterRange_Pebble(b *testing.B) {
 }
 
 func BenchmarkBatchApplyBatchRepr_Pebble(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	ctx := context.Background()
 	for _, indexed := range []bool{false, true} {
 		b.Run(fmt.Sprintf("indexed=%t", indexed), func(b *testing.B) {

--- a/pkg/storage/bench_rocksdb_test.go
+++ b/pkg/storage/bench_rocksdb_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -51,9 +52,7 @@ func setupMVCCInMemRocksDB(_ testing.TB, loc string) Engine {
 // Read benchmarks. All of them run with on-disk data.
 
 func BenchmarkMVCCScan_RocksDB(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+	skip.UnderShort(b, "TODO: fix benchmark")
 
 	ctx := context.Background()
 	for _, numRows := range []int{1, 10, 100, 1000, 10000} {
@@ -79,9 +78,7 @@ func BenchmarkMVCCScan_RocksDB(b *testing.B) {
 }
 
 func BenchmarkMVCCReverseScan_RocksDB(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+	skip.UnderShort(b, "TODO: fix benchmark")
 
 	ctx := context.Background()
 	for _, numRows := range []int{1, 10, 100, 1000, 10000} {
@@ -135,9 +132,7 @@ func BenchmarkMVCCGet_RocksDB(b *testing.B) {
 }
 
 func BenchmarkMVCCComputeStats_RocksDB(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	ctx := context.Background()
 	for _, valueSize := range []int{8, 32, 256} {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
@@ -318,9 +313,7 @@ func BenchmarkMVCCMergeTimeSeries_RocksDB(b *testing.B) {
 // BenchmarkMVCCGetMergedTimeSeries computes performance of reading merged
 // time series data using `MVCCGet()`. Uses an in-memory engine.
 func BenchmarkMVCCGetMergedTimeSeries_RocksDB(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	ctx := context.Background()
 	for _, numKeys := range []int{1, 16, 256} {
 		b.Run(fmt.Sprintf("numKeys=%d", numKeys), func(b *testing.B) {
@@ -336,9 +329,7 @@ func BenchmarkMVCCGetMergedTimeSeries_RocksDB(b *testing.B) {
 // DeleteRange benchmarks below (using on-disk data).
 
 func BenchmarkMVCCDeleteRange_RocksDB(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	ctx := context.Background()
 	for _, valueSize := range []int{8, 32, 256} {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
@@ -348,9 +339,7 @@ func BenchmarkMVCCDeleteRange_RocksDB(b *testing.B) {
 }
 
 func BenchmarkClearRange_RocksDB(b *testing.B) {
-	if testing.Short() {
-		b.Skip("TODO: fix benchmark")
-	}
+	skip.UnderShort(b, "TODO: fix benchmark")
 	ctx := context.Background()
 	runClearRange(ctx, b, setupMVCCRocksDB, func(eng Engine, batch Batch, start, end MVCCKey) error {
 		return batch.ClearRange(start, end)
@@ -367,9 +356,7 @@ func BenchmarkClearIterRange_RocksDB(b *testing.B) {
 }
 
 func BenchmarkBatchApplyBatchRepr_RocksDB(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	ctx := context.Background()
 	for _, indexed := range []bool{false, true} {
 		b.Run(fmt.Sprintf("indexed=%t", indexed), func(b *testing.B) {

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/fileutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -39,9 +40,7 @@ import (
 // with the business logic for the implementation of the other tests following.
 
 func BenchmarkMVCCGarbageCollect(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 
 	// NB: To debug #16068, test only 128-128-15000-6.
 	keySizes := []int{128}

--- a/pkg/storage/cloudimpl/cloudimpltests/azure_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/azure_storage_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -27,11 +28,11 @@ func TestPutAzure(t *testing.T) {
 	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
 	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
 	if accountName == "" || accountKey == "" {
-		t.Skip("AZURE_ACCOUNT_NAME and AZURE_ACCOUNT_KEY env vars must be set")
+		skip.IgnoreLint(t, "AZURE_ACCOUNT_NAME and AZURE_ACCOUNT_KEY env vars must be set")
 	}
 	bucket := os.Getenv("AZURE_CONTAINER")
 	if bucket == "" {
-		t.Skip("AZURE_CONTAINER env var must be set")
+		skip.IgnoreLint(t, "AZURE_CONTAINER env var must be set")
 	}
 
 	testExportStore(t, fmt.Sprintf("azure://%s/%s?%s=%s&%s=%s",

--- a/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
@@ -446,7 +447,7 @@ func TestPutGoogleCloud(t *testing.T) {
 
 	bucket := os.Getenv("GS_BUCKET")
 	if bucket == "" {
-		t.Skip("GS_BUCKET env var must be set")
+		skip.IgnoreLint(t, "GS_BUCKET env var must be set")
 	}
 
 	user := security.RootUser
@@ -462,7 +463,7 @@ func TestPutGoogleCloud(t *testing.T) {
 	t.Run("specified", func(t *testing.T) {
 		credentials := os.Getenv("GS_JSONKEY")
 		if credentials == "" {
-			t.Skip("GS_JSONKEY env var must be set")
+			skip.IgnoreLint(t, "GS_JSONKEY env var must be set")
 		}
 		encoded := base64.StdEncoding.EncodeToString([]byte(credentials))
 		testExportStore(t, fmt.Sprintf("gs://%s/%s?%s=%s&%s=%s",
@@ -489,7 +490,7 @@ func TestPutGoogleCloud(t *testing.T) {
 	t.Run("implicit", func(t *testing.T) {
 		// Only test these if they exist.
 		if _, err := google.FindDefaultCredentials(context.Background()); err != nil {
-			t.Skip(err)
+			skip.IgnoreLint(t, err)
 		}
 		testExportStore(t, fmt.Sprintf("gs://%s/%s?%s=%s", bucket, "backup-test-implicit",
 			cloudimpl.AuthParam, cloudimpl.AuthParamImplicit), false, user, nil, nil)

--- a/pkg/storage/cloudimpl/cloudimpltests/gcs_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/gcs_storage_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
@@ -83,7 +84,7 @@ func TestAntagonisticRead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
 		// This test requires valid GS credential file.
-		t.Skip("GOOGLE_APPLICATION_CREDENTIALS env var must be set")
+		skip.IgnoreLint(t, "GOOGLE_APPLICATION_CREDENTIALS env var must be set")
 	}
 
 	rnd, _ := randutil.NewPseudoRand()
@@ -126,7 +127,7 @@ func TestFileDoesNotExist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
 		// This test requires valid GS credential file.
-		t.Skip("GOOGLE_APPLICATION_CREDENTIALS env var must be set")
+		skip.IgnoreLint(t, "GOOGLE_APPLICATION_CREDENTIALS env var must be set")
 	}
 	user := security.RootUser
 

--- a/pkg/storage/cloudimpl/cloudimpltests/s3_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/s3_storage_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -37,11 +38,11 @@ func TestPutS3(t *testing.T) {
 	// it is not used in auth-implicit.
 	creds, err := credentials.NewEnvCredentials().Get()
 	if err != nil {
-		t.Skip("No AWS credentials")
+		skip.IgnoreLint(t, "No AWS credentials")
 	}
 	bucket := os.Getenv("AWS_S3_BUCKET")
 	if bucket == "" {
-		t.Skip("AWS_S3_BUCKET env var must be set")
+		skip.IgnoreLint(t, "AWS_S3_BUCKET env var must be set")
 	}
 
 	ctx := context.Background()
@@ -65,7 +66,7 @@ func TestPutS3(t *testing.T) {
 		credentialsProvider := credentials.SharedCredentialsProvider{}
 		_, err := credentialsProvider.Retrieve()
 		if err != nil {
-			t.Skip(err)
+			skip.IgnoreLint(t, err)
 		}
 
 		testExportStore(t, fmt.Sprintf(
@@ -107,14 +108,14 @@ func TestPutS3Endpoint(t *testing.T) {
 	for env, param := range expect {
 		v := os.Getenv(env)
 		if v == "" {
-			t.Skipf("%s env var must be set", env)
+			skip.IgnoreLintf(t, "%s env var must be set", env)
 		}
 		q.Add(param, v)
 	}
 
 	bucket := os.Getenv("AWS_S3_ENDPOINT_BUCKET")
 	if bucket == "" {
-		t.Skip("AWS_S3_ENDPOINT_BUCKET env var must be set")
+		skip.IgnoreLint(t, "AWS_S3_ENDPOINT_BUCKET env var must be set")
 	}
 	user := security.RootUser
 
@@ -168,7 +169,7 @@ func TestS3BucketDoesNotExist(t *testing.T) {
 	for env, param := range expect {
 		v := os.Getenv(env)
 		if v == "" {
-			t.Skipf("%s env var must be set", env)
+			skip.IgnoreLintf(t, "%s env var must be set", env)
 		}
 		q.Add(param, v)
 	}

--- a/pkg/storage/disk_map_test.go
+++ b/pkg/storage/disk_map_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -344,9 +345,7 @@ func BenchmarkRocksDBMapWrite(b *testing.B) {
 }
 
 func BenchmarkRocksDBMapIteration(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	dir, err := ioutil.TempDir("", "BenchmarkRocksDBMapIteration")
 	if err != nil {
 		b.Fatal(err)
@@ -565,9 +564,7 @@ func BenchmarkPebbleMapWrite(b *testing.B) {
 }
 
 func BenchmarkPebbleMapIteration(b *testing.B) {
-	if testing.Short() {
-		b.Skip("short flag")
-	}
+	skip.UnderShort(b)
 	dir, err := ioutil.TempDir("", "BenchmarkPebbleMapIteration")
 	if err != nil {
 		b.Fatal(err)

--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -159,10 +159,8 @@ func TestRocksPebbleEquivalence(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	if util.RaceEnabled {
-		// This test times out with the race detector enabled.
-		return
-	}
+	// This test times out with the race detector enabled.
+	skip.UnderRace(t)
 
 	// Have one fixed seed, one user-specified seed, and one random seed.
 	seeds := []int64{123, *seed, rand.Int63()}
@@ -192,12 +190,10 @@ func TestRocksPebbleEquivalence(t *testing.T) {
 func TestRocksPebbleRestarts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	// This test times out with the race detector enabled.
+	skip.UnderRace(t)
 
 	ctx := context.Background()
-	if util.RaceEnabled {
-		// This test times out with the race detector enabled.
-		return
-	}
 
 	// Have one fixed seed, one user-specified seed, and one random seed.
 	seeds := []int64{123, *seed, rand.Int63()}

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -138,7 +139,7 @@ func TestMVCCHistories(t *testing.T) {
 					switch d.Cmd {
 					case "skip":
 						if len(d.CmdArgs) == 0 || d.CmdArgs[0].Key == engineImpl.name {
-							e.t.Skip("skipped")
+							skip.IgnoreLint(e.t, "skipped")
 						}
 						return d.Expected
 					case "run":

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/zerofields"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -4673,7 +4674,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 					t.Run("", func(t *testing.T) {
 						if tenant {
 							if test.skipTenant {
-								t.Skip("")
+								skip.IgnoreLint(t, "")
 							}
 							// Update all keys to include a tenant prefix.
 							tenPrefix := keys.MakeSQLCodec(roachpb.MinTenantID).TenantPrefix()

--- a/pkg/storage/rocksdb_test.go
+++ b/pkg/storage/rocksdb_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -555,9 +555,8 @@ func TestConcurrentBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if testutils.NightlyStress() || util.RaceEnabled {
-		t.Skip()
-	}
+	skip.UnderStress(t)
+	skip.UnderRace(t)
 
 	dir, err := ioutil.TempDir("", t.Name())
 	if err != nil {

--- a/pkg/testutils/buildutil/build.go
+++ b/pkg/testutils/buildutil/build.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/errors"
 )
 
@@ -40,7 +41,7 @@ func VerifyNoImports(
 
 	// Skip test if source is not available.
 	if build.Default.GOPATH == "" {
-		t.Skip("GOPATH isn't set")
+		skip.IgnoreLint(t, "GOPATH isn't set")
 	}
 
 	buildContext := build.Default
@@ -124,7 +125,7 @@ func VerifyNoImports(
 func VerifyTransitiveAllowlist(t testing.TB, pkg string, allowedPkgs []string) {
 	// Skip test if source is not available.
 	if build.Default.GOPATH == "" {
-		t.Skip("GOPATH isn't set")
+		skip.IgnoreLint(t, "GOPATH isn't set")
 	}
 
 	checked := make(map[string]struct{})

--- a/pkg/testutils/lint/nightly_lint_test.go
+++ b/pkg/testutils/lint/nightly_lint_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/urlcheck/lib/urlcheck"
 	sqlparser "github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 func TestNightlyLint(t *testing.T) {
@@ -27,11 +28,9 @@ func TestNightlyLint(t *testing.T) {
 
 	// TestHelpURLs checks that all help texts have a valid documentation URL.
 	t.Run("TestHelpURLs", func(t *testing.T) {
-		if testing.Short() {
-			t.Skip("short flag")
-		}
+		skip.UnderShort(t)
 		if pkgSpecified {
-			t.Skip("PKG specified")
+			skip.IgnoreLint(t, "PKG specified")
 		}
 
 		t.Parallel()

--- a/pkg/testutils/lint/passes/descriptormarshal/descriptormarshal_test.go
+++ b/pkg/testutils/lint/passes/descriptormarshal/descriptormarshal_test.go
@@ -13,15 +13,13 @@ package descriptormarshal_test
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/descriptormarshal"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
-	if testutils.NightlyStress() {
-		t.Skip("Go cache files don't work under stress")
-	}
+	skip.UnderStress(t)
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, descriptormarshal.Analyzer, "a")
 }

--- a/pkg/testutils/lint/passes/fmtsafe/fmtsafe_test.go
+++ b/pkg/testutils/lint/passes/fmtsafe/fmtsafe_test.go
@@ -13,15 +13,13 @@ package fmtsafe_test
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/fmtsafe"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
-	if testutils.NightlyStress() {
-		t.Skip("Go cache files don't work under stress")
-	}
+	skip.UnderStress(t)
 	fmtsafe.Tip = ""
 	testdata := analysistest.TestData()
 	results := analysistest.Run(t, testdata, fmtsafe.Analyzer, "a")

--- a/pkg/testutils/lint/passes/hash/hash_test.go
+++ b/pkg/testutils/lint/passes/hash/hash_test.go
@@ -13,15 +13,13 @@ package hash_test
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/hash"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
-	if testutils.NightlyStress() {
-		t.Skip("Go cache files don't work under stress")
-	}
+	skip.UnderStress(t)
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, hash.Analyzer, "a")
 }

--- a/pkg/testutils/lint/passes/nocopy/nocopy_test.go
+++ b/pkg/testutils/lint/passes/nocopy/nocopy_test.go
@@ -14,15 +14,13 @@ package nocopy_test
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/nocopy"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
-	if testutils.NightlyStress() {
-		t.Skip("Go cache files don't work under stress")
-	}
+	skip.UnderStress(t)
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, nocopy.Analyzer, "a")
 }

--- a/pkg/testutils/lint/passes/returnerrcheck/returnerrcheck_test.go
+++ b/pkg/testutils/lint/passes/returnerrcheck/returnerrcheck_test.go
@@ -13,15 +13,13 @@ package returnerrcheck_test
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/returnerrcheck"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
-	if testutils.NightlyStress() {
-		t.Skip("Go cache files don't work under stress")
-	}
+	skip.UnderStress(t, "Go cache files don't work under stress")
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, returnerrcheck.Analyzer, "a")
 }

--- a/pkg/testutils/lint/passes/timer/timer_test.go
+++ b/pkg/testutils/lint/passes/timer/timer_test.go
@@ -13,15 +13,13 @@ package timer_test
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/timer"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
-	if testutils.NightlyStress() {
-		t.Skip("Go cache files don't work under stress")
-	}
+	skip.UnderStress(t, "Go cache files don't work under stress")
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, timer.Analyzer, "a")
 }

--- a/pkg/testutils/lint/passes/unconvert/unconvert_test.go
+++ b/pkg/testutils/lint/passes/unconvert/unconvert_test.go
@@ -13,15 +13,13 @@ package unconvert_test
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/unconvert"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
-	if testutils.NightlyStress() {
-		t.Skip("Go cache files don't work under stress")
-	}
+	skip.UnderStress(t, "Go cache files don't work under stress")
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, unconvert.Analyzer, "a")
 }

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/datadriven"
 	"github.com/jackc/pgx/pgproto3"
 )
@@ -71,10 +72,10 @@ func RunTest(t *testing.T, path, addr, user string) {
 		switch d.Cmd {
 		case "only":
 			if d.HasArg("crdb") && !p.isCockroachDB {
-				t.Skip("only crdb")
+				skip.IgnoreLint(t, "only crdb")
 			}
 			if d.HasArg("noncrdb") && p.isCockroachDB {
-				t.Skip("only non-crdb")
+				skip.IgnoreLint(t, "only non-crdb")
 			}
 			return d.Expected
 

--- a/pkg/testutils/reduce/reducesql/reducesql_test.go
+++ b/pkg/testutils/reduce/reducesql/reducesql_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/reduce"
 	"github.com/cockroachdb/cockroach/pkg/testutils/reduce/reducesql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/jackc/pgx"
 )
 
@@ -29,7 +30,7 @@ var printUnknown = flag.Bool("unknown", false, "print unknown types during walk"
 
 func TestReduceSQL(t *testing.T) {
 	// These take a bit too long to need to run every time.
-	t.Skip("unnecessary")
+	skip.IgnoreLint(t, "unnecessary")
 	reducesql.LogUnknown = *printUnknown
 
 	reduce.Walk(t, "testdata", reducesql.Pretty, isInterestingSQL, reduce.ModeInteresting, reducesql.SQLPasses)

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -1,0 +1,66 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package skip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// WithIssue skips this test, logging the given issue ID as the reason.
+func WithIssue(t testing.TB, githubIssueID int, args ...interface{}) {
+	t.Skip(append([]interface{}{
+		fmt.Sprintf("https://github.com/cockroachdb/cockroach/issue/%d", githubIssueID)},
+		args...))
+}
+
+// IgnoreLint skips this test, explicitly marking it as not a test that
+// should be tracked as a "skipped test" by external tools. You should use this
+// if, for example, your test should only be run in Race mode.
+func IgnoreLint(t testing.TB, args ...interface{}) {
+	t.Skip(args...)
+}
+
+// IgnoreLintf is like IgnoreLint, and it also takes a format string.
+func IgnoreLintf(t testing.TB, format string, args ...interface{}) {
+	t.Skipf(format, args...)
+}
+
+// UnderRace skips this test if the race detector is enabled.
+func UnderRace(t testing.TB, args ...interface{}) {
+	if util.RaceEnabled {
+		t.Skip(append([]interface{}{"disabled under race"}, args...))
+	}
+}
+
+// UnderShort skips this test if the -short flag is specified.
+func UnderShort(t testing.TB, args ...interface{}) {
+	if testing.Short() {
+		t.Skip(append([]interface{}{"disabled under -short"}, args...))
+	}
+}
+
+// UnderStress skips this test when running under stress.
+func UnderStress(t testing.TB, args ...interface{}) {
+	if NightlyStress() {
+		t.Skip(append([]interface{}{"disabled under stress"}, args...))
+	}
+}
+
+// UnderStressRace skips this test during stressrace runs, which are tests
+// run under stress with the -race flag.
+func UnderStressRace(t testing.TB, args ...interface{}) {
+	if NightlyStress() && util.RaceEnabled {
+		t.Skip(append([]interface{}{"disabled under stressrace"}, args...))
+	}
+}

--- a/pkg/testutils/skip/stress.go
+++ b/pkg/testutils/skip/stress.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Cockroach Authors.
+// Copyright 2020 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package testutils
+package skip
 
 import "github.com/cockroachdb/cockroach/pkg/util/envutil"
 

--- a/pkg/util/binfetcher/binfetcher_test.go
+++ b/pkg/util/binfetcher/binfetcher_test.go
@@ -17,13 +17,11 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 func TestDownload(t *testing.T) {
-	if testutils.NightlyStress() {
-		t.Skip()
-	}
-	t.Skip("disabled by default because downloading files in CI is a silly idea")
+	skip.IgnoreLint(t, "disabled by default because downloading files in CI is a silly idea")
 
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()

--- a/pkg/util/grpcutil/grpc_util_test.go
+++ b/pkg/util/grpcutil/grpc_util_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
@@ -52,7 +53,7 @@ func (hs healthServer) Watch(*healthpb.HealthCheckRequest, healthpb.Health_Watch
 func TestRequestDidNotStart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/19708")
+	skip.WithIssue(t, 19708)
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/pkg/util/uuid/codec_test.go
+++ b/pkg/util/uuid/codec_test.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 // codecTestData holds []byte data for a UUID we commonly use for testing.
@@ -280,7 +282,7 @@ var seedFuzzCorpus = flag.Bool("seed_fuzz_corpus", false, "seed fuzz test corpus
 func TestSeedFuzzCorpus(t *testing.T) {
 	// flag.Parse() is called for us by the test binary.
 	if !*seedFuzzCorpus {
-		t.Skip("seeding fuzz test corpus only on demand")
+		skip.IgnoreLint(t, "seeding fuzz test corpus only on demand")
 	}
 	corpusDir := filepath.Join(".", "testdata", "corpus")
 	writeSeedFile := func(name, data string) error {

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
@@ -76,9 +77,7 @@ func BenchmarkInitialData(b *testing.B) {
 		benchmarkInitialData(b, bank.FromRows(1000))
 	})
 	b.Run(`tpch/scaleFactor=1`, func(b *testing.B) {
-		if testing.Short() {
-			b.Skip(`tpch loads a lot of data`)
-		}
+		skip.UnderShort(b, "tpch loads a lot of data")
 		benchmarkInitialData(b, tpch.FromScaleFactor(1))
 	})
 }

--- a/pkg/workload/ycsb/zipfgenerator_test.go
+++ b/pkg/workload/ycsb/zipfgenerator_test.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"golang.org/x/exp/rand"
@@ -60,9 +61,7 @@ var tests = []struct {
 
 func TestZetaFromScratch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if testing.Short() {
-		t.Skip("short")
-	}
+	skip.UnderShort(t)
 	for _, test := range tests {
 		computedZeta, err := computeZetaFromScratch(test.n, test.theta)
 		if err != nil {
@@ -76,9 +75,7 @@ func TestZetaFromScratch(t *testing.T) {
 
 func TestZetaIncrementally(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if testing.Short() {
-		t.Skip("short")
-	}
+	skip.UnderShort(t)
 	// Theta cannot be 1 by definition, so this is a safe initial value.
 	oldTheta := 1.0
 	var oldZetaN float64


### PR DESCRIPTION
This commit introduces a new family of methods in the testutils/skip
package:

- WithIssue, WithIssuef: skip a test temporarily, linking to a GitHub
  issue.
- UnderRace, UnderShort, UnderStress, UnderStressRace: skip a test when
  run under the race detector, -short flag, stress build, or stressrace
  build, respectively.
- IgnoreLint, IgnoreLintf: skip a test for another reason, without
  bothering the linter.

It also removes all naked t.Skip and t.Skipf calls, replacing them with
one of the above skip package methods, and adds a linter to ensure that
naked t.Skip is never used.

This opens the door to performing more analytics on our skipped tests,
because of the extra structured data these methods provide.

Release note: None