### PR TITLE
testcluster: don't create two stoppers in StartTestCluster

### DIFF
--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -141,7 +141,6 @@ func StartTestCluster(t testing.TB, nodes int, args base.TestClusterArgs) *TestC
 		stopper:         stop.NewStopper(),
 		replicationMode: args.ReplicationMode,
 	}
-	tc.stopper = stop.NewStopper()
 
 	// Check if any of the args have a locality set.
 	noLocalities := true


### PR DESCRIPTION
This looks harmless because the first stopper was never actually used, but it was caught by #51413.