### PR TITLE
kvserver: improve node liveness failure log, point to docs

### DIFF
--- a/pkg/kv/kvserver/node_liveness.go
+++ b/pkg/kv/kvserver/node_liveness.go
@@ -589,7 +589,7 @@ func (nl *NodeLiveness) StartHeartbeat(
 					}
 					return nil
 				}); err != nil {
-				log.Warningf(ctx, "failed node liveness heartbeat: %+v", err)
+				log.Warningf(ctx, heartbeatFailureLogFormat, err)
 			}
 
 			nl.heartbeatToken <- struct{}{}
@@ -601,6 +601,16 @@ func (nl *NodeLiveness) StartHeartbeat(
 		}
 	})
 }
+
+const heartbeatFailureLogFormat = `failed node liveness heartbeat: %+v
+
+An inability to maintain liveness will prevent a node from participating in a
+cluster. If this problem persists, it may be a sign of resource starvation or
+of network connectivity problems. For help troubleshooting, visit:
+
+    https://www.cockroachlabs.com/docs/stable/cluster-setup-troubleshooting.html#node-liveness-issues
+
+`
 
 // PauseHeartbeat stops or restarts the periodic heartbeat depending on the
 // pause parameter. When pause is true, waits until it acquires the heartbeatToken


### PR DESCRIPTION
This commit improves the message logged on node liveness failures, which
is logged roughly every 4.5 seconds during liveness unavailability. The
improved message describes some of the common causes of liveness
unavailability (resource starvation and network connectivity problems)
and then links to our troubleshooting docs about the topic.

This was an action item coming out of a recent support incident postmortem.