### PR TITLE
release-20.1: sql: never produce a NULL shard column value

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1858,7 +1858,23 @@ func makeHashShardComputeExpr(colNames []string, buckets int) *string {
 		return &tree.FuncExpr{
 			Func: unresolvedFunc("fnv32"),
 			Exprs: tree.Exprs{
-				&tree.CastExpr{Expr: unresolvedName(colName), Type: types.String},
+				// NB: We have created the hash shard column as NOT NULL so we need
+				// to coalesce NULLs into something else. There's a variety of different
+				// reasonable choices here. We could pick some outlandish value, we
+				// could pick a zero value for each type, or we can do the simple thing
+				// we do here, however the empty string seems pretty reasonable. At worst
+				// we'll have a collision for every combination of NULLable string
+				// columns. That seems just fine.
+				&tree.CoalesceExpr{
+					Name: "COALESCE",
+					Exprs: tree.Exprs{
+						&tree.CastExpr{
+							Type: types.String,
+							Expr: unresolvedName(colName),
+						},
+						tree.NewDString(""),
+					},
+				},
 			},
 		}
 	}
@@ -1872,7 +1888,9 @@ func makeHashShardComputeExpr(colNames []string, buckets int) *string {
 			expr = hashedColumnExpr(c)
 		} else {
 			expr = &tree.BinaryExpr{
-				Operator: tree.Plus, Left: hashedColumnExpr(c), Right: expr,
+				Left:     hashedColumnExpr(c),
+				Operator: tree.Plus,
+				Right:    expr,
 			}
 		}
 	}
@@ -1880,10 +1898,7 @@ func makeHashShardComputeExpr(colNames []string, buckets int) *string {
 		Func: unresolvedFunc("mod"),
 		Exprs: tree.Exprs{
 			expr,
-			tree.NewNumVal(
-				constant.MakeInt64(int64(buckets)),
-				strconv.Itoa(buckets),
-				false /* negative */),
+			tree.NewDInt(tree.DInt(buckets)),
 		},
 	})
 	return &str

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -273,30 +273,6 @@ DROP TABLE sharded_secondary
 statement ok
 CREATE TABLE sharded_secondary (a INT8, INDEX (a) USING HASH WITH BUCKET_COUNT=12)
 
-query TTTTT
-EXPLAIN (VERBOSE) INSERT INTO sharded_secondary (a) VALUES (1), (2)
-----
-·                           distributed    false                                              ·                                    ·
-·                           vectorized     false                                              ·                                    ·
-count                       ·              ·                                                  ()                                   ·
-    └── insert                 ·              ·                                                  ()                                   ·
-        │                     into           sharded_secondary(a, crdb_internal_a_shard_12, rowid)   ·                                    ·
-        │                     strategy       inserter                                           ·                                    ·
-        │                     auto commit    ·                                                  ·                                    ·
-        └── render            ·              ·                                                  (column1, column6, column5, check1)  ·
-            │                render 0       column1                                            ·                                    ·
-            │                render 1       column6                                            ·                                    ·
-            │                render 2       column5                                            ·                                    ·
-            │                render 3       column6 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)  ·                                    ·
-            └── render       ·              ·                                                  (column6, column5, column1)          ·
-                │           render 0       mod(fnv32(column1::STRING), 12)                    ·                                    ·
-                │           render 1       unique_rowid()                                     ·                                    ·
-                │           render 2       column1                                            ·                                    ·
-                └── values  ·              ·                                                  (column1)                            ·
-·                           size           1 column, 2 rows                                   ·                                    ·
-·                           row 0, expr 0  1                                                  ·                                    ·
-·                           row 1, expr 0  2                                                  ·                                    ·
-
 # Ensure that hash sharded indexes can be created on columns that are added in the same
 # statement, just like non-sharded indexes.
 statement ok
@@ -388,31 +364,6 @@ DROP INDEX column_used_on_unsharded_create_table_crdb_internal_a_shard_10_idx
 
 statement ok
 DROP TABLE sharded_primary
-
-statement ok
-CREATE TABLE sharded_primary (a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=11)
-
-query TTTTT
-EXPLAIN (VERBOSE) INSERT INTO sharded_primary (a) VALUES (1), (2)
-----
-·                           distributed    false                                          ·                           ·
-·                           vectorized     false                                          ·                           ·
-count                       ·              ·                                              ()                          ·
-    └── insert                 ·              ·                                              ()                          ·
-        │                     into           sharded_primary(crdb_internal_a_shard_11, a)        ·                           ·
-        │                     strategy       inserter                                       ·                           ·
-        │                     auto commit    ·                                              ·                           ·
-        └── render            ·              ·                                              (column4, column1, check1)  ·
-            │                render 0       column4                                        ·                           ·
-            │                render 1       column1                                        ·                           ·
-            │                render 2       column4 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)  ·                           ·
-            └── render       ·              ·                                              (column4, column1)          ·
-                │           render 0       mod(fnv32(column1::STRING), 11)                ·                           ·
-                │           render 1       column1                                        ·                           ·
-                └── values  ·              ·                                              (column1)                   ·
-·                           size           1 column, 2 rows                               ·                           ·
-·                           row 0, expr 0  1                                              ·                           ·
-·                           row 1, expr 0  2                                              ·                           ·
 
 statement ok
 SET experimental_enable_hash_sharded_indexes = false
