### PR TITLE
opt: move code that generates proto explain tree

### DIFF
--- a/pkg/sql/explain_tree.go
+++ b/pkg/sql/explain_tree.go
@@ -15,36 +15,17 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
-// planToTree uses a stack to "parse" the planObserver's sequence of calls
-// into a tree which can be easily serialized as JSON or Protobuf.
-//
-// e.g. for the plan
-//
-//   join [cond: t1.a = t2.b]
-//     scan [table: t1]
-//     scan [table: t2]
-//
-// the observer would call
-//
-//   enterNode join         // push onto stack
-//   enterNode scan         // push onto stack
-//   attr table: t1         // add attribute
-//   leaveNode              // pop scan node; add it as a child of join node
-//   enterNode scan         // push onto stack
-//   attr table: t2         // add attribute
-//   leaveNode              // pop scan node; add it as a child of join node
-//   expr cond: t1.a = t2.b // add attribute
-//   leaveNode              // keep root node on stack (base case because it's the root).
-//
-// and planToTree would return the join node.
+// planToTree returns a representation of the plan as a
+// roachpb.ExplainTreePlanNode tree.
 func planToTree(ctx context.Context, top *planTop) *roachpb.ExplainTreePlanNode {
-	var nodeStack planNodeStack
+	var ob explain.OutputBuilder
 	observer := planObserver{
 		// We set followRowSourceToPlanNode to true, to instruct the plan observer
 		// to follow the edges from rowSourceToPlanNodes (indicating that the prior
@@ -55,20 +36,18 @@ func planToTree(ctx context.Context, top *planTop) *roachpb.ExplainTreePlanNode 
 		//  planning to avoid mutating its input planNode tree instead.
 		followRowSourceToPlanNode: true,
 		enterNode: func(ctx context.Context, nodeName string, plan planNode) (bool, error) {
-			nodeStack.push(&roachpb.ExplainTreePlanNode{
-				Name: nodeName,
-			})
+			if plan == nil {
+				ob.EnterMetaNode(nodeName)
+			} else {
+				ob.EnterNode(nodeName, planColumns(plan), planReqOrdering(plan))
+			}
 			return true, nil
 		},
 		expr: func(_ observeVerbosity, nodeName, fieldName string, n int, expr tree.Expr) {
 			if expr == nil {
 				return
 			}
-			stackTop := nodeStack.peek()
-			stackTop.Attrs = append(stackTop.Attrs, &roachpb.ExplainTreePlanNode_Attr{
-				Key:   fieldName,
-				Value: tree.AsStringWithFlags(expr, sampledLogicalPlanFmtFlags),
-			})
+			ob.AddField(fieldName, tree.AsStringWithFlags(expr, sampledLogicalPlanFmtFlags))
 		},
 		spans: func(nodeName, fieldName string, index *sqlbase.IndexDescriptor, spans []roachpb.Span, hardLimitSet bool) {
 			// TODO(jordan): it's expensive to serialize long span
@@ -85,27 +64,14 @@ func planToTree(ctx context.Context, top *planTop) *roachpb.ExplainTreePlanNode 
 					// cannot be spelled out in the collected plan.
 					spanss = fmt.Sprintf("%d span%s", len(spans), util.Pluralize(int64(len(spans))))
 				}
-				stackTop := nodeStack.peek()
-				stackTop.Attrs = append(stackTop.Attrs, &roachpb.ExplainTreePlanNode_Attr{
-					Key:   fieldName,
-					Value: spanss,
-				})
+				ob.AddField(fieldName, spanss)
 			}
 		},
 		attr: func(nodeName, fieldName, attr string) {
-			stackTop := nodeStack.peek()
-			stackTop.Attrs = append(stackTop.Attrs, &roachpb.ExplainTreePlanNode_Attr{
-				Key:   fieldName,
-				Value: attr,
-			})
+			ob.AddField(fieldName, attr)
 		},
 		leaveNode: func(nodeName string, plan planNode) error {
-			if nodeStack.len() == 1 {
-				return nil
-			}
-			poppedNode := nodeStack.pop()
-			newStackTop := nodeStack.peek()
-			newStackTop.Children = append(newStackTop.Children, poppedNode)
+			ob.LeaveNode()
 			return nil
 		},
 	}
