### PR TITLE
storage: delake TestPebbleMapClose

### DIFF
--- a/pkg/storage/disk_map_test.go
+++ b/pkg/storage/disk_map_test.go
@@ -440,37 +440,6 @@ func TestPebbleMapClose(t *testing.T) {
 	}
 	defer e.Close()
 
-	decodeKey := func(v []byte) []byte {
-		var err error
-		v, _, err = encoding.DecodeUvarintAscending(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return v
-	}
-
-	getSSTables := func() string {
-		var buf bytes.Buffer
-		fmt.Fprintf(&buf, "\n")
-		for l, ssts := range e.db.SSTables() {
-			for _, sst := range ssts {
-				fmt.Fprintf(&buf, "%d: %s - %s\n",
-					l, decodeKey(sst.Smallest.UserKey), decodeKey(sst.Largest.UserKey))
-			}
-		}
-		return buf.String()
-	}
-
-	verifySSTables := func(expected string) {
-		actual := getSSTables()
-		if expected != actual {
-			t.Fatalf("expected%sgot%s", expected, actual)
-		}
-		if testing.Verbose() {
-			fmt.Printf("%s", actual)
-		}
-	}
-
 	diskMap := newPebbleMap(e.db, false /* allowDuplicates */)
 
 	// Put a small amount of data into the disk map.
@@ -498,22 +467,58 @@ func TestPebbleMapClose(t *testing.T) {
 	}
 
 	// Verify we have a single sstable.
-	verifySSTables(`
-6: a - z
-`)
+	var buf bytes.Buffer
+	fileNums := map[pebble.FileNum]bool{}
+	for l, ssts := range e.db.SSTables() {
+		for _, sst := range ssts {
+			sm := bytes.TrimPrefix(sst.Smallest.UserKey, diskMap.prefix)
+			la := bytes.TrimPrefix(sst.Largest.UserKey, diskMap.prefix)
+			fmt.Fprintf(&buf, "%d: %s - %s\n", l, sm, la)
+			fileNums[sst.FileNum] = true
+		}
+	}
+	const expected = "6: a - z\n"
+	actual := buf.String()
+	if expected != actual {
+		t.Fatalf("expected\n%sgot\n%s", expected, actual)
+	}
+	if testing.Verbose() {
+		fmt.Printf("%s", actual)
+	}
 
 	// Close the disk map. This should both delete the data, and initiate
 	// compactions for the deleted data.
 	diskMap.Close(ctx)
 
-	// Wait for the data stored in the engine to disappear.
+	// Wait for the previously-observed sstables to be removed. We can't
+	// assert that the LSM is completely empty because the range tombstone's
+	// sstable will not necessarily be compacted.
+	var lsmBuf bytes.Buffer
+	var stillExistBuf bytes.Buffer
 	testutils.SucceedsSoon(t, func() error {
-		actual := getSSTables()
-		if testing.Verbose() {
-			fmt.Printf("%s", actual)
+		lsmBuf.Reset()
+		stillExistBuf.Reset()
+		for l, ssts := range e.db.SSTables() {
+			if len(ssts) == 0 {
+				continue
+			}
+
+			fmt.Fprintf(&lsmBuf, "L%d:\n", l)
+			for _, sst := range ssts {
+				if fileNums[sst.FileNum] {
+					fmt.Fprintf(&stillExistBuf, "%s\n", sst.FileNum)
+				}
+				fmt.Fprintf(&lsmBuf, "  %s: %d bytes, %x (%s) - %x (%s)\n", sst.FileNum, sst.Size,
+					sst.Smallest.UserKey, bytes.TrimPrefix(sst.Smallest.UserKey, diskMap.prefix),
+					sst.Largest.UserKey, bytes.TrimPrefix(sst.Largest.UserKey, diskMap.prefix))
+			}
 		}
-		if actual != "\n" {
-			return fmt.Errorf("%s", actual)
+
+		if testing.Verbose() {
+			fmt.Println(buf.String())
+		}
+		if stillExist := stillExistBuf.String(); stillExist != "" {
+			return fmt.Errorf("%s", stillExist)
 		}
 		return nil
 	})


### PR DESCRIPTION
The TestPebbleMapClose test failed in CI with a sstable remaining after
the clearing of the disk map (#51786). A delete-only only compaction
followed by a move compaction resulted in a single remaining sstable
containing the range tombstone.

Adding compactions to elide deletions in L6 in Pebble would allow us to
revert to the old test condition. See cockroachdb/pebble#838.

Also, update this test to print a hex representation of
the raw, prefixed sstable bounds as well for easier debugging.

Fixes #51786.

Release note: none