### PR TITLE
geo: order geospatial objects by Hilbert Curve index

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -14,6 +14,7 @@ package geo
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geographiclib"
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
@@ -276,6 +277,57 @@ func (g *Geometry) CartesianBoundingBox() *CartesianBoundingBox {
 	return &CartesianBoundingBox{BoundingBox: *g.spatialObject.BoundingBox}
 }
 
+// SpaceCurveIndex returns an uint64 index to use representing an index into a space-filling curve.
+// This will return 0 for empty spatial objects, and math.MaxUint64 for any object outside
+// the defined bounds of the given SRID projection.
+func (g *Geometry) SpaceCurveIndex() uint64 {
+	bbox := g.CartesianBoundingBox()
+	if bbox == nil {
+		return 0
+	}
+	centerX := (bbox.BoundingBox.LoX + bbox.BoundingBox.HiX) / 2
+	centerY := (bbox.BoundingBox.LoY + bbox.BoundingBox.HiY) / 2
+	// By default, bound by MaxInt32 (we have not typically seen bounds greater than 1B).
+	bounds := geoprojbase.Bounds{
+		MinX: math.MinInt32,
+		MaxX: math.MaxInt32,
+		MinY: math.MinInt32,
+		MaxY: math.MaxInt32,
+	}
+	if proj, ok := geoprojbase.Projection(g.SRID()); ok {
+		bounds = proj.Bounds
+	}
+	// If we're out of bounds, give up and return a large number.
+	if centerX > bounds.MaxX || centerY > bounds.MaxY || centerX < bounds.MinX || centerY < bounds.MinY {
+		return math.MaxUint64
+	}
+
+	const boxLength = 1 << 32
+	// Add 1 to each bound so that we normalize the coordinates to [0, 1) before
+	// multiplying by boxLength to give coordinates that are integers in the interval [0, boxLength-1].
+	xBounds := (bounds.MaxX - bounds.MinX) + 1
+	yBounds := (bounds.MaxY - bounds.MinY) + 1
+	// hilbertInverse returns values in the interval [0, boxLength^2-1], so return [0, 2^64-1].
+	xPos := uint64(((centerX - bounds.MinX) / xBounds) * boxLength)
+	yPos := uint64(((centerY - bounds.MinY) / yBounds) * boxLength)
+	return hilbertInverse(boxLength, xPos, yPos)
+}
+
+// Compare compares a Geometry against another.
+// It compares using SpaceCurveIndex, followed by the byte representation of the Geometry.
+// This must produce the same ordering as the index mechanism.
+func (g *Geometry) Compare(o *Geometry) int {
+	lhs := g.SpaceCurveIndex()
+	rhs := o.SpaceCurveIndex()
+	if lhs > rhs {
+		return 1
+	}
+	if lhs < rhs {
+		return -1
+	}
+	return compareSpatialObjectBytes(g.SpatialObject(), o.SpatialObject())
+}
+
 //
 // Geography
 //
@@ -489,6 +541,35 @@ func (g *Geography) BoundingCap() s2.Cap {
 	return g.BoundingRect().CapBound()
 }
 
+// SpaceCurveIndex returns an uint64 index to use representing an index into a space-filling curve.
+// This will return 0 for empty spatial objects.
+func (g *Geography) SpaceCurveIndex() uint64 {
+	rect := g.BoundingRect()
+	if rect.IsEmpty() {
+		return 0
+	}
+	return uint64(s2.CellIDFromLatLng(rect.Center()))
+}
+
+// Compare compares a Geography against another.
+// It compares using SpaceCurveIndex, followed by the byte representation of the Geography.
+// This must produce the same ordering as the index mechanism.
+func (g *Geography) Compare(o *Geography) int {
+	lhs := g.SpaceCurveIndex()
+	rhs := o.SpaceCurveIndex()
+	if lhs > rhs {
+		return 1
+	}
+	if lhs < rhs {
+		return -1
+	}
+	return compareSpatialObjectBytes(g.SpatialObject(), o.SpatialObject())
+}
+
+//
+// Common
+//
+
 // IsLinearRingCCW returns whether a given linear ring is counter clock wise.
 // See 2.07 of http://www.faqs.org/faqs/graphics/algorithms-faq/.
 // "Find the lowest vertex (or, if  there is more than one vertex with the same lowest coordinate,
