### PR TITLE
release-20.1: kv/kvserver: ignore discovered intents from prior lease sequences

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -3138,6 +3138,124 @@ func TestStrictGCEnforcement(t *testing.T) {
 	})
 }
 
+// TestDiscoverIntentAcrossLeaseTransferAwayAndBack tests a scenario where a
+// read hits an intent, but only informs its lock-table about the discovered
+// intent after the corresponding range's lease has been transferred away and
+// back. If the intent is replaced during this time and the replacement intent
+// has made its way into the lock-table, the initial read's discovery should not
+// hit an assertion failure. It used to.
+//
+// The test uses a TestCluster to mirror the setup from:
+//   concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+func TestDiscoverIntentAcrossLeaseTransferAwayAndBack(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	// Detect when txn2 has completed its read of txn1's intent and block.
+	var txn2ID atomic.Value
+	var txn2BBlockOnce sync.Once
+	txn2BlockedC := make(chan chan struct{})
+	knobs := &kvserver.StoreTestingKnobs{}
+	knobs.EvalKnobs.TestingPostEvalFilter = func(args storagebase.FilterArgs) *roachpb.Error {
+		if txn := args.Hdr.Txn; txn != nil && txn.ID == txn2ID.Load() {
+			txn2BBlockOnce.Do(func() {
+				if _, ok := args.Err.(*roachpb.WriteIntentError); !ok {
+					t.Errorf("expected WriteIntentError; got %v", args.Err)
+				}
+
+				unblockCh := make(chan struct{})
+				txn2BlockedC <- unblockCh
+				<-unblockCh
+			})
+		}
+		return nil
+	}
+
+	// Detect when txn4 discovers txn3's intent and begins to push.
+	var txn4ID atomic.Value
+	txn4PushingC := make(chan struct{}, 1)
+	knobs.TestingRequestFilter = func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+		if !ba.IsSinglePushTxnRequest() {
+			return nil
+		}
+		if ba.Requests[0].GetPushTxn().PusherTxn.ID == txn4ID.Load() {
+			select {
+			case txn4PushingC <- struct{}{}:
+			default:
+			}
+		}
+		return nil
+	}
+
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{Knobs: base.TestingKnobs{Store: knobs}},
+	})
+	defer tc.Stopper().Stop(ctx)
+	kvDB := tc.Servers[0].DB()
+
+	key := []byte("a")
+	rangeDesc, err := tc.LookupRange(key)
+	require.NoError(t, err)
+
+	// Transfer the lease to Server 0 so we start in a known state.
+	err = tc.TransferRangeLease(rangeDesc, tc.Target(0))
+	require.NoError(t, err)
+
+	// txn1 writes the first intent.
+	txn1 := kvDB.NewTxn(ctx, "txn1")
+	err = txn1.Put(ctx, key, "val1")
+	require.NoError(t, err)
+
+	// txn2 reads the first intent. Should block during evaluation.
+	txn2 := kvDB.NewTxn(ctx, "txn2")
+	txn2ID.Store(txn2.ID())
+	err2C := make(chan error)
+	go func() {
+		_, err := txn2.Get(ctx, key)
+		err2C <- err
+	}()
+	txn2UnblockC := <-txn2BlockedC
+
+	// Transfer the lease to Server 1.
+	err = tc.TransferRangeLease(rangeDesc, tc.Target(1))
+	require.NoError(t, err)
+
+	// Roll back txn1.
+	err = txn1.Rollback(ctx)
+	require.NoError(t, err)
+
+	// txn3 writes the second intent.
+	txn3 := kvDB.NewTxn(ctx, "txn3")
+	err = txn3.Put(ctx, key, "val3")
+	require.NoError(t, err)
+
+	// Make sure txn3 creates its record before a lease transfer to avoid it
+	// being aborted.
+	hb, hbH := heartbeatArgs(txn3.TestingCloneTxn(), kvDB.Clock().Now())
+	_, pErr := kv.SendWrappedWith(ctx, kvDB.GetFactory().NonTransactionalSender(), hbH, hb)
+	require.NoError(t, pErr.GoError())
+
+	// Transfer the lease back to Server 0.
+	err = tc.TransferRangeLease(rangeDesc, tc.Target(0))
+	require.NoError(t, err)
+
+	// txn4 reads the second intent. Should discover intent and wait in lockTable.
+	txn4 := kvDB.NewTxn(ctx, "txn4")
+	txn4ID.Store(txn4.ID())
+	err4C := make(chan error)
+	go func() {
+		_, err := txn4.Get(ctx, key)
+		err4C <- err
+	}()
+	<-txn4PushingC
+	close(txn2UnblockC)
+
+	err = txn3.Rollback(ctx)
+	require.NoError(t, err)
+	require.NoError(t, <-err2C)
+	require.NoError(t, <-err4C)
+}
+
 // getRangeInfo retreives range info by performing a get against the provided
 // key and setting the ReturnRangeInfo flag to true.
 func getRangeInfo(

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -192,12 +192,12 @@ type ContentionHandler interface {
 	// HandleWriterIntentError consumes a WriteIntentError by informing the
 	// concurrency manager about the replicated write intent that was missing
 	// from its lock table which was found during request evaluation (while
-	// holding latches). After doing so, it enqueues the request that hit the
-	// error in the lock's wait-queue (but does not wait) and releases the
-	// guard's latches. It returns an updated guard reflecting this change.
-	// After the method returns, the original guard should no longer be used.
-	// If an error is returned then the provided guard will be released and no
-	// guard will be returned.
+	// holding latches) under the provided lease sequence. After doing so, it
+	// enqueues the request that hit the error in the lock's wait-queue (but
+	// does not wait) and releases the guard's latches. It returns an updated
+	// guard reflecting this change. After the method returns, the original
+	// guard should no longer be used. If an error is returned then the provided
+	// guard will be released and no guard will be returned.
 	//
 	// Example usage: Txn A scans the lock table and does not see an intent on
 	// key K from txn B because the intent is not being tracked in the lock
@@ -206,7 +206,9 @@ type ContentionHandler interface {
 	// method before txn A retries its scan. During the retry, txn A scans the
 	// lock table and observes the lock on key K, so it enters the lock's
 	// wait-queue and waits for it to be resolved.
-	HandleWriterIntentError(context.Context, *Guard, *roachpb.WriteIntentError) (*Guard, *Error)
+	HandleWriterIntentError(
+		context.Context, *Guard, roachpb.LeaseSequence, *roachpb.WriteIntentError,
+	) (*Guard, *Error)
 
 	// HandleTransactionPushError consumes a TransactionPushError thrown by a
 	// PushTxnRequest by informing the concurrency manager about a transaction
@@ -263,7 +265,7 @@ type RangeStateListener interface {
 	// OnRangeLeaseUpdated informs the concurrency manager that its range's
 	// lease has been updated. The argument indicates whether this manager's
 	// replica is the leaseholder going forward.
-	OnRangeLeaseUpdated(isLeaseholder bool)
+	OnRangeLeaseUpdated(_ roachpb.LeaseSequence, isLeaseholder bool)
 
 	// OnRangeSplit informs the concurrency manager that its range has split off
 	// a new range to its RHS.
@@ -464,8 +466,9 @@ type lockTable interface {
 	// require latches to be held.
 	Dequeue(lockTableGuard)
 
-	// AddDiscoveredLock informs the lockTable of a lock that was discovered
-	// during evaluation which the lockTable wasn't previously tracking.
+	// AddDiscoveredLock informs the lockTable of a lock which is wasn't
+	// previously tracking that was discovered during evaluation under the
+	// provided lease sequence.
 	//
 	// The method is called when an exclusive replicated lock held by a
 	// different transaction is discovered when reading the MVCC keys during
@@ -474,13 +477,19 @@ type lockTable interface {
 	// locks before acquiring its own locks, since the request needs to repeat
 	// ScanAndEnqueue.
 	//
+	// The lease sequence is used to detect lease changes between the when
+	// request that found the lock started evaluating and when the discovered
+	// lock is added to the lockTable. If there has been a lease change between
+	// these times, information about the discovered lock may be stale, so it is
+	// ignored.
+	//
 	// A latch consistent with the access desired by the guard must be held on
 	// the span containing the discovered lock's key.
 	//
 	// The method returns a boolean indicating whether the discovered lock was
 	// added to the lockTable (true) or whether it was ignored because the
 	// lockTable is currently disabled (false).
-	AddDiscoveredLock(*roachpb.Intent, lockTableGuard) (bool, error)
+	AddDiscoveredLock(*roachpb.Intent, roachpb.LeaseSequence, lockTableGuard) (bool, error)
 
 	// AcquireLock informs the lockTable that a new lock was acquired or an
 	// existing lock was updated.
@@ -799,7 +808,9 @@ type txnWaitQueue interface {
 // requestQueuer queues requests until some condition is met.
 type requestQueuer interface {
 	// Enable allows requests to be queued. The method is idempotent.
-	Enable()
+	// The lease sequence is used to avoid mixing incompatible requests
+	// or other state from different leasing periods.
+	Enable(roachpb.LeaseSequence)
 
 	// Clear empties the queue(s) and causes all waiting requests to
 	// return. If disable is true, future requests must not be enqueued.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/acquire_wrong_txn_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/acquire_wrong_txn_race
@@ -120,7 +120,7 @@ sequence req=req3
 [4] sequence req3: acquiring latches
 [4] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
 
-handle-write-intent-error req=req2
+handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn1 key=k
 ----
 [3] sequence reqRes1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -19,7 +19,7 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1
+handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn2 key=a
   intent txn=txn2 key=b
   intent txn=txn2 key=c
@@ -151,7 +151,7 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1
+handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn2 key=a
 ----
 [2] handle write intent error req1: handled conflicting intents on "a", released latches
@@ -182,7 +182,7 @@ on-txn-updated txn=txn2 status=committed
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1
+handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn2 key=b
 ----
 [4] handle write intent error req1: handled conflicting intents on "b", released latches
@@ -210,7 +210,7 @@ sequence req=req1
 [5] sequence req1: scanning lock table for conflicting locks
 [5] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1
+handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn2 key=c
 ----
 [6] handle write intent error req1: handled conflicting intents on "c", released latches

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -1,0 +1,200 @@
+# -------------------------------------------------------------
+# The following sequence of events used to trigger an assertion
+# in lock-table that a lock was acquired by a different
+# transaction than the current lock holder. This was due to an
+# a scan discovering an intent but not informing the lock-table
+# about this until after the range lease had been transferred
+# away and returned. If the intent was replaced (resolved and
+# rewritten by another transaction) during the time that the
+# lease was held by a different node, it would be possible for
+# the original scan's discovery of the old intent to trigger
+# the incorrect transaction assertion.
+#
+# Setup: txn1 writes intent on key k
+#        
+# Test:  txn2 sequences and begins evaluating
+#        txn2 hits intent, stalls before informing lock-table
+#
+#        lease is transferred away from node
+#        (other node) txn1's intent is resolved
+#        (other node) txn2 writes intent on key k
+#
+#        lease is transferred back to node
+#        txn4 sequences and begins evaluating
+#        txn4 hits new intent, informs lock-table
+#        txn2 unpauses, informs lock-table of txn1's intent [*]
+#        txn3 commits
+#        txn2 and txn4 proceed
+#
+# [*] This used to panic. The fix for this was to keep track of the
+#     lease epoch that intents are discovered within and to only add
+#     those intents to the lock-table if they are from the currently
+#     active lease.
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10 epoch=0
+----
+
+new-txn name=txn2 ts=10 epoch=0
+----
+
+new-txn name=txn3 ts=10 epoch=0
+----
+
+new-txn name=txn4 ts=10 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10
+  put key=k value=v
+----
+
+new-request name=req2 txn=txn2 ts=10
+  get key=k
+----
+
+new-request name=req3 txn=txn3 ts=10
+  put key=k value=v2
+----
+
+new-request name=req4 txn=txn4 ts=10
+  get key=k
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+# NOTE: replicated locks are not immediately stored in the lock-table.
+on-lock-acquired req=req1 key=k dur=r
+----
+[-] acquire lock: txn 00000001 @ k
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+# --------------------------------
+# Setup complete, test starts here
+# --------------------------------
+
+# req2 begins evaluating and hits the replicated intent. However, before
+# handle-write-intent-error, it pauses.
+sequence req=req2
+----
+[2] sequence req2: sequencing request
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: sequencing complete, returned guard
+
+# Replica loses lease.
+on-lease-updated leaseholder=false lease-seq=2
+----
+[-] transfer lease: released
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+# The following series of events takes place on the new leaseholder.
+#
+# on-txn-updated txn=txn1 status=aborted
+# ----
+# [-] update txn: aborting txn1
+# 
+# sequence req=req3
+# ----
+# 
+# on-lock-acquired req=req3 key=k dur=r
+# ----
+# 
+# finish req=req3
+# ----
+
+# Replica acquires lease.
+on-lease-updated leaseholder=true lease-seq=3
+----
+[-] transfer lease: acquired
+
+sequence req=req4
+----
+[3] sequence req4: sequencing request
+[3] sequence req4: acquiring latches
+[3] sequence req4: scanning lock table for conflicting locks
+[3] sequence req4: sequencing complete, returned guard
+
+handle-write-intent-error req=req4 lease-seq=3
+  intent txn=txn3 key=k
+----
+[4] handle write intent error req4: handled conflicting intents on "k", released latches
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
+local: num=0
+
+sequence req=req4
+----
+[5] sequence req4: re-sequencing request
+[5] sequence req4: acquiring latches
+[5] sequence req4: scanning lock table for conflicting locks
+[5] sequence req4: waiting in lock wait-queues
+[5] sequence req4: pushing timestamp of txn 00000003 above 0.000000010,0
+[5] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+handle-write-intent-error req=req2 lease-seq=1
+  intent txn=txn1 key=k
+----
+[6] handle write intent error req2: handled conflicting intents on "k", released latches
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000003-0000-0000-0000-000000000000, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 3, txn: 00000004-0000-0000-0000-000000000000
+   distinguished req: 3
+local: num=0
+
+sequence req=req2
+----
+[7] sequence req2: re-sequencing request
+[7] sequence req2: acquiring latches
+[7] sequence req2: scanning lock table for conflicting locks
+[7] sequence req2: waiting in lock wait-queues
+[7] sequence req2: pushing timestamp of txn 00000003 above 0.000000010,0
+[7] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn3 status=committed
+----
+[-] update txn: committing txn3
+[5] sequence req4: resolving intent "k" for txn 00000003 with COMMITTED status
+[5] sequence req4: acquiring latches
+[5] sequence req4: scanning lock table for conflicting locks
+[5] sequence req4: sequencing complete, returned guard
+[7] sequence req2: resolving intent "k" for txn 00000003 with COMMITTED status
+[7] sequence req2: acquiring latches
+[7] sequence req2: scanning lock table for conflicting locks
+[7] sequence req2: sequencing complete, returned guard
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+finish req=req4
+----
+[-] finish req4: finishing request
+
+reset
+----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -20,7 +20,7 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1
+handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: handled conflicting intents on "k", released latches
@@ -72,7 +72,7 @@ new-request name=req1 txn=txn2 ts=12,1
   get key=k
 ----
 
-on-lease-updated leaseholder=false
+on-lease-updated leaseholder=false lease-seq=2
 ----
 [-] transfer lease: released
 
@@ -83,7 +83,7 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1
+handle-write-intent-error req=req1 lease-seq=2
   intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: pushing timestamp of txn 00000001 above 0.000000012,1
@@ -130,7 +130,7 @@ new-request name=req1 txn=txn2 ts=12,1
   put key=k value=v
 ----
 
-on-lease-updated leaseholder=false
+on-lease-updated leaseholder=false lease-seq=2
 ----
 [-] transfer lease: released
 
@@ -141,7 +141,7 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1
+handle-write-intent-error req=req1 lease-seq=2
   intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: pushing txn 00000001 to abort
@@ -189,7 +189,7 @@ new-request name=req1 txn=txn2 ts=12,1
   get key=k
 ----
 
-on-lease-updated leaseholder=false
+on-lease-updated leaseholder=false lease-seq=2
 ----
 [-] transfer lease: released
 
@@ -200,7 +200,7 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1
+handle-write-intent-error req=req1 lease-seq=2
   intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: pushing timestamp of txn 00000001 above 0.000000012,1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -23,6 +23,8 @@ debug-disable-txn-pushes
 #        txn2 proceeds and acquires lock (ignored)
 #
 #        replica acquire lease
+#        txn3 discovers txn1's lock under old lease (ignored)
+#        txn3 re-sequences
 #        txn3 discovers txn2's lock      (not ignored)
 #        txn3 queue's on txn2's lock
 #        txn2's lock is released         (not ignored)
@@ -107,7 +109,7 @@ global: num=2
 local: num=0
 
 # Replica loses lease.
-on-lease-updated leaseholder=false
+on-lease-updated leaseholder=false lease-seq=2
 ----
 [-] transfer lease: released
 [2] sequence req2: acquiring latches
@@ -119,7 +121,7 @@ debug-lock-table
 global: num=0
 local: num=0
 
-handle-write-intent-error req=req2
+handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn1 key=k
 ----
 [3] handle write intent error req2: pushing txn 00000001 to abort
@@ -143,7 +145,7 @@ sequence req=req2
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: sequencing complete, returned guard
 
-handle-write-intent-error req=req2
+handle-write-intent-error req=req2 lease-seq=2
   intent txn=txn1 key=k2
 ----
 [5] handle write intent error req2: pushing timestamp of txn 00000001 above 0.000000010,1
@@ -176,7 +178,7 @@ finish req=req2
 [-] finish req2: finishing request
 
 # Replica acquires lease.
-on-lease-updated leaseholder=true
+on-lease-updated leaseholder=true lease-seq=3
 ----
 [-] transfer lease: acquired
 
@@ -192,10 +194,31 @@ sequence req=req3
 [7] sequence req3: scanning lock table for conflicting locks
 [7] sequence req3: sequencing complete, returned guard
 
-handle-write-intent-error req=req3
+# Discover the initial intent, as if this request had been in-flight
+# this entire time. This isn't quite realistic, given the setup of this
+# test, but it is possible (see discover_lock_after_lease_race) and the
+# discovery should be ignored.
+handle-write-intent-error req=req3 lease-seq=1
   intent txn=txn2 key=k
 ----
 [8] handle write intent error req3: handled conflicting intents on "k", released latches
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+sequence req=req3
+----
+[9] sequence req3: re-sequencing request
+[9] sequence req3: acquiring latches
+[9] sequence req3: scanning lock table for conflicting locks
+[9] sequence req3: sequencing complete, returned guard
+
+handle-write-intent-error req=req3 lease-seq=3
+  intent txn=txn2 key=k
+----
+[10] handle write intent error req3: handled conflicting intents on "k", released latches
 
 debug-lock-table
 ----
@@ -208,11 +231,11 @@ local: num=0
 
 sequence req=req3
 ----
-[9] sequence req3: re-sequencing request
-[9] sequence req3: acquiring latches
-[9] sequence req3: scanning lock table for conflicting locks
-[9] sequence req3: waiting in lock wait-queues
-[9] sequence req3: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+[11] sequence req3: re-sequencing request
+[11] sequence req3: acquiring latches
+[11] sequence req3: scanning lock table for conflicting locks
+[11] sequence req3: waiting in lock wait-queues
+[11] sequence req3: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
 ----
@@ -230,21 +253,21 @@ new-request name=reqRes2 txn=none ts=10,1
 
 sequence req=reqRes2
 ----
-[10] sequence reqRes2: sequencing request
-[10] sequence reqRes2: acquiring latches
-[10] sequence reqRes2: sequencing complete, returned guard
+[12] sequence reqRes2: sequencing request
+[12] sequence reqRes2: acquiring latches
+[12] sequence reqRes2: sequencing complete, returned guard
 
 on-lock-updated req=reqRes2 txn=txn2 key=k status=committed
 ----
 [-] update lock: committing txn 00000002 @ k
-[9] sequence req3: acquiring latches
-[9] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
+[11] sequence req3: acquiring latches
+[11] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes2
 ----
 [-] finish reqRes2: finishing request
-[9] sequence req3: scanning lock table for conflicting locks
-[9] sequence req3: sequencing complete, returned guard
+[11] sequence req3: scanning lock table for conflicting locks
+[11] sequence req3: sequencing complete, returned guard
 
 debug-lock-table
 ----
@@ -360,7 +383,7 @@ debug-lock-table
 global: num=0
 local: num=0
 
-handle-write-intent-error req=req2
+handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn1 key=k
 ----
 [3] handle write intent error req2: handled conflicting intents on "k", released latches
@@ -530,7 +553,7 @@ debug-lock-table
 global: num=0
 local: num=0
 
-handle-write-intent-error req=req2
+handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn1 key=k
 ----
 [3] handle write intent error req2: pushing txn 00000001 to abort
@@ -554,7 +577,7 @@ sequence req=req2
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: sequencing complete, returned guard
 
-handle-write-intent-error req=req2
+handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn1 key=k2
 ----
 [5] handle write intent error req2: pushing timestamp of txn 00000001 above 0.000000010,1
@@ -678,7 +701,7 @@ debug-lock-table
 global: num=0
 local: num=0
 
-handle-write-intent-error req=req2
+handle-write-intent-error req=req2 lease-seq=1
   intent txn=txn1 key=k
 ----
 [3] handle write intent error req2: handled conflicting intents on "k", released latches

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -22,7 +22,7 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1
+handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: handled conflicting intents on "k", released latches
@@ -83,7 +83,7 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1
+handle-write-intent-error req=req1 lease-seq=1
   intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: handled conflicting intents on "k", released latches

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered_old_lease
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered_old_lease
@@ -1,0 +1,46 @@
+new-lock-table maxlocks=10000
+----
+
+new-txn txn=txn1 ts=10 epoch=0
+----
+
+new-txn txn=txn2 ts=10 epoch=0
+----
+
+new-request r=req1 txn=txn1 ts=10 spans=w@a+r@b+w@c
+----
+
+clear disable
+----
+global: num=0
+local: num=0
+
+enable lease-seq=5
+----
+
+scan r=req1
+----
+start-waiting: false
+
+add-discovered r=req1 k=a txn=txn2 lease-seq=4
+----
+global: num=0
+local: num=0
+
+add-discovered r=req1 k=b txn=txn2 lease-seq=5
+----
+global: num=1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
+local: num=0
+
+add-discovered r=req1 k=c txn=txn2 lease-seq=6
+----
+unexpected lease sequence: 6 > 5
+
+print
+----
+global: num=1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: repl epoch: 0, seqs: [0]
+local: num=0

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -487,6 +487,25 @@ func evaluateCommand(
 		log.Infof(ctx, "evaluated %s command %+v: %+v, err=%v", args.Method(), args, reply, err)
 	}
 
+	if filter := rec.EvalKnobs().TestingPostEvalFilter; filter != nil {
+		filterArgs := storagebase.FilterArgs{
+			Ctx:   ctx,
+			CmdID: raftCmdID,
+			Index: index,
+			Sid:   rec.StoreID(),
+			Req:   args,
+			Hdr:   h,
+			Err:   err,
+		}
+		if pErr := filter(filterArgs); pErr != nil {
+			if pErr.GetTxn() == nil {
+				pErr.SetTxn(h.Txn)
+			}
+			log.Infof(ctx, "test injecting error: %s", pErr)
+			return result.Result{}, pErr
+		}
+	}
+
 	// Create a roachpb.Error by initializing txn from the request/response header.
 	var pErr *roachpb.Error
 	if err != nil {

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -365,6 +365,9 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease, pe
 		}
 	}
 
+	// Inform the concurrency manager that the lease holder has been updated.
+	r.concMgr.OnRangeLeaseUpdated(newLease.Sequence, iAmTheLeaseHolder)
+
 	// Sanity check to make sure that the lease sequence is moving in the right
 	// direction.
 	if s1, s2 := prevLease.Sequence, newLease.Sequence; s1 != 0 {
@@ -437,9 +440,6 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease, pe
 			r.leaseholderStats.resetRequestCounts()
 		}
 	}
-
-	// Inform the concurrency manager that the lease holder has been updated.
-	r.concMgr.OnRangeLeaseUpdated(iAmTheLeaseHolder)
 
 	// Potentially re-gossip if the range contains system data (e.g. system
 	// config or node liveness). We need to perform this gossip at startup as

--- a/pkg/kv/kvserver/storagebase/base.go
+++ b/pkg/kv/kvserver/storagebase/base.go
@@ -50,6 +50,7 @@ type FilterArgs struct {
 	Sid   roachpb.StoreID
 	Req   roachpb.Request
 	Hdr   roachpb.Header
+	Err   error // only used for TestingPostEvalFilter
 }
 
 // ProposalFilterArgs groups the arguments to ReplicaProposalFilter.

--- a/pkg/kv/kvserver/storagebase/knobs.go
+++ b/pkg/kv/kvserver/storagebase/knobs.go
@@ -19,6 +19,9 @@ type BatchEvalTestingKnobs struct {
 	// TestingEvalFilter is called before evaluating each command.
 	TestingEvalFilter ReplicaCommandFilter
 
+	// TestingPostEvalFilter is called after evaluating each command.
+	TestingPostEvalFilter ReplicaCommandFilter
+
 	// NumKeysEvaluatedForRangeIntentResolution is set by the stores to the
 	// number of keys evaluated for range intent resolution.
 	NumKeysEvaluatedForRangeIntentResolution *int64

--- a/pkg/kv/kvserver/storagebase/knobs.go
+++ b/pkg/kv/kvserver/storagebase/knobs.go
@@ -16,14 +16,7 @@ package storagebase
 
 // BatchEvalTestingKnobs contains testing helpers that are used during batch evaluation.
 type BatchEvalTestingKnobs struct {
-	// TestingEvalFilter is called before evaluating each command. This filter is
-	// deprecated in favor of either TestingProposalFilter (which runs only on the
-	// lease holder) or TestingApplyFilter (which runs on each replica). If your
-	// filter is not idempotent, consider wrapping it in a
-	// ReplayProtectionFilterWrapper.
-	// TODO(bdarnell,tschottdorf): Migrate existing tests which use this
-	// to one of the other filters. See #10493
-	// TODO(andrei): Provide guidance on what to use instead for trapping reads.
+	// TestingEvalFilter is called before evaluating each command.
 	TestingEvalFilter ReplicaCommandFilter
 
 	// NumKeysEvaluatedForRangeIntentResolution is set by the stores to the

--- a/pkg/kv/kvserver/txn_wait_queue_test.go
+++ b/pkg/kv/kvserver/txn_wait_queue_test.go
@@ -187,7 +187,7 @@ func TestTxnWaitQueueCancel(t *testing.T) {
 	}
 
 	q := tc.repl.concMgr.TxnWaitQueue()
-	q.Enable()
+	q.Enable(1 /* leaseSeq */)
 	if err := checkAllGaugesZero(tc); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -253,7 +253,7 @@ func TestTxnWaitQueueUpdateTxn(t *testing.T) {
 	req2.PusherTxn = *pusher2
 
 	q := tc.repl.concMgr.TxnWaitQueue()
-	q.Enable()
+	q.Enable(1 /* leaseSeq */)
 	q.EnqueueTxn(txn)
 	m := tc.store.txnWaitMetrics
 	assert.EqualValues(tc, 1, m.PusheeWaiting.Value())
@@ -371,7 +371,7 @@ func TestTxnWaitQueueTxnSilentlyCompletes(t *testing.T) {
 	}
 
 	q := tc.repl.concMgr.TxnWaitQueue()
-	q.Enable()
+	q.Enable(1 /* leaseSeq */)
 	q.EnqueueTxn(txn)
 
 	retCh := make(chan RespWithErr, 2)
@@ -446,7 +446,7 @@ func TestTxnWaitQueueUpdateNotPushedTxn(t *testing.T) {
 	}
 
 	q := tc.repl.concMgr.TxnWaitQueue()
-	q.Enable()
+	q.Enable(1 /* leaseSeq */)
 	q.EnqueueTxn(txn)
 
 	retCh := make(chan RespWithErr, 1)
@@ -521,7 +521,7 @@ func TestTxnWaitQueuePusheeExpires(t *testing.T) {
 	}
 
 	q := tc.repl.concMgr.TxnWaitQueue()
-	q.Enable()
+	q.Enable(1 /* leaseSeq */)
 	q.EnqueueTxn(txn)
 
 	retCh := make(chan RespWithErr, 2)
@@ -624,7 +624,7 @@ func TestTxnWaitQueuePusherUpdate(t *testing.T) {
 				}
 
 				q := tc.repl.concMgr.TxnWaitQueue()
-				q.Enable()
+				q.Enable(1 /* leaseSeq */)
 				q.EnqueueTxn(txn)
 
 				retCh := make(chan RespWithErr, 1)
@@ -738,7 +738,7 @@ func TestTxnWaitQueueDependencyCycle(t *testing.T) {
 	}
 
 	q := tc.repl.concMgr.TxnWaitQueue()
-	q.Enable()
+	q.Enable(1 /* leaseSeq */)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -829,7 +829,7 @@ func TestTxnWaitQueueDependencyCycleWithPriorityInversion(t *testing.T) {
 	}
 
 	q := tc.repl.concMgr.TxnWaitQueue()
-	q.Enable()
+	q.Enable(1 /* leaseSeq */)
 
 	for _, txn := range []*roachpb.Transaction{txnA, txnB} {
 		q.EnqueueTxn(txn)

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -198,7 +198,7 @@ func NewQueue(cfg Config) *Queue {
 // Enable allows transactions to be enqueued and waiting pushers
 // added. This method must be idempotent as it can be invoked multiple
 // times as range leases are updated for the same replica.
-func (q *Queue) Enable() {
+func (q *Queue) Enable(_ roachpb.LeaseSequence) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if q.mu.txns == nil {

--- a/pkg/kv/kvserver/txnwait/queue_test.go
+++ b/pkg/kv/kvserver/txnwait/queue_test.go
@@ -189,7 +189,7 @@ func TestMaybeWaitForQueryWithContextCancellation(t *testing.T) {
 	cfg := makeConfig(nil)
 	defer cfg.Stopper.Stop(context.Background())
 	q := NewQueue(cfg)
-	q.Enable()
+	q.Enable(1 /* leaseSeq */)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	waitingRes := make(chan *roachpb.Error)
@@ -231,7 +231,7 @@ func TestPushersReleasedAfterAnyQueryTxnFindsAbortedTxn(t *testing.T) {
 	})
 	defer cfg.Stopper.Stop(context.Background())
 	q := NewQueue(cfg)
-	q.Enable()
+	q.Enable(1 /* leaseSeq */)
 
 	// Set an extremely high transaction liveness threshold so that the pushee
 	// is only queried once per pusher.

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -11,7 +11,6 @@
 package roachpb
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -574,7 +573,7 @@ func (e *WriteIntentError) Error() string {
 }
 
 func (e *WriteIntentError) message(_ *Error) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteString("conflicting intents on ")
 
 	// If we have a lot of intents, we only want to show the first and the last.


### PR DESCRIPTION
Backport 3/3 commits from #51615.

/cc @cockroachdb/release

---

Fixes #50996.

This commit fixes what I suspect to be the underlying cause of the crash in #50996 (whose only occurrence was seen on a known customer's cluster).

The fix addresses an assertion failure caused by a scan that discovers an intent but does not inform the lock-table about the discovery until after the corresponding range's lease has been transferred away and back. If, during the time that the lease was remote, the intent that the scan discovered is removed and replaced, the scan can end up placing the wrong intent into the lock-table once the lease is returned. If another request had already discovered the new intent and placed that in the lock-table by the time that the original scan informs the lockTable, then the "discovered lock by different transaction than existing lock" assertion would be hit.

This PR demonstrates that this sequence of events could trigger the assertion in two ways. First, it demonstrates it in the new `discover_lock_after_lease_race` ConcurrencyManager data-driven test. This one is fairly synthetic, as it doesn't actually prove that it is possible for a scan to inform the lockTable about a stale intent after a lease is transferred away and back, only that if it did, it would hit the assertion. The PR then demonstrates using a TestCluster in `TestDiscoverIntentAcrossLeaseTransferAwayAndBack` that because of the lack of latching during lease transfers and requests, such an ordering is possible and, without proper protection in the lockTable, could trigger the assertion. Without the fix, both tests panic every time they are run.

The PR then fixes the issue. The fix is to not only track an "enabled" boolean in the lockTable, but also the lease sequence that the lockTable is operating under when the lockTable is enabled. We then also provide the lease sequence that a scan ran under when discovering intents (`AddDiscoveredLock`), and ignore discovered intents from prior lease sequences. If a request provides a stale discovered intent, it is safe to try its scan again – the intent is either incorrect and shouldn't be added to the lockTable or it is correct and will be added once the scan retries under the new lease sequence.

Release note (bug fix): It is no longer possible for rapid Range lease movement to trigger a rare assertion failure under contended workloads.
