### PR TITLE
cloud/cloudimpl: adds KMS API and AWS KMS integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/apache/arrow/go/arrow v0.0.0-20200610220642-670890229854
 	github.com/apache/thrift v0.0.0-20181211084444-2b7365c54f82 // indirect
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
-	github.com/aws/aws-sdk-go v1.16.19
+	github.com/aws/aws-sdk-go v1.33.8
 	github.com/axiomhq/hyperloglog v0.0.0-20181223111420-4b99d0c2c99e
 	github.com/benesch/cgosymbolizer v0.0.0-20180702220239-70e1ee2b39d3
 	github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8
@@ -62,7 +62,7 @@ require (
 	github.com/frankban/quicktest v1.7.3 // indirect
 	github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9
 	github.com/go-ole/go-ole v1.2.2 // indirect
-	github.com/go-sql-driver/mysql v1.4.1-0.20181218123637-c45f530f8e7f
+	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gofrs/uuid v3.3.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang-commonmark/html v0.0.0-20180910111043-7d7c804e1d46 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/apache/thrift v0.0.0-20181211084444-2b7365c54f82/go.mod h1:cp2SuWMxlE
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/aws/aws-sdk-go v1.16.19 h1:eQypou1JciH0C87wYbj9uii0YVG3hS0S4UY78oWmUvM=
-github.com/aws/aws-sdk-go v1.16.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.33.8 h1:2/sOfb9oPHTRZ0lxinoaTPDcYwNa1H/SpKP4nVRBwmg=
+github.com/aws/aws-sdk-go v1.33.8/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/axiomhq/hyperloglog v0.0.0-20181223111420-4b99d0c2c99e h1:190ugM9MsyFauTkR/UqcHG/mn5nmFe6SvHJqEHIrtrA=
 github.com/axiomhq/hyperloglog v0.0.0-20181223111420-4b99d0c2c99e/go.mod h1:IOXAcuKIFq/mDyuQ4wyJuJ79XLMsmLM+5RdQ+vWrL7o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
@@ -271,8 +271,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-ole/go-ole v1.2.2 h1:QNWhweRd9D5Py2rRVboZ2L4SEoW/dyraWJCc8bgS8kE=
 github.com/go-ole/go-ole v1.2.2/go.mod h1:pnvuG7BrDMZ8ifMurTQmxwhQM/odqm9sSqNe5BUI7v4=
-github.com/go-sql-driver/mysql v1.4.1-0.20181218123637-c45f530f8e7f h1:V53hwNJdyT/R1Vd4oIoQllhkt6m+czKLY4MIgYr3wgA=
-github.com/go-sql-driver/mysql v1.4.1-0.20181218123637-c45f530f8e7f/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
@@ -439,8 +439,8 @@ github.com/jcmturner/gokrb5/v8 v8.2.0 h1:lzPl/30ZLkTveYsYZPKMcgXc8MbnE6RsTd4F9Kg
 github.com/jcmturner/gokrb5/v8 v8.2.0/go.mod h1:T1hnNppQsBtxW0tCHMHTkAt8n/sABdzZgZdoFrZaZNM=
 github.com/jcmturner/rpc/v2 v2.0.2 h1:gMB4IwRXYsWw4Bc6o/az2HJgFUA1ffSh90i26ZJ6Xl0=
 github.com/jcmturner/rpc/v2 v2.0.2/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
-github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jordanlewis/gcassert v0.0.0-20200706043056-bf61eb72ee48 h1:d1Ov7s7RbMdHcgE1Eh1CxR+yd2TTKYOCHZf92Tm/fLs=
 github.com/jordanlewis/gcassert v0.0.0-20200706043056-bf61eb72ee48/go.mod h1:Qc93dJSt1iLNJCuG9Gy9ds0k/oh4ckhXGkD4AI3cEtM=
@@ -775,6 +775,7 @@ golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7 h1:AeiKBIuRw3UomYXSbLy0Mc2dDLfdtbT/IVn4keq83P0=

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -528,6 +528,8 @@ type TempStorageConfig struct {
 
 // ExternalIODirConfig describes various configuration options pertaining
 // to external storage implementations.
+// TODO(adityamaru): Rename ExternalIODirConfig to ExternalIOConfig because it
+// is now used to configure both ExternalStorage and KMS.
 type ExternalIODirConfig struct {
 	// Disables the use of external HTTP endpoints.
 	// This turns off http:// external storage as well as any custom

--- a/pkg/ccl/backupccl/backup_cloud_test.go
+++ b/pkg/ccl/backupccl/backup_cloud_test.go
@@ -56,8 +56,8 @@ func TestCloudBackupRestoreS3(t *testing.T) {
 	prefix := fmt.Sprintf("TestBackupRestoreS3-%d", timeutil.Now().UnixNano())
 	uri := url.URL{Scheme: "s3", Host: bucket, Path: prefix}
 	values := uri.Query()
-	values.Add(cloudimpl.S3AccessKeyParam, creds.AccessKeyID)
-	values.Add(cloudimpl.S3SecretParam, creds.SecretAccessKey)
+	values.Add(cloudimpl.AWSAccessKeyParam, creds.AccessKeyID)
+	values.Add(cloudimpl.AWSSecretParam, creds.SecretAccessKey)
 	uri.RawQuery = values.Encode()
 
 	backupAndRestore(ctx, t, tc, []string{uri.String()}, []string{uri.String()}, numAccounts)

--- a/pkg/storage/cloud/kms.go
+++ b/pkg/storage/cloud/kms.go
@@ -1,0 +1,75 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cloud
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/fmtsafe/testdata/src/github.com/cockroachdb/errors"
+)
+
+// KMS provides an API to interact with a KMS service.
+type KMS interface {
+	// MasterKeyID will return the identifier used to reference the master key
+	// associated with the KMS object.
+	MasterKeyID() (string, error)
+	// Encrypt returns the ciphertext version of data after encrypting it using
+	// the KMS.
+	Encrypt(ctx context.Context, data []byte) ([]byte, error)
+	// Decrypt returns the plaintext version of data after decrypting it using the
+	// KMS.
+	Decrypt(ctx context.Context, data []byte) ([]byte, error)
+	// Close may be used to perform the necessary cleanup and shutdown of the
+	// KMS connection.
+	Close() error
+}
+
+// KMSEnv is the environment in which a KMS is configured and used.
+type KMSEnv interface {
+	ClusterSettings() *cluster.Settings
+	KMSConfig() *base.ExternalIODirConfig
+}
+
+// KMSFromURIFactory describes a factory function for KMS given a URI.
+type KMSFromURIFactory func(uri string, env KMSEnv) (KMS, error)
+
+// Mapping from KMS scheme to its registered factory method.
+var kmsFactoryMap = make(map[string]KMSFromURIFactory)
+
+// RegisterKMSFromURIFactory is used by every concrete KMS implementation to
+// register its factory method.
+func RegisterKMSFromURIFactory(factory KMSFromURIFactory, scheme string) {
+	if _, ok := kmsFactoryMap[scheme]; ok {
+		panic("factory method for " + scheme + " has already been registered")
+	}
+	kmsFactoryMap[scheme] = factory
+}
+
+// KMSFromURI is the method used to create a KMS instance from the provided URI.
+func KMSFromURI(uri string, env KMSEnv) (KMS, error) {
+	var kmsURL *url.URL
+	var err error
+	if kmsURL, err = url.ParseRequestURI(uri); err != nil {
+		return nil, err
+	}
+
+	// Find the factory method for the given KMS scheme.
+	var factory KMSFromURIFactory
+	var ok bool
+	if factory, ok = kmsFactoryMap[kmsURL.Scheme]; !ok {
+		return nil, errors.Newf("no factory method found for scheme %s", kmsURL.Scheme)
+	}
+
+	return factory(uri, env)
+}

--- a/pkg/storage/cloudimpl/aws_kms.go
+++ b/pkg/storage/cloudimpl/aws_kms.go
@@ -1,0 +1,190 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cloudimpl
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
+	"github.com/cockroachdb/errors"
+)
+
+const awsScheme = "aws"
+
+type awsKMS struct {
+	kms                 *kms.KMS
+	customerMasterKeyID string
+}
+
+var _ cloud.KMS = &awsKMS{}
+
+func init() {
+	cloud.RegisterKMSFromURIFactory(MakeAWSKMS, awsScheme)
+}
+
+type kmsURIParams struct {
+	accessKey string
+	secret    string
+	tempToken string
+	endpoint  string
+	region    string
+	auth      string
+}
+
+func resolveKMSURIParams(kmsURI url.URL) kmsURIParams {
+	params := kmsURIParams{
+		accessKey: kmsURI.Query().Get(AWSAccessKeyParam),
+		secret:    kmsURI.Query().Get(AWSSecretParam),
+		tempToken: kmsURI.Query().Get(AWSTempTokenParam),
+		endpoint:  kmsURI.Query().Get(AWSEndpointParam),
+		region:    kmsURI.Query().Get(KMSRegionParam),
+		auth:      kmsURI.Query().Get(AuthParam),
+	}
+
+	// AWS secrets often contain + characters, which must be escaped when
+	// included in a query string; otherwise, they represent a space character.
+	// More than a few users have been bitten by this.
+	//
+	// Luckily, AWS secrets are base64-encoded data and thus will never actually
+	// contain spaces. We can convert any space characters we see to +
+	// characters to recover the original secret.
+	params.secret = strings.Replace(params.secret, " ", "+", -1)
+	return params
+}
+
+// MakeAWSKMS is the factory method which returns a configured, ready-to-use
+// AWS KMS object.
+func MakeAWSKMS(uri string, env cloud.KMSEnv) (cloud.KMS, error) {
+	kmsURI, err := url.ParseRequestURI(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the URI parameters required to setup the AWS KMS session.
+	kmsURIParams := resolveKMSURIParams(*kmsURI)
+	region := kmsURIParams.region
+	awsConfig := &aws.Config{
+		Credentials: credentials.NewStaticCredentials(kmsURIParams.accessKey,
+			kmsURIParams.secret, kmsURIParams.tempToken),
+	}
+	if kmsURIParams.endpoint != "" {
+		if env.KMSConfig().DisableHTTP {
+			return nil, errors.New(
+				"custom endpoints disallowed for aws kms due to --aws-kms-disable-http flag")
+		}
+		awsConfig.Endpoint = &kmsURIParams.endpoint
+		if region == "" {
+			// TODO(adityamaru): Think about what the correct way to handle this
+			// situation is.
+			region = "default-region"
+		}
+		client, err := makeHTTPClient(env.ClusterSettings())
+		if err != nil {
+			return nil, err
+		}
+		awsConfig.HTTPClient = client
+	}
+
+	// "specified": use credentials provided in URI params; error if not present.
+	// "implicit": enable SharedConfig, which loads in credentials from environment.
+	//             Detailed in https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
+	// "": default to `specified`.
+	opts := session.Options{}
+	switch kmsURIParams.auth {
+	case "", AuthParamSpecified:
+		if kmsURIParams.accessKey == "" {
+			return nil, errors.Errorf(
+				"%s is set to '%s', but %s is not set",
+				AuthParam,
+				AuthParamSpecified,
+				AWSAccessKeyParam,
+			)
+		}
+		if kmsURIParams.secret == "" {
+			return nil, errors.Errorf(
+				"%s is set to '%s', but %s is not set",
+				AuthParam,
+				AuthParamSpecified,
+				AWSSecretParam,
+			)
+		}
+		opts.Config.MergeIn(awsConfig)
+	case AuthParamImplicit:
+		if env.KMSConfig().DisableImplicitCredentials {
+			return nil, errors.New(
+				"implicit credentials disallowed for s3 due to --external-io-implicit-credentials flag")
+		}
+		opts.SharedConfigState = session.SharedConfigEnable
+	default:
+		return nil, errors.Errorf("unsupported value %s for %s", kmsURIParams.auth, AuthParam)
+	}
+
+	sess, err := session.NewSessionWithOptions(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "new aws session")
+	}
+	if region == "" {
+		// TODO(adityamaru): Maybe use the KeyID to get the region, similar to how
+		// we infer the region from the bucket for s3_storage.
+		return nil, errors.New("could not find the aws kms region")
+	}
+	sess.Config.Region = aws.String(region)
+	return &awsKMS{
+		kms:                 kms.New(sess),
+		customerMasterKeyID: strings.TrimPrefix(kmsURI.Path, "/"),
+	}, nil
+}
+
+// MasterKeyID implements the KMS interface.
+func (k *awsKMS) MasterKeyID() (string, error) {
+	return k.customerMasterKeyID, nil
+}
+
+// Encrypt implements the KMS interface.
+func (k *awsKMS) Encrypt(ctx context.Context, data []byte) ([]byte, error) {
+	encryptInput := &kms.EncryptInput{
+		KeyId:     &k.customerMasterKeyID,
+		Plaintext: data,
+	}
+
+	encryptOutput, err := k.kms.Encrypt(encryptInput)
+	if err != nil {
+		return nil, err
+	}
+
+	return encryptOutput.CiphertextBlob, nil
+}
+
+// Decrypt implements the KMS interface.
+func (k *awsKMS) Decrypt(ctx context.Context, data []byte) ([]byte, error) {
+	decryptInput := &kms.DecryptInput{
+		KeyId:          &k.customerMasterKeyID,
+		CiphertextBlob: data,
+	}
+
+	decryptOutput, err := k.kms.Decrypt(decryptInput)
+	if err != nil {
+		return nil, err
+	}
+
+	return decryptOutput.Plaintext, nil
+}
+
+// Close implements the KMS interface.
+func (k *awsKMS) Close() error {
+	return nil
+}

--- a/pkg/storage/cloudimpl/cloudimpltests/aws_kms_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/aws_kms_test.go
@@ -1,0 +1,168 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package cloudimpltests
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+var awsKMSTestSettings *cluster.Settings
+
+func init() {
+	awsKMSTestSettings = cluster.MakeTestingClusterSettings()
+}
+
+func TestEncryptDecryptAWS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// If environment credentials are not present, we want to
+	// skip all AWS KMS tests, including auth-implicit, even though
+	// it is not used in auth-implicit.
+	_, err := credentials.NewEnvCredentials().Get()
+	if err != nil {
+		skip.IgnoreLint(t, "Test only works with AWS credentials")
+	}
+
+	q := make(url.Values)
+	expect := map[string]string{
+		"AWS_ACCESS_KEY_ID":     cloudimpl.AWSAccessKeyParam,
+		"AWS_SECRET_ACCESS_KEY": cloudimpl.AWSSecretParam,
+		"AWS_REGION":            cloudimpl.KMSRegionParam,
+	}
+	for env, param := range expect {
+		v := os.Getenv(env)
+		if v == "" {
+			skip.IgnoreLintf(t, "%s env var must be set", env)
+		}
+		q.Add(param, v)
+	}
+
+	// Get AWS Key ARN from env variable.
+	// TODO(adityamaru): Check if there is a way to specify this in the default
+	// role and if we can derive it from there instead?
+	keyARN := os.Getenv("AWS_KEY_ARN")
+	if keyARN == "" {
+		skip.IgnoreLint(t, "AWS_KEY_ARN env var must be set")
+	}
+
+	t.Run("auth-empty-no-cred", func(t *testing.T) {
+		// Set AUTH to specified but don't provide AccessKey params.
+		params := make(url.Values)
+		params.Add(cloudimpl.AuthParam, cloudimpl.AuthParamSpecified)
+
+		uri := fmt.Sprintf("aws:///%s?%s", keyARN, params.Encode())
+		_, err := cloud.KMSFromURI(uri, &testKMSEnv{})
+		require.EqualError(t, err, fmt.Sprintf(
+			`%s is set to '%s', but %s is not set`,
+			cloudimpl.AuthParam,
+			cloudimpl.AuthParamSpecified,
+			cloudimpl.AWSAccessKeyParam,
+		))
+	})
+
+	t.Run("auth-implicit", func(t *testing.T) {
+		// You can create an IAM that can access AWS KMS
+		// in the AWS console, then set it up locally.
+		// https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html
+		// We only run this test if default role exists.
+		credentialsProvider := credentials.SharedCredentialsProvider{}
+		_, err := credentialsProvider.Retrieve()
+		if err != nil {
+			skip.IgnoreLint(t, err)
+		}
+
+		// Set AUTH to implicit
+		q.Set(cloudimpl.AuthParam, cloudimpl.AuthParamImplicit)
+
+		uri := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
+		testEncryptDecrypt(t, uri, testKMSEnv{
+			cluster.NoSettings, &base.ExternalIODirConfig{},
+		})
+	})
+
+	t.Run("auth-specified", func(t *testing.T) {
+		// Set AUTH to specified.
+		q.Set(cloudimpl.AuthParam, cloudimpl.AuthParamSpecified)
+		uri := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
+
+		testEncryptDecrypt(t, uri, testKMSEnv{
+			cluster.NoSettings, &base.ExternalIODirConfig{},
+		})
+	})
+}
+
+func TestPutAWSKMSEndpoint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	q := make(url.Values)
+	expect := map[string]string{
+		"AWS_KMS_ENDPOINT":        cloudimpl.AWSEndpointParam,
+		"AWS_KMS_ENDPOINT_KEY":    cloudimpl.AWSAccessKeyParam,
+		"AWS_KMS_ENDPOINT_REGION": cloudimpl.KMSRegionParam,
+		"AWS_KMS_ENDPOINT_SECRET": cloudimpl.AWSSecretParam,
+	}
+	for env, param := range expect {
+		v := os.Getenv(env)
+		if v == "" {
+			skip.IgnoreLintf(t, "%s env var must be set", env)
+		}
+		q.Add(param, v)
+	}
+
+	keyARN := os.Getenv("AWS_KMS_KEY_ARN")
+	if keyARN == "" {
+		skip.IgnoreLint(t, "AWS_KMS_KEY_ARN env var must be set")
+	}
+
+	t.Run("allow-endpoints", func(t *testing.T) {
+		uri := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
+		testEncryptDecrypt(t, uri, testKMSEnv{
+			awsKMSTestSettings, &base.ExternalIODirConfig{},
+		})
+	})
+
+	t.Run("disallow-endpoints", func(t *testing.T) {
+		uri := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
+		_, err := cloud.KMSFromURI(uri, &testKMSEnv{awsKMSTestSettings,
+			&base.ExternalIODirConfig{DisableHTTP: true}})
+		require.True(t, testutils.IsError(err, "custom endpoints disallowed"))
+	})
+}
+
+func TestAWSKMSDisallowImplicitCredentials(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	q := make(url.Values)
+	q.Add("AWS_REGION", cloudimpl.KMSRegionParam)
+
+	// Set AUTH to implicit
+	q.Add(cloudimpl.AuthParam, cloudimpl.AuthParamImplicit)
+
+	keyARN := os.Getenv("AWS_KMS_KEY_ARN")
+	if keyARN == "" {
+		skip.IgnoreLint(t, "AWS_KMS_KEY_ARN env var must be set")
+	}
+	uri := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
+	_, err := cloud.KMSFromURI(uri, &testKMSEnv{cluster.NoSettings,
+		&base.ExternalIODirConfig{DisableImplicitCredentials: true}})
+	require.True(t, testutils.IsError(err, "implicit credentials disallowed"))
+}

