### PR TITLE
backupccl: revive backup benches

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -94,19 +94,19 @@ func getDescriptorFromDB(
 }
 
 // Load converts r into SSTables and backup descriptors. database is the name
-// of the database into which the SSTables will eventually be written. uri
-// is the storage location. ts is the time at which the MVCC data will
-// be set. loadChunkBytes is the size at which to create a new SSTable
+// of the database into which the SSTables will eventually be written.
+// - uri is the storage location (e.g. nodelocal://0/my/dir).
+// - ts is the time at which the MVCC data will be set.
+// - loadChunkBytes is the size at which to create a new SSTable
 // (which will translate into a new range during restore); set to 0 to use
 // the zone's default range max / 2.
 func Load(
 	ctx context.Context,
 	db *gosql.DB,
 	r io.Reader,
-	database, uri string,
+	database, user, externalIODir, uri string,
 	ts hlc.Timestamp,
 	loadChunkBytes int64,
-	tempPrefix, writeToDir, user string,
 ) (backupccl.BackupManifest, error) {
 	if loadChunkBytes == 0 {
 		loadChunkBytes = *zonepb.DefaultZoneConfig().RangeMaxBytes / 2
@@ -120,7 +120,7 @@ func Load(
 	evalCtx.Codec = keys.TODOSQLCodec
 	semaCtx := tree.MakeSemaContext()
 
-	blobClientFactory := blobs.TestBlobServiceClient(writeToDir)
+	blobClientFactory := blobs.TestBlobServiceClient(externalIODir)
 	conf, err := cloudimpl.ExternalStorageConfFromURI(uri, user)
 	if err != nil {
 		return backupccl.BackupManifest{}, err
@@ -178,7 +178,7 @@ func Load(
 		switch s := stmt.AST.(type) {
 		case *tree.CreateTable:
 			if tableDesc != nil {
-				if err := writeSST(ctx, &backup, dir, tempPrefix, kvs, ts); err != nil {
+				if err := writeSST(ctx, &backup, dir, kvs, ts); err != nil {
 					return backupccl.BackupManifest{}, errors.Wrap(err, "writeSST")
 				}
 				kvs = kvs[:0]
@@ -269,7 +269,7 @@ func Load(
 			}
 
 			if kvBytes > loadChunkBytes {
-				if err := writeSST(ctx, &backup, dir, tempPrefix, kvs, ts); err != nil {
+				if err := writeSST(ctx, &backup, dir, kvs, ts); err != nil {
 					return backupccl.BackupManifest{}, errors.Wrap(err, "writeSST")
 				}
 				kvs = kvs[:0]
@@ -282,7 +282,7 @@ func Load(
 	}
 
 	if tableDesc != nil {
-		if err := writeSST(ctx, &backup, dir, tempPrefix, kvs, ts); err != nil {
+		if err := writeSST(ctx, &backup, dir, kvs, ts); err != nil {
 			return backupccl.BackupManifest{}, errors.Wrap(err, "writeSST")
 		}
 	}
@@ -385,7 +385,6 @@ func writeSST(
 	ctx context.Context,
 	backup *backupccl.BackupManifest,
 	base cloud.ExternalStorage,
-	tempPrefix string,
 	kvs []storage.MVCCKeyValue,
 	ts hlc.Timestamp,
 ) error {

--- a/pkg/ccl/importccl/load_test.go
+++ b/pkg/ccl/importccl/load_test.go
@@ -118,8 +118,8 @@ func TestImportChunking(t *testing.T) {
 	}
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	desc, err := importccl.Load(ctx, tc.Conns[0], bankBuf(numAccounts), "data",
-		"nodelocal://0"+dir, ts, chunkSize, dir, dir, security.RootUser)
+	desc, err := importccl.Load(ctx, tc.Conns[0], bankBuf(numAccounts),
+		"data", security.RootUser, dir, "nodelocal://0"+dir, ts, chunkSize)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -153,8 +153,8 @@ func TestImportOutOfOrder(t *testing.T) {
 	fmt.Fprintf(&buf, "INSERT INTO %s VALUES (%s);\n", bankData.Name, strings.Join(row1, `,`))
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	_, err := importccl.Load(ctx, tc.Conns[0], &buf, "data", "nodelocal://0/foo", ts,
-		0, dir, dir, security.RootUser)
+	_, err := importccl.Load(ctx, tc.Conns[0], &buf, "data", security.RootUser,
+		dir, "nodelocal://0/foo", ts, 0)
 	if !testutils.IsError(err, "out of order row") {
 		t.Fatalf("expected out of order row, got: %+v", err)
 	}
@@ -179,8 +179,8 @@ func BenchmarkLoad(b *testing.B) {
 	buf := bankBuf(b.N)
 	b.SetBytes(int64(buf.Len() / b.N))
 	b.ResetTimer()
-	if _, err := importccl.Load(ctx, tc.Conns[0], buf, "data", dir, ts,
-		0, dir, dir, security.RootUser); err != nil {
+	if _, err := importccl.Load(ctx, tc.Conns[0], buf, "data", security.RootUser,
+		dir, "nodelocal://0", ts, 0); err != nil {
 		b.Fatalf("%+v", err)
 	}
 }

--- a/pkg/ccl/storageccl/bench_test.go
+++ b/pkg/ccl/storageccl/bench_test.go
@@ -11,7 +11,6 @@ package storageccl_test
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -38,8 +37,8 @@ func BenchmarkAddSSTable(b *testing.B) {
 	for _, numEntries := range []int{100, 1000, 10000, 300000} {
 		b.Run(fmt.Sprintf("numEntries=%d", numEntries), func(b *testing.B) {
 			bankData := bank.FromRows(numEntries).Tables()[0]
-			backupDir := filepath.Join(tempDir, strconv.Itoa(numEntries))
-			backup, err := sampledataccl.ToBackup(b, bankData, backupDir)
+			backup, err := sampledataccl.ToBackup(b, bankData, tempDir,
+				strconv.Itoa(numEntries))
 			if err != nil {
 				b.Fatalf("%+v", err)
 			}
@@ -96,8 +95,8 @@ func BenchmarkWriteBatch(b *testing.B) {
 	for _, numEntries := range []int{100, 1000, 10000} {
 		b.Run(fmt.Sprintf("numEntries=%d", numEntries), func(b *testing.B) {
 			bankData := bank.FromRows(numEntries).Tables()[0]
-			backupDir := filepath.Join(tempDir, strconv.Itoa(numEntries))
-			backup, err := sampledataccl.ToBackup(b, bankData, backupDir)
+			backup, err := sampledataccl.ToBackup(b, bankData, tempDir,
+				strconv.Itoa(numEntries))
 			if err != nil {
 				b.Fatalf("%+v", err)
 			}
@@ -148,8 +147,7 @@ func BenchmarkImport(b *testing.B) {
 		b.Run(fmt.Sprintf("numEntries=%d", numEntries), func(b *testing.B) {
 			bankData := bank.FromRows(numEntries).Tables()[0]
 			subdir := strconv.Itoa(numEntries)
-			backupDir := filepath.Join(tempDir, subdir)
-			backup, err := sampledataccl.ToBackup(b, bankData, backupDir)
+			backup, err := sampledataccl.ToBackup(b, bankData, tempDir, subdir)
 			if err != nil {
 				b.Fatalf("%+v", err)
 			}

--- a/pkg/ccl/utilccl/sampledataccl/bankdata_test.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata_test.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -52,7 +51,7 @@ func TestToBackup(t *testing.T) {
 			t.Run(fmt.Sprintf("rows=%d/chunk=%d", rows, chunkBytes), func(t *testing.T) {
 				dir := fmt.Sprintf("%d-%d", rows, chunkBytes)
 				data := bank.FromConfig(rows, rows, payloadBytes, ranges).Tables()[0]
-				backup, err := toBackup(t, data, filepath.Join(outerDir, dir), chunkBytes)
+				backup, err := toBackup(t, data, outerDir, dir, chunkBytes)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -175,8 +175,9 @@ func ExternalStorageConfFromURI(path, user string) (roachpb.ExternalStorage, err
 	case "nodelocal":
 		if uri.Host == "" {
 			return conf, errors.Errorf(
-				"host component of nodelocal URI must be a node ID (" +
-					"use 'self' to specify each node should access its own local filesystem)",
+				"host component of nodelocal URI must be a node ID ("+
+					"use 'self' to specify each node should access its own local filesystem): %s",
+				path,
 			)
 		} else if uri.Host == "self" {
 			uri.Host = "0"


### PR DESCRIPTION
This commit fixes up the benchmarks in the backupccl package to actually
be able to run. It also cleans-up the helper methods it was relying on.

Release note: None