### PR TITLE
dump: fix dump-backwards-compatibility remote roachtest

### DIFF
--- a/pkg/cmd/roachtest/dump.go
+++ b/pkg/cmd/roachtest/dump.go
@@ -62,7 +62,7 @@ func runDump(nodes nodeListOption, mainVersion, expected string) versionStep {
 	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
 		// Put the new version of Cockroach onto the node.
 		u.uploadVersion(ctx, t, nodes, mainVersion)
-		raw, err := u.c.RunWithBuffer(ctx, t.logger(), nodes, `cockroach dump --insecure d`)
+		raw, err := u.c.RunWithBuffer(ctx, t.logger(), nodes, `./cockroach dump --insecure d`)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This commit changes the execution of the cockroach binary from
`cockroach` to `./cockroach`. This follows how other CLI roachtests run
the binary. Before this commit, this test would fail when run on a GCE
roachprod cluster, it now passes.

Release note: None