### PR TITLE
opt: improve the partial index label in EXPLAIN

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -286,9 +286,8 @@ InitPut /Table/53/4/"foo"/22/0 -> /BYTES/
 query TTT
 EXPLAIN SELECT b FROM t WHERE b > 10
 ----
-·     distribution   local
-·     vectorized     true
-scan  ·              ·
-·     table          t@b_partial
-·     spans          FULL SCAN
-·     partial index  ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t@b_partial (partial index)
+·     spans         FULL SCAN


### PR DESCRIPTION
This commit moves the "partial index" mention next to the name of the
index.

Release note: None