### PR TITLE
sql: check volatility of all operators

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -369,7 +369,7 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN ((SELECT 1))
 )
 
-statement error PARTITION p1: now\(\): context-dependent functions are not allowed in partition
+statement error PARTITION p1: now\(\): context-dependent operators are not allowed in partition
 CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (now())
 )
@@ -379,7 +379,7 @@ CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (uuid_v4() || 'foo')
 )
 
-statement error PARTITION p1: 'now'::TIMESTAMP: partition values must be constant
+statement error PARTITION p1: string::timestamp: context-dependent operators are not allowed in partition
 CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN ('now')
 )

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -289,9 +289,22 @@ CREATE TABLE y (
   b INT AS (a) STORED
 )
 
-statement error context-dependent functions are not allowed in computed column
+statement error context-dependent operators are not allowed in computed column
 CREATE TABLE y (
   a TIMESTAMP AS (now()) STORED
+)
+
+statement error context-dependent operators are not allowed in computed column
+CREATE TABLE y (
+  a STRING,
+  b TIMESTAMPTZ AS (a::TIMESTAMPTZ) STORED
+)
+
+statement error context-dependent operators are not allowed in computed column
+CREATE TABLE y (
+  a TIMESTAMPTZ,
+  b INTERVAL,
+  c TIMESTAMPTZ AS (a+ b) STORED
 )
 
 statement error volatile functions are not allowed in computed column

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -24,12 +24,18 @@ CREATE TABLE error (a INT, INDEX (a) WHERE 1)
 statement error pgcode 42703 column "b" does not exist
 CREATE TABLE error (a INT, INDEX (a) WHERE b = 3)
 
-# Don't allow mutable functions.
+# Don't allow non-immutable operators.
 # TODO(mgartner): The error code for this should be 42P17, not 0A000.
-statement error pgcode 0A000 context-dependent functions are not allowed in index predicate
+statement error pgcode 0A000 now\(\): context-dependent operators are not allowed in index predicate
 CREATE TABLE error (t TIMESTAMPTZ, INDEX (t) WHERE t < now())
 
-statement error pgcode 0A000 volatile functions are not allowed in index predicate
+statement error pgcode 0A000 timestamptz::string: context-dependent operators are not allowed in index predicate
+CREATE TABLE error (t TIMESTAMPTZ, INDEX (t) WHERE t::string = 'foo')
+
+statement error pgcode 0A000 =: context-dependent operators are not allowed in index predicate
+CREATE TABLE error (t TIMESTAMPTZ, i TIMESTAMP, INDEX (t) WHERE i = t)
+
+statement error pgcode 0A000 random\(\): volatile functions are not allowed in index predicate
 CREATE TABLE error (t FLOAT, INDEX (t) WHERE t < random())
 
 # Don't allow variable subexpressions.

--- a/pkg/sql/sem/tree/datum_invariants_test.go
+++ b/pkg/sql/sem/tree/datum_invariants_test.go
@@ -27,7 +27,7 @@ func TestAllTypesCastableToString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	for _, typ := range types.Scalar {
-		if ok, _ := isCastDeepValid(typ, types.String); !ok {
+		if ok, _, _ := isCastDeepValid(typ, types.String); !ok {
 			t.Errorf("%s is not castable to STRING, all types should be", typ)
 		}
 	}
@@ -37,7 +37,7 @@ func TestAllTypesCastableFromString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	for _, typ := range types.Scalar {
-		if ok, _ := isCastDeepValid(types.String, typ); !ok {
+		if ok, _, _ := isCastDeepValid(types.String, typ); !ok {
 			t.Errorf("%s is not castable from STRING, all types should be", typ)
 		}
 	}

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -55,9 +55,7 @@ func SanitizeVarFreeExpr(
 
 	switch maxVolatility {
 	case tree.VolatilityImmutable:
-		// TODO(radu): we only check the volatility of functions; we need to check
-		// the volatility of operators and casts as well!
-		flags |= tree.RejectStableFunctions
+		flags |= tree.RejectStableOperators
 		fallthrough
 
 	case tree.VolatilityStable:


### PR DESCRIPTION
`TypeCheck` supports flags that cause it to error out if it encounters
volatile or stable functions. This change generalizes this
infrastructure to cover potentially stable operators and casts as
well.

Fixes #51228.

Release note (bug fix): better detection of invalid computed column or
partial index predicates that contain context-dependent operators.