### PR TITLE
cmd/docgen: add HTTP extractor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,6 +383,7 @@ bin/.bootstrap: $(GITHOOKS) | bin/.submodules-initialized
 		github.com/mattn/goveralls \
 		github.com/mibk/dupl \
 		github.com/mmatczuk/go_generics/cmd/go_generics \
+		github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc \
 		github.com/wadey/gocovmerge \
 		golang.org/x/lint/golint \
 		golang.org/x/perf/cmd/benchstat \
@@ -850,7 +851,7 @@ SQLPARSER_TARGETS = \
 
 PROTOBUF_TARGETS := bin/.go_protobuf_sources bin/.gw_protobuf_sources bin/.cpp_protobuf_sources bin/.cpp_ccl_protobuf_sources
 
-DOCGEN_TARGETS := bin/.docgen_bnfs bin/.docgen_functions docs/generated/redact_safe.md
+DOCGEN_TARGETS := bin/.docgen_bnfs bin/.docgen_functions docs/generated/redact_safe.md bin/.docgen_http
 
 EXECGEN_TARGETS = \
   pkg/col/coldata/vec.eg.go \
@@ -1555,6 +1556,14 @@ bin/.docgen_bnfs: bin/docgen
 
 bin/.docgen_functions: bin/docgen
 	docgen functions docs/generated/sql --quiet