--- a/pkg/storage/cloudimpl/cloudimpltests/kms_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/kms_test.go
@@ -1,0 +1,54 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package cloudimpltests
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
+	"github.com/stretchr/testify/require"
+)
+
+type testKMSEnv struct {
+	settings         *cluster.Settings
+	externalIOConfig *base.ExternalIODirConfig
+}
+
+var _ cloud.KMSEnv = &testKMSEnv{}
+
+func (e *testKMSEnv) ClusterSettings() *cluster.Settings {
+	return e.settings
+}
+
+func (e *testKMSEnv) KMSConfig() *base.ExternalIODirConfig {
+	return e.externalIOConfig
+}
+
+func testEncryptDecrypt(t *testing.T, kmsURI string, env testKMSEnv) {
+	ctx := context.Background()
+	kms, err := cloud.KMSFromURI(kmsURI, &env)
+	require.NoError(t, err)
+
+	t.Run("simple encrypt decrypt", func(t *testing.T) {
+		sampleBytes := "hello world"
+
+		encryptedBytes, err := kms.Encrypt(ctx, []byte(sampleBytes))
+		require.NoError(t, err)
+
+		decryptedBytes, err := kms.Decrypt(ctx, encryptedBytes)
+		require.NoError(t, err)
+
+		require.True(t, bytes.Equal(decryptedBytes, []byte(sampleBytes)))
+	})
+}

