### PR TITLE
kvserver: add chart tracking QPS for follower reads

### DIFF
--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -280,7 +280,7 @@ func verifySQLLatency(
 	}
 }
 
-const followerReadsMetric = "follower_reads_success_count"
+const followerReadsMetric = "requests_success_follower_read_count"
 
 // getFollowerReadCounts returns a slice from node to follower read count
 // according to the metric.

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -222,7 +222,7 @@ func rangeUsageInfoForRepl(repl *Replica) RangeUsageInfo {
 	info := RangeUsageInfo{
 		LogicalBytes: repl.GetMVCCStats().Total(),
 	}
-	if queriesPerSecond, dur := repl.leaseholderStats.avgQPS(); dur >= MinStatsDuration {
+	if queriesPerSecond, dur := repl.replicaStats.avgQPS(); dur >= MinStatsDuration {
 		info.QueriesPerSecond = queriesPerSecond
 	}
 	if writesPerSecond, dur := repl.writeStats.avgQPS(); dur >= MinStatsDuration {

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -925,7 +925,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	repl.mu.state.Stats = &enginepb.MVCCStats{}
 	repl.mu.Unlock()
 
-	repl.leaseholderStats = newReplicaStats(clock, nil)
+	repl.replicaStats = newReplicaStats(clock, nil)
 	repl.writeStats = newReplicaStats(clock, nil)
 
 	var rangeUsageInfo RangeUsageInfo

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -286,11 +286,11 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 
-	// Metric for tracking follower reads.
+	// Metrics for tracking follower reads.
 	metaFollowerReadsCount = metric.Metadata{
-		Name:        "follower_reads.success_count",
+		Name:        "requests.success.follower_read_count",
 		Help:        "Number of reads successfully processed by any replica",
-		Measurement: "Read Ops",
+		Measurement: "Requests",
 		Unit:        metric.Unit_COUNT,
 	}
 
@@ -960,6 +960,14 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 
+	// Leaseholder request metrics
+	metaTotalReadsCount = metric.Metadata{
+		Name:        "requests.success.total_read_count",
+		Help:        "Number of read requests successfully served by any replica",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+
 	// Backpressure metrics.
 	metaBackpressuredOnSplitRequests = metric.Metadata{
 		Name:        "requests.backpressure.split",
@@ -1063,7 +1071,8 @@ type StoreMetrics struct {
 	AverageQueriesPerSecond *metric.GaugeFloat64
 	AverageWritesPerSecond  *metric.GaugeFloat64
 
-	// Follower read metrics.
+	// Read request metrics.
+	TotalReadsCount    *metric.Counter
 	FollowerReadsCount *metric.Counter
 
 	// RocksDB metrics.
@@ -1431,7 +1440,8 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		AverageQueriesPerSecond: metric.NewGaugeFloat64(metaAverageQueriesPerSecond),
 		AverageWritesPerSecond:  metric.NewGaugeFloat64(metaAverageWritesPerSecond),
 
-		// Follower reads metrics.
+		// Read request metrics.
+		TotalReadsCount:    metric.NewCounter(metaTotalReadsCount),
 		FollowerReadsCount: metric.NewCounter(metaFollowerReadsCount),
 
 		// RocksDB metrics.

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -198,9 +198,9 @@ type Replica struct {
 	store     *Store
 	abortSpan *abortspan.AbortSpan // Avoids anomalous reads after abort
 
-	// leaseholderStats tracks all incoming BatchRequests to the replica and which
+	// replicaStats tracks all incoming BatchRequests to the replica and which
 	// localities they come from in order to aid in lease rebalancing decisions.
-	leaseholderStats *replicaStats
+	replicaStats *replicaStats
 	// writeStats tracks the number of keys written by applied raft commands
 	// in order to aid in replica rebalancing decisions.
 	writeStats *replicaStats

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -100,7 +100,7 @@ func newUnloadedReplica(
 		r.leaseHistory = newLeaseHistory()
 	}
 	if store.cfg.StorePool != nil {
-		r.leaseholderStats = newReplicaStats(store.Clock(), store.cfg.StorePool.getNodeLocalityString)
+		r.replicaStats = newReplicaStats(store.Clock(), store.cfg.StorePool.getNodeLocalityString)
 	}
 	// Pass nil for the localityOracle because we intentionally don't track the
 	// origin locality of write load.

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -227,7 +227,7 @@ func calcBehindCount(
 // that weren't sent through a DistSender, which in practice should be
 // practically none).
 func (r *Replica) QueriesPerSecond() float64 {
-	qps, _ := r.leaseholderStats.avgQPS()
+	qps, _ := r.replicaStats.avgQPS()
 	return qps
 }
 

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -391,8 +391,8 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease, pe
 
 		// Reset the request counts used to make lease placement decisions whenever
 		// starting a new lease.
-		if r.leaseholderStats != nil {
-			r.leaseholderStats.resetRequestCounts()
+		if r.replicaStats != nil {
+			r.replicaStats.resetRequestCounts()
 		}
 	}
 
@@ -442,8 +442,8 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease, pe
 		} else if prevOwner {
 			r.store.maybeGossipOnCapacityChange(ctx, leaseRemoveEvent)
 		}
-		if r.leaseholderStats != nil {
-			r.leaseholderStats.resetRequestCounts()
+		if r.replicaStats != nil {
+			r.replicaStats.resetRequestCounts()
 		}
 	}
 

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -106,6 +106,7 @@ func (r *Replica) executeReadOnlyBatch(
 	if pErr != nil {
 		log.VErrEventf(ctx, 3, "%v", pErr.String())
 	} else {
+		r.store.metrics.TotalReadsCount.Inc(1)
 		log.Event(ctx, "read completed")
 	}
 	return br, nil, pErr

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -52,8 +52,8 @@ func (r *Replica) sendWithRangeID(
 	ctx context.Context, rangeID roachpb.RangeID, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	var br *roachpb.BatchResponse
-	if r.leaseholderStats != nil && ba.Header.GatewayNodeID != 0 {
-		r.leaseholderStats.record(ba.Header.GatewayNodeID)
+	if r.replicaStats != nil && ba.Header.GatewayNodeID != 0 {
+		r.replicaStats.record(ba.Header.GatewayNodeID)
 	}
 
 	// Add the range log tag.

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -245,7 +245,7 @@ func (rq *replicateQueue) shouldQueue(
 	if lease, _ := repl.GetLease(); repl.IsLeaseValid(ctx, lease, now) {
 		if rq.canTransferLease() &&
 			rq.allocator.ShouldTransferLease(
-				ctx, zone, voterReplicas, lease.Replica.StoreID, repl.leaseholderStats) {
+				ctx, zone, voterReplicas, lease.Replica.StoreID, repl.replicaStats) {
 			log.VEventf(ctx, 2, "lease transfer needed, enqueuing")
 			return true, 0
 		}
@@ -960,7 +960,7 @@ func (rq *replicateQueue) findTargetAndTransferLease(
 		zone,
 		desc.Replicas().Voters(),
 		repl.store.StoreID(),
-		repl.leaseholderStats,
+		repl.replicaStats,
 		opts.checkTransferLeaseSource,
 		opts.checkCandidateFullness,
 		false, /* alwaysAllowDecisionWithoutStats */
@@ -974,7 +974,7 @@ func (rq *replicateQueue) findTargetAndTransferLease(
 		return false, nil
 	}
 
-	avgQPS, qpsMeasurementDur := repl.leaseholderStats.avgQPS()
+	avgQPS, qpsMeasurementDur := repl.replicaStats.avgQPS()
 	if qpsMeasurementDur < MinStatsDuration {
 		avgQPS = 0
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2365,7 +2365,7 @@ func (s *Store) Capacity(ctx context.Context, useCached bool) (roachpb.StoreCapa
 		// starts? We can't easily have a countdown as its value changes like for
 		// leases/replicas.
 		var qps float64
-		if avgQPS, dur := r.leaseholderStats.avgQPS(); dur >= MinStatsDuration {
+		if avgQPS, dur := r.replicaStats.avgQPS(); dur >= MinStatsDuration {
 			qps = avgQPS
 			totalQueriesPerSecond += avgQPS
 			// TODO(a-robinson): Calculate percentiles for qps? Get rid of other percentiles?
@@ -2540,7 +2540,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			}
 		}
 		behindCount += metrics.BehindCount
-		if qps, dur := rep.leaseholderStats.avgQPS(); dur >= MinStatsDuration {
+		if qps, dur := rep.replicaStats.avgQPS(); dur >= MinStatsDuration {
 			averageQueriesPerSecond += qps
 		}
 		if wps, dur := rep.writeStats.avgQPS(); dur >= MinStatsDuration {

--- a/pkg/kv/kvserver/store_merge.go
+++ b/pkg/kv/kvserver/store_merge.go
@@ -56,8 +56,8 @@ func (s *Store) MergeRange(
 		return errors.Errorf("cannot remove range: %s", err)
 	}
 
-	if leftRepl.leaseholderStats != nil {
-		leftRepl.leaseholderStats.resetRequestCounts()
+	if leftRepl.replicaStats != nil {
+		leftRepl.replicaStats.resetRequestCounts()
 	}
 	if leftRepl.writeStats != nil {
 		// Note: this could be drastically improved by adding a replicaStats method

--- a/pkg/kv/kvserver/store_merge.go
+++ b/pkg/kv/kvserver/store_merge.go
@@ -59,10 +59,10 @@ func (s *Store) MergeRange(
 	if leftRepl.replicaStats != nil {
 		leftRepl.replicaStats.resetRequestCounts()
 	}
+	// Note: this could be drastically improved by adding a replicaStats method
+	// that merges stats. Resetting stats is typically bad for the rebalancing
+	// logic that depends on them.
 	if leftRepl.writeStats != nil {
-		// Note: this could be drastically improved by adding a replicaStats method
-		// that merges stats. Resetting stats is typically bad for the rebalancing
-		// logic that depends on them.
 		leftRepl.writeStats.resetRequestCounts()
 	}
 

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -500,7 +500,7 @@ func TestStorePoolUpdateLocalStore(t *testing.T) {
 		rs.record(store.Node.NodeID)
 	}
 	manual.Increment(int64(MinStatsDuration + time.Second))
-	replica.leaseholderStats = rs
+	replica.replicaStats = rs
 	replica.writeStats = rs
 
 	rangeUsageInfo := rangeUsageInfoForRepl(replica)
@@ -510,7 +510,7 @@ func TestStorePoolUpdateLocalStore(t *testing.T) {
 	if !ok {
 		t.Fatalf("couldn't find StoreDescriptor for Store ID %d", 1)
 	}
-	QPS, _ := replica.leaseholderStats.avgQPS()
+	QPS, _ := replica.replicaStats.avgQPS()
 	WPS, _ := replica.writeStats.avgQPS()
 	if expectedRangeCount := int32(6); desc.Capacity.RangeCount != expectedRangeCount {
 		t.Errorf("expected RangeCount %d, but got %d", expectedRangeCount, desc.Capacity.RangeCount)
@@ -607,7 +607,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("make replica error : %+v", err)
 	}
-	replica.leaseholderStats = newReplicaStats(store.Clock(), nil)
+	replica.replicaStats = newReplicaStats(store.Clock(), nil)
 
 	rangeUsageInfo := rangeUsageInfoForRepl(replica)
 

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -443,7 +443,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 				*localDesc,
 				candidate.StoreID,
 				candidates,
-				replWithStats.repl.leaseholderStats,
+				replWithStats.repl.replicaStats,
 			) {
 				log.VEventf(ctx, 3, "r%d is on s%d due to follow-the-workload; skipping",
 					desc.RangeID, localDesc.StoreID)

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -97,7 +97,7 @@ func loadRanges(rr *replicaRankings, s *Store, ranges []testRange) {
 		// TODO(a-robinson): The below three lines won't be needed once the old
 		// rangeInfo code is ripped out of the allocator.
 		repl.mu.state.Stats = &enginepb.MVCCStats{}
-		repl.leaseholderStats = newReplicaStats(s.Clock(), nil)
+		repl.replicaStats = newReplicaStats(s.Clock(), nil)
 		repl.writeStats = newReplicaStats(s.Clock(), nil)
 		acc.addReplica(replicaWithStats{
 			repl: repl,

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -319,7 +319,7 @@ func (s *Store) SplitRange(
 
 	// Clear the original range's request stats, since they include requests for
 	// spans that are now owned by the new range.
-	leftRepl.leaseholderStats.resetRequestCounts()
+	leftRepl.replicaStats.resetRequestCounts()
 
 	if rightReplOrNil == nil {
 		throwawayRightWriteStats := new(replicaStats)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -596,8 +596,8 @@ var charts = []sectionDescription{
 				Metrics: []string{"kv.closed_timestamp.max_behind_nanos"},
 			},
 			{
-				Title:   "Count",
-				Metrics: []string{"follower_reads.success_count"},
+				Title:   "Successful Reads",
+				Metrics: []string{"requests.success.follower_read_count"},
 			},
 		},
 	},
@@ -702,6 +702,13 @@ var charts = []sectionDescription{
 					"exec.error",
 					"exec.success",
 				},
+			},
+			{
+				Title:       "Successful Reads",
+				Downsampler: DescribeAggregator_MAX,
+				Rate:        DescribeDerivative_NON_NEGATIVE_DERIVATIVE,
+				Percentiles: false,
+				Metrics:     []string{"requests.success.total_read_count"},
 			},
 			{
 				Title:       "Storage Engine Stalls",

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -17,13 +17,20 @@ import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources } = props;
+  const { nodeIDs, nodesSummary, nodeSources, storeSources } = props;
 
   return [
-    <LineGraph title="Batches" sources={nodeSources}>
+    <LineGraph title="Batches Sent" sources={nodeSources}>
       <Axis label="batches">
         <Metric name="cr.node.distsender.batches" title="Batches" nonNegativeRate />
         <Metric name="cr.node.distsender.batches.partial" title="Partial Batches" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="Successful Read-Only Batches" sources={storeSources}>
+      <Axis label="batches">
+        <Metric name="cr.store.requests.success.total_read_count" title="Total Reads" nonNegativeRate/>
+        <Metric name="cr.store.requests.success.follower_read_count" title="Follower Reads" nonNegativeRate/>
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
This commit adds an Admin UI chart that tracks the count of total
successful read-only batch requests along with the count of requests
served via follower reads.

This provides some much-needed observability into the efficacy of a
cluster topology as it pertains to leveraging non-leaseholder replicas
to serve historical `AS OF SYSTEM TIME` queries. This also paves the way
for potentially demonstrating use cases / cluster configurations for the
upcoming non-voting replicas.

For instance, running the `follower-reads/nodes=3` roachtest with this
change:
![Screenshot from 2020-10-09 02-08-06](https://user-images.githubusercontent.com/10788754/95549063-77a5bf80-09d4-11eb-9251-918c878b6ff2.png)
![Screenshot from 2020-10-09 02-07-18](https://user-images.githubusercontent.com/10788754/95549120-a02db980-09d4-11eb-9604-4490301f4958.png)


Release note (admin ui change): Added a chart to track follower read
requests successfully served per second by a store.