### PR TITLE
sql: fix multi-row updates with partial indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -220,3 +220,24 @@ query II
 SELECT * FROM b
 ----
 1  1
+
+#### Update two rows where one is in a partial index and one is not.
+
+statement ok
+CREATE TABLE c (
+    k INT PRIMARY KEY,
+    i INT,
+    INDEX i_0_100_idx (i) WHERE i > 0 AND i < 100
+)
+
+statement ok
+INSERT INTO c VALUES (3, 30);
+INSERT INTO c VALUES (300, 3000)
+
+statement ok
+UPDATE c SET i = i + 1
+
+query II
+SELECT * FROM c@i_0_100_idx WHERE i > 0 AND i < 100
+----
+3  31

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -346,7 +346,9 @@ func (ru *Updater) UpdateRow(
 		// exists in ignoreIndexesForDel and ignoreIndexesForPut, respectively.
 		// Index IDs in these sets indicate that old and new values for the row
 		// do not satisfy a partial index's predicate expression.
-		if !pm.IgnoreForDel.Contains(int(index.ID)) {
+		if pm.IgnoreForDel.Contains(int(index.ID)) {
+			ru.oldIndexEntries[i] = nil
+		} else {
 			ru.oldIndexEntries[i], err = sqlbase.EncodeSecondaryIndex(
 				ru.Helper.Codec,
 				ru.Helper.TableDesc.TableDesc(),
@@ -359,7 +361,9 @@ func (ru *Updater) UpdateRow(
 				return nil, err
 			}
 		}
-		if !pm.IgnoreForPut.Contains(int(index.ID)) {
+		if pm.IgnoreForPut.Contains(int(index.ID)) {
+			ru.newIndexEntries[i] = nil
+		} else {
 			ru.newIndexEntries[i], err = sqlbase.EncodeSecondaryIndex(
 				ru.Helper.Codec,
 				ru.Helper.TableDesc.TableDesc(),


### PR DESCRIPTION
This commit fixes a bug in which an `UPDATE` to multiple rows caused a
panic when some of the rows are included in the partial index and others
are not.

The `Updater` stores lists of old and new index entries that are reused
for updating multiple rows in order to reduce allocations. When a row
was updated that did not belonging to a partial index, the `Updater`
would reuse `IndexEntry`s created for previously updated rows, causing
a panic in the KV layer.

This commit fixes the issue by replacing the index entries of previous
rows with `nil`.

Fixes #51929 

Release note: None