### PR TITLE
sql,stats: fix flakes in TestCacheWait and TestQueryCache

### DIFF
--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -377,7 +377,7 @@ func TestCacheWait(t *testing.T) {
 		before := sc.mu.numInternalQueries
 
 		id := tableIDs[rand.Intn(len(tableIDs))]
-		sc.RefreshTableStats(ctx, id)
+		sc.InvalidateTableStats(ctx, id)
 		// Run GetTableStats multiple times in parallel.
 		var wg sync.WaitGroup
 		for n := 0; n < 10; n++ {


### PR DESCRIPTION
**stats: fix flake in TestCacheWait**

This commit fixes a flake in `TestCacheWait`, which was introduced
by #51616. That PR changed the call to `InvalidateTableStats` in
`TestCacheWait` to `RefreshTableStats`, but that change should not have
been made. The purpose of the test is to test that the cache invalidation
and waiting mechanisms work correctly, and therefore it must call
`InvalidateTableStats`, not `RefreshTableStats`.

Fixes #51712

**sql: fix flake in TestQueryCache/group/statschange**

This commit fixes a flake in TestQueryCache/group/statschange,
which was introduced by #51616. That PR made updates to the stats
cache asynchronous, so we can no longer expect the query cache to
be invalidated immediately after a stats update. This commit fixes
the problem by introducing a retry mechanism into the test.

Fixes #51693