### PR TITLE
backupccl: stop reading on MutationJobs on RESTORE

### DIFF
--- a/pkg/ccl/backupccl/restore_schema_change_creation.go
+++ b/pkg/ccl/backupccl/restore_schema_change_creation.go
@@ -126,11 +126,18 @@ func createSchemaChangeJobsFromMutations(
 	username string,
 	tableDesc *sqlbase.TableDescriptor,
 ) ([]*jobs.StartableJob, error) {
-	mutationJobs := make([]sqlbase.TableDescriptor_MutationJob, 0, len(tableDesc.MutationJobs))
-	newJobs := make([]*jobs.StartableJob, 0, len(tableDesc.MutationJobs))
-	for _, mj := range tableDesc.MutationJobs {
-		mutationID := mj.MutationID
-		jobDesc, mutationCount, err := jobDescriptionFromMutationID(tableDesc, mj.MutationID)
+	mutationJobs := make([]sqlbase.TableDescriptor_MutationJob, 0, len(tableDesc.Mutations))
+	newJobs := make([]*jobs.StartableJob, 0, len(tableDesc.Mutations))
+	seenMutations := make(map[sqlbase.MutationID]bool)
+	for _, mutation := range tableDesc.Mutations {
+		if seenMutations[mutation.MutationID] {
+			// We've already seen a mutation with this ID, so a job that handles all
+			// mutations with this ID has already been created.
+			continue
+		}
+		mutationID := mutation.MutationID
+		seenMutations[mutationID] = true
+		jobDesc, mutationCount, err := jobDescriptionFromMutationID(tableDesc, mutationID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This change stops reading the MutationJobs field on table descriptors
that we are importing. It previously assumed that the MutationsJobs and
Mutations remain in sync. However, in practice there are descriptors
where this is not the case and RESTORE should no longer rely on this
assumption.

Release note (bug fix): Increase robustness of restore against
descriptors which may be in an unexpected state.