@@ -617,10 +698,6 @@ func S2RegionsFromGeomT(geomRepr geom.T, emptyBehavior EmptyBehavior) ([]s2.Regi
 	}
 	return regions, nil
 }
-
-//
-// Common
-//
 
 // normalizeLngLat normalizes geographical coordinates into a valid range.
 func normalizeLngLat(lng float64, lat float64) (float64, float64) {
@@ -789,9 +866,10 @@ func GeomTContainsEmpty(g geom.T) bool {
 	return false
 }
 
-// CompareSpatialObject compares the SpatialObject.
-// This must match the byte ordering that is be produced by encoding.EncodeGeoAscending.
-func CompareSpatialObject(lhs geopb.SpatialObject, rhs geopb.SpatialObject) int {
+// compareSpatialObjectBytes compares the SpatialObject if they were serialized.
+// This is used for comparison operations, and must be kept consistent with the indexing
+// encoding.
+func compareSpatialObjectBytes(lhs geopb.SpatialObject, rhs geopb.SpatialObject) int {
 	marshalledLHS, err := protoutil.Marshal(&lhs)
 	if err != nil {
 		panic(err)

--- a/pkg/geo/hilbert.go
+++ b/pkg/geo/hilbert.go
@@ -1,0 +1,44 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geo
+
+// hilbertInverse converts (x,y) to d on a Hilbert Curve.
+// Adapted from `xy2d` from https://en.wikipedia.org/wiki/Hilbert_curve#Applications_and_mapping_algorithms.
+func hilbertInverse(n, x, y uint64) uint64 {
+	var d uint64
+	for s := n / 2; s > 0; s /= 2 {
+		var rx uint64
+		if (x & s) > 0 {
+			rx = 1
+		}
+		var ry uint64
+		if (y & s) > 0 {
+			ry = 1
+		}
+		d += s * s * ((3 * rx) ^ ry)
+		x, y = hilbertRotate(n, x, y, rx, ry)
+	}
+	return d
+}
+
+// hilberRoate rotates/flips a quadrant appropriately.
+// Adapted from `rot` in https://en.wikipedia.org/wiki/Hilbert_curve#Applications_and_mapping_algorithms.
+func hilbertRotate(n, x, y, rx, ry uint64) (uint64, uint64) {
+	if ry == 0 {
+		if rx == 1 {
+			x = n - 1 - x
+			y = n - 1 - y
+		}
+
+		x, y = y, x
+	}
+	return x, y
+}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2766,7 +2766,7 @@ func (d *DGeography) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	return geo.CompareSpatialObject(d.Geography.SpatialObject(), other.(*DGeography).SpatialObject())
+	return d.Geography.Compare(other.(*DGeography).Geography)
 }
 
 // Prev implements the Datum interface.
@@ -2874,7 +2874,7 @@ func (d *DGeometry) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	return geo.CompareSpatialObject(d.Geometry.SpatialObject(), other.(*DGeometry).SpatialObject())
+	return d.Geometry.Compare(other.(*DGeometry).Geometry)
 }
 
 // Prev implements the Datum interface.

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -97,15 +97,15 @@ func EncodeTableKey(b []byte, val tree.Datum, dir encoding.Direction) ([]byte, e
 	case *tree.DGeography:
 		so := t.Geography.SpatialObject()
 		if dir == encoding.Ascending {
-			return encoding.EncodeGeoAscending(b, &so)
+			return encoding.EncodeGeoAscending(b, t.Geography.SpaceCurveIndex(), &so)
 		}
-		return encoding.EncodeGeoDescending(b, &so)
+		return encoding.EncodeGeoDescending(b, t.Geography.SpaceCurveIndex(), &so)
 	case *tree.DGeometry:
 		so := t.Geometry.SpatialObject()
 		if dir == encoding.Ascending {
-			return encoding.EncodeGeoAscending(b, &so)
+			return encoding.EncodeGeoAscending(b, t.Geometry.SpaceCurveIndex(), &so)
 		}
-		return encoding.EncodeGeoDescending(b, &so)
+		return encoding.EncodeGeoDescending(b, t.Geometry.SpaceCurveIndex(), &so)
 	case *tree.DDate:
 		if dir == encoding.Ascending {
 			return encoding.EncodeVarintAscending(b, t.UnixEpochDaysWithOrig()), nil

--- a/pkg/sql/sqlbase/encoded_datum_test.go
+++ b/pkg/sql/sqlbase/encoded_datum_test.go
@@ -208,7 +208,7 @@ func TestEncDatumCompare(t *testing.T) {
 
 	for _, typ := range types.OidToType {
 		switch typ.Family() {
-		case types.AnyFamily, types.UnknownFamily, types.ArrayFamily, types.JsonFamily, types.TupleFamily, types.GeometryFamily, types.GeographyFamily:
+		case types.AnyFamily, types.UnknownFamily, types.ArrayFamily, types.JsonFamily, types.TupleFamily:
 			continue
 		case types.CollatedStringFamily:
 			typ = types.MakeCollatedString(types.String, *RandCollationLocale(rng))

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -16,6 +16,7 @@ import (
 	"math"
 	"math/rand"
 	"regexp"
+	"strconv"
 	"testing"
 	"time"
 
@@ -1147,37 +1148,115 @@ func TestEncodeDecodeTimeTZ(t *testing.T) {
 	}
 }
 
-func TestEncodeDecodeGeo(t *testing.T) {
-	testCases := []string{
-		"SRID=4326;POINT(1.0 1.0)",
-		"POINT(2.0 2.0)",
+func TestEncodeDecodeGeometry(t *testing.T) {
+	testCases := []struct {
+		orderedWKTs []string
+	}{
+		{
+			orderedWKTs: []string{
+				"SRID=4326;POLYGON EMPTY",
+				"SRID=4326;POINT EMPTY",
+				"SRID=4326;LINESTRING(0 0, -90 -80)",
+				"SRID=4326;POINT(-80 80)",
+				"SRID=4326;POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+			},
+		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc, func(t *testing.T) {
-			for _, dir := range []Direction{Ascending, Descending} {
+	for i, tc := range testCases {
+		for _, dir := range []Direction{Ascending, Descending} {
+			t.Run(strconv.Itoa(i+1), func(t *testing.T) {
 				t.Run(fmt.Sprintf("dir:%d", dir), func(t *testing.T) {
-					parsed, err := geo.ParseGeometry(tc)
-					require.NoError(t, err)
-					spatialObject := parsed.SpatialObject()
+					var lastEncoded []byte
+					for _, wkt := range tc.orderedWKTs {
+						parsed, err := geo.ParseGeometry(wkt)
+						require.NoError(t, err)
+						spatialObject := parsed.SpatialObject()
 
-					var b []byte
-					var decoded geopb.SpatialObject
-					if dir == Ascending {
-						b, err = EncodeGeoAscending(b, &spatialObject)
-						require.NoError(t, err)
-						_, decoded, err = DecodeGeoAscending(b)
-						require.NoError(t, err)
-					} else {
-						b, err = EncodeGeoDescending(b, &spatialObject)
-						require.NoError(t, err)
-						_, decoded, err = DecodeGeoDescending(b)
-						require.NoError(t, err)
+						var b []byte
+						var decoded geopb.SpatialObject
+						if dir == Ascending {
+							b, err = EncodeGeoAscending(b, parsed.SpaceCurveIndex(), &spatialObject)
+							require.NoError(t, err)
+							_, decoded, err = DecodeGeoAscending(b)
+							require.NoError(t, err)
+						} else {
+							b, err = EncodeGeoDescending(b, parsed.SpaceCurveIndex(), &spatialObject)
+							require.NoError(t, err)
+							_, decoded, err = DecodeGeoDescending(b)
+							require.NoError(t, err)
+						}
+						require.Equal(t, spatialObject, decoded)
+						testPeekLength(t, b)
+
+						if i > 0 {
+							if dir == Ascending {
+								assert.Truef(t, bytes.Compare(b, lastEncoded) > 0, "expected %s > %s", tc.orderedWKTs[i], tc.orderedWKTs[i-1])
+							} else {
+								assert.Truef(t, bytes.Compare(b, lastEncoded) < 0, "expected %s < %s", tc.orderedWKTs[i], tc.orderedWKTs[i-1])
+							}
+						}
+
+						lastEncoded = b
 					}
-					require.Equal(t, spatialObject, decoded)
-					testPeekLength(t, b)
 				})
-			}
-		})
+			})
+		}
+	}
+}
+
+func TestEncodeDecodeGeography(t *testing.T) {
+	testCases := []struct {
+		orderedWKTs []string
+	}{
+		{
+			orderedWKTs: []string{
+				"SRID=4326;POLYGON EMPTY",
+				"SRID=4326;POINT EMPTY",
+				"SRID=4326;POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+				"SRID=4326;POINT(-80 80)",
+				"SRID=4326;LINESTRING(0 0, -90 -80)",
+			},
+		},
+	}
+	for i, tc := range testCases {
+		for _, dir := range []Direction{Ascending, Descending} {
+			t.Run(strconv.Itoa(i+1), func(t *testing.T) {
+				t.Run(fmt.Sprintf("dir:%d", dir), func(t *testing.T) {
+					var lastEncoded []byte
+					for _, wkt := range tc.orderedWKTs {
+						parsed, err := geo.ParseGeography(wkt)
+						require.NoError(t, err)
+						spatialObject := parsed.SpatialObject()
+
+						var b []byte
+						var decoded geopb.SpatialObject
+						if dir == Ascending {
+							b, err = EncodeGeoAscending(b, parsed.SpaceCurveIndex(), &spatialObject)
+							require.NoError(t, err)
+							_, decoded, err = DecodeGeoAscending(b)
+							require.NoError(t, err)
+						} else {
+							b, err = EncodeGeoDescending(b, parsed.SpaceCurveIndex(), &spatialObject)
+							require.NoError(t, err)
+							_, decoded, err = DecodeGeoDescending(b)
+							require.NoError(t, err)
+						}
+						require.Equal(t, spatialObject, decoded)
+						testPeekLength(t, b)
+
+						if i > 0 {
+							if dir == Ascending {
+								assert.Truef(t, bytes.Compare(b, lastEncoded) > 0, "expected %s > %s", tc.orderedWKTs[i], tc.orderedWKTs[i-1])
+							} else {
+								assert.Truef(t, bytes.Compare(b, lastEncoded) < 0, "expected %s < %s", tc.orderedWKTs[i], tc.orderedWKTs[i-1])
+							}
+						}
+
+						lastEncoded = b
+					}
+				})
+			})
+		}
 	}
 }
 
@@ -1259,9 +1338,9 @@ func TestPeekType(t *testing.T) {
 	require.NoError(t, err)
 	encodedDurationDescending, err := EncodeDurationDescending(nil, duration.Duration{})
 	require.NoError(t, err)
-	encodedGeoAscending, err := EncodeGeoAscending(nil, &geopb.SpatialObject{})
+	encodedGeoAscending, err := EncodeGeoAscending(nil, 0, &geopb.SpatialObject{})
 	require.NoError(t, err)
-	encodedGeoDescending, err := EncodeGeoDescending(nil, &geopb.SpatialObject{})
+	encodedGeoDescending, err := EncodeGeoDescending(nil, 0, &geopb.SpatialObject{})
 	require.NoError(t, err)
 	testCases := []struct {
 		enc []byte


### PR DESCRIPTION
This follows the [PostGIS way](https://info.crunchydata.com/blog/waiting-for-postgis-3-hilbert-geometry-sorting),
but does not follow the same encoding.

Visualisation for Geometry for 10000 random points: 
![image](https://user-images.githubusercontent.com/3646147/88688829-9a4f5a00-d0ae-11ea-9618-0179fb7ac327.png)

Visualisation for Geography  10000 random points:
![image](https://user-images.githubusercontent.com/3646147/88449411-93e58780-cdfb-11ea-9e85-eff8c5a94787.png)

Release note (sql change): When ordering by geospatial columns, it will
now order by the Hilbert Space Curve index so that points which are
geographically similar are clustered together.