### PR TITLE
release-20.1: util/tracing: fix DistSQL trace collection

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -875,8 +875,6 @@ func (s *vectorizedFlowCreator) setupOutput(
 				metadataSourcesQueue,
 				execinfrapb.CallbackMetadataSource{
 					DrainMetaCb: func(ctx context.Context) []execinfrapb.ProducerMetadata {
-						// TODO(asubiotto): Who is responsible for the recording of the
-						// parent context?
 						// Start a separate recording so that GetRecording will return
 						// the recordings for only the child spans containing stats.
 						ctx, span := tracing.ChildSpanSeparateRecording(ctx, "")


### PR DESCRIPTION
Backport 1/1 commits from #50913.

/cc @cockroachdb/release

---

Before this patch, the collection of traces from remote DistSQL flows
was broken: the traces for the remote processors were collected as
orphans. The spans corresponding to each processor were collected with a
missing parent - the span corresponding to the SetupFlow RPC which
creates the processor (the relationship there is a FollowsFrom because
the execution of the processors is generally async wrt the RPC). This
was causing the Recording.String() method to ignore them - it was simply
skipping orphans.

Release note (bug fix): A bug causing traces collected through the
sql.trace.txn.enable_threshold setting to be sometimes incomplete was
fixed.
