### PR TITLE
sql: don't list spans in non-verbose EXPLAIN

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
@@ -284,12 +285,21 @@ func (e *explainer) spans(
 	spans []roachpb.Span,
 	hardLimitSet bool,
 ) {
-	spanss := sqlbase.PrettySpans(index, spans, 2)
-	if spanss != "" {
-		if spanss == "-" {
-			spanss = getAttrForSpansAll(hardLimitSet)
-		}
-		e.attr(nodeName, fieldName, spanss)
+	if len(spans) == 0 {
+		return
+	}
+	str := sqlbase.PrettySpans(index, spans, 2)
+	if str == "-" {
+		e.attr(nodeName, fieldName, getAttrForSpansAll(hardLimitSet))
+		return
+	}
+	if e.flags.Verbose {
+		e.attr(nodeName, fieldName, str)
+	} else {
+		e.attr(
+			nodeName, fieldName,
+			fmt.Sprintf("%d span%s", len(spans), util.Pluralize(int64(len(spans)))),
+		)
 	}
 }
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/array
+++ b/pkg/sql/opt/exec/execbuilder/testdata/array
@@ -102,7 +102,7 @@ filter     ·             ·
  │         filter        y > ARRAY[1,NULL]
  └── scan  ·             ·
 ·          table         parent@primary
-·          spans         /2-
+·          spans         1 span
 
 query TTT
 EXPLAIN SELECT y FROM parent WHERE x = 1 AND y = ARRAY[NULL, NULL]
@@ -114,7 +114,7 @@ render          ·             ·
       │         filter        y = ARRAY[NULL,NULL]
       └── scan  ·             ·
 ·               table         parent@primary
-·               spans         /1-/1/#
+·               spans         1 span
 
 query TTT
 EXPLAIN SELECT z FROM child WHERE x = 1 AND y = ARRAY[NULL, NULL]
@@ -126,4 +126,4 @@ render          ·             ·
       │         filter        y = ARRAY[NULL,NULL]
       └── scan  ·             ·
 ·               table         child@primary
-·               spans         /1/#/56/1-/1/#/56/1/#
+·               spans         1 span

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -114,7 +114,7 @@ EXPLAIN DELETE FROM unindexed WHERE k > 0
 ·             vectorized    false
 delete range  ·             ·
 ·             from          unindexed
-·             spans         /1-
+·             spans         1 span
 
 # Check fast DELETE with reverse scans (not supported by optimizer).
 query error DELETE statement requires LIMIT when ORDER BY is used
@@ -133,7 +133,7 @@ count           ·             ·
       │         auto commit   ·
       └── scan  ·             ·
 ·               table         unindexed@primary
-·               spans         /1-
+·               spans         1 span
 ·               limit         1
 
 query TTT
@@ -148,7 +148,7 @@ count           ·             ·
       │         auto commit   ·
       └── scan  ·             ·
 ·               table         indexed@indexed_value_idx
-·               spans         /5-/6
+·               spans         1 span
 ·               limit         10
 
 query TTT
@@ -179,7 +179,7 @@ run             ·             ·
       │         auto commit   ·
       └── scan  ·             ·
 ·               table         indexed@indexed_value_idx
-·               spans         /5-/6
+·               spans         1 span
 ·               limit         10
 
 # Ensure that index hints in DELETE statements force the choice of a specific index
@@ -251,7 +251,7 @@ EXPLAIN DELETE FROM parent WHERE id > 10
 ·             vectorized    false
 delete range  ·             ·
 ·             from          parent
-·             spans         /11-
+·             spans         1 span
 
 statement ok
 CREATE TABLE child (
@@ -269,7 +269,7 @@ EXPLAIN DELETE FROM parent WHERE id > 10
 ·             vectorized    false
 delete range  ·             ·
 ·             from          parent
-·             spans         /11-
+·             spans         1 span
 
 # Delete range should not be used when deleting from the child.
 query TTT
@@ -304,7 +304,7 @@ EXPLAIN DELETE FROM parent WHERE id > 10
 ·             vectorized    false
 delete range  ·             ·
 ·             from          parent
-·             spans         /11-
+·             spans         1 span
 
 statement ok
 CREATE TABLE grandchild (
@@ -323,7 +323,7 @@ EXPLAIN DELETE FROM parent WHERE id > 10
 ·             vectorized    false
 delete range  ·             ·
 ·             from          parent
-·             spans         /11-
+·             spans         1 span
 
 statement ok
 CREATE TABLE external_ref (
@@ -348,7 +348,7 @@ root                        ·             ·
  │              │           label         buffer 1
  │              └── scan    ·             ·
  │                          table         parent@primary
- │                          spans         /11-
+ │                          spans         1 span
  ├── fk-cascade             ·             ·
  │                          fk            fk_pid_ref_parent
  │                          input         buffer 1
@@ -384,7 +384,7 @@ root                                       ·                   ·
  │              │                          label               buffer 1
  │              └── scan                   ·                   ·
  │                                         table               parent@primary
- │                                         spans               /11-
+ │                                         spans               1 span
  ├── fk-cascade                            ·                   ·
  │                                         fk                  fk_pid_ref_parent
  │                                         input               buffer 1
@@ -434,7 +434,7 @@ root                                       ·                   ·
  │              │                          label               buffer 1
  │              └── scan                   ·                   ·
  │                                         table               parent@primary
- │                                         spans               /11-
+ │                                         spans               1 span
  ├── fk-cascade                            ·                   ·
  │                                         fk                  fk_pid_ref_parent
  │                                         input               buffer 1
@@ -483,7 +483,7 @@ root                        ·             ·
  │              │           label         buffer 1
  │              └── scan    ·             ·
  │                          table         parent@primary
- │                          spans         /11-
+ │                          spans         1 span
  ├── fk-cascade             ·             ·
  │                          fk            fk_pid_ref_parent
  │                          input         buffer 1
@@ -522,7 +522,7 @@ root                        ·             ·
  │              │           label         buffer 1
  │              └── scan    ·             ·
  │                          table         ab@primary
- │                          spans         /1-/2
+ │                          spans         1 span
  └── fk-cascade             ·             ·
 ·                           fk            fk_b_ref_ab
 ·                           input         buffer 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
@@ -139,7 +139,7 @@ EXPLAIN SELECT * FROM p1 WHERE b <= 3
 ·     vectorized    true
 scan  ·             ·
 ·     table         p1@b
-·     spans         -/4
+·     spans         1 span
 
 # Partial predicate on primary key should not be tightened.
 query TTT
@@ -149,7 +149,7 @@ EXPLAIN SELECT * FROM p1 WHERE a <= 3
 ·     vectorized    true
 scan  ·             ·
 ·     table         p1@primary
-·     spans         -/4
+·     spans         1 span
 
 # Tighten end key if span contains full primary key.
 query TTT
@@ -161,7 +161,7 @@ filter     ·             ·
  │         filter        b <= 3
  └── scan  ·             ·
 ·          table         p1@primary
-·          spans         -/3/3/#
+·          spans         1 span
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b < 4
@@ -172,7 +172,7 @@ filter     ·             ·
  │         filter        b < 4
  └── scan  ·             ·
 ·          table         p1@primary
-·          spans         -/3/3/#
+·          spans         1 span
 
 # Mixed bounds.
 query TTT
@@ -184,7 +184,7 @@ filter     ·             ·
  │         filter        b <= 3
  └── scan  ·             ·
 ·          table         p1@primary
-·          spans         /2-
+·          spans         1 span
 
 # Edge cases.
 
@@ -197,7 +197,7 @@ filter     ·             ·
  │         filter        b <= 0
  └── scan  ·             ·
 ·          table         p1@primary
-·          spans         -/0/0/#
+·          spans         1 span
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= -1 AND b <= -1
@@ -208,7 +208,7 @@ filter     ·             ·
  │         filter        b <= -1
  └── scan  ·             ·
 ·          table         p1@primary
-·          spans         -/-1/-1/#
+·          spans         1 span
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= -9223372036854775808
@@ -217,7 +217,7 @@ EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= -9223372036854775808
 ·     vectorized    true
 scan  ·             ·
 ·     table         p1@primary
-·     spans         /1-/1/-9223372036854775808/#
+·     spans         1 span
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= 9223372036854775807
@@ -226,7 +226,7 @@ EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= 9223372036854775807
 ·     vectorized    true
 scan  ·             ·
 ·     table         p1@primary
-·     spans         /1-/1/9223372036854775807/#
+·     spans         1 span
 
 # Table c1 (interleaved table)
 
@@ -239,7 +239,7 @@ EXPLAIN SELECT * FROM c1 WHERE a <= 3
 ·     vectorized    true
 scan  ·             ·
 ·     table         c1@primary
-·     spans         -/4
+·     spans         1 span
 
 # Tighten span on fully primary key.
 query TTT
@@ -251,7 +251,7 @@ filter     ·             ·
  │         filter        b <= 3
  └── scan  ·             ·
 ·          table         c1@primary
-·          spans         -/3/3/#/54/1/#
+·          spans         1 span
 
 # Table p2 with interleaved index.
 
@@ -265,7 +265,7 @@ EXPLAIN SELECT * FROM p2 WHERE i >= 2
 ·     vectorized    true
 scan  ·             ·
 ·     table         p2@primary
-·     spans         /2-
+·     spans         1 span
 
 # Upper bound (i <= 5)
 
@@ -276,7 +276,7 @@ EXPLAIN SELECT * FROM p2 WHERE i <= 5
 ·     vectorized    true
 scan  ·             ·
 ·     table         p2@primary
-·     spans         -/5/#
+·     spans         1 span
 
 # From the interleaved index: no tightening at all.
 
@@ -292,7 +292,7 @@ filter     ·             ·
  │         filter        d >= 2
  └── scan  ·             ·
 ·          table         p2@p2_id
-·          spans         /1/#/55/2/2-
+·          spans         1 span
 
 # Upper bound (i <= 6 AND d <= 5)
 
@@ -305,7 +305,7 @@ filter     ·             ·
  │         filter        d <= 5
  └── scan  ·             ·
 ·          table         p2@p2_id
-·          spans         -/6/#/55/2/6
+·          spans         1 span
 
 # IS NULL
 
@@ -318,7 +318,7 @@ filter     ·             ·
  │         filter        d IS NULL
  └── scan  ·             ·
 ·          table         p2@p2_id
-·          spans         /1/#/55/2/NULL-
+·          spans         1 span
 
 # IS NOT NULL
 
@@ -331,7 +331,7 @@ filter     ·             ·
  │         filter        d IS NOT NULL
  └── scan  ·             ·
 ·          table         p2@p2_id
-·          spans         /1/#/55/2/!NULL-
+·          spans         1 span
 
 # String table
 
@@ -343,7 +343,7 @@ tree  field         description
 ·     vectorized    true
 scan  ·             ·
 ·     table         bytes_t@primary
-·     spans         /"a"-/"a"/#
+·     spans         1 span
 
 # No tightening.
 
@@ -355,7 +355,7 @@ tree  field         description
 ·     vectorized    true
 scan  ·             ·
 ·     table         bytes_t@primary
-·     spans         -/"aa"
+·     spans         1 span
 
 query TTT colnames
 EXPLAIN SELECT * FROM decimal_t WHERE a = 1.00
@@ -365,7 +365,7 @@ tree  field         description
 ·     vectorized    true
 scan  ·             ·
 ·     table         decimal_t@primary
-·     spans         /1-/1/#
+·     spans         1 span
 
 # No tightening.
 
@@ -377,4 +377,4 @@ tree  field         description
 ·     vectorized    true
 scan  ·             ·
 ·     table         decimal_t@primary
-·     spans         -/2
+·     spans         1 span

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -508,7 +508,7 @@ EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ·     vectorized    true
 scan  ·             ·
 ·     table         t@primary
-·     spans         /1-/1/# /3-/3/#
+·     spans         2 spans
 ·     parallel      ·
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -230,7 +230,7 @@ root                                       ·             ·
  │              │                          label         buffer 1
  │              └── scan                   ·             ·
  │                                         table         parent@primary
- │                                         spans         /3-/3/#
+ │                                         spans         1 span
  ├── fk-check                              ·             ·
  │    └── error if rows                    ·             ·
  │         └── lookup-join                 ·             ·
@@ -267,7 +267,7 @@ root                                       ·             ·
  │              │                          label         buffer 1
  │              └── scan                   ·             ·
  │                                         table         parent@primary
- │                                         spans         /3-/3/#
+ │                                         spans         1 span
  ├── fk-check                              ·             ·
  │    └── error if rows                    ·             ·
  │         └── lookup-join                 ·             ·
@@ -322,7 +322,7 @@ root                                  ·             ·
  │              │                     label         buffer 1
  │              └── scan              ·             ·
  │                                    table         doubleparent@primary
- │                                    spans         /10-/11
+ │                                    spans         1 span
  └── fk-check                         ·             ·
       └── error if rows               ·             ·
            └── lookup-join            ·             ·
@@ -381,7 +381,7 @@ root                                       ·                      ·
  │              └── render                 ·                      ·
  │                   └── scan              ·                      ·
  │                                         table                  child@primary
- │                                         spans                  /10-/10/#
+ │                                         spans                  1 span
  │                                         locking strength       for update
  └── fk-check                              ·                      ·
       └── error if rows                    ·                      ·
@@ -472,7 +472,7 @@ root                                            ·                 ·
  │              └── render                      ·                 ·
  │                   └── scan                   ·                 ·
  │                                              table             parent@parent_other_key
- │                                              spans             /10-/11
+ │                                              spans             1 span
  │                                              locking strength  for update
  ├── fk-check                                   ·                 ·
  │    └── error if rows                         ·                 ·
@@ -959,7 +959,7 @@ render                    ·                   ·
            │    │         filter              (a_y IS NOT NULL) AND (a_x IS NOT NULL)
            │    └── scan  ·                   ·
            │              table               b@idx
-           │              spans               /!NULL-
+           │              spans               1 span
            └── scan       ·                   ·
 ·                         table               a@primary
 ·                         spans               FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -56,7 +56,7 @@ EXPLAIN SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 ·     vectorized    true
 scan  ·             ·
 ·     table         level4@primary
-·     spans         /2/#/54/1/#/55/1-/2/#/54/1/#/55/2
+·     spans         1 span
 
 query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
@@ -65,7 +65,7 @@ EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
 ·     vectorized    true
 scan  ·             ·
 ·     table         level4@primary
-·     spans         /2/#/54/1/#/55/1/11-/2/#/54/1/#/55/1/30
+·     spans         1 span
 
 query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
@@ -74,7 +74,7 @@ EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
 ·     vectorized    true
 scan  ·             ·
 ·     table         level4@primary
-·     spans         /2/#/54/1/#/55/1/20/101/#/56/1-/2/#/54/1/#/55/1/20/299/#/56/1/#
+·     spans         1 span
 ·     parallel      ·
 
 query TTT
@@ -84,7 +84,7 @@ EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200
 ·     vectorized    true
 scan  ·             ·
 ·     table         level4@primary
-·     spans         /2/#/54/1/#/55/1/20/200/#/56/1-/2/#/54/1/#/55/1/20/200/#/56/1/#
+·     spans         1 span
 
 # ------------------------------------------------------------------------------
 # Trace of interleaved fetches from interesting interleaved hierarchy.

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -1296,7 +1296,7 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)",+"(b=b)"
       ├── scan   ·                   ·
       │          table               abcdef@primary
-      │          spans               /1/2/6/9-
+      │          spans               1 span
       └── scan   ·                   ·
 ·                table               abg@primary
 ·                spans               FULL SCAN
@@ -1537,7 +1537,7 @@ filter           ·             ·
       │          key columns   a
       └── scan   ·             ·
 ·                table         zigzag@b_idx
-·                spans         /5-/6
+·                spans         1 span
 
 # Enable zigzag joins.
 statement ok
@@ -1631,7 +1631,7 @@ filter           ·             ·
       │          key columns   rowid
       └── scan   ·             ·
 ·                table         zigzag2@a_b_idx
-·                spans         /1/2-/1/3
+·                spans         1 span
 
 # Test that we can force a merge join.
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/mvcc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/mvcc
@@ -14,7 +14,7 @@ EXPLAIN SELECT z FROM t WHERE x = 1
 render     ·             ·
  └── scan  ·             ·
 ·          table         t@primary
-·          spans         /1/0-/1/1 /1/2/1-/1/2/2
+·          spans         2 spans
 
 query TTT
 EXPLAIN SELECT crdb_internal_mvcc_timestamp, z FROM t WHERE x = 1
@@ -24,7 +24,7 @@ EXPLAIN SELECT crdb_internal_mvcc_timestamp, z FROM t WHERE x = 1
 render     ·             ·
  └── scan  ·             ·
 ·          table         t@primary
-·          spans         /1-/1/#
+·          spans         1 span
 
 # Ensure that the presence of mutation columns doesn't affect accessing system
 # columns.

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -275,7 +275,7 @@ render                ·                ·
            │          key columns      a, b, c
            └── scan   ·                ·
 ·                     table            abc@ba
-·                     spans            /11-/30
+·                     spans            1 span
 
 # An inequality should not be enough to force the use of the index.
 query TTT
@@ -417,7 +417,7 @@ EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
 render     ·             ·
  └── scan  ·             ·
 ·          table         abc@bc
-·          spans         /2-/3
+·          spans         1 span
 
 query TTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
@@ -427,7 +427,7 @@ EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 render        ·             ·
  └── revscan  ·             ·
 ·             table         abc@bc
-·             spans         /2-/3
+·             spans         1 span
 
 # Verify that the ordering of the primary index is still used for the outer sort.
 query TTTTT
@@ -476,7 +476,7 @@ EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ·     vectorized    true
 scan  ·             ·
 ·     table         abcd@abc
-·     spans         /1/4-/1/5
+·     spans         1 span
 
 query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
@@ -485,7 +485,7 @@ EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ·     vectorized    true
 scan  ·             ·
 ·     table         abcd@abc
-·     spans         /1/4-/1/5
+·     spans         1 span
 
 query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
@@ -494,7 +494,7 @@ EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ·     vectorized    true
 scan  ·             ·
 ·     table         abcd@abc
-·     spans         /1/4-/1/5
+·     spans         1 span
 
 query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
@@ -503,7 +503,7 @@ EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ·     vectorized    true
 scan  ·             ·
 ·     table         abcd@abc
-·     spans         /1/4-/1/5
+·     spans         1 span
 
 statement ok
 CREATE TABLE nan (id INT PRIMARY KEY, x REAL)

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -29,7 +29,7 @@ EXECUTE change_index
 ·     vectorized    true
 scan  ·             ·
 ·     table         ab@bindex
-·     spans         /10-/11
+·     spans         1 span
 
 statement ok
 DROP INDEX bindex

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -262,7 +262,7 @@ EXPLAIN SELECT y, z, v FROM t@i WHERE y = 2.01 AND z = 3.001
 ·     vectorized    true
 scan  ·             ·
 ·     table         t@i
-·     spans         /2.01/3.001/0-/2.01/3.001/1 /2.01/3.001/2/1-/2.01/3.001/2/2
+·     spans         2 spans
 
 # Ensure that we always have a k/v in family 0.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1257,7 +1257,7 @@ EXPLAIN SELECT * FROM a WHERE a = 10
 ·     vectorized    true
 scan  ·             ·
 ·     table         a@primary
-·     spans         /10-/10/#
+·     spans         1 span
 
 query TTT
 EXPLAIN SELECT * FROM a WHERE a = 10 OR a = 20
@@ -1266,7 +1266,7 @@ EXPLAIN SELECT * FROM a WHERE a = 10 OR a = 20
 ·     vectorized    true
 scan  ·             ·
 ·     table         a@primary
-·     spans         /10-/10/# /20-/20/#
+·     spans         2 spans
 ·     parallel      ·
 
 query TTT
@@ -1276,7 +1276,7 @@ EXPLAIN SELECT * FROM a WHERE a IN (10, 20)
 ·     vectorized    true
 scan  ·             ·
 ·     table         a@primary
-·     spans         /10-/10/# /20-/20/#
+·     spans         2 spans
 ·     parallel      ·
 
 # Verify that consolidated point spans are still parallelized.
@@ -1287,7 +1287,7 @@ EXPLAIN SELECT * FROM a WHERE a in (10, 11)
 ·     vectorized    true
 scan  ·             ·
 ·     table         a@primary
-·     spans         /10-/11/#
+·     spans         1 span
 ·     parallel      ·
 
 query TTT
@@ -1297,7 +1297,7 @@ EXPLAIN SELECT * FROM a WHERE a > 10 AND a < 20
 ·     vectorized    true
 scan  ·             ·
 ·     table         a@primary
-·     spans         /11-/19/#
+·     spans         1 span
 ·     parallel      ·
 
 # This ticks all the boxes for parallelization apart from the fact that there
@@ -1309,7 +1309,7 @@ EXPLAIN SELECT * FROM a WHERE a > 10
 ·     vectorized    true
 scan  ·             ·
 ·     table         a@primary
-·     spans         /11-
+·     spans         1 span
 
 # Test non-int types.
 
@@ -1325,7 +1325,7 @@ render           ·             ·
       │          key columns   a
       └── scan   ·             ·
 ·                table         a@item
-·                spans         /"ball"-/"ball"/PrefixEnd /"sock"-/"sock"/PrefixEnd
+·                spans         2 spans
 ·                parallel      ·
 
 # Range queries on non-int types are not parallel due to unbounded number of
@@ -1341,7 +1341,7 @@ render           ·             ·
       │          key columns   a
       └── scan   ·             ·
 ·                table         a@p
-·                spans         /5.000000000000001-/9.999999999999998/PrefixEnd /20.000000000000004-/39.99999999999999/PrefixEnd
+·                spans         2 spans
 
 query TTT
 EXPLAIN SELECT * FROM b WHERE (a = 10 AND b = 10) OR (a = 20 AND b = 20)
@@ -1350,7 +1350,7 @@ EXPLAIN SELECT * FROM b WHERE (a = 10 AND b = 10) OR (a = 20 AND b = 20)
 ·     vectorized    true
 scan  ·             ·
 ·     table         b@primary
-·     spans         /10/10-/10/10/# /20/20-/20/20/#
+·     spans         2 spans
 ·     parallel      ·
 
 # This one isn't parallelizable because it's not a point lookup - only part of
@@ -1362,7 +1362,7 @@ EXPLAIN SELECT * FROM b WHERE a = 10 OR a = 20
 ·     vectorized    true
 scan  ·             ·
 ·     table         b@primary
-·     spans         /10-/11 /20-/21
+·     spans         2 spans
 
 # This one isn't parallelizable because it has a LIMIT clause.
 query TTT
@@ -1372,7 +1372,7 @@ EXPLAIN SELECT * FROM a WHERE a = 10 OR a = 20 LIMIT 1
 ·     vectorized    true
 scan  ·             ·
 ·     table         a@primary
-·     spans         /10-/10/# /20-/20/#
+·     spans         2 spans
 ·     limit         1
 
 statement ok
@@ -1386,7 +1386,7 @@ EXPLAIN SELECT b FROM b WHERE b = 10 OR b = 20
 ·     vectorized    true
 scan  ·             ·
 ·     table         b@b_b_idx
-·     spans         /10-/11 /20-/21
+·     spans         2 spans
 
 statement ok
 CREATE UNIQUE INDEX on b(c)
@@ -1400,7 +1400,7 @@ EXPLAIN SELECT c FROM b WHERE c = 10 OR c = 20
 ·     vectorized    true
 scan  ·             ·
 ·     table         b@b_c_key
-·     spans         /10-/11 /20-/21
+·     spans         2 spans
 ·     parallel      ·
 
 query TTT
@@ -1410,7 +1410,7 @@ EXPLAIN SELECT c FROM b WHERE c = 10 OR c < 2
 ·     vectorized    true
 scan  ·             ·
 ·     table         b@b_c_key
-·     spans         /!NULL-/2 /10-/11
+·     spans         2 spans
 
 statement ok
 CREATE UNIQUE INDEX on b(d DESC)
@@ -1424,7 +1424,7 @@ EXPLAIN SELECT d FROM b WHERE d = 10 OR d < 2
 ·     vectorized    true
 scan  ·             ·
 ·     table         b@b_d_key
-·     spans         /10-/9 /1-/NULL
+·     spans         2 spans
 
 statement ok
 CREATE UNIQUE INDEX ON b(c, d)
@@ -1439,7 +1439,7 @@ EXPLAIN SELECT d FROM b WHERE c = 10 AND d = 10 OR c IS NULL AND d > 0 AND d < 2
 render     ·             ·
  └── scan  ·             ·
 ·          table         b@b_c_d_key
-·          spans         /NULL/1-/NULL/2 /10/10-/10/11
+·          spans         2 spans
 
 statement ok
 DROP INDEX b_b_idx
@@ -1455,7 +1455,7 @@ EXPLAIN SELECT b FROM b WHERE b = 10 OR b = 20
 ·     vectorized    true
 scan  ·             ·
 ·     table         b@b_b_key
-·     spans         /10-/11 /20-/21
+·     spans         2 spans
 ·     parallel      ·
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -114,7 +114,7 @@ EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             /1-/1/#
+·     spans             1 span
 ·     locking strength  for update
 
 query TTT
@@ -124,7 +124,7 @@ EXPLAIN SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             /1-/1/#
+·     spans             1 span
 ·     locking strength  for no key update
 
 query TTT
@@ -134,7 +134,7 @@ EXPLAIN SELECT * FROM t WHERE a = 1 FOR SHARE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             /1-/1/#
+·     spans             1 span
 ·     locking strength  for share
 
 query TTT
@@ -144,7 +144,7 @@ EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             /1-/1/#
+·     spans             1 span
 ·     locking strength  for key share
 
 query TTT
@@ -154,7 +154,7 @@ EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             /1-/1/#
+·     spans             1 span
 ·     locking strength  for share
 
 query TTT
@@ -164,7 +164,7 @@ EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             /1-/1/#
+·     spans             1 span
 ·     locking strength  for no key update
 
 query TTT
@@ -174,7 +174,7 @@ EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FO
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             /1-/1/#
+·     spans             1 span
 ·     locking strength  for update
 
 query TTT
@@ -184,7 +184,7 @@ EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE OF t
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             /1-/1/#
+·     spans             1 span
 ·     locking strength  for update
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
@@ -198,7 +198,7 @@ EXPLAIN SELECT 1 FROM t WHERE a = 1 FOR UPDATE OF t
 render     ·                 ·
  └── scan  ·                 ·
 ·          table             t@primary
-·          spans             /1-/1/#
+·          spans             1 span
 ·          locking strength  for update
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -802,7 +802,7 @@ sort                 ·             ·
       └── render     ·             ·
            └── scan  ·             ·
 ·                    table         favorites@favorites_glob_fav_idx
-·                    spans         /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"/PrefixEnd
+·                    spans         3 spans
 
 query TI rowsort
 SELECT
@@ -1078,7 +1078,7 @@ index-join  ·             ·
  │          key columns   a
  └── scan   ·             ·
 ·           table         noncover@b
-·           spans         /2-/3
+·           spans         1 span
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE b = 2; SET tracing = off
@@ -1105,7 +1105,7 @@ index-join  ·             ·
  │          key columns   a
  └── scan   ·             ·
 ·           table         noncover@c
-·           spans         /6-/7
+·           spans         1 span
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE c = 7; SET tracing = off
@@ -1481,7 +1481,7 @@ EXPLAIN SELECT c FROM t4 WHERE a = 10 and b = 20
 render     ·             ·
  └── scan  ·             ·
 ·          table         t4@primary
-·          spans         /10/20/0-/10/20/1/2
+·          spans         1 span
 
 statement ok
 SET tracing = on,kv,results; SELECT c FROM t4 WHERE a = 10 and b = 20; SET tracing = off
@@ -1504,7 +1504,7 @@ EXPLAIN SELECT d FROM t4 WHERE a = 10 and b = 20
 render     ·             ·
  └── scan  ·             ·
 ·          table         t4@primary
-·          spans         /10/20/0-/10/20/1 /10/20/2/1-/10/20/2/2
+·          spans         2 spans
 
 statement ok
 SET tracing = on,kv,results; SELECT d FROM t4 WHERE a = 10 and b = 20; SET tracing = off
@@ -1528,7 +1528,7 @@ EXPLAIN SELECT d, e FROM t4 WHERE a = 10 and b = 20
 render     ·             ·
  └── scan  ·             ·
 ·          table         t4@primary
-·          spans         /10/20/0-/10/20/1 /10/20/2/1-/10/20/3/2
+·          spans         2 spans
 
 # Optimization should also be applied for updates.
 query TTT
@@ -1545,7 +1545,7 @@ count                ·                 ·
       └── render     ·                 ·
            └── scan  ·                 ·
 ·                    table             t4@primary
-·                    spans             /10/20/0-/10/20/1/2
+·                    spans             1 span
 ·                    locking strength  for update
 
 # Optimization should not be applied for deletes.
@@ -1557,7 +1557,7 @@ EXPLAIN DELETE FROM t4 WHERE a = 10 and b = 20
 delete range  ·             ·
 ·             from          t4
 ·             auto commit   ·
-·             spans         /10/20-/10/20/#
+·             spans         1 span
 
 # Optimization should not be applied for non point lookups.
 query TTT
@@ -1568,7 +1568,7 @@ EXPLAIN SELECT c FROM t4 WHERE a = 10 and b >= 20 and b < 22
 render     ·             ·
  └── scan  ·             ·
 ·          table         t4@primary
-·          spans         /10/20-/10/21/#
+·          spans         1 span
 ·          parallel      ·
 
 # Optimization should not be applied for partial primary key filter.
@@ -1580,7 +1580,7 @@ EXPLAIN SELECT c FROM t4 WHERE a = 10
 render     ·             ·
  └── scan  ·             ·
 ·          table         t4@primary
-·          spans         /10-/11
+·          spans         1 span
 
 # Regression test for #40890: a point lookup on a single column family of a
 # table should still work properly in the face of a constraint disjunction.
@@ -1592,5 +1592,5 @@ EXPLAIN SELECT a FROM t4 WHERE a in (1, 5) and b in (1, 5)
 render     ·             ·
  └── scan  ·             ·
 ·          table         t4@primary
-·          spans         /1/1/0-/1/1/1 /1/5/0-/1/5/1 /5/1/0-/5/1/1 /5/5/0-/5/5/1
+·          spans         4 spans
 ·          parallel      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -19,7 +19,7 @@ EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ·     vectorized    true
 scan  ·             ·
 ·     table         abcd@primary
-·     spans         /20-/30/#
+·     spans         1 span
 ·     parallel      ·
 
 # No hint, reverse scan.
@@ -30,7 +30,7 @@ EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ·        vectorized    true
 revscan  ·             ·
 ·        table         abcd@primary
-·        spans         /20-/30/#
+·        spans         1 span
 ·        parallel      ·
 
 # Force primary
@@ -41,7 +41,7 @@ EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ·     vectorized    true
 scan  ·             ·
 ·     table         abcd@primary
-·     spans         /20-/30/#
+·     spans         1 span
 ·     parallel      ·
 
 # Force primary, reverse scan.
@@ -52,7 +52,7 @@ EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=primary,DESC} WHERE a >= 20 AND a <= 30
 ·        vectorized    true
 revscan  ·             ·
 ·        table         abcd@primary
-·        spans         /20-/30/#
+·        spans         1 span
 ·        parallel      ·
 
 # Force primary, allow reverse scan.
@@ -63,7 +63,7 @@ EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ·        vectorized    true
 revscan  ·             ·
 ·        table         abcd@primary
-·        spans         /20-/30/#
+·        spans         1 span
 ·        parallel      ·
 
 # Force primary, forward scan.
@@ -76,7 +76,7 @@ sort       ·             ·
  │         order         -a
  └── scan  ·             ·
 ·          table         abcd@primary
-·          spans         /20-/30/#
+·          spans         1 span
 ·          parallel      ·
 
 # Force index b
@@ -219,7 +219,7 @@ EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ·     vectorized    true
 scan  ·             ·
 ·     table         abcd@cd
-·     spans         /20-/40
+·     spans         1 span
 
 # Force primary index
 query TTT
@@ -272,7 +272,7 @@ index-join  ·             ·
  │          key columns   a
  └── scan   ·             ·
 ·           table         abcd@cd
-·           spans         /10-/11
+·           spans         1 span
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -264,7 +264,7 @@ count                ·                 ·
       └── render     ·                 ·
            └── scan  ·                 ·
 ·                    table             kv@primary
-·                    spans             -/2/#
+·                    spans             1 span
 ·                    limit             1
 ·                    locking strength  for update
 
@@ -443,7 +443,7 @@ count                ·                 ·
       └── render     ·                 ·
            └── scan  ·                 ·
 ·                    table             kv@primary
-·                    spans             /3-/3/#
+·                    spans             1 span
 ·                    locking strength  for update
 
 query TTT
@@ -460,7 +460,7 @@ count                ·                 ·
       └── render     ·                 ·
            └── scan  ·                 ·
 ·                    table             kv@primary
-·                    spans             /2-/9/#
+·                    spans             1 span
 ·                    parallel          ·
 ·                    locking strength  for update
 
@@ -507,7 +507,7 @@ count                      ·                 ·
                 │          key columns       k
                 └── scan   ·                 ·
 ·                          table             kv3@kv3_v_idx
-·                          spans             /10-/11
+·                          spans             1 span
 ·                          locking strength  for update
 
 query TTT
@@ -527,7 +527,7 @@ count                      ·                 ·
                 │          key columns       k
                 └── scan   ·                 ·
 ·                          table             kv3@kv3_v_idx
-·                          spans             /2-/10
+·                          spans             1 span
 ·                          locking strength  for update
 
 statement ok
@@ -547,7 +547,7 @@ count                ·             ·
       └── render     ·             ·
            └── scan  ·             ·
 ·                    table         kv@primary
-·                    spans         /3-/3/#
+·                    spans         1 span
 
 query TTT
 EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
@@ -563,7 +563,7 @@ count                ·             ·
       └── render     ·             ·
            └── scan  ·             ·
 ·                    table         kv@primary
-·                    spans         /2-/9/#
+·                    spans         1 span
 ·                    parallel      ·
 
 query TTT
@@ -617,7 +617,7 @@ count                ·             ·
       └── render     ·             ·
            └── scan  ·             ·
 ·                    table         kv@primary
-·                    spans         -/2/#
+·                    spans         1 span
 ·                    limit         1
 
 query TTT
@@ -637,7 +637,7 @@ count                      ·             ·
                 │          key columns   k
                 └── scan   ·             ·
 ·                          table         kv3@kv3_v_idx
-·                          spans         /10-/11
+·                          spans         1 span
 
 query TTT
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
@@ -656,7 +656,7 @@ count                      ·             ·
                 │          key columns   k
                 └── scan   ·             ·
 ·                          table         kv3@kv3_v_idx
-·                          spans         /2-/10
+·                          spans         1 span
 
 # Update single column family.
 query TTT


### PR DESCRIPTION
Change the way we show spans in the non-verbose version of EXPLAIN. We
now only show a summary like "2 spans" instead of listing all the
spans.  We can still see the spans if necessary with EXPLAIN
(VERBOSE).

Note that this is now consistent with the explain_tree code that
generates what is shown in the UI.

Release note (sql change): EXPLAIN now shows just a summary of scan
spans instead of listing them (unless VERBOSE is used).