### PR TITLE
sql: don't show the "hidden" column flag in EXPLAIN

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -601,16 +601,16 @@ CREATE TABLE tc (a INT, b INT, INDEX c(a), FAMILY "primary" (a, b, rowid))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-·                distribution  local       ·                   ·
-·                vectorized    true        ·                   ·
-sort             ·             ·           (a, b)              +b
- │               order         +b          ·                   ·
- └── index-join  ·             ·           (a, b)              ·
-      │          table         tc@primary  ·                   ·
-      │          key columns   rowid       ·                   ·
-      └── scan   ·             ·           (a, rowid[hidden])  ·
-·                table         tc@c        ·                   ·
-·                spans         /10-/11     ·                   ·
+·                distribution  local       ·           ·
+·                vectorized    true        ·           ·
+sort             ·             ·           (a, b)      +b
+ │               order         +b          ·           ·
+ └── index-join  ·             ·           (a, b)      ·
+      │          table         tc@primary  ·           ·
+      │          key columns   rowid       ·           ·
+      └── scan   ·             ·           (a, rowid)  ·
+·                table         tc@c        ·           ·
+·                spans         /10-/11     ·           ·
 
 query TTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -428,8 +428,8 @@ INSERT INTO insert_t (SELECT length(k), 2 FROM kv ORDER BY k || v LIMIT 10) RETU
 ·                                        vectorized    false                   ·                               ·
 render                                   ·             ·                       ("?column?")                    ·
  │                                       render 0      x + v                   ·                               ·
- └── run                                 ·             ·                       (x, v, rowid[hidden])           ·
-      └── insert                         ·             ·                       (x, v, rowid[hidden])           ·
+ └── run                                 ·             ·                       (x, v, rowid)                   ·
+      └── insert                         ·             ·                       (x, v, rowid)                   ·
            │                             into          insert_t(x, v, rowid)   ·                               ·
            │                             strategy      inserter                ·                               ·
            └── render                    ·             ·                       (length, "?column?", column11)  ·
@@ -462,18 +462,18 @@ BEGIN; ALTER TABLE mutation DROP COLUMN y
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO mutation(x) VALUES (2) RETURNING *
 ----
-·                           distribution   local                  ·                   ·
-·                           vectorized     false                  ·                   ·
-render                      ·              ·                      (x)                 ·
- │                          render 0       x                      ·                   ·
- └── run                    ·              ·                      (x, rowid[hidden])  ·
-      └── insert-fast-path  ·              ·                      (x, rowid[hidden])  ·
-·                           into           mutation(x, rowid, y)  ·                   ·
-·                           strategy       inserter               ·                   ·
-·                           size           3 columns, 1 row       ·                   ·
-·                           row 0, expr 0  2                      ·                   ·
-·                           row 0, expr 1  unique_rowid()         ·                   ·
-·                           row 0, expr 2  10                     ·                   ·
+·                           distribution   local                  ·           ·
+·                           vectorized     false                  ·           ·
+render                      ·              ·                      (x)         ·
+ │                          render 0       x                      ·           ·
+ └── run                    ·              ·                      (x, rowid)  ·
+      └── insert-fast-path  ·              ·                      (x, rowid)  ·
+·                           into           mutation(x, rowid, y)  ·           ·
+·                           strategy       inserter               ·           ·
+·                           size           3 columns, 1 row       ·           ·
+·                           row 0, expr 0  2                      ·           ·
+·                           row 0, expr 1  unique_rowid()         ·           ·
+·                           row 0, expr 2  10                     ·           ·
 
 statement ok
 ROLLBACK
@@ -527,8 +527,8 @@ root                                          ·             ·                 
            └── spool                          ·             ·                                                    (z)                  ·
                 └── render                    ·             ·                                                    (z)                  ·
                      │                        render 0      z                                                    ·                    ·
