### PR TITLE
ui: update login security documentation link

### DIFF
--- a/pkg/ui/src/util/docs.ts
+++ b/pkg/ui/src/util/docs.ts
@@ -23,7 +23,7 @@ function docsURLNoVersion(pageName: string): string {
   return `${docsURLBaseNoVersion}/${pageName}`;
 }
 
-export const adminUILoginNoVersion = docsURLNoVersion("admin-ui-access-and-navigate.html#secure-the-admin-ui");
+export const adminUILoginNoVersion = docsURLNoVersion("admin-ui-overview.html#admin-ui-security");
 export const startFlags = docsURL("start-a-node.html#flags");
 export const pauseJob = docsURL("pause-job.html");
 export const cancelJob = docsURL("cancel-job.html");


### PR DESCRIPTION
Prior link is no longer active on the docs page
for the latest stable release.

Updated to point to:
https://www.cockroachlabs.com/docs/stable/admin-ui-overview.html#admin-ui-security

Release note (admin ui change): Updated link on
login page for secure clusters to point to moved
documentation URL.