@@ -510,3 +461,19 @@ ROLLBACK;
 
 statement ok
 DROP TABLE create_idx_drop_column;
+
+# Test that NULL values can be a part of a hash-sharded index.
+subtest null_values_in_sharded_columns
+
+statement ok
+CREATE TABLE sharded_index_with_nulls (
+     a INT8 PRIMARY KEY,
+     b INT8,
+     INDEX (b) USING HASH WITH BUCKET_COUNT = 8
+)
+
+statement ok
+INSERT INTO sharded_index_with_nulls VALUES (1, NULL);
+
+statement ok
+DROP TABLE sharded_index_with_nulls;

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -1,0 +1,56 @@
+# LogicTest: local
+
+statement ok
+SET experimental_enable_hash_sharded_indexes = true;
+
+statement ok
+CREATE TABLE sharded_primary (a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=11)
+
+query TTTTT
+EXPLAIN (VERBOSE) INSERT INTO sharded_primary (a) VALUES (1), (2)
+----
+·                           distributed    false                                          ·                           ·
+·                           vectorized     false                                          ·                           ·
+count                       ·              ·                                              ()                          ·
+ └── insert                 ·              ·                                              ()                          ·
+      │                     into           sharded_primary(crdb_internal_a_shard_11, a)   ·                           ·
+      │                     strategy       inserter                                       ·                           ·
+      │                     auto commit    ·                                              ·                           ·
+      └── render            ·              ·                                              (column4, column1, check1)  ·
+           │                render 0       column4                                        ·                           ·
+           │                render 1       column1                                        ·                           ·
+           │                render 2       column4 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)  ·                           ·
+           └── render       ·              ·                                              (column4, column1)          ·
+                │           render 0       mod(fnv32(COALESCE(column1::STRING, '')), 11)  ·                           ·
+                │           render 1       column1                                        ·                           ·
+                └── values  ·              ·                                              (column1)                   ·
+·                           size           1 column, 2 rows                               ·                           ·
+·                           row 0, expr 0  1                                              ·                           ·
+·                           row 1, expr 0  2                                              ·                           ·
+
+statement ok
+CREATE TABLE sharded_secondary (a INT8, INDEX (a) USING HASH WITH BUCKET_COUNT=12)
+
+query TTTTT
+EXPLAIN (VERBOSE) INSERT INTO sharded_secondary (a) VALUES (1), (2)
+----
+·                           distributed    false                                                  ·                                    ·
+·                           vectorized     false                                                  ·                                    ·
+count                       ·              ·                                                      ()                                   ·
+ └── insert                 ·              ·                                                      ()                                   ·
+      │                     into           sharded_secondary(a, crdb_internal_a_shard_12, rowid)  ·                                    ·
+      │                     strategy       inserter                                               ·                                    ·
+      │                     auto commit    ·                                                      ·                                    ·
+      └── render            ·              ·                                                      (column1, column6, column5, check1)  ·
+           │                render 0       column1                                                ·                                    ·
+           │                render 1       column6                                                ·                                    ·
+           │                render 2       column5                                                ·                                    ·
+           │                render 3       column6 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)      ·                                    ·
+           └── render       ·              ·                                                      (column6, column5, column1)          ·
+                │           render 0       mod(fnv32(COALESCE(column1::STRING, '')), 12)          ·                                    ·
+                │           render 1       unique_rowid()                                         ·                                    ·
+                │           render 2       column1                                                ·                                    ·
+                └── values  ·              ·                                                      (column1)                            ·
+·                           size           1 column, 2 rows                                       ·                                    ·
+·                           row 0, expr 0  1                                                      ·                                    ·
+·                           row 1, expr 0  2                                                      ·                                    ·


### PR DESCRIPTION
Backport 1/1 commits from #47311.

/cc @cockroachdb/release

---

This commit fixes a bug whereby NULL valued members of hash-sharded indexes
would produce a NULL shard column value. This was especially problematic
because the shard column is marked NOT NULL. This bug meant that such
NULL values could not be added to the table.

The commit chooses to coalesce NULL values with the empty string for the
purposes of hashing. This choice is relatively arbitrary but is simple
and cheap.

Fixes #47055

Release note (bug fix): Fix bug preventing NULL index members from being
added to hash sharded indexes.