-                     └── run                  ·             ·                                                    (z, rowid[hidden])   ·
-                          └── insert          ·             ·                                                    (z, rowid[hidden])   ·
+                     └── run                  ·             ·                                                    (z, rowid)           ·
+                          └── insert          ·             ·                                                    (z, rowid)           ·
                                │              into          xyz(x, y, z, rowid)                                  ·                    ·
                                │              strategy      inserter                                             ·                    ·
                                └── render     ·             ·                                                    (a, b, c, column11)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -907,15 +907,15 @@ CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyz WHERE z=1 AND x=y ORDER BY x;
 ----
-·                     distribution  local            ·                      ·
-·                     vectorized    true             ·                      ·
-sort                  ·             ·                (x, y, z)              +x
- │                    order         +x               ·                      ·
- └── filter           ·             ·                (x, y, z)              ·
-      │               filter        x = y            ·                      ·
-      └── index-join  ·             ·                (x, y, z)              ·
-           │          table         xyz@primary      ·                      ·
-           │          key columns   rowid            ·                      ·
-           └── scan   ·             ·                (y, z, rowid[hidden])  ·
-·                     table         xyz@xyz_z_y_idx  ·                      ·
-·                     spans         /1/!NULL-/2      ·                      ·
+·                     distribution  local            ·              ·
+·                     vectorized    true             ·              ·
+sort                  ·             ·                (x, y, z)      +x
+ │                    order         +x               ·              ·
+ └── filter           ·             ·                (x, y, z)      ·
+      │               filter        x = y            ·              ·
+      └── index-join  ·             ·                (x, y, z)      ·
+           │          table         xyz@primary      ·              ·
+           │          key columns   rowid            ·              ·
+           └── scan   ·             ·                (y, z, rowid)  ·
+·                     table         xyz@xyz_z_y_idx  ·              ·
+·                     spans         /1/!NULL-/2      ·              ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -238,11 +238,11 @@ scan  ·             ·                       ()  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT rowid FROM [54(3) AS num_ref_alias]
 ----
-·     distribution  local                   ·                ·
-·     vectorized    true                    ·                ·
-scan  ·             ·                       (rowid[hidden])  ·
-·     table         num_ref_hidden@primary  ·                ·
-·     spans         FULL SCAN               ·                ·
+·     distribution  local                   ·        ·
+·     vectorized    true                    ·        ·
+scan  ·             ·                       (rowid)  ·
+·     table         num_ref_hidden@primary  ·        ·
+·     spans         FULL SCAN               ·        ·
 
 query error pq: \[666\(1\) AS num_ref_alias\]: relation \"\[666\]\" does not exist
 EXPLAIN (VERBOSE) SELECT * FROM [666(1) AS num_ref_alias]
