### PR TITLE
release-20.1: colflow,colexec: fixes around cancellation

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -609,7 +609,12 @@ func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 	}
 	atomic.AddInt32(&s.numOutboxes, 1)
 	run := func(ctx context.Context, cancelFn context.CancelFunc) {
-		outbox.Run(ctx, s.nodeDialer, stream.TargetNodeID, s.flowID, stream.StreamID, cancelFn)
+		// cancelFn is the cancellation function of the context of the whole
+		// flow, and we want to call it only when the last outbox exits, so we
+		// derive a separate child context for each outbox.
+		var outboxCancelFn context.CancelFunc
+		ctx, outboxCancelFn = context.WithCancel(ctx)
+		outbox.Run(ctx, s.nodeDialer, stream.TargetNodeID, s.flowID, stream.StreamID, outboxCancelFn)
 		currentOutboxes := atomic.AddInt32(&s.numOutboxes, -1)
 		// When the last Outbox on this node exits, we want to make sure that
 		// everything is shutdown; namely, we need to call cancelFn if:


### PR DESCRIPTION
Backport 1/2 commits from #51772.

/cc @cockroachdb/release

---

**colflow: fix cancellation of the outbox**

Previously, we were passing in the cancellation function of the flow's
context to each outbox which would result in too early of a cancellation
whenever any outboxes encounters a stream error. This is now fixed by
deriving a separate child context with separate cancellation function
for each outbox and only canceling the flow's context when the last
outbox exits.

Release note (bug fix): CockroachDB could previously encounter benign
internal "context canceled" errors when queries were executed by the
vectorized engine.