@@ -115,33 +81,5 @@ func planToTree(ctx context.Context, top *planTop) *roachpb.ExplainTreePlanNode 
 	); err != nil {
 		panic(errors.AssertionFailedf("error while walking plan to save it to statement stats: %s", err.Error()))
 	}
-	return nodeStack.peek()
-}
-
-type planNodeStack struct {
-	stack []*roachpb.ExplainTreePlanNode
-}
-
-func (ns *planNodeStack) push(node *roachpb.ExplainTreePlanNode) {
-	ns.stack = append(ns.stack, node)
-}
-
-func (ns *planNodeStack) pop() *roachpb.ExplainTreePlanNode {
-	if len(ns.stack) == 0 {
-		return nil
-	}
-	stackTop := ns.stack[len(ns.stack)-1]
-	ns.stack = ns.stack[0 : len(ns.stack)-1]
-	return stackTop
-}
-
-func (ns *planNodeStack) peek() *roachpb.ExplainTreePlanNode {
-	if len(ns.stack) == 0 {
-		return nil
-	}
-	return ns.stack[len(ns.stack)-1]
-}
-
-func (ns *planNodeStack) len() int {
-	return len(ns.stack)
+	return ob.BuildProtoTree()
 }

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func ExampleOutputBuilder() {
@@ -80,7 +81,12 @@ func ExampleOutputBuilder() {
 
 		fmt.Printf("\n-- %s (string) --\n", name)
 		fmt.Print(ob.BuildString())
-		fmt.Printf("\n")
+
+		treeYaml, err := yaml.Marshal(ob.BuildProtoTree())
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("\n-- %s (tree) --\n%s\n", name, treeYaml)
 	}
 
 	example("basic", explain.Flags{})
@@ -114,6 +120,33 @@ func ExampleOutputBuilder() {
 	//            └── scan
 	//                      table        bar
 	//
+	// -- basic (tree) --
+	// name: meta
+	// attrs: []
+	// children:
+	// - name: render
+	//   attrs:
+	//   - key: render 0
+	//     value: foo
+	//   - key: render 1
+	//     value: bar
+	//   children:
+	//   - name: join
+	//     attrs:
+	//     - key: type
+	//       value: outer
+	//     children:
+	//     - name: scan
+	//       attrs:
+	//       - key: table
+	//         value: foo
+	//       children: []
+	//     - name: scan
+	//       attrs:
+	//       - key: table
+	//         value: bar
+	//       children: []
+	//
 	// -- verbose (datums) --
 	//                      0          distributed  true
 	// meta                 0  meta
@@ -140,6 +173,33 @@ func ExampleOutputBuilder() {
 	//            └── scan                      ()
 	//                      table        bar
 	//
+	// -- verbose (tree) --
+	// name: meta
+	// attrs: []
+	// children:
+	// - name: render
+	//   attrs:
+	//   - key: render 0
+	//     value: foo
+	//   - key: render 1
+	//     value: bar
+	//   children:
+	//   - name: join
+	//     attrs:
+	//     - key: type
+	//       value: outer
+	//     children:
+	//     - name: scan
+	//       attrs:
+	//       - key: table
+	//         value: foo
+	//       children: []
+	//     - name: scan
+	//       attrs:
+	//       - key: table
+	//         value: bar
+	//       children: []
+	//
 	// -- verbose+types (datums) --
 	//                      0          distributed  true
 	// meta                 0  meta
@@ -165,4 +225,31 @@ func ExampleOutputBuilder() {
 	//            │         table        foo
 	//            └── scan                      ()
 	//                      table        bar
+	//
+	// -- verbose+types (tree) --
+	// name: meta
+	// attrs: []
+	// children:
+	// - name: render
+	//   attrs:
+	//   - key: render 0
+	//     value: foo
+	//   - key: render 1
+	//     value: bar
+	//   children:
+	//   - name: join
+	//     attrs:
+	//     - key: type
+	//       value: outer
+	//     children:
+	//     - name: scan
+	//       attrs:
+	//       - key: table
+	//         value: foo
+	//       children: []
+	//     - name: scan
+	//       attrs:
+	//       - key: table
+	//         value: bar
+	//       children: []
 }


### PR DESCRIPTION
Move the code that generates the `roachpb.ExplainTreePlanNode` tree
(shown in the UI) to exec/explain. It parallels the existing code for
generating other explain output.

Release note: None