@@ -400,11 +400,11 @@ scan  ·             ·          (x, y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, y, rowid FROM b WHERE rowid > 0
 ----
-·     distribution  local      ·                      ·
-·     vectorized    true       ·                      ·
-scan  ·             ·          (x, y, rowid[hidden])  ·
-·     table         b@primary  ·                      ·
-·     spans         /1-        ·                      ·
+·     distribution  local      ·              ·
+·     vectorized    true       ·              ·
+scan  ·             ·          (x, y, rowid)  ·
+·     table         b@primary  ·              ·
+·     spans         /1-        ·              ·
 
 statement ok
 DROP TABLE b

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -966,40 +966,40 @@ CREATE TABLE xy (x INT, y INT, INDEX (y))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM NULL
 ----
-·           distribution  local         ·                   ·
-·           vectorized    true          ·                   ·
-index-join  ·             ·             (x, y)              ·
- │          table         xy@primary    ·                   ·
- │          key columns   rowid         ·                   ·
- └── scan   ·             ·             (y, rowid[hidden])  ·
-·           table         xy@xy_y_idx   ·                   ·
-·           spans         /NULL-/!NULL  ·                   ·
+·           distribution  local         ·           ·
+·           vectorized    true          ·           ·
+index-join  ·             ·             (x, y)      ·
+ │          table         xy@primary    ·           ·
+ │          key columns   rowid         ·           ·
+ └── scan   ·             ·             (y, rowid)  ·
+·           table         xy@xy_y_idx   ·           ·
+·           spans         /NULL-/!NULL  ·           ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM 4
 ----
-·           distribution  local        ·                   ·
-·           vectorized    true         ·                   ·
-index-join  ·             ·            (x, y)              ·
- │          table         xy@primary   ·                   ·
- │          key columns   rowid        ·                   ·
- └── scan   ·             ·            (y, rowid[hidden])  ·
-·           table         xy@xy_y_idx  ·                   ·
-·           spans         /4-/5        ·                   ·
+·           distribution  local        ·           ·
+·           vectorized    true         ·           ·
+index-join  ·             ·            (x, y)      ·
+ │          table         xy@primary   ·           ·
+ │          key columns   rowid        ·           ·
+ └── scan   ·             ·            (y, rowid)  ·
+·           table         xy@xy_y_idx  ·           ·
+·           spans         /4-/5        ·           ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
 ----
-·                distribution  local        ·                   ·
-·                vectorized    true         ·                   ·
-render           ·             ·            (x)                 ·
- │               render 0      x            ·                   ·
- └── index-join  ·             ·            (x, y)              ·
-      │          table         xy@primary   ·                   ·
-      │          key columns   rowid        ·                   ·
-      └── scan   ·             ·            (y, rowid[hidden])  ·
-·                table         xy@xy_y_idx  ·                   ·
-·                spans         /1-/2        ·                   ·
+·                distribution  local        ·           ·
+·                vectorized    true         ·           ·
+render           ·             ·            (x)         ·
+ │               render 0      x            ·           ·
+ └── index-join  ·             ·            (x, y)      ·
+      │          table         xy@primary   ·           ·
+      │          key columns   rowid        ·           ·
+      └── scan   ·             ·            (y, rowid)  ·
+·                table         xy@xy_y_idx  ·           ·
+·                spans         /1-/2        ·           ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -144,18 +144,18 @@ WHERE
     OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27))
     AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
-·                    distribution  local            ·                                  ·
-·                    vectorized    true             ·                                  ·
-render               ·             ·                (col0)                             ·
- │                   render 0      col0             ·                                  ·
- └── index-join      ·             ·                (col0, col3, col4, rowid[hidden])  ·
-      │              table         tab4@primary     ·                                  ·
-      │              key columns   rowid            ·                                  ·
-      └── filter     ·             ·                (col0, col4, rowid[hidden])        ·
-           │         filter        col0 <= 0        ·                                  ·
-           └── scan  ·             ·                (col0, col4, rowid[hidden])        ·
-·                    table         tab4@idx_tab4_0  ·                                  ·
-·                    spans         /!NULL-/5.38/1   ·                                  ·
+·                    distribution  local            ·                          ·
+·                    vectorized    true             ·                          ·
+render               ·             ·                (col0)                     ·
+ │                   render 0      col0             ·                          ·
+ └── index-join      ·             ·                (col0, col3, col4, rowid)  ·
+      │              table         tab4@primary     ·                          ·
+      │              key columns   rowid            ·                          ·
+      └── filter     ·             ·                (col0, col4, rowid)        ·
+           │         filter        col0 <= 0        ·                          ·
+           └── scan  ·             ·                (col0, col4, rowid)        ·
+·                    table         tab4@idx_tab4_0  ·                          ·
+·                    spans         /!NULL-/5.38/1   ·                          ·
 
 # ------------------------------------------------------------------------------
 # Correlated subqueries.

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -87,16 +87,16 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3) AND (a,b,c) < (8, 9, 10)
 ----
