### PR TITLE
interval/generic: improve randomized testing, fix upper bound bug

### DIFF
--- a/pkg/kv/kvserver/concurrency/lockstate_interval_btree.go
+++ b/pkg/kv/kvserver/concurrency/lockstate_interval_btree.go
@@ -416,12 +416,17 @@ func (n *node) removeMax() *lockState {
 		n.adjustUpperBoundOnRemoval(out, nil)
 		return out
 	}
-	child := mut(&n.children[n.count])
-	if child.count <= minItems {
-		n.rebalanceOrMerge(int(n.count))
-		return n.removeMax()
+	// Recurse into max child.
+	i := int(n.count)
+	if n.children[i].count <= minItems {
+		// Child not large enough to remove from.
+		n.rebalanceOrMerge(i)
+		return n.removeMax() // redo
 	}
-	return child.removeMax()
+	child := mut(&n.children[i])
+	out := child.removeMax()
+	n.adjustUpperBoundOnRemoval(out, nil)
+	return out
 }
 
 // remove removes a item from the subtree rooted at this node. Returns
@@ -439,7 +444,7 @@ func (n *node) remove(item *lockState) (out *lockState, newBound bool) {
 	if n.children[i].count <= minItems {
 		// Child not large enough to remove from.
 		n.rebalanceOrMerge(i)
-		return n.remove(item)
+		return n.remove(item) // redo
 	}
 	child := mut(&n.children[i])
 	if found {
@@ -619,7 +624,7 @@ func (n *node) adjustUpperBoundOnInsertion(item *lockState, child *node) bool {
 }
 
 // adjustUpperBoundOnRemoval adjusts the upper key bound for this node
-// given a item and an optional child node that were removed. Returns
+// given a item and an optional child node that was removed. Returns
 // true is the upper bound was changed and false if not.
 func (n *node) adjustUpperBoundOnRemoval(item *lockState, child *node) bool {
 	up := upperBound(item)

--- a/pkg/kv/kvserver/concurrency/lockstate_interval_btree.go
+++ b/pkg/kv/kvserver/concurrency/lockstate_interval_btree.go
@@ -371,9 +371,9 @@ func (n *node) split(i int) (*lockState, *node) {
 	return out, next
 }
 
-// insert inserts a item into the subtree rooted at this node, making sure no
+// insert inserts an item into the subtree rooted at this node, making sure no
 // nodes in the subtree exceed maxItems items. Returns true if an existing item
-// was replaced and false if a item was inserted. Also returns whether the
+// was replaced and false if an item was inserted. Also returns whether the
 // node's upper bound changes.
 func (n *node) insert(item *lockState) (replaced, newBound bool) {
 	i, found := n.find(item)
@@ -406,8 +406,8 @@ func (n *node) insert(item *lockState) (replaced, newBound bool) {
 	return replaced, newBound
 }
 
-// removeMax removes and returns the maximum item from the subtree rooted
-// at this node.
+// removeMax removes and returns the maximum item from the subtree rooted at
+// this node.
 func (n *node) removeMax() *lockState {
 	if n.leaf {
 		n.count--
@@ -429,9 +429,9 @@ func (n *node) removeMax() *lockState {
 	return out
 }
 
-// remove removes a item from the subtree rooted at this node. Returns
-// the item that was removed or nil if no matching item was found.
-// Also returns whether the node's upper bound changes.
+// remove removes an item from the subtree rooted at this node. Returns the item
+// that was removed or nil if no matching item was found. Also returns whether
+// the node's upper bound changes.
 func (n *node) remove(item *lockState) (out *lockState, newBound bool) {
 	i, found := n.find(item)
 	if n.leaf {
@@ -462,7 +462,7 @@ func (n *node) remove(item *lockState) (out *lockState, newBound bool) {
 }
 
 // rebalanceOrMerge grows child 'i' to ensure it has sufficient room to remove
-// a item from it while keeping it at or above minItems.
+// an item from it while keeping it at or above minItems.
 func (n *node) rebalanceOrMerge(i int) {
 	switch {
 	case i > 0 && n.children[i-1].count > minItems:
@@ -606,9 +606,9 @@ func (n *node) findUpperBound() keyBound {
 	return max
 }
 
-// adjustUpperBoundOnInsertion adjusts the upper key bound for this node
-// given a item and an optional child node that was inserted. Returns
-// true is the upper bound was changed and false if not.
+// adjustUpperBoundOnInsertion adjusts the upper key bound for this node given
+// an item and an optional child node that was inserted. Returns true is the
+// upper bound was changed and false if not.
 func (n *node) adjustUpperBoundOnInsertion(item *lockState, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
@@ -623,9 +623,9 @@ func (n *node) adjustUpperBoundOnInsertion(item *lockState, child *node) bool {
 	return false
 }
 
-// adjustUpperBoundOnRemoval adjusts the upper key bound for this node
-// given a item and an optional child node that was removed. Returns
-// true is the upper bound was changed and false if not.
+// adjustUpperBoundOnRemoval adjusts the upper key bound for this node given an
+// item and an optional child node that was removed. Returns true is the upper
+// bound was changed and false if not.
 func (n *node) adjustUpperBoundOnRemoval(item *lockState, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
@@ -692,7 +692,7 @@ func (t *btree) Clone() btree {
 	return c
 }
 
-// Delete removes a item equal to the passed in item from the tree.
+// Delete removes an item equal to the passed in item from the tree.
 func (t *btree) Delete(item *lockState) {
 	if t.root == nil || t.root.count == 0 {
 		return
@@ -711,8 +711,8 @@ func (t *btree) Delete(item *lockState) {
 	}
 }
 
-// Set adds the given item to the tree. If a item in the tree already
-// equals the given one, it is replaced with the new item.
+// Set adds the given item to the tree. If an item in the tree already equals
+// the given one, it is replaced with the new item.
 func (t *btree) Set(item *lockState) {
 	if t.root == nil {
 		t.root = newLeafNode()

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
@@ -416,12 +416,17 @@ func (n *node) removeMax() *latch {
 		n.adjustUpperBoundOnRemoval(out, nil)
 		return out
 	}
-	child := mut(&n.children[n.count])
-	if child.count <= minItems {
-		n.rebalanceOrMerge(int(n.count))
-		return n.removeMax()
+	// Recurse into max child.
+	i := int(n.count)
+	if n.children[i].count <= minItems {
+		// Child not large enough to remove from.
+		n.rebalanceOrMerge(i)
+		return n.removeMax() // redo
 	}
-	return child.removeMax()
+	child := mut(&n.children[i])
+	out := child.removeMax()
+	n.adjustUpperBoundOnRemoval(out, nil)
+	return out
 }
 
 // remove removes a item from the subtree rooted at this node. Returns
@@ -439,7 +444,7 @@ func (n *node) remove(item *latch) (out *latch, newBound bool) {
 	if n.children[i].count <= minItems {
 		// Child not large enough to remove from.
 		n.rebalanceOrMerge(i)
-		return n.remove(item)
+		return n.remove(item) // redo
 	}
 	child := mut(&n.children[i])
 	if found {
@@ -619,7 +624,7 @@ func (n *node) adjustUpperBoundOnInsertion(item *latch, child *node) bool {
 }
 
 // adjustUpperBoundOnRemoval adjusts the upper key bound for this node
-// given a item and an optional child node that were removed. Returns
+// given a item and an optional child node that was removed. Returns
 // true is the upper bound was changed and false if not.
 func (n *node) adjustUpperBoundOnRemoval(item *latch, child *node) bool {
 	up := upperBound(item)

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
@@ -371,9 +371,9 @@ func (n *node) split(i int) (*latch, *node) {
 	return out, next
 }
 
-// insert inserts a item into the subtree rooted at this node, making sure no
+// insert inserts an item into the subtree rooted at this node, making sure no
 // nodes in the subtree exceed maxItems items. Returns true if an existing item
-// was replaced and false if a item was inserted. Also returns whether the
+// was replaced and false if an item was inserted. Also returns whether the
 // node's upper bound changes.
 func (n *node) insert(item *latch) (replaced, newBound bool) {
 	i, found := n.find(item)
@@ -406,8 +406,8 @@ func (n *node) insert(item *latch) (replaced, newBound bool) {
 	return replaced, newBound
 }
 
-// removeMax removes and returns the maximum item from the subtree rooted
-// at this node.
+// removeMax removes and returns the maximum item from the subtree rooted at
+// this node.
 func (n *node) removeMax() *latch {
 	if n.leaf {
 		n.count--
@@ -429,9 +429,9 @@ func (n *node) removeMax() *latch {
 	return out
 }
 
-// remove removes a item from the subtree rooted at this node. Returns
-// the item that was removed or nil if no matching item was found.
-// Also returns whether the node's upper bound changes.
+// remove removes an item from the subtree rooted at this node. Returns the item
+// that was removed or nil if no matching item was found. Also returns whether
+// the node's upper bound changes.
 func (n *node) remove(item *latch) (out *latch, newBound bool) {
 	i, found := n.find(item)
 	if n.leaf {
@@ -462,7 +462,7 @@ func (n *node) remove(item *latch) (out *latch, newBound bool) {
 }
 
 // rebalanceOrMerge grows child 'i' to ensure it has sufficient room to remove
-// a item from it while keeping it at or above minItems.
+// an item from it while keeping it at or above minItems.
 func (n *node) rebalanceOrMerge(i int) {
 	switch {
 	case i > 0 && n.children[i-1].count > minItems:
@@ -606,9 +606,9 @@ func (n *node) findUpperBound() keyBound {
 	return max
 }
 
-// adjustUpperBoundOnInsertion adjusts the upper key bound for this node
-// given a item and an optional child node that was inserted. Returns
-// true is the upper bound was changed and false if not.
+// adjustUpperBoundOnInsertion adjusts the upper key bound for this node given
+// an item and an optional child node that was inserted. Returns true is the
+// upper bound was changed and false if not.
 func (n *node) adjustUpperBoundOnInsertion(item *latch, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
@@ -623,9 +623,9 @@ func (n *node) adjustUpperBoundOnInsertion(item *latch, child *node) bool {
 	return false
 }
 
-// adjustUpperBoundOnRemoval adjusts the upper key bound for this node
-// given a item and an optional child node that was removed. Returns
-// true is the upper bound was changed and false if not.
+// adjustUpperBoundOnRemoval adjusts the upper key bound for this node given an
+// item and an optional child node that was removed. Returns true is the upper
+// bound was changed and false if not.
 func (n *node) adjustUpperBoundOnRemoval(item *latch, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
@@ -692,7 +692,7 @@ func (t *btree) Clone() btree {
 	return c
 }
 
-// Delete removes a item equal to the passed in item from the tree.
+// Delete removes an item equal to the passed in item from the tree.
 func (t *btree) Delete(item *latch) {
 	if t.root == nil || t.root.count == 0 {
 		return
@@ -711,8 +711,8 @@ func (t *btree) Delete(item *latch) {
 	}
 }
 
-// Set adds the given item to the tree. If a item in the tree already
-// equals the given one, it is replaced with the new item.
+// Set adds the given item to the tree. If an item in the tree already equals
+// the given one, it is replaced with the new item.
 func (t *btree) Set(item *latch) {
 	if t.root == nil {
 		t.root = newLeafNode()

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
@@ -410,6 +410,310 @@ func TestBTreeSeekOverlap(t *testing.T) {
 	}
 }
 
+// TestBTreeCmp tests the btree item comparison.
+func TestBTreeCmp(t *testing.T) {
+	// NB: go_generics doesn't do well with anonymous types, so name this type.
+	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
+	// anonymous constructors with.
+	type testCase struct {
+		spanA, spanB roachpb.Span
+		idA, idB     uint64
+		exp          int
+	}
+	var testCases []testCase
+	testCases = append(testCases,
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a")},
+			idA:   1,
+			idB:   1,
+			exp:   0,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+			idA:   1,
+			idB:   1,
+			exp:   -1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+			idA:   1,
+			idB:   1,
+			exp:   1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			idA:   1,
+			idB:   1,
+			exp:   0,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a")},
+			idA:   1,
+			idB:   2,
+			exp:   -1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a")},
+			idA:   2,
+			idB:   1,
+			exp:   1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("b")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			idA:   1,
+			idB:   1,
+			exp:   1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("e")},
+			spanB: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+			idA:   1,
+			idB:   1,
+			exp:   -1,
+		},
+	)
+	for _, tc := range testCases {
+		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
+		t.Run(name, func(t *testing.T) {
+			laA := newItem(tc.spanA)
+			laA.SetID(tc.idA)
+			laB := newItem(tc.spanB)
+			laB.SetID(tc.idB)
+			require.Equal(t, tc.exp, cmp(laA, laB))
+		})
+	}
+}
+
+// TestIterStack tests the interface of the iterStack type.
+func TestIterStack(t *testing.T) {
+	f := func(i int) iterFrame { return iterFrame{pos: int16(i)} }
+	var is iterStack
+	for i := 1; i <= 2*len(iterStackArr{}); i++ {
+		var j int
+		for j = 0; j < i; j++ {
+			is.push(f(j))
+		}
+		require.Equal(t, j, is.len())
+		for j--; j >= 0; j-- {
+			require.Equal(t, f(j), is.pop())
+		}
+		is.reset()
+	}
+}
+
+//////////////////////////////////////////
+//        Randomized Unit Tests         //
+//////////////////////////////////////////
+
+// perm returns a random permutation of items with spans in the range [0, n).
+func perm(n int) (out []*latch) {
+	for _, i := range rand.Perm(n) {
+		out = append(out, newItem(spanWithEnd(i, i+1)))
+	}
+	return out
+}
+
+// rang returns an ordered list of items with spans in the range [m, n].
+func rang(m, n int) (out []*latch) {
+	for i := m; i <= n; i++ {
+		out = append(out, newItem(spanWithEnd(i, i+1)))
+	}
+	return out
+}
+
+// all extracts all items from a tree in order as a slice.
+func all(tr *btree) (out []*latch) {
+	it := tr.MakeIter()
+	it.First()
+	for it.Valid() {
+		out = append(out, it.Cur())
+		it.Next()
+	}
+	return out
+}
+
+func run(tb testing.TB, name string, f func(testing.TB)) {
+	switch v := tb.(type) {
+	case *testing.T:
+		v.Run(name, func(t *testing.T) {
+			f(t)
+		})
+	case *testing.B:
+		v.Run(name, func(b *testing.B) {
+			f(b)
+		})
+	default:
+		tb.Fatalf("unknown %T", tb)
+	}
+}
+
+func verify(tb testing.TB, tr *btree) {
+	if tt, ok := tb.(*testing.T); ok {
+		tr.Verify(tt)
+	}
+}
+
+func resetTimer(tb testing.TB) {
+	if b, ok := tb.(*testing.B); ok {
+		b.ResetTimer()
+	}
+}
+
+func stopTimer(tb testing.TB) {
+	if b, ok := tb.(*testing.B); ok {
+		b.StopTimer()
+	}
+}
+
+func startTimer(tb testing.TB) {
+	if b, ok := tb.(*testing.B); ok {
+		b.StartTimer()
+	}
+}
+
+func runBTreeInsert(tb testing.TB, count, iters int) {
+	insertP := perm(count)
+	resetTimer(tb)
+	for i := 0; i < iters; {
+		var tr btree
+		for _, item := range insertP {
+			tr.Set(item)
+			verify(tb, &tr)
+			i++
+			if i >= iters {
+				return
+			}
+		}
+	}
+}
+
+func runBTreeDelete(tb testing.TB, count, iters int) {
+	insertP, removeP := perm(count), perm(count)
+	resetTimer(tb)
+	for i := 0; i < iters; {
+		stopTimer(tb)
+		var tr btree
+		for _, item := range insertP {
+			tr.Set(item)
+			verify(tb, &tr)
+		}
+		startTimer(tb)
+		for _, item := range removeP {
+			tr.Delete(item)
+			verify(tb, &tr)
+			i++
+			if i >= iters {
+				return
+			}
+		}
+		if tr.Len() > 0 {
+			tb.Fatalf("tree not empty: %s", &tr)
+		}
+	}
+}
+
+func runBTreeDeleteInsert(tb testing.TB, count, iters int) {
+	insertP := perm(count)
+	var tr btree
+	for _, item := range insertP {
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+	resetTimer(tb)
+	for i := 0; i < iters; i++ {
+		item := insertP[i%count]
+		tr.Delete(item)
+		verify(tb, &tr)
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+}
+
+func runBTreeDeleteInsertCloneOnce(tb testing.TB, count, iters int) {
+	insertP := perm(count)
+	var tr btree
+	for _, item := range insertP {
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+	tr = tr.Clone()
+	resetTimer(tb)
+	for i := 0; i < iters; i++ {
+		item := insertP[i%count]
+		tr.Delete(item)
+		verify(tb, &tr)
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+}
+
+func runBTreeDeleteInsertCloneEachTime(tb testing.TB, count, iters int) {
+	for _, reset := range []bool{false, true} {
+		run(tb, fmt.Sprintf("reset=%t", reset), func(tb testing.TB) {
+			insertP := perm(count)
+			var tr, trReset btree
+			for _, item := range insertP {
+				tr.Set(item)
+				verify(tb, &tr)
+			}
+			resetTimer(tb)
+			for i := 0; i < iters; i++ {
+				item := insertP[i%count]
+				if reset {
+					trReset.Reset()
+					trReset = tr
+				}
+				tr = tr.Clone()
+				tr.Delete(item)
+				verify(tb, &tr)
+				tr.Set(item)
+				verify(tb, &tr)
+			}
+		})
+	}
+}
+
+// randN returns a random integer in the range [min, max).
+func randN(min, max int) int { return rand.Intn(max-min) + min }
+func randCount() int {
+	if testing.Short() {
+		return randN(1, 128)
+	}
+	return randN(1, 1024)
+}
+
+func TestBTreeInsert(t *testing.T) {
+	count := randCount()
+	runBTreeInsert(t, count, count)
+}
+
+func TestBTreeDelete(t *testing.T) {
+	count := randCount()
+	runBTreeDelete(t, count, count)
+}
+
+func TestBTreeDeleteInsert(t *testing.T) {
+	count := randCount()
+	runBTreeDeleteInsert(t, count, count)
+}
+
+func TestBTreeDeleteInsertCloneOnce(t *testing.T) {
+	count := randCount()
+	runBTreeDeleteInsertCloneOnce(t, count, count)
+}
+
+func TestBTreeDeleteInsertCloneEachTime(t *testing.T) {
+	count := randCount()
+	runBTreeDeleteInsertCloneEachTime(t, count, count)
+}
+
 // TestBTreeSeekOverlapRandom tests btree iterator overlap operations using
 // randomized input.
 func TestBTreeSeekOverlapRandom(t *testing.T) {
@@ -542,134 +846,9 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 	}
 }
 
-// TestBTreeCmp tests the btree item comparison.
-func TestBTreeCmp(t *testing.T) {
-	// NB: go_generics doesn't do well with anonymous types, so name this type.
-	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
-	// anonymous constructors with.
-	type testCase struct {
-		spanA, spanB roachpb.Span
-		idA, idB     uint64
-		exp          int
-	}
-	var testCases []testCase
-	testCases = append(testCases,
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a")},
-			idA:   1,
-			idB:   1,
-			exp:   0,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
-			idA:   1,
-			idB:   1,
-			exp:   -1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
-			idA:   1,
-			idB:   1,
-			exp:   1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			idA:   1,
-			idB:   1,
-			exp:   0,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a")},
-			idA:   1,
-			idB:   2,
-			exp:   -1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a")},
-			idA:   2,
-			idB:   1,
-			exp:   1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("b")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			idA:   1,
-			idB:   1,
-			exp:   1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("e")},
-			spanB: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
-			idA:   1,
-			idB:   1,
-			exp:   -1,
-		},
-	)
-	for _, tc := range testCases {
-		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
-		t.Run(name, func(t *testing.T) {
-			laA := newItem(tc.spanA)
-			laA.SetID(tc.idA)
-			laB := newItem(tc.spanB)
-			laB.SetID(tc.idB)
-			require.Equal(t, tc.exp, cmp(laA, laB))
-		})
-	}
-}
-
-// TestIterStack tests the interface of the iterStack type.
-func TestIterStack(t *testing.T) {
-	f := func(i int) iterFrame { return iterFrame{pos: int16(i)} }
-	var is iterStack
-	for i := 1; i <= 2*len(iterStackArr{}); i++ {
-		var j int
-		for j = 0; j < i; j++ {
-			is.push(f(j))
-		}
-		require.Equal(t, j, is.len())
-		for j--; j >= 0; j-- {
-			require.Equal(t, f(j), is.pop())
-		}
-		is.reset()
-	}
-}
-
 //////////////////////////////////////////
 //              Benchmarks              //
 //////////////////////////////////////////
-
-// perm returns a random permutation of items with spans in the range [0, n).
-func perm(n int) (out []*latch) {
-	for _, i := range rand.Perm(n) {
-		out = append(out, newItem(spanWithEnd(i, i+1)))
-	}
-	return out
-}
-
-// rang returns an ordered list of items with spans in the range [m, n].
-func rang(m, n int) (out []*latch) {
-	for i := m; i <= n; i++ {
-		out = append(out, newItem(spanWithEnd(i, i+1)))
-	}
-	return out
-}
-
-// all extracts all items from a tree in order as a slice.
-func all(tr *btree) (out []*latch) {
-	it := tr.MakeIter()
-	it.First()
-	for it.Valid() {
-		out = append(out, it.Cur())
-		it.Next()
-	}
-	return out
-}
 
 func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {
 	for _, count := range []int{16, 128, 1024, 8192, 65536} {
@@ -682,61 +861,21 @@ func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {
 // BenchmarkBTreeInsert measures btree insertion performance.
 func BenchmarkBTreeInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP := perm(count)
-		b.ResetTimer()
-		for i := 0; i < b.N; {
-			var tr btree
-			for _, item := range insertP {
-				tr.Set(item)
-				i++
-				if i >= b.N {
-					return
-				}
-			}
-		}
+		runBTreeInsert(b, count, b.N)
 	})
 }
 
 // BenchmarkBTreeDelete measures btree deletion performance.
 func BenchmarkBTreeDelete(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP, removeP := perm(count), perm(count)
-		b.ResetTimer()
-		for i := 0; i < b.N; {
-			b.StopTimer()
-			var tr btree
-			for _, item := range insertP {
-				tr.Set(item)
-			}
-			b.StartTimer()
-			for _, item := range removeP {
-				tr.Delete(item)
-				i++
-				if i >= b.N {
-					return
-				}
-			}
-			if tr.Len() > 0 {
-				b.Fatalf("tree not empty: %s", &tr)
-			}
-		}
+		runBTreeDelete(b, count, b.N)
 	})
 }
 
 // BenchmarkBTreeDeleteInsert measures btree deletion and insertion performance.
 func BenchmarkBTreeDeleteInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP := perm(count)
-		var tr btree
-		for _, item := range insertP {
-			tr.Set(item)
-		}
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			item := insertP[i%count]
-			tr.Delete(item)
-			tr.Set(item)
-		}
+		runBTreeDeleteInsert(b, count, b.N)
 	})
 }
 
@@ -744,46 +883,16 @@ func BenchmarkBTreeDeleteInsert(b *testing.B) {
 // performance after the tree has been copy-on-write cloned once.
 func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP := perm(count)
-		var tr btree
-		for _, item := range insertP {
-			tr.Set(item)
-		}
-		tr = tr.Clone()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			item := insertP[i%count]
-			tr.Delete(item)
-			tr.Set(item)
-		}
+		runBTreeDeleteInsertCloneOnce(b, count, b.N)
 	})
 }
 
 // BenchmarkBTreeDeleteInsertCloneEachTime measures btree deletion and insertion
 // performance while the tree is repeatedly copy-on-write cloned.
 func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
-	for _, reset := range []bool{false, true} {
-		b.Run(fmt.Sprintf("reset=%t", reset), func(b *testing.B) {
-			forBenchmarkSizes(b, func(b *testing.B, count int) {
-				insertP := perm(count)
-				var tr, trReset btree
-				for _, item := range insertP {
-					tr.Set(item)
-				}
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
-					item := insertP[i%count]
-					if reset {
-						trReset.Reset()
-						trReset = tr
-					}
-					tr = tr.Clone()
-					tr.Delete(item)
-					tr.Set(item)
-				}
-			})
-		})
-	}
+	forBenchmarkSizes(b, func(b *testing.B, count int) {
+		runBTreeDeleteInsertCloneEachTime(b, count, b.N)
+	})
 }
 
 // BenchmarkBTreeMakeIter measures the cost of creating a btree iterator.

--- a/pkg/util/interval/generic/example_interval_btree.go
+++ b/pkg/util/interval/generic/example_interval_btree.go
@@ -416,12 +416,17 @@ func (n *node) removeMax() *example {
 		n.adjustUpperBoundOnRemoval(out, nil)
 		return out
 	}
-	child := mut(&n.children[n.count])
-	if child.count <= minItems {
-		n.rebalanceOrMerge(int(n.count))
-		return n.removeMax()
+	// Recurse into max child.
+	i := int(n.count)
+	if n.children[i].count <= minItems {
+		// Child not large enough to remove from.
+		n.rebalanceOrMerge(i)
+		return n.removeMax() // redo
 	}
-	return child.removeMax()
+	child := mut(&n.children[i])
+	out := child.removeMax()
+	n.adjustUpperBoundOnRemoval(out, nil)
+	return out
 }
 
 // remove removes a item from the subtree rooted at this node. Returns
@@ -439,7 +444,7 @@ func (n *node) remove(item *example) (out *example, newBound bool) {
 	if n.children[i].count <= minItems {
 		// Child not large enough to remove from.
 		n.rebalanceOrMerge(i)
-		return n.remove(item)
+		return n.remove(item) // redo
 	}
 	child := mut(&n.children[i])
 	if found {
@@ -619,7 +624,7 @@ func (n *node) adjustUpperBoundOnInsertion(item *example, child *node) bool {
 }
 
 // adjustUpperBoundOnRemoval adjusts the upper key bound for this node
-// given a item and an optional child node that were removed. Returns
+// given a item and an optional child node that was removed. Returns
 // true is the upper bound was changed and false if not.
 func (n *node) adjustUpperBoundOnRemoval(item *example, child *node) bool {
 	up := upperBound(item)

--- a/pkg/util/interval/generic/example_interval_btree.go
+++ b/pkg/util/interval/generic/example_interval_btree.go
@@ -371,9 +371,9 @@ func (n *node) split(i int) (*example, *node) {
 	return out, next
 }
 
-// insert inserts a item into the subtree rooted at this node, making sure no
+// insert inserts an item into the subtree rooted at this node, making sure no
 // nodes in the subtree exceed maxItems items. Returns true if an existing item
-// was replaced and false if a item was inserted. Also returns whether the
+// was replaced and false if an item was inserted. Also returns whether the
 // node's upper bound changes.
 func (n *node) insert(item *example) (replaced, newBound bool) {
 	i, found := n.find(item)
@@ -406,8 +406,8 @@ func (n *node) insert(item *example) (replaced, newBound bool) {
 	return replaced, newBound
 }
 
-// removeMax removes and returns the maximum item from the subtree rooted
-// at this node.
+// removeMax removes and returns the maximum item from the subtree rooted at
+// this node.
 func (n *node) removeMax() *example {
 	if n.leaf {
 		n.count--
@@ -429,9 +429,9 @@ func (n *node) removeMax() *example {
 	return out
 }
 
-// remove removes a item from the subtree rooted at this node. Returns
-// the item that was removed or nil if no matching item was found.
-// Also returns whether the node's upper bound changes.
+// remove removes an item from the subtree rooted at this node. Returns the item
+// that was removed or nil if no matching item was found. Also returns whether
+// the node's upper bound changes.
 func (n *node) remove(item *example) (out *example, newBound bool) {
 	i, found := n.find(item)
 	if n.leaf {
@@ -462,7 +462,7 @@ func (n *node) remove(item *example) (out *example, newBound bool) {
 }
 
 // rebalanceOrMerge grows child 'i' to ensure it has sufficient room to remove
-// a item from it while keeping it at or above minItems.
+// an item from it while keeping it at or above minItems.
 func (n *node) rebalanceOrMerge(i int) {
 	switch {
 	case i > 0 && n.children[i-1].count > minItems:
@@ -606,9 +606,9 @@ func (n *node) findUpperBound() keyBound {
 	return max
 }
 
-// adjustUpperBoundOnInsertion adjusts the upper key bound for this node
-// given a item and an optional child node that was inserted. Returns
-// true is the upper bound was changed and false if not.
+// adjustUpperBoundOnInsertion adjusts the upper key bound for this node given
+// an item and an optional child node that was inserted. Returns true is the
+// upper bound was changed and false if not.
 func (n *node) adjustUpperBoundOnInsertion(item *example, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
@@ -623,9 +623,9 @@ func (n *node) adjustUpperBoundOnInsertion(item *example, child *node) bool {
 	return false
 }
 
-// adjustUpperBoundOnRemoval adjusts the upper key bound for this node
-// given a item and an optional child node that was removed. Returns
-// true is the upper bound was changed and false if not.
+// adjustUpperBoundOnRemoval adjusts the upper key bound for this node given an
+// item and an optional child node that was removed. Returns true is the upper
+// bound was changed and false if not.
 func (n *node) adjustUpperBoundOnRemoval(item *example, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
@@ -692,7 +692,7 @@ func (t *btree) Clone() btree {
 	return c
 }
 
-// Delete removes a item equal to the passed in item from the tree.
+// Delete removes an item equal to the passed in item from the tree.
 func (t *btree) Delete(item *example) {
 	if t.root == nil || t.root.count == 0 {
 		return
@@ -711,8 +711,8 @@ func (t *btree) Delete(item *example) {
 	}
 }
 
-// Set adds the given item to the tree. If a item in the tree already
-// equals the given one, it is replaced with the new item.
+// Set adds the given item to the tree. If an item in the tree already equals
+// the given one, it is replaced with the new item.
 func (t *btree) Set(item *example) {
 	if t.root == nil {
 		t.root = newLeafNode()

--- a/pkg/util/interval/generic/example_interval_btree_test.go
+++ b/pkg/util/interval/generic/example_interval_btree_test.go
@@ -410,6 +410,310 @@ func TestBTreeSeekOverlap(t *testing.T) {
 	}
 }
 
+// TestBTreeCmp tests the btree item comparison.
+func TestBTreeCmp(t *testing.T) {
+	// NB: go_generics doesn't do well with anonymous types, so name this type.
+	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
+	// anonymous constructors with.
+	type testCase struct {
+		spanA, spanB roachpb.Span
+		idA, idB     uint64
+		exp          int
+	}
+	var testCases []testCase
+	testCases = append(testCases,
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a")},
+			idA:   1,
+			idB:   1,
+			exp:   0,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+			idA:   1,
+			idB:   1,
+			exp:   -1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+			idA:   1,
+			idB:   1,
+			exp:   1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			idA:   1,
+			idB:   1,
+			exp:   0,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a")},
+			idA:   1,
+			idB:   2,
+			exp:   -1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a")},
+			idA:   2,
+			idB:   1,
+			exp:   1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("b")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			idA:   1,
+			idB:   1,
+			exp:   1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("e")},
+			spanB: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+			idA:   1,
+			idB:   1,
+			exp:   -1,
+		},
+	)
+	for _, tc := range testCases {
+		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
+		t.Run(name, func(t *testing.T) {
+			laA := newItem(tc.spanA)
+			laA.SetID(tc.idA)
+			laB := newItem(tc.spanB)
+			laB.SetID(tc.idB)
+			require.Equal(t, tc.exp, cmp(laA, laB))
+		})
+	}
+}
+
+// TestIterStack tests the interface of the iterStack type.
+func TestIterStack(t *testing.T) {
+	f := func(i int) iterFrame { return iterFrame{pos: int16(i)} }
+	var is iterStack
+	for i := 1; i <= 2*len(iterStackArr{}); i++ {
+		var j int
+		for j = 0; j < i; j++ {
+			is.push(f(j))
+		}
+		require.Equal(t, j, is.len())
+		for j--; j >= 0; j-- {
+			require.Equal(t, f(j), is.pop())
+		}
+		is.reset()
+	}
+}
+
+//////////////////////////////////////////
+//        Randomized Unit Tests         //
+//////////////////////////////////////////
+
+// perm returns a random permutation of items with spans in the range [0, n).
+func perm(n int) (out []*example) {
+	for _, i := range rand.Perm(n) {
+		out = append(out, newItem(spanWithEnd(i, i+1)))
+	}
+	return out
+}
+
+// rang returns an ordered list of items with spans in the range [m, n].
+func rang(m, n int) (out []*example) {
+	for i := m; i <= n; i++ {
+		out = append(out, newItem(spanWithEnd(i, i+1)))
+	}
+	return out
+}
+
+// all extracts all items from a tree in order as a slice.
+func all(tr *btree) (out []*example) {
+	it := tr.MakeIter()
+	it.First()
+	for it.Valid() {
+		out = append(out, it.Cur())
+		it.Next()
+	}
+	return out
+}
+
+func run(tb testing.TB, name string, f func(testing.TB)) {
+	switch v := tb.(type) {
+	case *testing.T:
+		v.Run(name, func(t *testing.T) {
+			f(t)
+		})
+	case *testing.B:
+		v.Run(name, func(b *testing.B) {
+			f(b)
+		})
+	default:
+		tb.Fatalf("unknown %T", tb)
+	}
+}
+
+func verify(tb testing.TB, tr *btree) {
+	if tt, ok := tb.(*testing.T); ok {
+		tr.Verify(tt)
+	}
+}
+
+func resetTimer(tb testing.TB) {
+	if b, ok := tb.(*testing.B); ok {
+		b.ResetTimer()
+	}
+}
+
+func stopTimer(tb testing.TB) {
+	if b, ok := tb.(*testing.B); ok {
+		b.StopTimer()
+	}
+}
+
+func startTimer(tb testing.TB) {
+	if b, ok := tb.(*testing.B); ok {
+		b.StartTimer()
+	}
+}
+
+func runBTreeInsert(tb testing.TB, count, iters int) {
+	insertP := perm(count)
+	resetTimer(tb)
+	for i := 0; i < iters; {
+		var tr btree
+		for _, item := range insertP {
+			tr.Set(item)
+			verify(tb, &tr)
+			i++
+			if i >= iters {
+				return
+			}
+		}
+	}
+}
+
+func runBTreeDelete(tb testing.TB, count, iters int) {
+	insertP, removeP := perm(count), perm(count)
+	resetTimer(tb)
+	for i := 0; i < iters; {
+		stopTimer(tb)
+		var tr btree
+		for _, item := range insertP {
+			tr.Set(item)
+			verify(tb, &tr)
+		}
+		startTimer(tb)
+		for _, item := range removeP {
+			tr.Delete(item)
+			verify(tb, &tr)
+			i++
+			if i >= iters {
+				return
+			}
+		}
+		if tr.Len() > 0 {
+			tb.Fatalf("tree not empty: %s", &tr)
+		}
+	}
+}
+
+func runBTreeDeleteInsert(tb testing.TB, count, iters int) {
+	insertP := perm(count)
+	var tr btree
+	for _, item := range insertP {
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+	resetTimer(tb)
+	for i := 0; i < iters; i++ {
+		item := insertP[i%count]
+		tr.Delete(item)
+		verify(tb, &tr)
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+}
+
+func runBTreeDeleteInsertCloneOnce(tb testing.TB, count, iters int) {
+	insertP := perm(count)
+	var tr btree
+	for _, item := range insertP {
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+	tr = tr.Clone()
+	resetTimer(tb)
+	for i := 0; i < iters; i++ {
+		item := insertP[i%count]
+		tr.Delete(item)
+		verify(tb, &tr)
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+}
+
+func runBTreeDeleteInsertCloneEachTime(tb testing.TB, count, iters int) {
+	for _, reset := range []bool{false, true} {
+		run(tb, fmt.Sprintf("reset=%t", reset), func(tb testing.TB) {
+			insertP := perm(count)
+			var tr, trReset btree
+			for _, item := range insertP {
+				tr.Set(item)
+				verify(tb, &tr)
+			}
+			resetTimer(tb)
+			for i := 0; i < iters; i++ {
+				item := insertP[i%count]
+				if reset {
+					trReset.Reset()
+					trReset = tr
+				}
+				tr = tr.Clone()
+				tr.Delete(item)
+				verify(tb, &tr)
+				tr.Set(item)
+				verify(tb, &tr)
+			}
+		})
+	}
+}
+
+// randN returns a random integer in the range [min, max).
+func randN(min, max int) int { return rand.Intn(max-min) + min }
+func randCount() int {
+	if testing.Short() {
+		return randN(1, 128)
+	}
+	return randN(1, 1024)
+}
+
+func TestBTreeInsert(t *testing.T) {
+	count := randCount()
+	runBTreeInsert(t, count, count)
+}
+
+func TestBTreeDelete(t *testing.T) {
+	count := randCount()
+	runBTreeDelete(t, count, count)
+}
+
+func TestBTreeDeleteInsert(t *testing.T) {
+	count := randCount()
+	runBTreeDeleteInsert(t, count, count)
+}
+
+func TestBTreeDeleteInsertCloneOnce(t *testing.T) {
+	count := randCount()
+	runBTreeDeleteInsertCloneOnce(t, count, count)
+}
+
+func TestBTreeDeleteInsertCloneEachTime(t *testing.T) {
+	count := randCount()
+	runBTreeDeleteInsertCloneEachTime(t, count, count)
+}
+
 // TestBTreeSeekOverlapRandom tests btree iterator overlap operations using
 // randomized input.
 func TestBTreeSeekOverlapRandom(t *testing.T) {
@@ -542,134 +846,9 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 	}
 }
 
-// TestBTreeCmp tests the btree item comparison.
-func TestBTreeCmp(t *testing.T) {
-	// NB: go_generics doesn't do well with anonymous types, so name this type.
-	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
-	// anonymous constructors with.
-	type testCase struct {
-		spanA, spanB roachpb.Span
-		idA, idB     uint64
-		exp          int
-	}
-	var testCases []testCase
-	testCases = append(testCases,
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a")},
-			idA:   1,
-			idB:   1,
-			exp:   0,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
-			idA:   1,
-			idB:   1,
-			exp:   -1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
-			idA:   1,
-			idB:   1,
-			exp:   1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			idA:   1,
-			idB:   1,
-			exp:   0,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a")},
-			idA:   1,
-			idB:   2,
-			exp:   -1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a")},
-			idA:   2,
-			idB:   1,
-			exp:   1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("b")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			idA:   1,
-			idB:   1,
-			exp:   1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("e")},
-			spanB: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
-			idA:   1,
-			idB:   1,
-			exp:   -1,
-		},
-	)
-	for _, tc := range testCases {
-		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
-		t.Run(name, func(t *testing.T) {
-			laA := newItem(tc.spanA)
-			laA.SetID(tc.idA)
-			laB := newItem(tc.spanB)
-			laB.SetID(tc.idB)
-			require.Equal(t, tc.exp, cmp(laA, laB))
-		})
-	}
-}
-
-// TestIterStack tests the interface of the iterStack type.
-func TestIterStack(t *testing.T) {
-	f := func(i int) iterFrame { return iterFrame{pos: int16(i)} }
-	var is iterStack
-	for i := 1; i <= 2*len(iterStackArr{}); i++ {
-		var j int
-		for j = 0; j < i; j++ {
-			is.push(f(j))
-		}
-		require.Equal(t, j, is.len())
-		for j--; j >= 0; j-- {
-			require.Equal(t, f(j), is.pop())
-		}
-		is.reset()
-	}
-}
-
 //////////////////////////////////////////
 //              Benchmarks              //
 //////////////////////////////////////////
-
-// perm returns a random permutation of items with spans in the range [0, n).
-func perm(n int) (out []*example) {
-	for _, i := range rand.Perm(n) {
-		out = append(out, newItem(spanWithEnd(i, i+1)))
-	}
-	return out
-}
-
-// rang returns an ordered list of items with spans in the range [m, n].
-func rang(m, n int) (out []*example) {
-	for i := m; i <= n; i++ {
-		out = append(out, newItem(spanWithEnd(i, i+1)))
-	}
-	return out
-}
-
-// all extracts all items from a tree in order as a slice.
-func all(tr *btree) (out []*example) {
-	it := tr.MakeIter()
-	it.First()
-	for it.Valid() {
-		out = append(out, it.Cur())
-		it.Next()
-	}
-	return out
-}
 
 func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {
 	for _, count := range []int{16, 128, 1024, 8192, 65536} {
@@ -682,61 +861,21 @@ func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {
 // BenchmarkBTreeInsert measures btree insertion performance.
 func BenchmarkBTreeInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP := perm(count)
-		b.ResetTimer()
-		for i := 0; i < b.N; {
-			var tr btree
-			for _, item := range insertP {
-				tr.Set(item)
-				i++
-				if i >= b.N {
-					return
-				}
-			}
-		}
+		runBTreeInsert(b, count, b.N)
 	})
 }
 
 // BenchmarkBTreeDelete measures btree deletion performance.
 func BenchmarkBTreeDelete(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP, removeP := perm(count), perm(count)
-		b.ResetTimer()
-		for i := 0; i < b.N; {
-			b.StopTimer()
-			var tr btree
-			for _, item := range insertP {
-				tr.Set(item)
-			}
-			b.StartTimer()
-			for _, item := range removeP {
-				tr.Delete(item)
-				i++
-				if i >= b.N {
-					return
-				}
-			}
-			if tr.Len() > 0 {
-				b.Fatalf("tree not empty: %s", &tr)
-			}
-		}
+		runBTreeDelete(b, count, b.N)
 	})
 }
 
 // BenchmarkBTreeDeleteInsert measures btree deletion and insertion performance.
 func BenchmarkBTreeDeleteInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP := perm(count)
-		var tr btree
-		for _, item := range insertP {
-			tr.Set(item)
-		}
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			item := insertP[i%count]
-			tr.Delete(item)
-			tr.Set(item)
-		}
+		runBTreeDeleteInsert(b, count, b.N)
 	})
 }
 
@@ -744,46 +883,16 @@ func BenchmarkBTreeDeleteInsert(b *testing.B) {
 // performance after the tree has been copy-on-write cloned once.
 func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP := perm(count)
-		var tr btree
-		for _, item := range insertP {
-			tr.Set(item)
-		}
-		tr = tr.Clone()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			item := insertP[i%count]
-			tr.Delete(item)
-			tr.Set(item)
-		}
+		runBTreeDeleteInsertCloneOnce(b, count, b.N)
 	})
 }
 
 // BenchmarkBTreeDeleteInsertCloneEachTime measures btree deletion and insertion
 // performance while the tree is repeatedly copy-on-write cloned.
 func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
-	for _, reset := range []bool{false, true} {
-		b.Run(fmt.Sprintf("reset=%t", reset), func(b *testing.B) {
-			forBenchmarkSizes(b, func(b *testing.B, count int) {
-				insertP := perm(count)
-				var tr, trReset btree
-				for _, item := range insertP {
-					tr.Set(item)
-				}
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
-					item := insertP[i%count]
-					if reset {
-						trReset.Reset()
-						trReset = tr
-					}
-					tr = tr.Clone()
-					tr.Delete(item)
-					tr.Set(item)
-				}
-			})
-		})
-	}
+	forBenchmarkSizes(b, func(b *testing.B, count int) {
+		runBTreeDeleteInsertCloneEachTime(b, count, b.N)
+	})
 }
 
 // BenchmarkBTreeMakeIter measures the cost of creating a btree iterator.

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl.go
@@ -416,12 +416,17 @@ func (n *node) removeMax() T {
 		n.adjustUpperBoundOnRemoval(out, nil)
 		return out
 	}
-	child := mut(&n.children[n.count])
-	if child.count <= minItems {
-		n.rebalanceOrMerge(int(n.count))
-		return n.removeMax()
+	// Recurse into max child.
+	i := int(n.count)
+	if n.children[i].count <= minItems {
+		// Child not large enough to remove from.
+		n.rebalanceOrMerge(i)
+		return n.removeMax() // redo
 	}
-	return child.removeMax()
+	child := mut(&n.children[i])
+	out := child.removeMax()
+	n.adjustUpperBoundOnRemoval(out, nil)
+	return out
 }
 
 // remove removes a item from the subtree rooted at this node. Returns
@@ -439,7 +444,7 @@ func (n *node) remove(item T) (out T, newBound bool) {
 	if n.children[i].count <= minItems {
 		// Child not large enough to remove from.
 		n.rebalanceOrMerge(i)
-		return n.remove(item)
+		return n.remove(item) // redo
 	}
 	child := mut(&n.children[i])
 	if found {
@@ -619,7 +624,7 @@ func (n *node) adjustUpperBoundOnInsertion(item T, child *node) bool {
 }
 
 // adjustUpperBoundOnRemoval adjusts the upper key bound for this node
-// given a item and an optional child node that were removed. Returns
+// given a item and an optional child node that was removed. Returns
 // true is the upper bound was changed and false if not.
 func (n *node) adjustUpperBoundOnRemoval(item T, child *node) bool {
 	up := upperBound(item)

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl.go
@@ -371,9 +371,9 @@ func (n *node) split(i int) (T, *node) {
 	return out, next
 }
 
-// insert inserts a item into the subtree rooted at this node, making sure no
+// insert inserts an item into the subtree rooted at this node, making sure no
 // nodes in the subtree exceed maxItems items. Returns true if an existing item
-// was replaced and false if a item was inserted. Also returns whether the
+// was replaced and false if an item was inserted. Also returns whether the
 // node's upper bound changes.
 func (n *node) insert(item T) (replaced, newBound bool) {
 	i, found := n.find(item)
@@ -406,8 +406,8 @@ func (n *node) insert(item T) (replaced, newBound bool) {
 	return replaced, newBound
 }
 
-// removeMax removes and returns the maximum item from the subtree rooted
-// at this node.
+// removeMax removes and returns the maximum item from the subtree rooted at
+// this node.
 func (n *node) removeMax() T {
 	if n.leaf {
 		n.count--
@@ -429,9 +429,9 @@ func (n *node) removeMax() T {
 	return out
 }
 
-// remove removes a item from the subtree rooted at this node. Returns
-// the item that was removed or nil if no matching item was found.
-// Also returns whether the node's upper bound changes.
+// remove removes an item from the subtree rooted at this node. Returns the item
+// that was removed or nil if no matching item was found. Also returns whether
+// the node's upper bound changes.
 func (n *node) remove(item T) (out T, newBound bool) {
 	i, found := n.find(item)
 	if n.leaf {
@@ -462,7 +462,7 @@ func (n *node) remove(item T) (out T, newBound bool) {
 }
 
 // rebalanceOrMerge grows child 'i' to ensure it has sufficient room to remove
-// a item from it while keeping it at or above minItems.
+// an item from it while keeping it at or above minItems.
 func (n *node) rebalanceOrMerge(i int) {
 	switch {
 	case i > 0 && n.children[i-1].count > minItems:
@@ -606,9 +606,9 @@ func (n *node) findUpperBound() keyBound {
 	return max
 }
 
-// adjustUpperBoundOnInsertion adjusts the upper key bound for this node
-// given a item and an optional child node that was inserted. Returns
-// true is the upper bound was changed and false if not.
+// adjustUpperBoundOnInsertion adjusts the upper key bound for this node given
+// an item and an optional child node that was inserted. Returns true is the
+// upper bound was changed and false if not.
 func (n *node) adjustUpperBoundOnInsertion(item T, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
@@ -623,9 +623,9 @@ func (n *node) adjustUpperBoundOnInsertion(item T, child *node) bool {
 	return false
 }
 
-// adjustUpperBoundOnRemoval adjusts the upper key bound for this node
-// given a item and an optional child node that was removed. Returns
-// true is the upper bound was changed and false if not.
+// adjustUpperBoundOnRemoval adjusts the upper key bound for this node given an
+// item and an optional child node that was removed. Returns true is the upper
+// bound was changed and false if not.
 func (n *node) adjustUpperBoundOnRemoval(item T, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
@@ -692,7 +692,7 @@ func (t *btree) Clone() btree {
 	return c
 }
 
-// Delete removes a item equal to the passed in item from the tree.
+// Delete removes an item equal to the passed in item from the tree.
 func (t *btree) Delete(item T) {
 	if t.root == nil || t.root.count == 0 {
 		return
@@ -711,8 +711,8 @@ func (t *btree) Delete(item T) {
 	}
 }
 
-// Set adds the given item to the tree. If a item in the tree already
-// equals the given one, it is replaced with the new item.
+// Set adds the given item to the tree. If an item in the tree already equals
+// the given one, it is replaced with the new item.
 func (t *btree) Set(item T) {
 	if t.root == nil {
 		t.root = newLeafNode()

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
@@ -410,6 +410,310 @@ func TestBTreeSeekOverlap(t *testing.T) {
 	}
 }
 
+// TestBTreeCmp tests the btree item comparison.
+func TestBTreeCmp(t *testing.T) {
+	// NB: go_generics doesn't do well with anonymous types, so name this type.
+	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
+	// anonymous constructors with.
+	type testCase struct {
+		spanA, spanB roachpb.Span
+		idA, idB     uint64
+		exp          int
+	}
+	var testCases []testCase
+	testCases = append(testCases,
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a")},
+			idA:   1,
+			idB:   1,
+			exp:   0,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+			idA:   1,
+			idB:   1,
+			exp:   -1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+			idA:   1,
+			idB:   1,
+			exp:   1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			idA:   1,
+			idB:   1,
+			exp:   0,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a")},
+			idA:   1,
+			idB:   2,
+			exp:   -1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("a")},
+			spanB: roachpb.Span{Key: roachpb.Key("a")},
+			idA:   2,
+			idB:   1,
+			exp:   1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("b")},
+			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			idA:   1,
+			idB:   1,
+			exp:   1,
+		},
+		testCase{
+			spanA: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("e")},
+			spanB: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+			idA:   1,
+			idB:   1,
+			exp:   -1,
+		},
+	)
+	for _, tc := range testCases {
+		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
+		t.Run(name, func(t *testing.T) {
+			laA := newItem(tc.spanA)
+			laA.SetID(tc.idA)
+			laB := newItem(tc.spanB)
+			laB.SetID(tc.idB)
+			require.Equal(t, tc.exp, cmp(laA, laB))
+		})
+	}
+}
+
+// TestIterStack tests the interface of the iterStack type.
+func TestIterStack(t *testing.T) {
+	f := func(i int) iterFrame { return iterFrame{pos: int16(i)} }
+	var is iterStack
+	for i := 1; i <= 2*len(iterStackArr{}); i++ {
+		var j int
+		for j = 0; j < i; j++ {
+			is.push(f(j))
+		}
+		require.Equal(t, j, is.len())
+		for j--; j >= 0; j-- {
+			require.Equal(t, f(j), is.pop())
+		}
+		is.reset()
+	}
+}
+
+//////////////////////////////////////////
+//        Randomized Unit Tests         //
+//////////////////////////////////////////
+
+// perm returns a random permutation of items with spans in the range [0, n).
+func perm(n int) (out []T) {
+	for _, i := range rand.Perm(n) {
+		out = append(out, newItem(spanWithEnd(i, i+1)))
+	}
+	return out
+}
+
+// rang returns an ordered list of items with spans in the range [m, n].
+func rang(m, n int) (out []T) {
+	for i := m; i <= n; i++ {
+		out = append(out, newItem(spanWithEnd(i, i+1)))
+	}
+	return out
+}
+
+// all extracts all items from a tree in order as a slice.
+func all(tr *btree) (out []T) {
+	it := tr.MakeIter()
+	it.First()
+	for it.Valid() {
+		out = append(out, it.Cur())
+		it.Next()
+	}
+	return out
+}
+
+func run(tb testing.TB, name string, f func(testing.TB)) {
+	switch v := tb.(type) {
+	case *testing.T:
+		v.Run(name, func(t *testing.T) {
+			f(t)
+		})
+	case *testing.B:
+		v.Run(name, func(b *testing.B) {
+			f(b)
+		})
+	default:
+		tb.Fatalf("unknown %T", tb)
+	}
+}
+
+func verify(tb testing.TB, tr *btree) {
+	if tt, ok := tb.(*testing.T); ok {
+		tr.Verify(tt)
+	}
+}
+
+func resetTimer(tb testing.TB) {
+	if b, ok := tb.(*testing.B); ok {
+		b.ResetTimer()
+	}
+}
+
+func stopTimer(tb testing.TB) {
+	if b, ok := tb.(*testing.B); ok {
+		b.StopTimer()
+	}
+}
+
+func startTimer(tb testing.TB) {
+	if b, ok := tb.(*testing.B); ok {
+		b.StartTimer()
+	}
+}
+
+func runBTreeInsert(tb testing.TB, count, iters int) {
+	insertP := perm(count)
+	resetTimer(tb)
+	for i := 0; i < iters; {
+		var tr btree
+		for _, item := range insertP {
+			tr.Set(item)
+			verify(tb, &tr)
+			i++
+			if i >= iters {
+				return
+			}
+		}
+	}
+}
+
+func runBTreeDelete(tb testing.TB, count, iters int) {
+	insertP, removeP := perm(count), perm(count)
+	resetTimer(tb)
+	for i := 0; i < iters; {
+		stopTimer(tb)
+		var tr btree
+		for _, item := range insertP {
+			tr.Set(item)
+			verify(tb, &tr)
+		}
+		startTimer(tb)
+		for _, item := range removeP {
+			tr.Delete(item)
+			verify(tb, &tr)
+			i++
+			if i >= iters {
+				return
+			}
+		}
+		if tr.Len() > 0 {
+			tb.Fatalf("tree not empty: %s", &tr)
+		}
+	}
+}
+
+func runBTreeDeleteInsert(tb testing.TB, count, iters int) {
+	insertP := perm(count)
+	var tr btree
+	for _, item := range insertP {
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+	resetTimer(tb)
+	for i := 0; i < iters; i++ {
+		item := insertP[i%count]
+		tr.Delete(item)
+		verify(tb, &tr)
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+}
+
+func runBTreeDeleteInsertCloneOnce(tb testing.TB, count, iters int) {
+	insertP := perm(count)
+	var tr btree
+	for _, item := range insertP {
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+	tr = tr.Clone()
+	resetTimer(tb)
+	for i := 0; i < iters; i++ {
+		item := insertP[i%count]
+		tr.Delete(item)
+		verify(tb, &tr)
+		tr.Set(item)
+		verify(tb, &tr)
+	}
+}
+
+func runBTreeDeleteInsertCloneEachTime(tb testing.TB, count, iters int) {
+	for _, reset := range []bool{false, true} {
+		run(tb, fmt.Sprintf("reset=%t", reset), func(tb testing.TB) {
+			insertP := perm(count)
+			var tr, trReset btree
+			for _, item := range insertP {
+				tr.Set(item)
+				verify(tb, &tr)
+			}
+			resetTimer(tb)
+			for i := 0; i < iters; i++ {
+				item := insertP[i%count]
+				if reset {
+					trReset.Reset()
+					trReset = tr
+				}
+				tr = tr.Clone()
+				tr.Delete(item)
+				verify(tb, &tr)
+				tr.Set(item)
+				verify(tb, &tr)
+			}
+		})
+	}
+}
+
+// randN returns a random integer in the range [min, max).
+func randN(min, max int) int { return rand.Intn(max-min) + min }
+func randCount() int {
+	if testing.Short() {
+		return randN(1, 128)
+	}
+	return randN(1, 1024)
+}
+
+func TestBTreeInsert(t *testing.T) {
+	count := randCount()
+	runBTreeInsert(t, count, count)
+}
+
+func TestBTreeDelete(t *testing.T) {
+	count := randCount()
+	runBTreeDelete(t, count, count)
+}
+
+func TestBTreeDeleteInsert(t *testing.T) {
+	count := randCount()
+	runBTreeDeleteInsert(t, count, count)
+}
+
+func TestBTreeDeleteInsertCloneOnce(t *testing.T) {
+	count := randCount()
+	runBTreeDeleteInsertCloneOnce(t, count, count)
+}
+
+func TestBTreeDeleteInsertCloneEachTime(t *testing.T) {
+	count := randCount()
+	runBTreeDeleteInsertCloneEachTime(t, count, count)
+}
+
 // TestBTreeSeekOverlapRandom tests btree iterator overlap operations using
 // randomized input.
 func TestBTreeSeekOverlapRandom(t *testing.T) {
@@ -542,134 +846,9 @@ func TestBTreeCloneConcurrentOperations(t *testing.T) {
 	}
 }
 
-// TestBTreeCmp tests the btree item comparison.
-func TestBTreeCmp(t *testing.T) {
-	// NB: go_generics doesn't do well with anonymous types, so name this type.
-	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
-	// anonymous constructors with.
-	type testCase struct {
-		spanA, spanB roachpb.Span
-		idA, idB     uint64
-		exp          int
-	}
-	var testCases []testCase
-	testCases = append(testCases,
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a")},
-			idA:   1,
-			idB:   1,
-			exp:   0,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
-			idA:   1,
-			idB:   1,
-			exp:   -1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
-			idA:   1,
-			idB:   1,
-			exp:   1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			idA:   1,
-			idB:   1,
-			exp:   0,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a")},
-			idA:   1,
-			idB:   2,
-			exp:   -1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("a")},
-			spanB: roachpb.Span{Key: roachpb.Key("a")},
-			idA:   2,
-			idB:   1,
-			exp:   1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("b")},
-			spanB: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
-			idA:   1,
-			idB:   1,
-			exp:   1,
-		},
-		testCase{
-			spanA: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("e")},
-			spanB: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
-			idA:   1,
-			idB:   1,
-			exp:   -1,
-		},
-	)
-	for _, tc := range testCases {
-		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
-		t.Run(name, func(t *testing.T) {
-			laA := newItem(tc.spanA)
-			laA.SetID(tc.idA)
-			laB := newItem(tc.spanB)
-			laB.SetID(tc.idB)
-			require.Equal(t, tc.exp, cmp(laA, laB))
-		})
-	}
-}
-
-// TestIterStack tests the interface of the iterStack type.
-func TestIterStack(t *testing.T) {
-	f := func(i int) iterFrame { return iterFrame{pos: int16(i)} }
-	var is iterStack
-	for i := 1; i <= 2*len(iterStackArr{}); i++ {
-		var j int
-		for j = 0; j < i; j++ {
-			is.push(f(j))
-		}
-		require.Equal(t, j, is.len())
-		for j--; j >= 0; j-- {
-			require.Equal(t, f(j), is.pop())
-		}
-		is.reset()
-	}
-}
-
 //////////////////////////////////////////
 //              Benchmarks              //
 //////////////////////////////////////////
-
-// perm returns a random permutation of items with spans in the range [0, n).
-func perm(n int) (out []T) {
-	for _, i := range rand.Perm(n) {
-		out = append(out, newItem(spanWithEnd(i, i+1)))
-	}
-	return out
-}
-
-// rang returns an ordered list of items with spans in the range [m, n].
-func rang(m, n int) (out []T) {
-	for i := m; i <= n; i++ {
-		out = append(out, newItem(spanWithEnd(i, i+1)))
-	}
-	return out
-}
-
-// all extracts all items from a tree in order as a slice.
-func all(tr *btree) (out []T) {
-	it := tr.MakeIter()
-	it.First()
-	for it.Valid() {
-		out = append(out, it.Cur())
-		it.Next()
-	}
-	return out
-}
 
 func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {
 	for _, count := range []int{16, 128, 1024, 8192, 65536} {
@@ -682,61 +861,21 @@ func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {
 // BenchmarkBTreeInsert measures btree insertion performance.
 func BenchmarkBTreeInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP := perm(count)
-		b.ResetTimer()
-		for i := 0; i < b.N; {
-			var tr btree
-			for _, item := range insertP {
-				tr.Set(item)
-				i++
-				if i >= b.N {
-					return
-				}
-			}
-		}
+		runBTreeInsert(b, count, b.N)
 	})
 }
 
 // BenchmarkBTreeDelete measures btree deletion performance.
 func BenchmarkBTreeDelete(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP, removeP := perm(count), perm(count)
-		b.ResetTimer()
-		for i := 0; i < b.N; {
-			b.StopTimer()
-			var tr btree
-			for _, item := range insertP {
-				tr.Set(item)
-			}
-			b.StartTimer()
-			for _, item := range removeP {
-				tr.Delete(item)
-				i++
-				if i >= b.N {
-					return
-				}
-			}
-			if tr.Len() > 0 {
-				b.Fatalf("tree not empty: %s", &tr)
-			}
-		}
+		runBTreeDelete(b, count, b.N)
 	})
 }
 
 // BenchmarkBTreeDeleteInsert measures btree deletion and insertion performance.
 func BenchmarkBTreeDeleteInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP := perm(count)
-		var tr btree
-		for _, item := range insertP {
-			tr.Set(item)
-		}
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			item := insertP[i%count]
-			tr.Delete(item)
-			tr.Set(item)
-		}
+		runBTreeDeleteInsert(b, count, b.N)
 	})
 }
 
@@ -744,46 +883,16 @@ func BenchmarkBTreeDeleteInsert(b *testing.B) {
 // performance after the tree has been copy-on-write cloned once.
 func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		insertP := perm(count)
-		var tr btree
-		for _, item := range insertP {
-			tr.Set(item)
-		}
-		tr = tr.Clone()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			item := insertP[i%count]
-			tr.Delete(item)
-			tr.Set(item)
-		}
+		runBTreeDeleteInsertCloneOnce(b, count, b.N)
 	})
 }
 
 // BenchmarkBTreeDeleteInsertCloneEachTime measures btree deletion and insertion
 // performance while the tree is repeatedly copy-on-write cloned.
 func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
-	for _, reset := range []bool{false, true} {
-		b.Run(fmt.Sprintf("reset=%t", reset), func(b *testing.B) {
-			forBenchmarkSizes(b, func(b *testing.B, count int) {
-				insertP := perm(count)
-				var tr, trReset btree
-				for _, item := range insertP {
-					tr.Set(item)
-				}
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
-					item := insertP[i%count]
-					if reset {
-						trReset.Reset()
-						trReset = tr
-					}
-					tr = tr.Clone()
-					tr.Delete(item)
-					tr.Set(item)
-				}
-			})
-		})
-	}
+	forBenchmarkSizes(b, func(b *testing.B, count int) {
+		runBTreeDeleteInsertCloneEachTime(b, count, b.N)
+	})
 }
 
 // BenchmarkBTreeMakeIter measures the cost of creating a btree iterator.


### PR DESCRIPTION
In an effort to track down the bug that triggered #51913, this commit
ports the randomized interval btree benchmarks to also be unit tests.
This allows us to run invariant checks (see `btree.Verify`) on randomized
tree configurations.

Doing so revealed a violation of the `isUpperBoundCorrect` invariant.
This was determined to be a bug in `node.removeMax`. When removing an
item from a grandchild node, we were failing to adjust the upper bound
of the child node. It doesn't look like this could cause user-visible
effects because the upper bound of a subtree is only ever decreased on
removal, so at worst, this caused searches in the tree to do more work
than strictly necessary. Still, this is a good bug to fix and it's
encouraging that the new randomized testing using the existing invariant
validation caught it.