### PR TITLE
sql: use the descs.Collection to access types during distributed flows

### DIFF
--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -138,7 +138,8 @@ func newCSVWriterProcessor(
 		input:       input,
 		output:      output,
 	}
-	if err := c.out.Init(&execinfrapb.PostProcessSpec{}, c.OutputTypes(), flowCtx.NewEvalCtx(), output); err != nil {
+	semaCtx := tree.MakeSemaContext()
+	if err := c.out.Init(&execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx(), output); err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -120,43 +119,7 @@ func makeInputConverter(
 	evalCtx *tree.EvalContext,
 	kvCh chan row.KVBatch,
 ) (inputConverter, error) {
-
-	// installTypeMetadata is a closure that performs the work of installing
-	// type metadata in all of the tables being imported.
-	installTypeMetadata := func(evalCtx *tree.EvalContext) error {
-		for _, table := range spec.Tables {
-			var colTypes []*types.T
-			for _, col := range table.Desc.Columns {
-				colTypes = append(colTypes, col.Type)
-			}
-			if err := execinfrapb.HydrateTypeSlice(evalCtx, colTypes); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
 	injectTimeIntoEvalCtx(evalCtx, spec.WalltimeNanos)
-
-	if evalCtx.Txn != nil {
-		// If we have a transaction, then use it.
-		if err := installTypeMetadata(evalCtx); err != nil {
-			return nil, err
-		}
-	} else if evalCtx.DB != nil {
-		// Otherwise, open up a new transaction to hydrate type metadata.
-		// We only perform this logic if evalCtx.DB != nil because there are
-		// some tests that pass an evalCtx with a nil DB to this function.
-		// TODO (rohany): Once we lease type descriptors, this should instead
-		//  look into the leased set using the DistSQLTypeResolver.
-		if err := evalCtx.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			evalCtx.Txn = txn
-			return installTypeMetadata(evalCtx)
-		}); err != nil {
-			return nil, err
-		}
-	}
-
 	var singleTable *sqlbase.TableDescriptor
 	var singleTableTargetCols tree.NameList
 	if len(spec.Tables) == 1 {

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -47,9 +48,26 @@ func runImport(
 ) (*roachpb.BulkOpSummary, error) {
 	// Used to send ingested import rows to the KV layer.
 	kvCh := make(chan row.KVBatch, 10)
-	evalCtx := flowCtx.NewEvalCtx()
-	evalCtx.DB = flowCtx.Cfg.DB
-	conv, err := makeInputConverter(ctx, spec, evalCtx, kvCh)
+
+	// Install type metadata in all of the import tables. The DB is nil in some
+	// tests, so check first here.
+	if flowCtx.Cfg.DB != nil {
+		if err := flowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			resolver := flowCtx.TypeResolverFactory.NewTypeResolver(txn)
+			for _, table := range spec.Tables {
+				if err := sqlbase.HydrateTypesInTableDescriptor(ctx, table.Desc, resolver); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		// Release leases on any accessed types now that type metadata is installed.
+		flowCtx.TypeResolverFactory.Descriptors.ReleaseAll(ctx)
+	}
+
+	conv, err := makeInputConverter(ctx, spec, flowCtx.NewEvalCtx(), kvCh)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -560,9 +560,13 @@ func (sc *SchemaChanger) validateConstraints(
 				// need a semaContext set up that can resolve types in order to pretty
 				// print the check expression back to the user.
 				evalCtx.Txn = txn
-				semaCtx := tree.MakeSemaContext()
 				// Use the DistSQLTypeResolver because we need to resolve types by ID.
-				semaCtx.TypeResolver = &execinfrapb.DistSQLTypeResolver{EvalContext: &evalCtx.EvalContext}
+				semaCtx := tree.MakeSemaContext()
+				collection := descs.NewCollection(sc.leaseMgr, sc.settings)
+				semaCtx.TypeResolver = descs.NewDistSQLTypeResolver(collection, txn)
+				// TODO (rohany): When to release this? As of now this is only going to get released
+				//  after the check is validated.
+				defer func() { collection.ReleaseAll(ctx) }()
 				switch c.ConstraintType {
 				case sqlbase.ConstraintToUpdate_CHECK:
 					if err := validateCheckInTxn(ctx, sc.leaseMgr, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check.Name); err != nil {
@@ -1374,7 +1378,7 @@ func runSchemaChangesInTxn(
 				if doneColumnBackfill || !sqlbase.ColumnNeedsBackfill(m.GetColumn()) {
 					break
 				}
-				if err := columnBackfillInTxn(ctx, planner.Txn(), planner.Descriptors(), planner.EvalContext(), immutDesc, traceKV); err != nil {
+				if err := columnBackfillInTxn(ctx, planner.Txn(), planner.EvalContext(), planner.SemaCtx(), immutDesc, traceKV); err != nil {
 					return err
 				}
 				doneColumnBackfill = true
@@ -1435,7 +1439,7 @@ func runSchemaChangesInTxn(
 					break
 				}
 				if err := columnBackfillInTxn(
-					ctx, planner.Txn(), planner.Descriptors(), planner.EvalContext(), immutDesc, traceKV,
+					ctx, planner.Txn(), planner.EvalContext(), planner.SemaCtx(), immutDesc, traceKV,
 				); err != nil {
 					return err
 				}
@@ -1675,8 +1679,8 @@ func validateFkInTxn(
 func columnBackfillInTxn(
 	ctx context.Context,
 	txn *kv.Txn,
-	tc *descs.Collection,
 	evalCtx *tree.EvalContext,
+	semaCtx *tree.SemaContext,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	traceKV bool,
 ) error {
@@ -1685,7 +1689,7 @@ func columnBackfillInTxn(
 		return nil
 	}
 	var backfiller backfill.ColumnBackfiller
-	if err := backfiller.Init(ctx, evalCtx, tableDesc); err != nil {
+	if err := backfiller.InitForLocalUse(ctx, evalCtx, semaCtx, tableDesc); err != nil {
 		return err
 	}
 	sp := tableDesc.PrimaryIndexSpan(evalCtx.Codec)

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
@@ -54,23 +54,18 @@ type backfiller struct {
 type ColumnBackfiller struct {
 	backfiller
 
-	added []sqlbase.ColumnDescriptor
+	added   []sqlbase.ColumnDescriptor
+	dropped []sqlbase.ColumnDescriptor
+
 	// updateCols is a slice of all column descriptors that are being modified.
 	updateCols  []sqlbase.ColumnDescriptor
 	updateExprs []tree.TypedExpr
 	evalCtx     *tree.EvalContext
 }
 
-// Init initializes a column backfiller.
-func (cb *ColumnBackfiller) Init(
-	ctx context.Context, evalCtx *tree.EvalContext, desc *sqlbase.ImmutableTableDescriptor,
-) error {
-	cols := desc.Columns
-	cb.evalCtx = evalCtx
-	var dropped []sqlbase.ColumnDescriptor
+// initCols is a helper to populate some column metadata on a ColumnBackfiller.
+func (cb *ColumnBackfiller) initCols(desc *sqlbase.ImmutableTableDescriptor) {
 	if len(desc.Mutations) > 0 {
-		cols = make([]sqlbase.ColumnDescriptor, 0, len(desc.Columns)+len(desc.Mutations))
-		cols = append(cols, desc.Columns...)
 		for _, m := range desc.Mutations {
 			if ColumnMutationFilter(m) {
 				desc := *m.GetColumn()
@@ -78,72 +73,23 @@ func (cb *ColumnBackfiller) Init(
 				case sqlbase.DescriptorMutation_ADD:
 					cb.added = append(cb.added, desc)
 				case sqlbase.DescriptorMutation_DROP:
-					dropped = append(dropped, desc)
+					cb.dropped = append(cb.dropped, desc)
 				}
-				cols = append(cols, desc)
 			}
 		}
 	}
+}
 
-	colTyps := make([]*types.T, len(cols))
-	for i := range cols {
-		colTyps[i] = cols[i].Type
-	}
-
-	var defaultExprs, computedExprs []tree.TypedExpr
-	// Set up a closure to hydrate and preprocess expressions needed for
-	// the backfill.
-	hydrateTypes := func(ctx context.Context, evalCtx *tree.EvalContext) error {
-		// Hydrate all the types present in the table.
-		if err := execinfrapb.HydrateTypeSlice(cb.evalCtx, colTyps); err != nil {
-			return err
-		}
-		// Set up a SemaContext to type check the default and computed expressions.
-		semaCtx := tree.MakeSemaContext()
-		semaCtx.TypeResolver = cb.evalCtx.TypeResolver
-		var err error
-		defaultExprs, err = sqlbase.MakeDefaultExprs(
-			ctx, cb.added, &transform.ExprTransformContext{}, cb.evalCtx, &semaCtx,
-		)
-		if err != nil {
-			return err
-		}
-		var txCtx transform.ExprTransformContext
-		computedExprs, err = schemaexpr.MakeComputedExprs(
-			ctx,
-			cb.added,
-			desc,
-			tree.NewUnqualifiedTableName(tree.Name(desc.Name)),
-			&txCtx,
-			cb.evalCtx,
-			&semaCtx,
-			true, /* addingCols */
-		)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	if cb.evalCtx.Txn != nil {
-		// If we have a txn, then use it.
-		if err := hydrateTypes(ctx, cb.evalCtx); err != nil {
-			return err
-		}
-	} else {
-		// Otherwise, create one. We fall into this case when performing
-		// a distributed backfill outside of a transaction.
-		if err := cb.evalCtx.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			cb.evalCtx.Txn = txn
-			return hydrateTypes(ctx, cb.evalCtx)
-		}); err != nil {
-			return err
-		}
-		// Reset the evalCtx's transaction after type the expressions are processed.
-		cb.evalCtx.Txn = nil
-	}
-
-	cb.updateCols = append(cb.added, dropped...)
+// init performs initialization operations that are shared across the local
+// and distributed initialization procedures for the ColumnBackfiller.
+func (cb *ColumnBackfiller) init(
+	evalCtx *tree.EvalContext,
+	defaultExprs []tree.TypedExpr,
+	computedExprs []tree.TypedExpr,
+	desc *sqlbase.ImmutableTableDescriptor,
+) error {
+	cb.evalCtx = evalCtx
+	cb.updateCols = append(cb.added, cb.dropped...)
 	// Populate default or computed values.
 	cb.updateExprs = make([]tree.TypedExpr, len(cb.updateCols))
 	for j := range cb.added {
@@ -156,7 +102,7 @@ func (cb *ColumnBackfiller) Init(
 			cb.updateExprs[j] = defaultExprs[j]
 		}
 	}
-	for j := range dropped {
+	for j := range cb.dropped {
 		cb.updateExprs[j+len(cb.added)] = tree.DNull
 	}
 
@@ -179,6 +125,94 @@ func (cb *ColumnBackfiller) Init(
 		&cb.alloc,
 		tableArgs,
 	)
+}
+
+// InitForLocalUse initializes a ColumnBackfiller for use during local
+// execution within a transaction. In this case, the entire backfill process
+// is occurring on the gateway as part of the user's transaction.
+func (cb *ColumnBackfiller) InitForLocalUse(
+	ctx context.Context,
+	evalCtx *tree.EvalContext,
+	semaCtx *tree.SemaContext,
+	desc *sqlbase.ImmutableTableDescriptor,
+) error {
+	cb.initCols(desc)
+	defaultExprs, err := sqlbase.MakeDefaultExprs(
+		ctx, cb.added, &transform.ExprTransformContext{}, evalCtx, semaCtx,
+	)
+	if err != nil {
+		return err
+	}
+	var txCtx transform.ExprTransformContext
+	computedExprs, err := schemaexpr.MakeComputedExprs(
+		ctx,
+		cb.added,
+		desc,
+		tree.NewUnqualifiedTableName(tree.Name(desc.Name)),
+		&txCtx,
+		evalCtx,
+		semaCtx,
+		true, /* addingCols */
+	)
+	if err != nil {
+		return err
+	}
+	return cb.init(evalCtx, defaultExprs, computedExprs, desc)
+}
+
+// InitForDistributedUse initializes a ColumnBackfiller for use as part of a
+// backfill operation executing as part of a distributed flow. In this use,
+// the backfill operation manages its own transactions. This separation is
+// necessary due to the different procedure for accessing user defined type
+// metadata as part of a distributed flow.
+func (cb *ColumnBackfiller) InitForDistributedUse(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, desc *sqlbase.ImmutableTableDescriptor,
+) error {
+	cb.initCols(desc)
+	evalCtx := flowCtx.NewEvalCtx()
+	var defaultExprs, computedExprs []tree.TypedExpr
+	// Install type metadata in the target descriptors, as well as resolve any
+	// user defined types in the column expressions.
+	if err := flowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		resolver := flowCtx.TypeResolverFactory.NewTypeResolver(txn)
+		// Hydrate all the types present in the table.
+		if err := sqlbase.HydrateTypesInTableDescriptor(ctx, desc.TableDesc(), resolver); err != nil {
+			return err
+		}
+		// Set up a SemaContext to type check the default and computed expressions.
+		semaCtx := tree.MakeSemaContext()
+		semaCtx.TypeResolver = resolver
+		var err error
+		defaultExprs, err = sqlbase.MakeDefaultExprs(
+			ctx, cb.added, &transform.ExprTransformContext{}, evalCtx, &semaCtx,
+		)
+		if err != nil {
+			return err
+		}
+		var txCtx transform.ExprTransformContext
+		computedExprs, err = schemaexpr.MakeComputedExprs(
+			ctx,
+			cb.added,
+			desc,
+			tree.NewUnqualifiedTableName(tree.Name(desc.Name)),
+			&txCtx,
+			evalCtx,
+			&semaCtx,
+			true, /* addingCols */
+		)
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	// Release leases on any accessed types now that type metadata is installed.
+	// We do this so that leases on any accessed types are not held for the
+	// entire backfill process.
+	flowCtx.TypeResolverFactory.Descriptors.ReleaseAll(ctx)
+
+	return cb.init(evalCtx, defaultExprs, computedExprs, desc)
 }
 
 // RunColumnBackfillChunk runs column backfill over a chunk of the table using
@@ -380,26 +414,6 @@ func (ib *IndexBackfiller) Init(
 	for i := range cols {
 		ib.types[i] = cols[i].Type
 	}
-
-	// Hydrate types used by the backfiller.
-	// TODO (rohany): As part of #49261, this needs to use cached enum data.
-	if evalCtx.Txn != nil {
-		// If the evalCtx has a transaction (if the schema change is running on a
-		// new table within a transaction), then use that.
-		if err := execinfrapb.HydrateTypeSlice(evalCtx, ib.types); err != nil {
-			return err
-		}
-	} else {
-		// Otherwise, make a new transaction. This case will happen when we are
-		// performing a distributed schema change outside of a transaction.
-		if err := ib.evalCtx.DB.Txn(evalCtx.Context, func(_ context.Context, txn *kv.Txn) error {
-			evalCtx.Txn = txn
-			return execinfrapb.HydrateTypeSlice(evalCtx, ib.types)
-		}); err != nil {
-			return err
-		}
-	}
-
 	ib.colIdxMap = make(map[sqlbase.ColumnID]int, len(cols))
 	for i := range cols {
 		ib.colIdxMap[cols[i].ID] = i

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -137,7 +137,7 @@ func ResolveMutableType(
 	if err != nil || desc == nil {
 		return nil, nil, err
 	}
-	tn := tree.MakeTypeNameFromPrefix(prefix, tree.Name(un.Object()))
+	tn := tree.MakeNewQualifiedTypeName(prefix.Catalog(), prefix.Schema(), un.Object())
 	return &tn, desc.(*sqlbase.MutableTypeDescriptor), nil
 }
 

--- a/pkg/sql/colexec/expr.go
+++ b/pkg/sql/colexec/expr.go
@@ -26,7 +26,7 @@ import (
 type ExprHelper interface {
 	// ProcessExpr processes the given expression and returns a well-typed
 	// expression.
-	ProcessExpr(execinfrapb.Expression, *tree.EvalContext, []*types.T) (tree.TypedExpr, error)
+	ProcessExpr(execinfrapb.Expression, *tree.SemaContext, *tree.EvalContext, []*types.T) (tree.TypedExpr, error)
 }
 
 // ExprDeserialization describes how expression deserialization should be
@@ -73,14 +73,17 @@ func NewDefaultExprHelper() ExprHelper {
 }
 
 func (h *defaultExprHelper) ProcessExpr(
-	expr execinfrapb.Expression, evalCtx *tree.EvalContext, typs []*types.T,
+	expr execinfrapb.Expression,
+	semaCtx *tree.SemaContext,
+	evalCtx *tree.EvalContext,
+	typs []*types.T,
 ) (tree.TypedExpr, error) {
 	if expr.LocalExpr != nil {
 		return expr.LocalExpr, nil
 	}
 	h.helper.Types = typs
 	tempVars := tree.MakeIndexedVarHelper(&h.helper, len(typs))
-	return execinfra.DeserializeExpr(expr.Expr, evalCtx, &tempVars)
+	return execinfra.DeserializeExpr(expr.Expr, semaCtx, evalCtx, &tempVars)
 }
 
 // forcedDeserializationExprHelper is an ExprHelper that always deserializes
@@ -93,11 +96,14 @@ type forcedDeserializationExprHelper struct {
 var _ ExprHelper = &forcedDeserializationExprHelper{}
 
 func (h *forcedDeserializationExprHelper) ProcessExpr(
-	expr execinfrapb.Expression, evalCtx *tree.EvalContext, typs []*types.T,
+	expr execinfrapb.Expression,
+	semaCtx *tree.SemaContext,
+	evalCtx *tree.EvalContext,
+	typs []*types.T,
 ) (tree.TypedExpr, error) {
 	h.helper.Types = typs
 	tempVars := tree.MakeIndexedVarHelper(&h.helper, len(typs))
-	return execinfra.DeserializeExpr(expr.Expr, evalCtx, &tempVars)
+	return execinfra.DeserializeExpr(expr.Expr, semaCtx, evalCtx, &tempVars)
 }
 
 // Remove unused warning.

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -142,18 +143,22 @@ func NewColBatchScan(
 		columnIdxMap[sysColDescs[i].ID] = len(columnIdxMap)
 	}
 
+	semaCtx := tree.MakeSemaContext()
 	evalCtx := flowCtx.NewEvalCtx()
 	// Before we can safely use types from the table descriptor, we need to
 	// make sure they are hydrated. In row execution engine it is done during
 	// the processor initialization, but neither ColBatchScan nor cFetcher are
 	// processors, so we need to do the hydration ourselves.
-	if err := execinfrapb.HydrateTypeSlice(evalCtx, typs); err != nil {
+	resolver := flowCtx.TypeResolverFactory.NewTypeResolver(evalCtx.Txn)
+	semaCtx.TypeResolver = resolver
+	if err := resolver.HydrateTypeSlice(evalCtx.Context, typs); err != nil {
 		return nil, err
 	}
 	helper := execinfra.ProcOutputHelper{}
 	if err := helper.Init(
 		post,
 		typs,
+		&semaCtx,
 		evalCtx,
 		nil, /* output */
 	); err != nil {

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -718,9 +718,11 @@ func (s *vectorizedFlowCreator) setupInput(
 	// don't do that. However, all operators (apart from the colBatchScan) get
 	// their types from InputSyncSpec, so this is a convenient place to do the
 	// hydration so that all operators get the valid types.
-	if err := execinfrapb.HydrateTypeSlice(flowCtx.EvalCtx, input.ColumnTypes); err != nil {
+	resolver := flowCtx.TypeResolverFactory.NewTypeResolver(flowCtx.EvalCtx.Txn)
+	if err := resolver.HydrateTypeSlice(ctx, input.ColumnTypes); err != nil {
 		return nil, nil, nil, err
 	}
+
 	for _, inputStream := range input.Streams {
 		switch inputStream.Type {
 		case execinfrapb.StreamEndpointSpec_LOCAL:

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2025,7 +2025,6 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			ReCache:            ex.server.reCache,
 			InternalExecutor:   &ie,
 			DB:                 ex.server.cfg.DB,
-			TypeResolver:       p,
 		},
 		SessionMutator:       ex.dataMutator,
 		VirtualSchemas:       ex.server.cfg.VirtualSchemas,

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -324,9 +326,6 @@ func (ds *ServerImpl) setupFlow(
 			InternalExecutor:   ie,
 			Txn:                leafTxn,
 		}
-		// Since we are constructing an EvalContext on a remote node, outfit it
-		// with a DistSQLTypeResolver.
-		evalCtx.TypeResolver = &execinfrapb.DistSQLTypeResolver{EvalContext: evalCtx}
 		evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.StmtTimestampNanos))
 		evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.TxnTimestampNanos))
 		var haveSequences bool
@@ -340,16 +339,9 @@ func (ds *ServerImpl) setupFlow(
 		}
 	}
 
-	// TODO(radu): we should sanity check some of these fields.
-	flowCtx := execinfra.FlowCtx{
-		AmbientContext: ds.AmbientContext,
-		Cfg:            &ds.ServerConfig,
-		ID:             req.Flow.FlowID,
-		EvalCtx:        evalCtx,
-		NodeID:         ds.ServerConfig.NodeID,
-		TraceKV:        req.TraceKV,
-		Local:          localState.IsLocal,
-	}
+	// Create the FlowCtx for the flow.
+	flowCtx := ds.NewFlowContext(req.Flow.FlowID, evalCtx, req.TraceKV, localState)
+
 	// req always contains the desired vectorize mode, regardless of whether we
 	// have non-nil localState.EvalContext. We don't want to update EvalContext
 	// itself when the vectorize mode needs to be changed because we would need
@@ -414,6 +406,45 @@ func (ds *ServerImpl) setupFlow(
 	return ctx, f, nil
 }
 
+// NewFlowContext creates a new FlowCtx that can be used during execution of
+// a flow.
+func (ds *ServerImpl) NewFlowContext(
+	id execinfrapb.FlowID, evalCtx *tree.EvalContext, traceKV bool, localState LocalState,
+) execinfra.FlowCtx {
+	// TODO(radu): we should sanity check some of these fields.
+	flowCtx := execinfra.FlowCtx{
+		AmbientContext: ds.AmbientContext,
+		Cfg:            &ds.ServerConfig,
+		ID:             id,
+		EvalCtx:        evalCtx,
+		NodeID:         ds.ServerConfig.NodeID,
+		TraceKV:        traceKV,
+		Local:          localState.IsLocal,
+	}
+
+	if localState.IsLocal && localState.Collection != nil {
+		// If we were passed a descs.Collection to use, then take it. In this case,
+		// the caller will handle releasing the used descriptors, so we don't need
+		// to cleanup the descriptors when cleaning up the flow.
+		flowCtx.TypeResolverFactory = &descs.DistSQLTypeResolverFactory{
+			Descriptors: localState.Collection,
+			CleanupFunc: func(ctx context.Context) {},
+		}
+	} else {
+		// If we weren't passed a descs.Collection, then make a new one. We are
+		// responsible for cleaning it up and releasing any accessed descriptors
+		// on flow cleanup.
+		collection := descs.NewCollection(ds.ServerConfig.LeaseManager.(*lease.Manager), ds.ServerConfig.Settings)
+		flowCtx.TypeResolverFactory = &descs.DistSQLTypeResolverFactory{
+			Descriptors: collection,
+			CleanupFunc: func(ctx context.Context) {
+				collection.ReleaseAll(ctx)
+			},
+		}
+	}
+	return flowCtx
+}
+
 func newFlow(
 	flowCtx execinfra.FlowCtx,
 	flowReg *flowinfra.FlowRegistry,
@@ -452,6 +483,11 @@ func (ds *ServerImpl) SetupSyncFlow(
 // planNodes.
 type LocalState struct {
 	EvalContext *tree.EvalContext
+
+	// Collection is set if this flow is running on the gateway as part of user
+	// SQL session. It is the current descs.Collection of the planner executing
+	// the flow.
+	Collection *descs.Collection
 
 	// IsLocal is set if the flow is running on the gateway and there are no
 	// remote flows.

--- a/pkg/sql/execinfra/expr.go
+++ b/pkg/sql/execinfra/expr.go
@@ -142,15 +142,13 @@ func (eh *ExprHelper) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 // DeserializeExpr deserializes expr, binds the indexed variables to the
 // provided IndexedVarHelper, and evaluates any constants in the expression.
 func DeserializeExpr(
-	expr string, evalCtx *tree.EvalContext, vars *tree.IndexedVarHelper,
+	expr string, semaCtx *tree.SemaContext, evalCtx *tree.EvalContext, vars *tree.IndexedVarHelper,
 ) (tree.TypedExpr, error) {
 	if expr == "" {
 		return nil, nil
 	}
 
-	semaContext := tree.MakeSemaContext()
-	semaContext.TypeResolver = evalCtx.TypeResolver
-	deserializedExpr, err := processExpression(execinfrapb.Expression{Expr: expr}, evalCtx, &semaContext, vars)
+	deserializedExpr, err := processExpression(execinfrapb.Expression{Expr: expr}, evalCtx, semaCtx, vars)
 	if err != nil {
 		return deserializedExpr, err
 	}
@@ -163,7 +161,10 @@ func DeserializeExpr(
 
 // Init initializes the ExprHelper.
 func (eh *ExprHelper) Init(
-	expr execinfrapb.Expression, types []*types.T, evalCtx *tree.EvalContext,
+	expr execinfrapb.Expression,
+	types []*types.T,
+	semaCtx *tree.SemaContext,
+	evalCtx *tree.EvalContext,
 ) error {
 	if expr.Empty() {
 		return nil
@@ -179,7 +180,7 @@ func (eh *ExprHelper) Init(
 		return nil
 	}
 	var err error
-	eh.Expr, err = DeserializeExpr(expr.Expr, evalCtx, &eh.Vars)
+	eh.Expr, err = DeserializeExpr(expr.Expr, semaCtx, evalCtx, &eh.Vars)
 	return err
 }
 

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -93,7 +93,11 @@ func (h *ProcOutputHelper) Reset() {
 // Note that the types slice may be stored directly; the caller should not
 // modify it.
 func (h *ProcOutputHelper) Init(
-	post *execinfrapb.PostProcessSpec, typs []*types.T, evalCtx *tree.EvalContext, output RowReceiver,
+	post *execinfrapb.PostProcessSpec,
+	typs []*types.T,
+	semaCtx *tree.SemaContext,
+	evalCtx *tree.EvalContext,
+	output RowReceiver,
 ) error {
 	if !post.Projection && len(post.OutputColumns) > 0 {
 		return errors.Errorf("post-processing has projection unset but output columns set: %s", post)
@@ -105,7 +109,7 @@ func (h *ProcOutputHelper) Init(
 	h.numInternalCols = len(typs)
 	if post.Filter != (execinfrapb.Expression{}) {
 		h.filter = &ExprHelper{}
-		if err := h.filter.Init(post.Filter, typs, evalCtx); err != nil {
+		if err := h.filter.Init(post.Filter, typs, semaCtx, evalCtx); err != nil {
 			return err
 		}
 	}
@@ -142,7 +146,7 @@ func (h *ProcOutputHelper) Init(
 		}
 		for i, expr := range post.RenderExprs {
 			h.renderExprs[i] = ExprHelper{}
-			if err := h.renderExprs[i].Init(expr, typs, evalCtx); err != nil {
+			if err := h.renderExprs[i].Init(expr, typs, semaCtx, evalCtx); err != nil {
 				return err
 			}
 			h.OutputTypes[i] = h.renderExprs[i].Expr.ResolvedType()
@@ -798,11 +802,14 @@ func (pb *ProcessorBase) InitWithEvalCtx(
 	pb.inputsToDrain = opts.InputsToDrain
 
 	// Hydrate all types used in the processor.
-	if err := execinfrapb.HydrateTypeSlice(evalCtx, types); err != nil {
+	resolver := flowCtx.TypeResolverFactory.NewTypeResolver(evalCtx.Txn)
+	if err := resolver.HydrateTypeSlice(evalCtx.Context, types); err != nil {
 		return err
 	}
+	semaCtx := tree.MakeSemaContext()
+	semaCtx.TypeResolver = resolver
 
-	return pb.Out.Init(post, types, pb.EvalCtx, output)
+	return pb.Out.Init(post, types, &semaCtx, pb.EvalCtx, output)
 }
 
 // AddInputToDrain adds an input to drain when moving the processor to a
@@ -905,7 +912,7 @@ func NewLimitedMonitor(
 type LocalProcessor interface {
 	RowSourcedProcessor
 	// InitWithOutput initializes this processor.
-	InitWithOutput(post *execinfrapb.PostProcessSpec, output RowReceiver) error
+	InitWithOutput(flowCtx *FlowCtx, post *execinfrapb.PostProcessSpec, output RowReceiver) error
 	// SetInput initializes this LocalProcessor with an input RowSource. Not all
 	// LocalProcessors need inputs, but this needs to be called if a
 	// LocalProcessor expects to get its data from another RowSource.

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -14,13 +14,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -72,60 +68,6 @@ func ConvertToMappedSpecOrdering(
 		}
 	}
 	return specOrdering
-}
-
-// DistSQLTypeResolver implements tree.ResolvableTypeReference for accessing
-// type information during DistSQL query evaluation.
-type DistSQLTypeResolver struct {
-	EvalContext *tree.EvalContext
-	// TODO (rohany): This struct should locally cache id -> types.T here
-	//  so that repeated lookups do not incur additional KV operations.
-}
-
-// ResolveType implements tree.ResolvableTypeReference.
-func (tr *DistSQLTypeResolver) ResolveType(
-	context.Context, *tree.UnresolvedObjectName,
-) (*types.T, error) {
-	return nil, errors.AssertionFailedf("cannot resolve types in DistSQL by name")
-}
-
-func makeTypeLookupFunc(
-	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec,
-) sqlbase.TypeLookupFunc {
-	return func(ctx context.Context, id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
-		return resolver.ResolveTypeDescByID(ctx, txn, codec, id, tree.ObjectLookupFlagsWithRequired())
-	}
-}
-
-// ResolveTypeByID implements tree.ResolvableTypeReference.
-func (tr *DistSQLTypeResolver) ResolveTypeByID(ctx context.Context, id uint32) (*types.T, error) {
-	// TODO (rohany): This should eventually look into the set of cached type
-	//  descriptors before attempting to access it here.
-	lookup := makeTypeLookupFunc(ctx, tr.EvalContext.Txn, tr.EvalContext.Codec)
-	name, typDesc, err := lookup(ctx, sqlbase.ID(id))
-	if err != nil {
-		return nil, err
-	}
-	return typDesc.MakeTypesT(ctx, name, lookup)
-}
-
-// HydrateTypeSlice hydrates all user defined types in an input slice of types.
-func HydrateTypeSlice(evalCtx *tree.EvalContext, typs []*types.T) error {
-	// TODO (rohany): This should eventually look into the set of cached type
-	//  descriptors before attempting to access it here.
-	lookup := makeTypeLookupFunc(evalCtx.Context, evalCtx.Txn, evalCtx.Codec)
-	for _, t := range typs {
-		if t.UserDefined() {
-			name, typDesc, err := lookup(evalCtx.Context, sqlbase.ID(t.StableTypeID()))
-			if err != nil {
-				return err
-			}
-			if err := typDesc.HydrateTypeInfoWithName(evalCtx.Context, t, name, lookup); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 // ExprFmtCtxBase produces a FmtCtx used for serializing expressions; a proper

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
@@ -129,6 +130,9 @@ func newFlowCtxForExplainPurposes(planCtx *PlanningCtx, params runParams) *execi
 			Settings:       params.p.execCfg.Settings,
 			DiskMonitor:    &mon.BytesMonitor{},
 			VecFDSemaphore: params.p.execCfg.DistSQLSrv.VecFDSemaphore,
+		},
+		TypeResolverFactory: &descs.DistSQLTypeResolverFactory{
+			Descriptors: params.p.Descriptors(),
 		},
 	}
 }

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -419,6 +419,11 @@ func (f *FlowBase) Cleanup(ctx context.Context) {
 		panic("flow cleanup called twice")
 	}
 
+	// Release any descriptors accessed by this flow
+	if f.TypeResolverFactory != nil {
+		f.TypeResolverFactory.CleanupFunc(ctx)
+	}
+
 	// This closes the monitor opened in ServerImpl.setupFlow.
 	f.EvalCtx.Stop(ctx)
 	for _, p := range f.processors {

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -419,7 +419,7 @@ SELECT * FROM enum_array
 query TTT
 SELECT pg_typeof(x), pg_typeof(x[1]), pg_typeof(ARRAY['hello']::_greeting) FROM enum_array LIMIT 1
 ----
-public.greeting[]  public.greeting  public.greeting[]
+greeting[]  greeting  greeting[]
 
 # Ensure that the implicitly created array type will tolerate collisions.
 # _collision will create __collision as its implicit array type, so the
@@ -584,7 +584,7 @@ statement error pq: failed to satisfy CHECK constraint \(x > 'hello':::public.gr
 INSERT INTO enum_checks VALUES ('hello')
 
 # Try adding a check that fails validation.
-statement error pq: validation of CHECK "x = 'hello':::public.greeting" failed
+statement error pq: validation of CHECK "x = 'hello':::greeting" failed
 ALTER TABLE enum_checks ADD CHECK (x = 'hello')
 
 # Check the above cases, but in a transaction.
@@ -1090,6 +1090,23 @@ query TTT
 SELECT * FROM [EXPLAIN SELECT * FROM local_table] LIMIT 1
 ----
 ·     distribution  local
+
+statement ok
+ROLLBACK
+
+# This test case ensures that DistSQL flows don't attempt to use the lease
+# manager to access type data once the current transaction has already modified
+# or created a type.
+statement ok
+BEGIN;
+CREATE TYPE local_type AS ENUM ('local');
+CREATE TABLE local_table (x local_type);
+INSERT INTO local_table VALUES ('local')
+
+query T
+SELECT * FROM local_table
+----
+local
 
 statement ok
 ROLLBACK

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1281,3 +1281,14 @@ SET vectorize = experimental_always
 
 statement ok
 SELECT random() from t51841
+
+# Regression test to ensure that we can EXPLAIN (VEC) plans that contain user
+# defined types. We aren't interested in the output here, but are just ensuring
+# that we don't panic.
+statement ok
+RESET vectorize;
+SET experimental_enable_enums = true;
+CREATE TYPE greeting AS ENUM ('hello');
+CREATE TABLE greeting_table (x greeting);
+EXPLAIN (VEC) SELECT * FROM greeting_table;
+SET vectorize = experimental_always

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -69,13 +69,13 @@ var _ execinfra.LocalProcessor = &planNodeToRowSource{}
 
 // InitWithOutput implements the LocalProcessor interface.
 func (p *planNodeToRowSource) InitWithOutput(
-	post *execinfrapb.PostProcessSpec, output execinfra.RowReceiver,
+	flowCtx *execinfra.FlowCtx, post *execinfrapb.PostProcessSpec, output execinfra.RowReceiver,
 ) error {
 	return p.InitWithEvalCtx(
 		p,
 		post,
 		p.outputTypes,
-		nil, /* flowCtx */
+		flowCtx,
 		p.params.EvalContext(),
 		0, /* processorID */
 		output,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -123,6 +123,10 @@ type schemaInterface struct {
 type planner struct {
 	txn *kv.Txn
 
+	// isInternalPlanner is set to true when this planner is not bound to
+	// a SQL session.
+	isInternalPlanner bool
+
 	// Reference to the corresponding sql Statement for this query.
 	stmt *Statement
 
@@ -286,6 +290,7 @@ func newInternalPlanner(
 	p.txn = txn
 	p.stmt = nil
 	p.cancelChecker = sqlbase.NewCancelChecker(ctx)
+	p.isInternalPlanner = true
 
 	p.semaCtx = tree.MakeSemaContext()
 	p.semaCtx.SearchPath = sd.SearchPath
@@ -310,7 +315,6 @@ func newInternalPlanner(
 	p.extendedEvalCtx.ClusterName = execCfg.RPCContext.ClusterName()
 	p.extendedEvalCtx.NodeID = execCfg.NodeID
 	p.extendedEvalCtx.Locality = execCfg.Locality
-	p.extendedEvalCtx.TypeResolver = p
 
 	p.sessionDataMutator = dataMutator
 	p.autoCommit = false

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -176,7 +176,7 @@ func (p *planner) ResolveType(
 	if err != nil {
 		return nil, err
 	}
-	tn := tree.MakeTypeNameFromPrefix(prefix, tree.Name(name.Object()))
+	tn := tree.MakeNewQualifiedTypeName(prefix.Catalog(), prefix.Schema(), name.Object())
 	tdesc := desc.(*sqlbase.ImmutableTypeDescriptor)
 
 	// Disllow cross-database type resolution. Note that we check

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -138,11 +138,12 @@ func (ag *aggregatorBase) init(
 			argTypes[j] = ag.inputTypes[c]
 		}
 
+		semaCtx := flowCtx.TypeResolverFactory.NewSemaContext(flowCtx.EvalCtx.Txn)
 		arguments := make(tree.Datums, len(aggInfo.Arguments))
 		for j, argument := range aggInfo.Arguments {
 			h := execinfra.ExprHelper{}
 			// Pass nil types and row - there are no variables in these expressions.
-			if err := h.Init(argument, nil /* types */, flowCtx.EvalCtx); err != nil {
+			if err := h.Init(argument, nil /* types */, semaCtx, flowCtx.EvalCtx); err != nil {
 				return errors.Wrapf(err, "%s", argument)
 			}
 			d, err := h.Eval(nil /* row */)

--- a/pkg/sql/rowexec/backfiller.go
+++ b/pkg/sql/rowexec/backfiller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -126,7 +127,8 @@ func (b *backfiller) Run(ctx context.Context) {
 }
 
 func (b *backfiller) doRun(ctx context.Context) *execinfrapb.ProducerMetadata {
-	if err := b.out.Init(&execinfrapb.PostProcessSpec{}, nil, b.flowCtx.NewEvalCtx(), b.output); err != nil {
+	semaCtx := tree.MakeSemaContext()
+	if err := b.out.Init(&execinfrapb.PostProcessSpec{}, nil, &semaCtx, b.flowCtx.NewEvalCtx(), b.output); err != nil {
 		return &execinfrapb.ProducerMetadata{Err: err}
 	}
 	mutations, err := b.getMutationsToProcess(ctx)

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -55,9 +55,7 @@ func newColumnBackfiller(
 	}
 	cb.backfiller.chunks = cb
 
-	evalCtx := cb.flowCtx.NewEvalCtx()
-	evalCtx.DB = cb.flowCtx.Cfg.DB
-	if err := cb.ColumnBackfiller.Init(ctx, evalCtx, cb.desc); err != nil {
+	if err := cb.ColumnBackfiller.InitForDistributedUse(ctx, flowCtx, cb.desc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -79,11 +79,22 @@ func newIndexBackfiller(
 	}
 	ib.backfiller.chunks = ib
 
-	// Copy in the DB pointer from flowCtx into evalCtx, because the Init
-	// step needs access to the DB.
-	evalCtx := flowCtx.NewEvalCtx()
-	evalCtx.DB = flowCtx.Cfg.DB
-	if err := ib.IndexBackfiller.Init(evalCtx, ib.desc); err != nil {
+	// TODO (rohany): When marcus implements backfills for partial indexes, we'll
+	//  most likely have to split up the index backfiller init into two functions
+	//  like the column backfiller.
+	// Install type metadata into any types present in the target descriptor.
+	if err := flowCtx.Cfg.DB.Txn(flowCtx.EvalCtx.Context, func(ctx context.Context, txn *kv.Txn) error {
+		resolver := flowCtx.TypeResolverFactory.NewTypeResolver(txn)
+		return sqlbase.HydrateTypesInTableDescriptor(ctx, ib.desc.TableDesc(), resolver)
+	}); err != nil {
+		return nil, err
+	}
+	// Release leases on any accessed types now that type metadata is installed.
+	// We do this so that leases on any accessed types are not held for the
+	// entire backfill process.
+	flowCtx.TypeResolverFactory.Descriptors.ReleaseAll(flowCtx.EvalCtx.Context)
+
+	if err := ib.IndexBackfiller.Init(flowCtx.NewEvalCtx(), ib.desc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/rowexec/interleaved_reader_joiner.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner.go
@@ -332,8 +332,10 @@ func newInterleavedReaderJoiner(
 		if table.Post.Limit != 0 || table.Post.Offset != 0 {
 			return nil, errors.AssertionFailedf("interleaved joiner cannot be used with limits")
 		}
+		evalCtx := flowCtx.NewEvalCtx()
+		semaCtx := flowCtx.TypeResolverFactory.NewSemaContext(evalCtx.Txn)
 		if err := tables[i].post.Init(
-			&table.Post, table.Desc.ColumnTypes(), flowCtx.NewEvalCtx(), nil, /*output*/
+			&table.Post, table.Desc.ColumnTypes(), semaCtx, evalCtx, nil, /*output*/
 		); err != nil {
 			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
 				"failed to initialize post-processing helper")

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -220,17 +220,18 @@ func newInvertedJoiner(
 		return nil, err
 	}
 
+	semaCtx := flowCtx.TypeResolverFactory.NewSemaContext(flowCtx.EvalCtx.Txn)
 	onExprColTypes := make([]*types.T, 0, len(ij.inputTypes)+len(rightColTypes))
 	onExprColTypes = append(onExprColTypes, ij.inputTypes...)
 	onExprColTypes = append(onExprColTypes, rightColTypes...)
-	if err := ij.onExprHelper.Init(spec.OnExpr, onExprColTypes, ij.EvalCtx); err != nil {
+	if err := ij.onExprHelper.Init(spec.OnExpr, onExprColTypes, semaCtx, ij.EvalCtx); err != nil {
 		return nil, err
 	}
 	ij.combinedRow = make(sqlbase.EncDatumRow, 0, len(onExprColTypes))
 
 	if ij.datumToInvertedExpr == nil {
 		var invertedExprHelper execinfra.ExprHelper
-		if err := invertedExprHelper.Init(spec.InvertedExpr, onExprColTypes, ij.EvalCtx); err != nil {
+		if err := invertedExprHelper.Init(spec.InvertedExpr, onExprColTypes, semaCtx, ij.EvalCtx); err != nil {
 			return nil, err
 		}
 		ij.datumToInvertedExpr, err = invertedidx.NewDatumToInvertedExpr(invertedExprHelper.Expr, ij.index)

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -109,7 +109,8 @@ func (jb *joinerBase) init(
 	); err != nil {
 		return err
 	}
-	return jb.onCond.Init(onExpr, condTypes, jb.EvalCtx)
+	semaCtx := flowCtx.TypeResolverFactory.NewSemaContext(flowCtx.EvalCtx.Txn)
+	return jb.onCond.Init(onExpr, condTypes, semaCtx, jb.EvalCtx)
 }
 
 // joinSide is the utility type to distinguish between two sides of the join.

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -320,7 +320,7 @@ func NewProcessor(
 			return nil, err
 		}
 		processor := localProcessors[*core.LocalPlanNode.RowSourceIdx]
-		if err := processor.InitWithOutput(post, outputs[0]); err != nil {
+		if err := processor.InitWithOutput(flowCtx, post, outputs[0]); err != nil {
 			return nil, err
 		}
 		if numInputs == 1 {

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -274,9 +274,10 @@ func TestPostProcess(t *testing.T) {
 			outBuf := &distsqlutils.RowBuffer{}
 
 			var out execinfra.ProcOutputHelper
+			semaCtx := tree.MakeSemaContext()
 			evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
-			if err := out.Init(&tc.post, inBuf.OutputTypes(), evalCtx, outBuf); err != nil {
+			if err := out.Init(&tc.post, inBuf.OutputTypes(), &semaCtx, evalCtx, outBuf); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -272,7 +272,8 @@ func (f *rowBasedFlow) setupInputSyncs(
 			// than processors that scan over tables get their inputs from here, so
 			// this is a convenient place to do the hydration. Processors that scan
 			// over tables will have their hydration performed in ProcessorBase.Init.
-			if err := execinfrapb.HydrateTypeSlice(f.EvalCtx, is.ColumnTypes); err != nil {
+			resolver := f.TypeResolverFactory.NewTypeResolver(f.EvalCtx.Txn)
+			if err := resolver.HydrateTypeSlice(ctx, is.ColumnTypes); err != nil {
 				return nil, err
 			}
 

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3100,9 +3100,6 @@ type EvalContext struct {
 
 	Tenant TenantOperator
 
-	// TypeResolver is a type resolver that can be used during execution.
-	TypeResolver TypeReferenceResolver
-
 	// The transaction in which the statement is executing.
 	Txn *kv.Txn
 	// A handle to the database.

--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -74,21 +74,14 @@ func NewUnqualifiedTypeName(typ Name) *TypeName {
 	}}
 }
 
-// MakeTypeNameFromPrefix creates a type name from an unqualified name
-// and a resolved prefix.
-func MakeTypeNameFromPrefix(prefix ObjectNamePrefix, object Name) TypeName {
-	return TypeName{objName{
-		ObjectNamePrefix: prefix,
-		ObjectName:       object,
-	}}
-}
-
 // MakeNewQualifiedTypeName creates a fully qualified type name.
 func MakeNewQualifiedTypeName(db, schema, typ string) TypeName {
 	return TypeName{objName{
 		ObjectNamePrefix: ObjectNamePrefix{
-			CatalogName: Name(db),
-			SchemaName:  Name(schema),
+			ExplicitCatalog: true,
+			ExplicitSchema:  true,
+			CatalogName:     Name(db),
+			SchemaName:      Name(schema),
 		},
 		ObjectName: Name(typ),
 	}}

--- a/pkg/sql/sqlbase/type_desc.go
+++ b/pkg/sql/sqlbase/type_desc.go
@@ -562,7 +562,12 @@ func HydrateTypesInTableDescriptor(
 func (desc *ImmutableTypeDescriptor) HydrateTypeInfoWithName(
 	ctx context.Context, typ *types.T, name *tree.TypeName, res TypeDescriptorResolver,
 ) error {
-	typ.TypeMeta.Name = types.MakeUserDefinedTypeName(name.Catalog(), name.Schema(), name.Object())
+	typ.TypeMeta.Name = &types.UserDefinedTypeName{
+		Catalog:        name.Catalog(),
+		ExplicitSchema: name.ExplicitSchema,
+		Schema:         name.Schema(),
+		Name:           name.Object(),
+	}
 	typ.TypeMeta.Version = uint32(desc.Version)
 	switch desc.Kind {
 	case TypeDescriptor_ENUM:

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -226,18 +226,10 @@ func (e *EnumMetadata) debugString() string {
 // private. Rather than expose private members of higher level packages,
 // we define a separate type here to be safe.
 type UserDefinedTypeName struct {
-	Catalog string
-	Schema  string
-	Name    string
-}
-
-// MakeUserDefinedTypeName creates a user defined type name.
-func MakeUserDefinedTypeName(catalog, schema, name string) *UserDefinedTypeName {
-	return &UserDefinedTypeName{
-		Catalog: catalog,
-		Schema:  schema,
-		Name:    name,
-	}
+	Catalog        string
+	ExplicitSchema bool
+	Schema         string
+	Name           string
 }
 
 // Basename returns the unqualified name.
@@ -250,8 +242,10 @@ func (u UserDefinedTypeName) FQName() string {
 	var sb strings.Builder
 	// Note that cross-database type references are disabled, so we only
 	// format the qualified name with the schema.
-	sb.WriteString(u.Schema)
-	sb.WriteString(".")
+	if u.ExplicitSchema {
+		sb.WriteString(u.Schema)
+		sb.WriteString(".")
+	}
 	sb.WriteString(u.Name)
 	return sb.String()
 }
@@ -1554,7 +1548,7 @@ func (t *T) SQLStandardNameWithTypmod(haveTypmod bool, typmod int) string {
 	case UuidFamily:
 		return "uuid"
 	case EnumFamily:
-		return t.TypeMeta.Name.FQName()
+		return t.TypeMeta.Name.Basename()
 	default:
 		panic(errors.AssertionFailedf("unexpected Family: %v", errors.Safe(t.Family())))
 	}


### PR DESCRIPTION
This commit enables distributed queries to access user defined type
metadata during flow setup via the lease manager, so that accesses to
this metadata is cached and doesn't have to go through k/v on every
access.

This is achieved by giving the `FlowContext` a `descs.Collection` is
used to access the descriptors through the lease manager.

Release note: None