-·                distribution  local                                                 ·                      ·
-·                vectorized    true                                                  ·                      ·
-filter           ·             ·                                                     (a, b, c)              ·
- │               filter        ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))  ·                      ·
- └── index-join  ·             ·                                                     (a, b, c)              ·
-      │          table         abc@primary                                           ·                      ·
-      │          key columns   rowid                                                 ·                      ·
-      └── scan   ·             ·                                                     (a, b, rowid[hidden])  ·
-·                table         abc@abc_a_b_idx                                       ·                      ·
-·                spans         /1/2-/8/10                                            ·                      ·
+·                distribution  local                                                 ·              ·
+·                vectorized    true                                                  ·              ·
+filter           ·             ·                                                     (a, b, c)      ·
+ │               filter        ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))  ·              ·
+ └── index-join  ·             ·                                                     (a, b, c)      ·
+      │          table         abc@primary                                           ·              ·
+      │          key columns   rowid                                                 ·              ·
+      └── scan   ·             ·                                                     (a, b, rowid)  ·
+·                table         abc@abc_a_b_idx                                       ·              ·
+·                spans         /1/2-/8/10                                            ·              ·
 
 statement ok
 DROP TABLE abc

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -339,37 +339,37 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(c) STORING(a,b))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [ UPDATE abc SET a=c RETURNING a ] ORDER BY a
 ----
-·                                             distribution      local                             ·                         ·
-·                                             vectorized        false                             ·                         ·
-root                                          ·                 ·                                 (a)                       +a
- ├── sort                                     ·                 ·                                 (a)                       +a
- │    │                                       order             +a                                ·                         ·
- │    └── scan buffer node                    ·                 ·                                 (a)                       ·
- │                                            label             buffer 1                          ·                         ·
- └── subquery                                 ·                 ·                                 ·                         ·
-      │                                       id                @S1                               ·                         ·
-      │                                       original sql      UPDATE abc SET a = c RETURNING a  ·                         ·
-      │                                       exec mode         all rows                          ·                         ·
-      └── buffer node                         ·                 ·                                 (a)                       ·
-           │                                  label             buffer 1                          ·                         ·
-           └── spool                          ·                 ·                                 (a)                       ·
-                └── render                    ·                 ·                                 (a)                       ·
-                     │                        render 0          a                                 ·                         ·
-                     └── run                  ·                 ·                                 (a, rowid[hidden])        ·
-                          └── update          ·                 ·                                 (a, rowid[hidden])        ·
-                               │              table             abc                               ·                         ·
-                               │              set               a                                 ·                         ·
-                               │              strategy          updater                           ·                         ·
-                               └── render     ·                 ·                                 (a, b, c, rowid, c)       ·
-                                    │         render 0          a                                 ·                         ·
-                                    │         render 1          b                                 ·                         ·
-                                    │         render 2          c                                 ·                         ·
-                                    │         render 3          rowid                             ·                         ·
-                                    │         render 4          c                                 ·                         ·
-                                    └── scan  ·                 ·                                 (a, b, c, rowid[hidden])  ·
-·                                             table             abc@primary                       ·                         ·
-·                                             spans             FULL SCAN                         ·                         ·
-·                                             locking strength  for update                        ·                         ·
+·                                             distribution      local                             ·                    ·
+·                                             vectorized        false                             ·                    ·
+root                                          ·                 ·                                 (a)                  +a
+ ├── sort                                     ·                 ·                                 (a)                  +a
+ │    │                                       order             +a                                ·                    ·
+ │    └── scan buffer node                    ·                 ·                                 (a)                  ·
+ │                                            label             buffer 1                          ·                    ·
+ └── subquery                                 ·                 ·                                 ·                    ·
+      │                                       id                @S1                               ·                    ·
+      │                                       original sql      UPDATE abc SET a = c RETURNING a  ·                    ·
+      │                                       exec mode         all rows                          ·                    ·
+      └── buffer node                         ·                 ·                                 (a)                  ·
+           │                                  label             buffer 1                          ·                    ·
+           └── spool                          ·                 ·                                 (a)                  ·
+                └── render                    ·                 ·                                 (a)                  ·
+                     │                        render 0          a                                 ·                    ·
+                     └── run                  ·                 ·                                 (a, rowid)           ·
+                          └── update          ·                 ·                                 (a, rowid)           ·
+                               │              table             abc                               ·                    ·
+                               │              set               a                                 ·                    ·
+                               │              strategy          updater                           ·                    ·
+                               └── render     ·                 ·                                 (a, b, c, rowid, c)  ·
+                                    │         render 0          a                                 ·                    ·
+                                    │         render 1          b                                 ·                    ·
+                                    │         render 2          c                                 ·                    ·
+                                    │         render 3          rowid                             ·                    ·
+                                    │         render 4          c                                 ·                    ·
+                                    └── scan  ·                 ·                                 (a, b, c, rowid)     ·
+·                                             table             abc@primary                       ·                    ·
+·                                             spans             FULL SCAN                         ·                    ·
+·                                             locking strength  for update                        ·                    ·
 
 # ------------------------------------------------------------------------------
 # Regression for #35364. This tests behavior that is different between the CBO

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -365,8 +365,8 @@ root                                               ·             ·            
            └── spool                               ·             ·                                                    (z)                           ·
                 └── render                         ·             ·                                                    (z)                           ·
                      │                             render 0      z                                                    ·                             ·