+	touch $@
+
+bin/.docgen_http: bin/docgen $(PROTOC)
+	docgen http \
+		--protoc $(PROTOC) \
+		--gendoc ./bin/protoc-gen-doc \
+		--out docs/generated/http \
+		--protobuf pkg:$(GOGO_PROTOBUF_PATH):$(PROTOBUF_PATH):$(COREOS_PATH):$(GRPC_GATEWAY_GOOGLEAPIS_PATH):$(ERRORS_PATH)
 	touch $@
 
 .PHONY: docs/generated/redact_safe.md

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1,0 +1,2049 @@
+## Certificates
+
+`GET /_status/certificates/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.CertificatesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| certificates | [CertificateDetails](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails"></a>
+#### CertificateDetails
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| type | [CertificateDetails.CertificateType](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.CertificateType) |  |  |
+| error_message | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  | "error_message" and "data" are mutually exclusive. |
+| data | [bytes](#cockroach.server.serverpb.CertificatesResponse-bytes) |  | data is the raw file contents of the certificate. This means PEM-encoded DER data. |
+| fields | [CertificateDetails.Fields](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.Fields) | repeated |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.Fields"></a>
+#### CertificateDetails.Fields
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| issuer | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
+| subject | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
+| valid_from | [int64](#cockroach.server.serverpb.CertificatesResponse-int64) |  |  |
+| valid_until | [int64](#cockroach.server.serverpb.CertificatesResponse-int64) |  |  |
+| addresses | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  |
+| signature_algorithm | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
+| public_key | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  |  |
+| key_usage | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  |
+| extended_key_usage | [string](#cockroach.server.serverpb.CertificatesResponse-string) | repeated |  |
+
+
+
+
+
+
+## Details
+
+`GET /_status/details/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.DetailsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int32](#cockroach.server.serverpb.DetailsResponse-int32) |  |  |
+| address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.DetailsResponse-cockroach.util.UnresolvedAddr) |  |  |
+| build_info | [cockroach.build.Info](#cockroach.server.serverpb.DetailsResponse-cockroach.build.Info) |  |  |
+| system_info | [SystemInfo](#cockroach.server.serverpb.DetailsResponse-cockroach.server.serverpb.SystemInfo) |  |  |
+| sql_address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.DetailsResponse-cockroach.util.UnresolvedAddr) |  |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.DetailsResponse-cockroach.server.serverpb.SystemInfo"></a>
+#### SystemInfo
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| system_info | [string](#cockroach.server.serverpb.DetailsResponse-string) |  | system_info is the output from `uname -a` |
+| kernel_info | [string](#cockroach.server.serverpb.DetailsResponse-string) |  | kernel_info is the output from `uname -r`. |
+
+
+
+
+
+
+## Nodes
+
+`GET /_status/nodes`
+
+Don't introduce additional usages of this RPC. See #50707 for more details.
+The underlying response type is something we're looking to get rid of.
+
+### Request Parameters
+
+
+
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| nodes | [cockroach.server.status.statuspb.NodeStatus](#cockroach.server.serverpb.NodesResponse-cockroach.server.status.statuspb.NodeStatus) | repeated |  |
+| liveness_by_node_id | [NodesResponse.LivenessByNodeIdEntry](#cockroach.server.serverpb.NodesResponse-cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesResponse-cockroach.server.serverpb.NodesResponse.LivenessByNodeIdEntry"></a>
+#### NodesResponse.LivenessByNodeIdEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [int32](#cockroach.server.serverpb.NodesResponse-int32) |  |  |
+| value | [cockroach.kv.kvserver.storagepb.NodeLivenessStatus](#cockroach.server.serverpb.NodesResponse-cockroach.kv.kvserver.storagepb.NodeLivenessStatus) |  |  |
+
+
+
+
+
+
+## Node
+
+`GET /_status/nodes/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.NodeRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+## RaftDebug
+
+`GET /_status/raft`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| range_ids | [int64](#cockroach.server.serverpb.RaftDebugRequest-int64) | repeated |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ranges | [RaftDebugResponse.RangesEntry](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftDebugResponse.RangesEntry) | repeated |  |
+| errors | [RaftRangeError](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftDebugResponse.RangesEntry"></a>
+#### RaftDebugResponse.RangesEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  |
+| value | [RaftRangeStatus](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeStatus) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeStatus"></a>
+#### RaftRangeStatus
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| range_id | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  |
+| errors | [RaftRangeError](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError) | repeated |  |
+| nodes | [RaftRangeNode](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeNode) | repeated |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError"></a>
+#### RaftRangeError
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeNode"></a>
+#### RaftRangeNode
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  |
+| range | [RangeInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeInfo) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeInfo"></a>
+#### RangeInfo
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| span | [PrettySpan](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.PrettySpan) |  |  |
+| raft_state | [RaftState](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState) |  |  |
+| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  |
+| source_node_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  |
+| source_store_id | [int32](#cockroach.server.serverpb.RaftDebugResponse-int32) |  |  |
+| error_message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RaftDebugResponse-cockroach.roachpb.Lease) | repeated |  |
+| problems | [RangeProblems](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeProblems) |  |  |
+| stats | [RangeStatistics](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeStatistics) |  |  |
+| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
+| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
+| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RaftDebugResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  |
+| quiescent | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
+| ticking | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.PrettySpan"></a>
+#### PrettySpan
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| start_key | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+| end_key | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState"></a>
+#### RaftState
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| replica_id | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
+| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RaftDebugResponse-raftpb.HardState) |  |  |
+| lead | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  | Lead is part of Raft's SoftState. |
+| state | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. |
+| applied | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
+| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  |
+| lead_transferee | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.ProgressEntry"></a>
+#### RaftState.ProgressEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
+| value | [RaftState.Progress](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftState.Progress"></a>
+#### RaftState.Progress
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| match | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
+| next | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
+| state | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+| paused | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
+| pending_snapshot | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeProblems"></a>
+#### RangeProblems
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| unavailable | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
+| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
+| no_raft_leader | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
+| underreplicated | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
+| overreplicated | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
+| no_lease | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  |
+| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. |
+| raft_log_too_large | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeStatistics"></a>
+#### RangeStatistics
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| queries_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. |
+| writes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError"></a>
+#### RaftRangeError
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| message | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  |  |
+
+
+
+
+
+
+## Ranges
+
+`GET /_status/ranges/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.RangesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+| range_ids | [int64](#cockroach.server.serverpb.RangesRequest-int64) | repeated |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ranges | [RangeInfo](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeInfo) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeInfo"></a>
+#### RangeInfo
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| span | [PrettySpan](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.PrettySpan) |  |  |
+| raft_state | [RaftState](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState) |  |  |
+| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  |
+| source_node_id | [int32](#cockroach.server.serverpb.RangesResponse-int32) |  |  |
+| source_store_id | [int32](#cockroach.server.serverpb.RangesResponse-int32) |  |  |
+| error_message | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
+| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RangesResponse-cockroach.roachpb.Lease) | repeated |  |
+| problems | [RangeProblems](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeProblems) |  |  |
+| stats | [RangeStatistics](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeStatistics) |  |  |
+| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
+| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
+| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RangesResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  |
+| quiescent | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
+| ticking | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.PrettySpan"></a>
+#### PrettySpan
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| start_key | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
+| end_key | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState"></a>
+#### RaftState
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| replica_id | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
+| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RangesResponse-raftpb.HardState) |  |  |
+| lead | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  | Lead is part of Raft's SoftState. |
+| state | [string](#cockroach.server.serverpb.RangesResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. |
+| applied | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
+| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  |
+| lead_transferee | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.ProgressEntry"></a>
+#### RaftState.ProgressEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
+| value | [RaftState.Progress](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RaftState.Progress"></a>
+#### RaftState.Progress
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| match | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
+| next | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
+| state | [string](#cockroach.server.serverpb.RangesResponse-string) |  |  |
+| paused | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
+| pending_snapshot | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeProblems"></a>
+#### RangeProblems
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| unavailable | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
+| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
+| no_raft_leader | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
+| underreplicated | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
+| overreplicated | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
+| no_lease | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  |
+| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. |
+| raft_log_too_large | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeStatistics"></a>
+#### RangeStatistics
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| queries_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. |
+| writes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  |  |
+
+
+
+
+
+
+## Gossip
+
+`GET /_status/gossip/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.GossipRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+## EngineStats
+
+`GET /_status/enginestats/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.EngineStatsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| stats | [EngineStatsInfo](#cockroach.server.serverpb.EngineStatsResponse-cockroach.server.serverpb.EngineStatsInfo) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.EngineStatsResponse-cockroach.server.serverpb.EngineStatsInfo"></a>
+#### EngineStatsInfo
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| store_id | [int32](#cockroach.server.serverpb.EngineStatsResponse-int32) |  |  |
+| tickers_and_histograms | [cockroach.storage.enginepb.TickersAndHistograms](#cockroach.server.serverpb.EngineStatsResponse-cockroach.storage.enginepb.TickersAndHistograms) |  |  |
+| engine_type | [cockroach.storage.enginepb.EngineType](#cockroach.server.serverpb.EngineStatsResponse-cockroach.storage.enginepb.EngineType) |  |  |
+
+
+
+
+
+
+## Allocator
+
+`GET /_status/allocator/node/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.AllocatorRequest-string) |  |  |
+| range_ids | [int64](#cockroach.server.serverpb.AllocatorRequest-int64) | repeated |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| dry_runs | [AllocatorDryRun](#cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.AllocatorDryRun) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.AllocatorDryRun"></a>
+#### AllocatorDryRun
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| range_id | [int64](#cockroach.server.serverpb.AllocatorResponse-int64) |  |  |
+| events | [TraceEvent](#cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.TraceEvent) | repeated |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.AllocatorResponse-cockroach.server.serverpb.TraceEvent"></a>
+#### TraceEvent
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.AllocatorResponse-google.protobuf.Timestamp) |  |  |
+| message | [string](#cockroach.server.serverpb.AllocatorResponse-string) |  |  |
+
+
+
+
+
+
+## AllocatorRange
+
+`GET /_status/allocator/range/{range_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| range_id | [int64](#cockroach.server.serverpb.AllocatorRangeRequest-int64) |  |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int64](#cockroach.server.serverpb.AllocatorRangeResponse-int64) |  | The NodeID of the store whose dry run is returned. Only the leaseholder for a given range will do an allocator dry run for it. |
+| dry_run | [AllocatorDryRun](#cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.AllocatorDryRun) |  |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.AllocatorDryRun"></a>
+#### AllocatorDryRun
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| range_id | [int64](#cockroach.server.serverpb.AllocatorRangeResponse-int64) |  |  |
+| events | [TraceEvent](#cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.TraceEvent) | repeated |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.AllocatorRangeResponse-cockroach.server.serverpb.TraceEvent"></a>
+#### TraceEvent
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| time | [google.protobuf.Timestamp](#cockroach.server.serverpb.AllocatorRangeResponse-google.protobuf.Timestamp) |  |  |
+| message | [string](#cockroach.server.serverpb.AllocatorRangeResponse-string) |  |  |
+
+
+
+
+
+
+## ListSessions
+
+`GET /_status/sessions`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| username | [string](#cockroach.server.serverpb.ListSessionsRequest-string) |  | Username of the user making this request. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. |
+| errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session"></a>
+#### Session
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node where this session exists. |
+| username | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Username of the user for this session. |
+| client_address | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Connected client's IP address and port. |
+| application_name | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Application name specified by the client. |
+| active_queries | [ActiveQuery](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery) | repeated | Queries in progress on this session. |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Timestamp of session's start. |
+| kv_txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the current KV transaction for this session. Nil if the session doesn't currently have a transaction. |
+| active_txn | [TxnInfo](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo) |  | Information about the txn in progress on this session. Nil if the session doesn't currently have a transaction. |
+| last_active_query | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL string of the last query executed on this session. |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the session (uint128 represented as raw bytes). |
+| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the session memory monitor. |
+| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the session memory monitor. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery"></a>
+#### ActiveQuery
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | ID of the query (uint128 presented as a hexadecimal string). |
+| txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | The UUID of the transaction this query is running in. |
+| sql | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL query string specified by the user. |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. |
+| is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. |
+| phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. |
+| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo"></a>
+#### TxnInfo
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  |  |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The start timestamp of the transaction. |
+| txn_description | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | txn_description is a text description of the underlying kv.Txn, intended for troubleshooting purposes. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError"></a>
+#### ListSessionsError
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node that was being contacted when this error occurred |
+| message | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message. |
+
+
+
+
+
+
+## ListLocalSessions
+
+`GET /_status/local_sessions`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| username | [string](#cockroach.server.serverpb.ListSessionsRequest-string) |  | Username of the user making this request. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. |
+| errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session"></a>
+#### Session
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node where this session exists. |
+| username | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Username of the user for this session. |
+| client_address | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Connected client's IP address and port. |
+| application_name | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Application name specified by the client. |
+| active_queries | [ActiveQuery](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery) | repeated | Queries in progress on this session. |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Timestamp of session's start. |
+| kv_txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the current KV transaction for this session. Nil if the session doesn't currently have a transaction. |
+| active_txn | [TxnInfo](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo) |  | Information about the txn in progress on this session. Nil if the session doesn't currently have a transaction. |
+| last_active_query | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL string of the last query executed on this session. |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | ID of the session (uint128 represented as raw bytes). |
+| alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | Number of currently allocated bytes in the session memory monitor. |
+| max_alloc_bytes | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | High water mark of allocated bytes in the session memory monitor. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery"></a>
+#### ActiveQuery
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | ID of the query (uint128 presented as a hexadecimal string). |
+| txn_id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  | The UUID of the transaction this query is running in. |
+| sql | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | SQL query string specified by the user. |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | Start timestamp of this query. |
+| is_distributed | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if this query is distributed. |
+| phase | [ActiveQuery.Phase](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ActiveQuery.Phase) |  | phase stores the current phase of execution for this query. |
+| progress | [float](#cockroach.server.serverpb.ListSessionsResponse-float) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.TxnInfo"></a>
+#### TxnInfo
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [bytes](#cockroach.server.serverpb.ListSessionsResponse-bytes) |  |  |
+| start | [google.protobuf.Timestamp](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Timestamp) |  | The start timestamp of the transaction. |
+| txn_description | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | txn_description is a text description of the underlying kv.Txn, intended for troubleshooting purposes. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError"></a>
+#### ListSessionsError
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int32](#cockroach.server.serverpb.ListSessionsResponse-int32) |  | ID of node that was being contacted when this error occurred |
+| message | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message. |
+
+
+
+
+
+
+## CancelQuery
+
+`GET /_status/cancel_query/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | ID of gateway node for the query to be canceled.
+
+TODO(itsbilal): use [(gogoproto.customname) = "NodeID"] below. Need to figure out how to teach grpc-gateway about custom names.
+
+node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+| query_id | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | ID of query to be canceled (converted to string). |
+| username | [string](#cockroach.server.serverpb.CancelQueryRequest-string) |  | Username of the user making this cancellation request. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| canceled | [bool](#cockroach.server.serverpb.CancelQueryResponse-bool) |  | Whether the cancellation request succeeded and the query was canceled. |
+| error | [string](#cockroach.server.serverpb.CancelQueryResponse-string) |  | Error message (accompanied with canceled = false). |
+
+
+
+
+
+
+
+## CancelSession
+
+`GET /_status/cancel_session/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.CancelSessionRequest-string) |  | TODO(abhimadan): use [(gogoproto.customname) = "NodeID"] below. Need to figure out how to teach grpc-gateway about custom names.
+
+node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+| session_id | [bytes](#cockroach.server.serverpb.CancelSessionRequest-bytes) |  |  |
+| username | [string](#cockroach.server.serverpb.CancelSessionRequest-string) |  |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| canceled | [bool](#cockroach.server.serverpb.CancelSessionResponse-bool) |  |  |
+| error | [string](#cockroach.server.serverpb.CancelSessionResponse-string) |  |  |
+
+
+
+
+
+
+
+## SpanStats
+
+`POST /_status/span`
+
+SpanStats accepts a key span and node ID, and returns a set of stats
+summed from all ranges on the stores on that node which contain keys
+in that span. This is designed to compute stats specific to a SQL table:
+it will be called with the highest/lowest key for a SQL table, and return
+information about the resources on a node used by that table.
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.SpanStatsRequest-string) |  |  |
+| start_key | [bytes](#cockroach.server.serverpb.SpanStatsRequest-bytes) |  |  |
+| end_key | [bytes](#cockroach.server.serverpb.SpanStatsRequest-bytes) |  |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| range_count | [int32](#cockroach.server.serverpb.SpanStatsResponse-int32) |  |  |
+| approximate_disk_bytes | [uint64](#cockroach.server.serverpb.SpanStatsResponse-uint64) |  |  |
+| total_stats | [cockroach.storage.enginepb.MVCCStats](#cockroach.server.serverpb.SpanStatsResponse-cockroach.storage.enginepb.MVCCStats) |  |  |
+
+
+
+
+
+
+
+## Stacks
+
+`GET /_status/stacks/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.StacksRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+| type | [StacksType](#cockroach.server.serverpb.StacksRequest-cockroach.server.serverpb.StacksType) |  |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  |
+
+
+
+
+
+
+
+## Profile
+
+`GET /_status/profile/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.ProfileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+| type | [ProfileRequest.Type](#cockroach.server.serverpb.ProfileRequest-cockroach.server.serverpb.ProfileRequest.Type) |  | The type of profile to retrieve. |
+| seconds | [int32](#cockroach.server.serverpb.ProfileRequest-int32) |  | applies only to Type=CPU, defaults to 30 |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  |
+
+
+
+
+
+
+
+## Metrics
+
+`GET /_status/metrics/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.MetricsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| data | [bytes](#cockroach.server.serverpb.JSONResponse-bytes) |  |  |
+
+
+
+
+
+
+
+## GetFiles
+
+`GET /_status/files/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.GetFilesRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+| list_only | [bool](#cockroach.server.serverpb.GetFilesRequest-bool) |  | If list_only is true then the contents of the files will not be populated in the response. Only filenames and sizes will be returned. |
+| type | [FileType](#cockroach.server.serverpb.GetFilesRequest-cockroach.server.serverpb.FileType) |  |  |
+| patterns | [string](#cockroach.server.serverpb.GetFilesRequest-string) | repeated | Each pattern given is matched with Files of the above type in the node using filepath.Glob(). The patterns only match to filenames and so path separators cannot be used. Example: * will match all files of requested type. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| files | [File](#cockroach.server.serverpb.GetFilesResponse-cockroach.server.serverpb.File) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.GetFilesResponse-cockroach.server.serverpb.File"></a>
+#### File
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#cockroach.server.serverpb.GetFilesResponse-string) |  |  |
+| file_size | [int64](#cockroach.server.serverpb.GetFilesResponse-int64) |  |  |
+| contents | [bytes](#cockroach.server.serverpb.GetFilesResponse-bytes) |  | Contents may not be populated if only a list of Files are requested. |
+
+
+
+
+
+
+## LogFilesList
+
+`GET /_status/logfiles/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.LogFilesListRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| files | [cockroach.util.log.FileInfo](#cockroach.server.serverpb.LogFilesListResponse-cockroach.util.log.FileInfo) | repeated |  |
+
+
+
+
+
+
+
+## LogFile
+
+`GET /_status/logfiles/{node_id}/{file}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.LogFileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+| file | [string](#cockroach.server.serverpb.LogFileRequest-string) |  |  |
+| redact | [bool](#cockroach.server.serverpb.LogFileRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the retrieved log entries. Only admin users can send a request with redact = false. |
+| keep_redactable | [bool](#cockroach.server.serverpb.LogFileRequest-bool) |  | keep_redactable, if true, requests that retrieved entries preserve the redaction markers if any were present in the log files. If false, redaction markers are stripped away. Note that redact = false && redactable = false implies "flat" entries with all sensitive information enclosed and no markers; this is suitable for backward-compatibility with RPC clients from prior the introduction of redactable logs. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  |
+
+
+
+
+
+
+
+## Logs
+
+`GET /_status/logs/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.LogsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+| level | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
+| start_time | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
+| end_time | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
+| max | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
+| pattern | [string](#cockroach.server.serverpb.LogsRequest-string) |  |  |
+| redact | [bool](#cockroach.server.serverpb.LogsRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the retrieved log entries. Only admin users can send a request with redact = false. |
+| keep_redactable | [bool](#cockroach.server.serverpb.LogsRequest-bool) |  | keep_redactable, if true, requests that retrieved entries preserve the redaction markers if any were present in the log files. If false, redaction markers are stripped away. Note that redact = false && redactable = false implies "flat" entries with all sensitive information enclosed and no markers; this is suitable for backward-compatibility with RPC clients from prior the introduction of redactable logs. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entries | [cockroach.util.log.Entry](#cockroach.server.serverpb.LogEntriesResponse-cockroach.util.log.Entry) | repeated |  |
+
+
+
+
+
+
+
+## ProblemRanges
+
+`GET /_status/problemranges`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.ProblemRangesRequest-string) |  | If left empty, problem ranges for all nodes/stores will be returned. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int32](#cockroach.server.serverpb.ProblemRangesResponse-int32) |  | NodeID is the node that submitted all the requests. |
+| problems_by_node_id | [ProblemRangesResponse.ProblemsByNodeIdEntry](#cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.ProblemsByNodeIdEntry) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.ProblemsByNodeIdEntry"></a>
+#### ProblemRangesResponse.ProblemsByNodeIdEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [int32](#cockroach.server.serverpb.ProblemRangesResponse-int32) |  |  |
+| value | [ProblemRangesResponse.NodeProblems](#cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.NodeProblems) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.ProblemRangesResponse-cockroach.server.serverpb.ProblemRangesResponse.NodeProblems"></a>
+#### ProblemRangesResponse.NodeProblems
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| error_message | [string](#cockroach.server.serverpb.ProblemRangesResponse-string) |  |  |
+| unavailable_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
+| raft_leader_not_lease_holder_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
+| no_raft_leader_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
+| no_lease_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
+| underreplicated_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
+| overreplicated_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
+| quiescent_equals_ticking_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
+| raft_log_too_large_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  |
+
+
+
+
+
+
+## HotRanges
+
+`GET /_status/hotranges`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  | If left empty, hot ranges for all nodes/stores will be returned. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | NodeID is the node that submitted all the requests. |
+| hot_ranges_by_node_id | [HotRangesResponse.HotRangesByNodeIdEntry](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry"></a>
+#### HotRangesResponse.HotRangesByNodeIdEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  |  |
+| value | [HotRangesResponse.NodeResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.NodeResponse) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.NodeResponse"></a>
+#### HotRangesResponse.NodeResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| error_message | [string](#cockroach.server.serverpb.HotRangesResponse-string) |  |  |
+| stores | [HotRangesResponse.StoreResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.StoreResponse) | repeated |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.StoreResponse"></a>
+#### HotRangesResponse.StoreResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| store_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  |  |
+| hot_ranges | [HotRangesResponse.HotRange](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRange) | repeated |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRange"></a>
+#### HotRangesResponse.HotRange
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| desc | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.HotRangesResponse-cockroach.roachpb.RangeDescriptor) |  |  |
+| queries_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  |  |
+
+
+
+
+
+
+## Range
+
+`GET /_status/range/{range_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| range_id | [int64](#cockroach.server.serverpb.RangeRequest-int64) |  |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  | NodeID is the node that submitted all the requests. |
+| range_id | [int64](#cockroach.server.serverpb.RangeResponse-int64) |  |  |
+| responses_by_node_id | [RangeResponse.ResponsesByNodeIdEntry](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.ResponsesByNodeIdEntry) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.ResponsesByNodeIdEntry"></a>
+#### RangeResponse.ResponsesByNodeIdEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  |
+| value | [RangeResponse.NodeResponse](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.NodeResponse) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeResponse.NodeResponse"></a>
+#### RangeResponse.NodeResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| response | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+| error_message | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
+| infos | [RangeInfo](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeInfo) | repeated |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeInfo"></a>
+#### RangeInfo
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| span | [PrettySpan](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.PrettySpan) |  |  |
+| raft_state | [RaftState](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState) |  |  |
+| state | [cockroach.kv.kvserver.storagepb.RangeInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.RangeInfo) |  |  |
+| source_node_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  |
+| source_store_id | [int32](#cockroach.server.serverpb.RangeResponse-int32) |  |  |
+| error_message | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
+| lease_history | [cockroach.roachpb.Lease](#cockroach.server.serverpb.RangeResponse-cockroach.roachpb.Lease) | repeated |  |
+| problems | [RangeProblems](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeProblems) |  |  |
+| stats | [RangeStatistics](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeStatistics) |  |  |
+| latches_local | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
+| latches_global | [cockroach.kv.kvserver.storagepb.LatchManagerInfo](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LatchManagerInfo) |  |  |
+| lease_status | [cockroach.kv.kvserver.storagepb.LeaseStatus](#cockroach.server.serverpb.RangeResponse-cockroach.kv.kvserver.storagepb.LeaseStatus) |  |  |
+| quiescent | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+| ticking | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.PrettySpan"></a>
+#### PrettySpan
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| start_key | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
+| end_key | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState"></a>
+#### RaftState
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| replica_id | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
+| hard_state | [raftpb.HardState](#cockroach.server.serverpb.RangeResponse-raftpb.HardState) |  |  |
+| lead | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  | Lead is part of Raft's SoftState. |
+| state | [string](#cockroach.server.serverpb.RangeResponse-string) |  | State is part of Raft's SoftState. It's not an enum because this is primarily for ui consumption and there are issues associated with them. |
+| applied | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
+| progress | [RaftState.ProgressEntry](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.ProgressEntry) | repeated |  |
+| lead_transferee | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.ProgressEntry"></a>
+#### RaftState.ProgressEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
+| value | [RaftState.Progress](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.Progress) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RaftState.Progress"></a>
+#### RaftState.Progress
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| match | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
+| next | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
+| state | [string](#cockroach.server.serverpb.RangeResponse-string) |  |  |
+| paused | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+| pending_snapshot | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeProblems"></a>
+#### RangeProblems
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| unavailable | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+| leader_not_lease_holder | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+| no_raft_leader | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+| underreplicated | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+| overreplicated | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+| no_lease | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  |
+| quiescent_equals_ticking | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  | Quiescent ranges do not tick by definition, but we track this in two different ways and suspect that they're getting out of sync. If the replica's quiescent flag doesn't agree with the store's list of replicas that are ticking, warn about it. |
+| raft_log_too_large | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeStatistics"></a>
+#### RangeStatistics
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| queries_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. |
+| writes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  |  |
+
+
+
+
+
+
+## Diagnostics
+
+`GET /_status/diagnostics/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.DiagnosticsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+## Stores
+
+`GET /_status/stores/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.StoresRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| stores | [StoreDetails](#cockroach.server.serverpb.StoresResponse-cockroach.server.serverpb.StoreDetails) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.StoresResponse-cockroach.server.serverpb.StoreDetails"></a>
+#### StoreDetails
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| store_id | [int32](#cockroach.server.serverpb.StoresResponse-int32) |  |  |
+| encryption_status | [bytes](#cockroach.server.serverpb.StoresResponse-bytes) |  | encryption_status is a serialized ccl/storageccl/engineccl/enginepbccl/stats.go::EncryptionStatus protobuf. |
+| total_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Basic file stats when encryption is enabled. Total files/bytes. |
+| total_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  |
+| active_key_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Files/bytes using the active data key. |
+| active_key_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  |
+
+
+
+
+
+
+## Statements
+
+`GET /_status/statements`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.StatementsRequest-string) |  |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| statements | [StatementsResponse.CollectedStatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.CollectedStatementStatistics) | repeated |  |
+| last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  | Timestamp of the last stats reset. |
+| internal_app_name_prefix | [string](#cockroach.server.serverpb.StatementsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.CollectedStatementStatistics"></a>
+#### StatementsResponse.CollectedStatementStatistics
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [StatementsResponse.ExtendedStatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedStatementStatisticsKey) |  |  |
+| stats | [cockroach.sql.StatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatistics) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedStatementStatisticsKey"></a>
+#### StatementsResponse.ExtendedStatementStatisticsKey
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key_data | [cockroach.sql.StatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatisticsKey) |  |  |
+| node_id | [int32](#cockroach.server.serverpb.StatementsResponse-int32) |  |  |
+
+
+
+
+
+
+## CreateStatementDiagnosticsReport
+
+`POST /_status/stmtdiagreports`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| statement_fingerprint | [string](#cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest-string) |  |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| report | [StatementDiagnosticsReport](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-cockroach.server.serverpb.StatementDiagnosticsReport) |  |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-cockroach.server.serverpb.StatementDiagnosticsReport"></a>
+#### StatementDiagnosticsReport
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [int64](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-int64) |  |  |
+| completed | [bool](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-bool) |  |  |
+| statement_fingerprint | [string](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-string) |  |  |
+| statement_diagnostics_id | [int64](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-int64) |  |  |
+| requested_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse-google.protobuf.Timestamp) |  |  |
+
+
+
+
+
+
+## StatementDiagnosticsRequests
+
+`GET /_status/stmtdiagreports`
+
+
+
+### Request Parameters
+
+
+
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| reports | [StatementDiagnosticsReport](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-cockroach.server.serverpb.StatementDiagnosticsReport) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.StatementDiagnosticsReportsResponse-cockroach.server.serverpb.StatementDiagnosticsReport"></a>
+#### StatementDiagnosticsReport
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [int64](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-int64) |  |  |
+| completed | [bool](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-bool) |  |  |
+| statement_fingerprint | [string](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-string) |  |  |
+| statement_diagnostics_id | [int64](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-int64) |  |  |
+| requested_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDiagnosticsReportsResponse-google.protobuf.Timestamp) |  |  |
+
+
+
+
+
+
+## StatementDiagnostics
+
+`GET /_status/stmtdiag/{statement_diagnostics_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| statement_diagnostics_id | [int64](#cockroach.server.serverpb.StatementDiagnosticsRequest-int64) |  |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| diagnostics | [StatementDiagnostics](#cockroach.server.serverpb.StatementDiagnosticsResponse-cockroach.server.serverpb.StatementDiagnostics) |  |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.StatementDiagnosticsResponse-cockroach.server.serverpb.StatementDiagnostics"></a>
+#### StatementDiagnostics
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [int64](#cockroach.server.serverpb.StatementDiagnosticsResponse-int64) |  |  |
+| statement_fingerprint | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  |
+| collected_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDiagnosticsResponse-google.protobuf.Timestamp) |  |  |
+| trace | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  |
+
+
+
+
+
+
+## JobRegistryStatus
+
+`GET /_status/job_registry/{node_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.JobRegistryStatusRequest-string) |  |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int32](#cockroach.server.serverpb.JobRegistryStatusResponse-int32) |  |  |
+| running_jobs | [JobRegistryStatusResponse.Job](#cockroach.server.serverpb.JobRegistryStatusResponse-cockroach.server.serverpb.JobRegistryStatusResponse.Job) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.JobRegistryStatusResponse-cockroach.server.serverpb.JobRegistryStatusResponse.Job"></a>
+#### JobRegistryStatusResponse.Job
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [int64](#cockroach.server.serverpb.JobRegistryStatusResponse-int64) |  |  |
+
+
+
+
+
+
+## JobStatus
+
+`GET /_status/job/{job_id}`
+
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job_id | [int64](#cockroach.server.serverpb.JobStatusRequest-int64) |  |  |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| job | [cockroach.sql.jobs.jobspb.Job](#cockroach.server.serverpb.JobStatusResponse-cockroach.sql.jobs.jobspb.Job) |  |  |
+
+
+
+
+
+
+

--- a/docs/generated/http/hotranges.md
+++ b/docs/generated/http/hotranges.md
@@ -1,0 +1,80 @@
+
+
+### Request Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  | If left empty, hot ranges for all nodes/stores will be returned. |
+
+
+
+
+
+
+
+### Response Parameters
+
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | NodeID is the node that submitted all the requests. |
+| hot_ranges_by_node_id | [HotRangesResponse.HotRangesByNodeIdEntry](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry) | repeated |  |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRangesByNodeIdEntry"></a>
+#### HotRangesResponse.HotRangesByNodeIdEntry
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  |  |
+| value | [HotRangesResponse.NodeResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.NodeResponse) |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.NodeResponse"></a>
+#### HotRangesResponse.NodeResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| error_message | [string](#cockroach.server.serverpb.HotRangesResponse-string) |  |  |
+| stores | [HotRangesResponse.StoreResponse](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.StoreResponse) | repeated |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.StoreResponse"></a>
+#### HotRangesResponse.StoreResponse
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| store_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  |  |
+| hot_ranges | [HotRangesResponse.HotRange](#cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRange) | repeated |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.HotRangesResponse-cockroach.server.serverpb.HotRangesResponse.HotRange"></a>
+#### HotRangesResponse.HotRange
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| desc | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.HotRangesResponse-cockroach.roachpb.RangeDescriptor) |  |  |
+| queries_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  |  |
+
+
+
+
+

--- a/go.mod
+++ b/go.mod
@@ -133,6 +133,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	github.com/prometheus/procfs v0.0.10 // indirect
+	github.com/pseudomuto/protoc-gen-doc v1.3.2
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563
 	github.com/sasha-s/go-deadlock v0.2.0
 	github.com/shirou/gopsutil v2.20.6+incompatible

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,13 @@ github.com/DataDog/zstd v1.4.4 h1:+IawcoXhCBylN7ccwdwf8LOH2jKq7NavGpEPanrlTzE=
 github.com/DataDog/zstd v1.4.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
+github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
+github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718 h1:FSsoaa1q4jAaeiAUxf9H0PgFP7eA/UL6c3PdJH+nMN4=
 github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718/go.mod h1:VVwKsx9Dc8rNG55BWqogoJzGubjKnRoXdUvpGbWqeCc=
@@ -90,6 +95,7 @@ github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9Pq
 github.com/andybalholm/cascadia v1.2.0 h1:vuRCkM5Ozh/BfmsaTm26kbjm0mIOM3yS5Ek/F5h18aE=
 github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
+github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
 github.com/apache/arrow/go/arrow v0.0.0-20200610220642-670890229854 h1:kLPoYgtEyqP5M5o1H+oAe5ZjOrL4LLo7jwF9W4hnNq8=
 github.com/apache/arrow/go/arrow v0.0.0-20200610220642-670890229854/go.mod h1:QNYViu/X0HXDHw7m3KXzWSVXIbfUvJqBFe6Gj8/pYA0=
 github.com/apache/thrift v0.0.0-20181211084444-2b7365c54f82 h1:v7Gpsj71uh9fOCX0v9mS7thFJdguCgV11wTv0wMe4pE=
@@ -194,6 +200,7 @@ github.com/dave/gopackages v0.0.0-20170318123100-46e7023ec56e/go.mod h1:i00+b/gK
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/dave/kerr v0.0.0-20170318121727-bc25dd6abe8e/go.mod h1:qZqlPyPvfsDJt+3wHJ1EvSXDuVjFTK0j2p/ca+gtsb8=
 github.com/dave/rebecca v0.9.1/go.mod h1:N6XYdMD/OKw3lkF3ywh8Z6wPGuwNFDNtWYEMFWEmXBA=
+github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -234,6 +241,8 @@ github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/protoc-gen-validate v0.0.14/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a h1:yDWHCSQ40h88yih2JAcL6Ls/kVkSE8GFACTGVnMPruw=
@@ -299,6 +308,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -334,6 +344,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181127221834-b4f47329b966/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190109223431-e84dfd68c163 h1:beB+Da4k9B1zmgag78k3k1Bx4L/fdWr5FwNa0f8RxmY=
 github.com/google/pprof v0.0.0-20190109223431-e84dfd68c163/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -365,12 +376,16 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
+github.com/huandu/xstrings v1.3.0 h1:gvV6jG9dTgFEncxo+AF7PH6MZXi/vZl25owA/8Dg8Wo=
 github.com/huandu/xstrings v1.3.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/ianlancetaylor/cgosymbolizer v0.0.0-20170921033129-f5072df9c550 h1:7Mr0IG3PMp/Z/iNN2vCCHdXS4RFzBwi9sr5Km6b2+N4=
 github.com/ianlancetaylor/cgosymbolizer v0.0.0-20170921033129-f5072df9c550/go.mod h1:a5aratAVTWyz+nJMmDsN8O4XTfaLfdAsB1ysCmZX5Bw=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 h1:UDMh68UUwekSh5iP2OMhRRZJiiBccgV7axzUG8vi56c=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -535,6 +550,7 @@ github.com/mediocregopher/radix/v3 v3.3.0/go.mod h1:EmfVyvspXz1uZEyPBMyGK+kjWiKQ
 github.com/mibk/dupl v1.0.0 h1:aZc3jqrF9n0tUHwHt/+jsRxA8cRgA0Gdl56M7W7PoqE=
 github.com/mibk/dupl v1.0.0/go.mod h1:pCr4pNxxIbFGvtyCOi0c7LVjmV6duhKWV+ex5vh38ME=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
+github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -553,6 +569,8 @@ github.com/montanaflynn/stats v0.4.1-0.20190115100425-713f2944833c h1:l4v5f5zMxq
 github.com/montanaflynn/stats v0.4.1-0.20190115100425-713f2944833c/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mwitkow/go-proto-validators v0.0.0-20180403085117-0950a7990007 h1:28i1IjGcx8AofiB4N3q5Yls55VEaitzuEPkFJEVgGkA=
+github.com/mwitkow/go-proto-validators v0.0.0-20180403085117-0950a7990007/go.mod h1:m2XC9Qq0AlmmVksL6FktJCdTYyLk7V3fKyp0sl1yWQo=
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
@@ -605,6 +623,7 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
+github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -628,6 +647,10 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.10 h1:QJQN3jYQhkamO4mhfUWqdDH2asK7ONOI9MTWjyAxNKM=
 github.com/prometheus/procfs v0.0.10/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/pseudomuto/protoc-gen-doc v1.3.2 h1:61vWZuxYa8D7Rn4h+2dgoTNqnluBmJya2MgbqO32z6g=
+github.com/pseudomuto/protoc-gen-doc v1.3.2/go.mod h1:y5+P6n3iGrbKG+9O04V5ld71in3v/bX88wUwgt+U8EA=
+github.com/pseudomuto/protokit v0.2.0 h1:hlnBDcy3YEDXH7kc9gV+NLaN0cDzhDvD1s7Y6FZ8RpM=
+github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 h1:dY6ETXrvDG7Sa4vE8ZQG4yqWg6UnOcbqTAahkV813vQ=
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -674,6 +697,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v0.0.0-20170130113145-4d4bfba8f1d1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -722,6 +746,7 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/arch v0.0.0-20180920145803-b19384d3c130/go.mod h1:cYlCBUl1MsqxdiKgmc4uh7TxZfWSFLOGSRR090WDxt8=
+golang.org/x/crypto v0.0.0-20180501155221-613d6eafa307/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -792,6 +817,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -867,6 +893,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/genproto v0.0.0-20180518175338-11a468237815/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+google.golang.org/genproto v0.0.0-20181107211654-5fc9ac540362/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20181202183823-bd91e49a0898/go.mod h1:7Ep/1NZk928CDR8SjdVbjWNpdIf6nzjE3BTgJDr2Atg=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=

--- a/pkg/cmd/docgen/http.go
+++ b/pkg/cmd/docgen/http.go
@@ -1,0 +1,356 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	gendoc "github.com/pseudomuto/protoc-gen-doc"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	var (
+		protocPath   string
+		protobufPath string
+		genDocPath   string
+		outPath      string
+	)
+
+	cmdHTTP := &cobra.Command{
+		Use:   "http",
+		Short: "Generate HTTP docs",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runHTTP(protocPath, genDocPath, protobufPath, outPath); err != nil {
+				fmt.Fprintln(os.Stdout, err)
+				os.Exit(1)
+			}
+		},
+	}
+	cmdHTTP.Flags().StringVar(&protocPath, "protoc", "protoc", "Path to protoc binary.")
+	cmdHTTP.Flags().StringVar(&protobufPath, "protobuf", "", "Protobuf include paths.")
+	cmdHTTP.Flags().StringVar(&genDocPath, "gendoc", "protoc-gen-doc", "Path to protoc-gen-doc binary.")
+	cmdHTTP.Flags().StringVar(&outPath, "out", "docs/generated/http", "File output path.")
+
+	cmds = append(cmds, cmdHTTP)
+}
+
+var singleMethods = []string{
+	"HotRanges",
+}
+
+// runHTTP extracts HTTP endpoint documentation. It does this by reading the
+// status.proto file and converting it into a JSON file. This JSON file is then
+// fed as data into various Go templates that are used to populate markdown
+// files. A full.md file is produced with all endpoints. The singleMethods
+// string slice is used to produce additional markdown files with a single
+// method per file.
+func runHTTP(protocPath, genDocPath, protobufPath, outPath string) error {
+	// Extract out all the data into a JSON file. We will use this JSON
+	// file to then generate full and single pages.
+	if err := os.MkdirAll(outPath, 0777); err != nil {
+		return err
+	}
+	tmpJSON, err := ioutil.TempDir("", "docgen-*")
+	if err != nil {
+		return err
+	}
+	// gen-doc wants a file on disk to use as its template. Make and
+	// cleanup a temp file.
+	jsonTmpl := filepath.Join(tmpJSON, "json.tmpl")
+	if err := ioutil.WriteFile(jsonTmpl, []byte(tmplJSON), 0666); err != nil {
+		return err
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpJSON)
+	}()
+	// Generate the JSON file.
+	cmd := exec.Command(protocPath,
+		fmt.Sprintf("-I%s", protobufPath),
+		fmt.Sprintf("--plugin=protoc-gen-doc=%s", genDocPath),
+		fmt.Sprintf("--doc_out=%s", tmpJSON),
+		fmt.Sprintf("--doc_opt=%s,http.json", jsonTmpl),
+		"./pkg/server/serverpb/status.proto",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Println(string(out))
+		return err
+	}
+	dataFile, err := ioutil.ReadFile(filepath.Join(tmpJSON, "http.json"))
+	if err != nil {
+		return err
+	}
+	var data protoData
+	if err := json.Unmarshal(dataFile, &data); err != nil {
+		return fmt.Errorf("json unmarshal: %w", err)
+	}
+	if len(data.Files) != 1 || len(data.Files[0].Services) != 1 {
+		return fmt.Errorf("expected 1 file with 1 service")
+	}
+	file := data.Files[0]
+	service := file.Services[0]
+
+	// Start by making maps of methods and messages for lookup.
+	messages := make(map[string]*protoMessage)
+	for i := range file.Messages {
+		messages[file.Messages[i].FullName] = &file.Messages[i]
+	}
+	methods := make(map[string]interface{})
+	for i := range service.Methods {
+		methods[service.Methods[i].Name] = &service.Methods[i]
+	}
+	tmplFuncs := template.FuncMap{
+		"nobr": gendoc.NoBrFilter,
+		"getMessage": func(name string) interface{} {
+			return messages[name]
+		},
+		// Given a message type, returns all message types in its type
+		// field that are also present in the messages map. Useful to
+		// recurse into types that have other types.
+		"extraMessages": func(name string) []string {
+			seen := make(map[string]bool)
+			var extraFn func(name string) []string
+			extraFn = func(name string) []string {
+				if seen[name] {
+					return nil
+				}
+				seen[name] = true
+				msg, ok := messages[name]
+				if !ok {
+					return nil
+				}
+				var other []string
+				for _, field := range msg.Fields {
+					if innerMsg, ok := messages[field.FullType]; ok {
+						other = append(other, field.FullType)
+						other = append(other, extraFn(innerMsg.FullName)...)
+					}
+				}
+				return other
+			}
+			return extraFn(name)
+		},
+	}
+	tmplFull := template.Must(template.New("full").Funcs(tmplFuncs).Parse(fullTemplate))
+	tmplSingle := template.Must(template.New("single").Funcs(tmplFuncs).Parse(singleTemplate))
+
+	// JSON data is now in memory. Generate full doc page.
+	if err := execHTTPTmpl(tmplFull, &file, filepath.Join(outPath, "full.md")); err != nil {
+		return fmt.Errorf("execHTTPTmpl: %w", err)
+	}
+
+	for _, methodName := range singleMethods {
+		method, ok := methods[methodName]
+		if !ok {
+			return fmt.Errorf("single method not found: %s", methodName)
+		}
+		path := filepath.Join(outPath, fmt.Sprintf("%s.md", strings.ToLower(methodName)))
+		if err := execHTTPTmpl(tmplSingle, method, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func execHTTPTmpl(tmpl *template.Template, data interface{}, path string) error {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path, buf.Bytes(), 0666)
+}
+
+type protoData struct {
+	Files []struct {
+		Name          string `json:"name"`
+		Description   string `json:"description"`
+		Package       string `json:"package"`
+		HasEnums      bool   `json:"hasEnums"`
+		HasExtensions bool   `json:"hasExtensions"`
+		HasMessages   bool   `json:"hasMessages"`
+		HasServices   bool   `json:"hasServices"`
+		Enums         []struct {
+			Name        string `json:"name"`
+			LongName    string `json:"longName"`
+			FullName    string `json:"fullName"`
+			Description string `json:"description"`
+			Values      []struct {
+				Name        string `json:"name"`
+				Number      string `json:"number"`
+				Description string `json:"description"`
+			} `json:"values"`
+		} `json:"enums"`
+		Extensions []interface{}  `json:"extensions"`
+		Messages   []protoMessage `json:"messages"`
+		Services   []struct {
+			Name        string `json:"name"`
+			LongName    string `json:"longName"`
+			FullName    string `json:"fullName"`
+			Description string `json:"description"`
+			Methods     []struct {
+				Name              string `json:"name"`
+				Description       string `json:"description"`
+				RequestType       string `json:"requestType"`
+				RequestLongType   string `json:"requestLongType"`
+				RequestFullType   string `json:"requestFullType"`
+				RequestStreaming  bool   `json:"requestStreaming"`
+				ResponseType      string `json:"responseType"`
+				ResponseLongType  string `json:"responseLongType"`
+				ResponseFullType  string `json:"responseFullType"`
+				ResponseStreaming bool   `json:"responseStreaming"`
+				Options           struct {
+					GoogleAPIHTTP struct {
+						Rules []struct {
+							Method  string `json:"method"`
+							Pattern string `json:"pattern"`
+						} `json:"rules"`
+					} `json:"google.api.http"`
+				} `json:"options"`
+			} `json:"methods"`
+		} `json:"services"`
+	} `json:"files"`
+	ScalarValueTypes []struct {
+		ProtoType  string `json:"protoType"`
+		Notes      string `json:"notes"`
+		CppType    string `json:"cppType"`
+		CsType     string `json:"csType"`
+		GoType     string `json:"goType"`
+		JavaType   string `json:"javaType"`
+		PhpType    string `json:"phpType"`
+		PythonType string `json:"pythonType"`
+		RubyType   string `json:"rubyType"`
+	} `json:"scalarValueTypes"`
+}
+
+type protoMessage struct {
+	Name          string        `json:"name"`
+	LongName      string        `json:"longName"`
+	FullName      string        `json:"fullName"`
+	Description   string        `json:"description"`
+	HasExtensions bool          `json:"hasExtensions"`
+	HasFields     bool          `json:"hasFields"`
+	Extensions    []interface{} `json:"extensions"`
+	Fields        []struct {
+		Name         string `json:"name"`
+		Description  string `json:"description"`
+		Label        string `json:"label"`
+		Type         string `json:"type"`
+		LongType     string `json:"longType"`
+		FullType     string `json:"fullType"`
+		Ismap        bool   `json:"ismap"`
+		DefaultValue string `json:"defaultValue"`
+	} `json:"fields"`
+}
+
+const tmplJSON = `{{toPrettyJson .}}`
+
+const fullTemplate = `
+{{- define "FIELDS" -}}
+{{with getMessage .}}
+{{$message := .}}
+{{with .Fields}}
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+{{- range .}}
+| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+{{- end}} {{- /* range */}}
+{{end}} {{- /* with .Fields */}}
+
+{{/* document extra messages */}}
+{{range extraMessages .FullName}}
+{{with getMessage .}}
+{{if .Fields}}
+<a name="{{$message.FullName}}-{{.FullName}}"></a>
+#### {{.LongName}}
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+{{- range .Fields}}
+| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+{{- end}} {{- /* range */}}
+{{end}} {{- /* if .Fields */}}
+{{end}} {{- /* with getMessage */}}
+{{end}} {{- /* range */}}
+
+{{end}} {{- /* with getMessage */}}
+{{- end}} {{- /* template */}}
+
+{{- range .Services}}
+
+{{- range .Methods -}}
+## {{.Name}}
+
+{{range .Options.GoogleAPIHTTP.Rules -}}
+` + "`{{.Method}} {{.Pattern}}`" + `
+{{- end}}
+
+{{with .Description}}{{.}}{{end}}
+
+### Request Parameters
+
+{{template "FIELDS" .RequestFullType}}
+
+### Response Parameters
+
+{{template "FIELDS" .ResponseFullType}}
+
+{{end}} {{- /* methods */}}
+
+{{- end -}} {{- /* services */ -}}
+`
+
+var singleTemplate = `
+{{- define "FIELDS" -}}
+{{with getMessage .}}
+{{$message := .}}
+{{with .Fields}}
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+{{- range .}}
+| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+{{- end}} {{- /* range */}}
+{{end}} {{- /* with .Fields */}}
+
+{{/* document extra messages */}}
+{{range extraMessages .FullName}}
+{{with getMessage .}}
+{{if .Fields}}
+<a name="{{$message.FullName}}-{{.FullName}}"></a>
+#### {{.LongName}}
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+{{- range .Fields}}
+| {{.Name}} | [{{.LongType}}](#{{$message.FullName}}-{{.FullType}}) | {{.Label}} | {{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+{{- end}} {{- /* range */}}
+{{end}} {{- /* if .Fields */}}
+{{end}} {{- /* with getMessage */}}
+{{end}} {{- /* range */}}
+
+{{end}} {{- /* with getMessage */}}
+{{- end}} {{- /* template */}}
+
+### Request Parameters
+
+{{template "FIELDS" .RequestFullType}}
+
+### Response Parameters
+
+{{template "FIELDS" .ResponseFullType}}
+`

--- a/pkg/cmd/docgen/main.go
+++ b/pkg/cmd/docgen/main.go
@@ -24,7 +24,7 @@ func main() {
 	rootCmd := func() *cobra.Command {
 		cmd := &cobra.Command{
 			Use:   "docgen",
-			Short: "docgen generates documentation for cockroachdb's SQL functions and grammar",
+			Short: "docgen generates documentation for cockroachdb's SQL functions, grammar, and HTTP endpoints",
 		}
 		cmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "suppress output where possible")
 		cmd.AddCommand(cmds...)

--- a/pkg/cmd/import-tools/main.go
+++ b/pkg/cmd/import-tools/main.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/mattn/goveralls"
 	_ "github.com/mibk/dupl"
 	_ "github.com/mmatczuk/go_generics/cmd/go_generics"
+	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
 	_ "github.com/wadey/gocovmerge"
 	_ "golang.org/x/lint/golint"
 	_ "golang.org/x/perf/cmd/benchstat"


### PR DESCRIPTION
Add a way to extract docs from the status.proto HTTP endpoint. These
can be imported into the docs project as needed.

Release note: None