### PR TITLE
util/log,cli/start: assert that config changes happen before logging

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -211,9 +211,11 @@ func (c *cliTest) restartServer(params cliTestParams) {
 // cleanup cleans up after the test, stopping the server if necessary.
 // The log files are removed if the test has succeeded.
 func (c *cliTest) cleanup() {
-	if c.t != nil {
-		defer c.logScope.Close(c.t)
-	}
+	defer func() {
+		if c.t != nil {
+			c.logScope.Close(c.t)
+		}
+	}()
 
 	// Restore stderr.
 	stderr = log.OrigStderr

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1202,6 +1202,10 @@ func logOutputDirectory() string {
 func setupAndInitializeLoggingAndProfiling(
 	ctx context.Context, cmd *cobra.Command,
 ) (stopper *stop.Stopper, err error) {
+	if active, firstUse := log.IsActive(); active {
+		panic(errors.Newf("logging already active; first used at:\n%s", firstUse))
+	}
+
 	// Default the log directory to the "logs" subdirectory of the first
 	// non-memory store. If more than one non-memory stores is detected,
 	// print a warning.

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -145,6 +145,10 @@ func hbaRunTest(t *testing.T, insecure bool) {
 		maybeSocketDir, maybeSocketFile, cleanup := makeSocketFile(t)
 		defer cleanup()
 
+		// We really need to have the logs go to files, so that -show-logs
+		// does not break the "authlog" directives.
+		defer log.ScopeWithoutShowLogs(t).Close(t)
+
 		s, conn, _ := serverutils.StartServer(t,
 			base.TestServerArgs{Insecure: insecure, SocketFile: maybeSocketFile})
 		defer s.Stopper().Stop(context.Background())
@@ -153,12 +157,6 @@ func hbaRunTest(t *testing.T, insecure bool) {
 		// We can't use the cluster settings to do this, because
 		// cluster settings propagate asynchronously.
 		s.(*server.TestServer).PGServer().TestingEnableConnAuthLogging()
-
-		// We really need to have the logs go to files, so that -show-logs
-		// does not break the "authlog" directives. We also must call
-		// this here and not earlier, because it needs to enforce the
-		// redirect on the secondary loggers created by StartServer().
-		defer log.ScopeWithoutShowLogs(t).Close(t)
 
 		pgServer := s.(*server.TestServer).PGServer()
 

--- a/pkg/util/log/no_file_log_scope.go
+++ b/pkg/util/log/no_file_log_scope.go
@@ -1,0 +1,54 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package log
+
+import "github.com/cockroachdb/errors"
+
+// NoFileLogScope represents the lifetime of a logging output with
+// logging to file being disabled. It is used for e.g. in-memory only
+// demo clusters.
+type NoFileLogScope struct {
+	prevDir string
+	cleanup func()
+}
+
+// ScopeWithoutFiles starts a logging environment where logging to
+// files is disabled. This is used for e.g. in-memory only
+// demo clusters.
+func ScopeWithoutFiles() (s NoFileLogScope) {
+	restoreActive := resetActive()
+
+	s.prevDir = mainLog.logDir.String()
+	if err := dirTestOverride(s.prevDir, ""); err != nil {
+		panic(errors.New("unable to override with empty directory"))
+	}
+	mainLog.mu.Lock()
+	defer mainLog.mu.Unlock()
+	prevStderrThreshold := mainLog.stderrThreshold.get()
+
+	s.cleanup = func() {
+		mainLog.mu.Lock()
+		defer mainLog.mu.Unlock()
+		mainLog.stderrThreshold.set(prevStderrThreshold)
+		restoreActive()
+	}
+
+	return s
+}
+
+// Close finalizes the given scope.
+func (s NoFileLogScope) Close() {
+	Flush()
+	// There cannot be an error here because the previous directory was
+	// valid before.
+	_ = mainLog.dirTestOverride("", s.prevDir)
+	s.cleanup()
+}

--- a/pkg/util/log/secondary_log.go
+++ b/pkg/util/log/secondary_log.go
@@ -51,6 +51,12 @@ func NewSecondaryLogger(
 ) *SecondaryLogger {
 	mainLog.mu.Lock()
 	defer mainLog.mu.Unlock()
+
+	// Any consumption of configuration off the main logger
+	// makes the logging module "active" and prevents further
+	// configuration changes.
+	setActive()
+
 	var dir string
 	if dirName != nil {
 		dir = dirName.String()


### PR DESCRIPTION
This commit adds an assertion that configuration changes in the
logging package happen before the first event is logged.

Release note: None