### PR TITLE
util: reduce log spam during network breakdown

### DIFF
--- a/pkg/util/grpcutil/log_test.go
+++ b/pkg/util/grpcutil/log_test.go
@@ -17,73 +17,53 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/errors"
-	"github.com/petermattis/goid"
 )
 
 func TestShouldPrint(t *testing.T) {
 	const duration = 100 * time.Millisecond
 
-	formatRe, err := regexp.Compile("^foo")
-	if err != nil {
-		t.Fatal(err)
-	}
 	argRe, err := regexp.Compile("[a-z][0-9]")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	testutils.RunTrueAndFalse(t, "formatMatch", func(t *testing.T, formatMatch bool) {
-		testutils.RunTrueAndFalse(t, "argsMatch", func(t *testing.T, argsMatch bool) {
-			format := "bar=%s"
-			if formatMatch {
-				format = "foobar=%s"
-			}
-			args := []interface{}{errors.New("baz")}
-			if argsMatch {
-				args = []interface{}{errors.New("a1")}
-			}
-			curriedShouldPrint := func() bool {
-				return shouldPrint(formatRe, argRe, duration, format, args...)
-			}
+	testutils.RunTrueAndFalse(t, "argsMatch", func(t *testing.T, argsMatch bool) {
+		msg := "baz"
+		if argsMatch {
+			msg = "a1"
+		}
 
-			// First call should always print.
+		args := []interface{}{msg}
+		curriedShouldPrint := func() bool {
+			return shouldPrint(argRe, duration, args...)
+		}
+
+		// First call should always print.
+		if !curriedShouldPrint() {
+			t.Error("expected first call to print")
+		}
+
+		// Should print if non-matching.
+		alwaysPrint := !argsMatch
+		if alwaysPrint {
 			if !curriedShouldPrint() {
-				t.Error("expected first call to print")
+				t.Error("expected second call to print")
 			}
+		} else {
+			if curriedShouldPrint() {
+				t.Error("unexpected second call to print")
+			}
+		}
 
-			// Call from another goroutine should always print.
-			done := make(chan bool)
-			go func() {
-				done <- curriedShouldPrint()
-			}()
-			if !<-done {
-				t.Error("expected other-goroutine call to print")
-			}
-
-			// Should print if non-matching.
-			alwaysPrint := !(formatMatch && argsMatch)
-
-			if alwaysPrint {
-				if !curriedShouldPrint() {
-					t.Error("expected second call to print")
-				}
-			} else {
-				if curriedShouldPrint() {
-					t.Error("unexpected second call to print")
-				}
-			}
-
-			if !alwaysPrint {
-				// Force printing by pretending the previous output was well in the
-				// past.
-				spamMu.Lock()
-				spamMu.gids[goid.Get()] = timeutil.Now().Add(-time.Hour)
-				spamMu.Unlock()
-			}
-			if !curriedShouldPrint() {
-				t.Error("expected third call to print")
-			}
-		})
+		if !alwaysPrint {
+			// Force printing by pretending the previous output was well in the
+			// past.
+			spamMu.Lock()
+			spamMu.strs[msg] = timeutil.Now().Add(-time.Hour)
+			spamMu.Unlock()
+		}
+		if !curriedShouldPrint() {
+			t.Error("expected third call to print")
+		}
 	})
 }


### PR DESCRIPTION
Touches #32581. We currently spam a lot whenever there is any issues
with network connectivity. Seems like we used to dedup this log spam
away before, but the strings we were matching against have gone stale
(there's no more `addConn.resetTransport` in grpc code). Also, we used
to dedup log spam away by looking at goroutine thread ID, instead of the
message itself, which this patch does instead. This reduces spam in
situations where we liberally construct one-off connections to
downed/partitioned nodes (for e.g., during start up).

```
W200727 19:02:29.108962 392
vendor/google.golang.org/grpc/internal/channelz/logging.go:73  grpc:
addrConn.createTransport failed to connect to {127.0.0.1:26257  <nil> 0
<nil>}. Err: connection error: desc = "transport: Error while dialing
dial tcp 127.0.0.1:26257: connect: connection refused". Reconnecting...

W200727 19:02:30.111670 392
vendor/google.golang.org/grpc/internal/channelz/logging.go:73  grpc:
addrConn.createTransport failed to connect to {127.0.0.1:26257  <nil> 0
<nil>}. Err: connection error: desc = "transport: Error while dialing
cannot reuse client connection". Reconnecting...
```

Release note (general change): Previously CRDB would spam its logs
when undergoing network connectivity issues. This patch reduces the
frequency of said spam.