-                     └── run                       ·             ·                                                    (z, rowid[hidden])            ·
-                          └── upsert               ·             ·                                                    (z, rowid[hidden])            ·
+                     └── run                       ·             ·                                                    (z, rowid)                    ·
+                          └── upsert               ·             ·                                                    (z, rowid)                    ·
                                │                   into          xyz(x, y, z, rowid)                                  ·                             ·
                                │                   strategy      opt upserter                                         ·                             ·
                                └── render          ·             ·                                                    (a, b, c, column11, a, b, c)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -59,8 +59,8 @@ root                                       ·              ·                   
            └── spool                       ·              ·                                     (a)                 ·
                 └── render                 ·              ·                                     (a)                 ·
                      │                     render 0       a                                     ·                   ·
-                     └── run               ·              ·                                     (a, rowid[hidden])  ·
-                          └── insert       ·              ·                                     (a, rowid[hidden])  ·
+                     └── run               ·              ·                                     (a, rowid)          ·
+                          └── insert       ·              ·                                     (a, rowid)          ·
                                │           into           x(a, rowid)                           ·                   ·
                                │           strategy       inserter                              ·                   ·
                                └── values  ·              ·                                     (column1, column5)  ·

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -61,7 +61,7 @@ func (ob *OutputBuilder) EnterNode(
 ) {
 	var colStr, ordStr string
 	if ob.flags.Verbose {
-		colStr = columns.String(ob.flags.ShowTypes)
+		colStr = columns.String(ob.flags.ShowTypes, false /* showHidden */)
 		ordStr = ordering.String(columns)
 	}
 	ob.enterNode(name, colStr, ordStr)

--- a/pkg/sql/sqlbase/result_columns.go
+++ b/pkg/sql/sqlbase/result_columns.go
@@ -103,8 +103,9 @@ func (r ResultColumns) NodeFormatter(colIdx int) tree.NodeFormatter {
 }
 
 // String formats result columns to a string.
-// The column types are printed if the argument specifies so.
-func (r ResultColumns) String(printTypes bool) string {
+// The column types are printed if printTypes is true.
+// The hidden property is printed if showHidden is true.
+func (r ResultColumns) String(printTypes bool, showHidden bool) string {
 	f := tree.NewFmtCtx(tree.FmtSimple)
 	f.WriteByte('(')
 	for i := range r {
@@ -124,7 +125,7 @@ func (r ResultColumns) String(printTypes bool) string {
 			hasProps = true
 			f.WriteString(prop)
 		}
-		if rCol.Hidden {
+		if showHidden && rCol.Hidden {
 			outputProp("hidden")
 		}
 		if hasProps {


### PR DESCRIPTION
The ResultColumns.Hidden flag is used internally; it does not carry
useful information for users and should not be visible in EXPLAIN.

Release note (sql change): EXPLAIN no longer shows the "hidden"
annotation for columns.