### PR TITLE
opt: add missing handling of JsonObjectAgg

### DIFF
--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -382,9 +382,9 @@ func AggregatesCanMerge(inner, outer Operator) bool {
 		// while CountOp and CountRowsOp both output int values.
 		return outer == SumIntOp
 
-	case ArrayAggOp, AvgOp, ConcatAggOp, CorrOp, JsonAggOp,
-		JsonbAggOp, PercentileContOp, PercentileDiscOp, SqrDiffOp,
-		StdDevOp, StringAggOp, VarianceOp, StdDevPopOp, VarPopOp:
+	case ArrayAggOp, AvgOp, ConcatAggOp, CorrOp, JsonAggOp, JsonbAggOp,
+		JsonObjectAggOp, JsonbObjectAggOp, PercentileContOp, PercentileDiscOp,
+		SqrDiffOp, StdDevOp, StringAggOp, VarianceOp, StdDevPopOp, VarPopOp:
 		return false
 
 	default:
@@ -402,7 +402,8 @@ func AggregateIgnoresDuplicates(op Operator) bool {
 
 	case ArrayAggOp, AvgOp, ConcatAggOp, CountOp, CorrOp, CountRowsOp, SumIntOp,
 		SumOp, SqrDiffOp, VarianceOp, StdDevOp, XorAggOp, JsonAggOp, JsonbAggOp,
-		StringAggOp, PercentileDiscOp, PercentileContOp, StdDevPopOp, VarPopOp:
+		StringAggOp, PercentileDiscOp, PercentileContOp, StdDevPopOp, VarPopOp,
+		JsonObjectAggOp, JsonbObjectAggOp:
 		return false
 
 	default:

--- a/pkg/sql/opt/operator_test.go
+++ b/pkg/sql/opt/operator_test.go
@@ -1,0 +1,58 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package opt
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+// TestAggregateProperties verifies that the various helper functions for
+// various properties of aggregations handle all aggregation operators.
+func TestAggregateProperties(t *testing.T) {
+	check := func(fn func()) bool {
+		ok := true
+		func() {
+			defer func() {
+				if x := recover(); x != nil {
+					ok = false
+				}
+			}()
+			fn()
+		}()
+		return ok
+	}
+
+	for _, op := range AggregateOperators {
+		funcs := []func(Operator) bool{
+			AggregateIgnoresDuplicates,
+			AggregateIgnoresNulls,
+			AggregateIsNeverNull,
+			AggregateIsNeverNullOnNonNullInput,
+			AggregateIsNullOnEmpty,
+		}
+
+		for _, fn := range funcs {
+			if !check(func() { fn(op) }) {
+				fnName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+				t.Errorf("%s not handled by %s", op, fnName)
+			}
+		}
+
+		for _, op2 := range AggregateOperators {
+			if !check(func() { AggregatesCanMerge(op, op2) }) {
+				t.Errorf("%s,%s not handled by AggregatesCanMerge", op, op2)
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
JsonObjectAgg and JsonbObjectAgg were added recently and were not
handled by some of the AggregateXX functions, which can result in
internal errors. This change fixes the issue and adds a test that
tries running all these functions against all aggregation operators.

Fixes #51874.

Release note (bug fix): fixed "unhandled op: json-object-agg" internal
error.