--- a/pkg/storage/cloudimpl/cloudimpltests/s3_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/s3_storage_test.go
@@ -55,7 +55,7 @@ func TestPutS3(t *testing.T) {
 			`%s is set to '%s', but %s is not set`,
 			cloudimpl.AuthParam,
 			cloudimpl.AuthParamSpecified,
-			cloudimpl.S3AccessKeyParam,
+			cloudimpl.AWSAccessKeyParam,
 		))
 	})
 	t.Run("auth-implicit", func(t *testing.T) {
@@ -80,15 +80,15 @@ func TestPutS3(t *testing.T) {
 		testExportStore(t, fmt.Sprintf(
 			"s3://%s/%s?%s=%s&%s=%s",
 			bucket, "backup-test",
-			cloudimpl.S3AccessKeyParam, url.QueryEscape(creds.AccessKeyID),
-			cloudimpl.S3SecretParam, url.QueryEscape(creds.SecretAccessKey),
+			cloudimpl.AWSAccessKeyParam, url.QueryEscape(creds.AccessKeyID),
+			cloudimpl.AWSSecretParam, url.QueryEscape(creds.SecretAccessKey),
 		), false, user, nil, nil)
 		testListFiles(t,
 			fmt.Sprintf(
 				"s3://%s/%s?%s=%s&%s=%s",
 				bucket, "listing-test",
-				cloudimpl.S3AccessKeyParam, url.QueryEscape(creds.AccessKeyID),
-				cloudimpl.S3SecretParam, url.QueryEscape(creds.SecretAccessKey),
+				cloudimpl.AWSAccessKeyParam, url.QueryEscape(creds.AccessKeyID),
+				cloudimpl.AWSSecretParam, url.QueryEscape(creds.SecretAccessKey),
 			),
 			user, nil, nil,
 		)
@@ -100,10 +100,10 @@ func TestPutS3Endpoint(t *testing.T) {
 
 	q := make(url.Values)
 	expect := map[string]string{
-		"AWS_S3_ENDPOINT":        cloudimpl.S3EndpointParam,
-		"AWS_S3_ENDPOINT_KEY":    cloudimpl.S3AccessKeyParam,
+		"AWS_S3_ENDPOINT":        cloudimpl.AWSEndpointParam,
+		"AWS_S3_ENDPOINT_KEY":    cloudimpl.AWSAccessKeyParam,
 		"AWS_S3_ENDPOINT_REGION": cloudimpl.S3RegionParam,
-		"AWS_S3_ENDPOINT_SECRET": cloudimpl.S3SecretParam,
+		"AWS_S3_ENDPOINT_SECRET": cloudimpl.AWSSecretParam,
 	}
 	for env, param := range expect {
 		v := os.Getenv(env)
@@ -161,10 +161,10 @@ func TestS3BucketDoesNotExist(t *testing.T) {
 
 	q := make(url.Values)
 	expect := map[string]string{
-		"AWS_S3_ENDPOINT":        cloudimpl.S3EndpointParam,
-		"AWS_S3_ENDPOINT_KEY":    cloudimpl.S3AccessKeyParam,
+		"AWS_S3_ENDPOINT":        cloudimpl.AWSEndpointParam,
+		"AWS_S3_ENDPOINT_KEY":    cloudimpl.AWSAccessKeyParam,
 		"AWS_S3_ENDPOINT_REGION": cloudimpl.S3RegionParam,
-		"AWS_S3_ENDPOINT_SECRET": cloudimpl.S3SecretParam,
+		"AWS_S3_ENDPOINT_SECRET": cloudimpl.AWSSecretParam,
 	}
 	for env, param := range expect {
 		v := os.Getenv(env)

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -35,16 +35,20 @@ import (
 )
 
 const (
-	// S3AccessKeyParam is the query parameter for access_key in an S3 URI.
-	S3AccessKeyParam = "AWS_ACCESS_KEY_ID"
-	// S3SecretParam is the query parameter for the 'secret' in an S3 URI.
-	S3SecretParam = "AWS_SECRET_ACCESS_KEY"
-	// S3TempTokenParam is the query parameter for session_token in an S3 URI.
-	S3TempTokenParam = "AWS_SESSION_TOKEN"
-	// S3EndpointParam is the query parameter for the 'endpoint' in an S3 URI.
-	S3EndpointParam = "AWS_ENDPOINT"
+	// AWSAccessKeyParam is the query parameter for access_key in an AWS URI.
+	AWSAccessKeyParam = "AWS_ACCESS_KEY_ID"
+	// AWSSecretParam is the query parameter for the 'secret' in an AWS URI.
+	AWSSecretParam = "AWS_SECRET_ACCESS_KEY"
+	// AWSTempTokenParam is the query parameter for session_token in an AWS URI.
+	AWSTempTokenParam = "AWS_SESSION_TOKEN"
+	// AWSEndpointParam is the query parameter for the 'endpoint' in an AWS URI.
+	AWSEndpointParam = "AWS_ENDPOINT"
+
 	// S3RegionParam is the query parameter for the 'endpoint' in an S3 URI.
 	S3RegionParam = "AWS_REGION"
+
+	// KMSRegionParam is the query parameter for the 'region' in every KMS URI.
+	KMSRegionParam = "REGION"
 
 	// AzureAccountNameParam is the query parameter for account_name in an azure URI.
 	AzureAccountNameParam = "AZURE_ACCOUNT_NAME"
@@ -94,8 +98,8 @@ const (
 
 // See SanitizeExternalStorageURI.
 var redactedQueryParams = map[string]struct{}{
-	S3SecretParam:        {},
-	S3TempTokenParam:     {},
+	AWSSecretParam:       {},
+	AWSTempTokenParam:    {},
 	AzureAccountKeyParam: {},
 	CredentialsParam:     {},
 }
@@ -121,10 +125,10 @@ func ExternalStorageConfFromURI(path, user string) (roachpb.ExternalStorage, err
 		conf.S3Config = &roachpb.ExternalStorage_S3{
 			Bucket:    uri.Host,
 			Prefix:    uri.Path,
-			AccessKey: uri.Query().Get(S3AccessKeyParam),
-			Secret:    uri.Query().Get(S3SecretParam),
-			TempToken: uri.Query().Get(S3TempTokenParam),
-			Endpoint:  uri.Query().Get(S3EndpointParam),
+			AccessKey: uri.Query().Get(AWSAccessKeyParam),
+			Secret:    uri.Query().Get(AWSSecretParam),
+			TempToken: uri.Query().Get(AWSTempTokenParam),
+			Endpoint:  uri.Query().Get(AWSEndpointParam),
 			Region:    uri.Query().Get(S3RegionParam),
 			Auth:      uri.Query().Get(AuthParam),
 			/* NB: additions here should also update s3QueryParams() serializer */

--- a/pkg/storage/cloudimpl/s3_storage.go
+++ b/pkg/storage/cloudimpl/s3_storage.go
@@ -47,10 +47,10 @@ func s3QueryParams(conf *roachpb.ExternalStorage_S3) string {
 			q.Set(key, value)
 		}
 	}
-	setIf(S3AccessKeyParam, conf.AccessKey)
-	setIf(S3SecretParam, conf.Secret)
-	setIf(S3TempTokenParam, conf.TempToken)
-	setIf(S3EndpointParam, conf.Endpoint)
+	setIf(AWSAccessKeyParam, conf.AccessKey)
+	setIf(AWSSecretParam, conf.Secret)
+	setIf(AWSTempTokenParam, conf.TempToken)
+	setIf(AWSEndpointParam, conf.Endpoint)
 	setIf(S3RegionParam, conf.Region)
 	setIf(AuthParam, conf.Auth)
 
@@ -97,7 +97,7 @@ func MakeS3Storage(
 				"%s is set to '%s', but %s is not set",
 				AuthParam,
 				AuthParamSpecified,
-				S3AccessKeyParam,
+				AWSAccessKeyParam,
 			)
 		}
 		if conf.Secret == "" {
@@ -105,7 +105,7 @@ func MakeS3Storage(
 				"%s is set to '%s', but %s is not set",
 				AuthParam,
 				AuthParamSpecified,
-				S3SecretParam,
+				AWSSecretParam,
 			)
 		}
 		opts.Config.MergeIn(config)


### PR DESCRIPTION
This change introduces a KMS API and a concrete implementation of the
AWS KMS service. It also adds a simple encrypt-decrypt unit test.

This is v2 of the API, discussions about v1 can be found at #51779.

Release note: None