### PR TITLE
importccl: restrict IMPORT INTO to only CSV and AVRO

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -568,6 +568,11 @@ func importPlanHook(
 			// - Look at if/how cleanup/rollback works. Reconsider the cpu from the
 			//   desc version (perhaps we should be re-reading instead?).
 			// - Write _a lot_ of tests.
+			if !(importStmt.FileFormat == "CSV" || importStmt.FileFormat == "AVRO") {
+				return errors.Newf(
+					"%s file format is currently unsupported by IMPORT INTO",
+					importStmt.FileFormat)
+			}
 			found, err := p.ResolveMutableTableDescriptor(ctx, table, true, tree.ResolveRequireTableDesc)
 			if err != nil {
 				return err

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1095,24 +1095,6 @@ CREATE TYPE greeting AS ENUM ('hello', 'hi');
 			verifyQuery: "SELECT * FROM t ORDER BY a",
 			expected:    [][]string{{"hello", "hello"}, {"hi", "hi"}},
 		},
-		// Test PGDump imports.
-		{
-			create:      "a greeting, b greeting",
-			intoCols:    "a, b",
-			typ:         "PGDUMP",
-			contents:    `INSERT INTO t VALUES ('hello', 'hello'), ('hi', 'hi')`,
-			verifyQuery: "SELECT * FROM t ORDER BY a",
-			expected:    [][]string{{"hello", "hello"}, {"hi", "hi"}},
-		},
-		// Test MySQL imports.
-		{
-			create:      "a greeting, b greeting",
-			intoCols:    "a, b",
-			typ:         "MYSQLDUMP",
-			contents:    "INSERT INTO `t` VALUES ('hello', 'hello'), ('hi', 'hi')",
-			verifyQuery: "SELECT * FROM t ORDER BY a",
-			expected:    [][]string{{"hello", "hello"}, {"hi", "hi"}},
-		},
 		// Test AVRO imports.
 		{
 			create:      "a greeting, b greeting",
@@ -3119,17 +3101,8 @@ func TestImportDefault(t *testing.T) {
 			format:        "CSV",
 			expectedError: "unsafe for import",
 		},
-		// Non CSV formats.
-		// TODO (anzoteh96): currently, DEFAULT expressions don't work well for
-		// MySQL and AVRO. Fix these and add tests here.
-		{
-			name:            "pgdump",
-			data:            "INSERT INTO t VALUES (1, 2), (3, 4)",
-			create:          `a INT, b INT DEFAULT 42, c INT`,
-			targetCols:      "c, a",
-			format:          "PGDUMP",
-			expectedResults: [][]string{{"2", "42", "1"}, {"4", "42", "3"}},
-		},
+		// TODO (anzoteh96): add AVRO format, and also MySQL and PGDUMP once
+		// IMPORT INTO are supported for these file formats.
 	}
 	for _, test := range tests {
 		if test.sequence != "" {
@@ -4126,7 +4099,36 @@ func TestImportMysql(t *testing.T) {
 	}
 }
 
-func TestImportMysqlOutfile(t *testing.T) {
+// TODO (anzoteh96): this should have been in TestImportMysql, but the
+// entire test was skipped. We should move this into TestImportMysql once
+// it's unskipped.
+func TestImportIntoMysql(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const (
+		nodes = 3
+	)
+	ctx := context.Background()
+	baseDir := filepath.Join("testdata")
+	args := base.TestServerArgs{ExternalIODir: baseDir}
+	tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{ServerArgs: args})
+	defer tc.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	data := `INSERT INTO t VALUES (1, 2), (3, 4)`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			_, _ = w.Write([]byte(data))
+		}
+	}))
+	defer srv.Close()
+	defer sqlDB.Exec(t, "DROP TABLE t")
+	sqlDB.Exec(t, "CREATE TABLE t (a INT, b INT)")
+	sqlDB.ExpectErr(t,
+		"MYSQLDUMP file format is currently unsupported by IMPORT INTO",
+		fmt.Sprintf(`IMPORT INTO t (a, b) MYSQLDUMP DATA (%q)`, srv.URL))
+}
+
+func TestImportDelimited(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -4186,6 +4188,22 @@ func TestImportMysqlOutfile(t *testing.T) {
 			}
 		})
 	}
+	t.Run("import-into-not-supported", func(t *testing.T) {
+		data := "1,2\n3,4"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" {
+				_, _ = w.Write([]byte(data))
+			}
+		}))
+		defer srv.Close()
+		defer sqlDB.Exec(t, "DROP TABLE t")
+		sqlDB.Exec(t, "CREATE TABLE t (a INT, b INT)")
+		sqlDB.ExpectErr(t,
+			"DELIMITED file format is currently unsupported by IMPORT INTO",
+			fmt.Sprintf(
+				`IMPORT INTO t (a, b) DELIMITED DATA (%q) WITH fields_terminated_by = ","`,
+				srv.URL))
+	})
 }
 
 func TestImportPgCopy(t *testing.T) {
@@ -4253,6 +4271,20 @@ func TestImportPgCopy(t *testing.T) {
 			}
 		})
 	}
+	t.Run("import-into-not-supported", func(t *testing.T) {
+		data := "1,2\n3,4"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" {
+				_, _ = w.Write([]byte(data))
+			}
+		}))
+		defer srv.Close()
+		defer sqlDB.Exec(t, "DROP TABLE t")
+		sqlDB.Exec(t, "CREATE TABLE t (a INT, b INT)")
+		sqlDB.ExpectErr(t,
+			"PGCOPY file format is currently unsupported by IMPORT INTO",
+			fmt.Sprintf(`IMPORT INTO t (a, b) PGCOPY DATA (%q) WITH delimiter = ","`, srv.URL))
+	})
 }
 
 func TestImportPgDump(t *testing.T) {
@@ -4421,6 +4453,20 @@ func TestImportPgDump(t *testing.T) {
 		defer sqlDB.Exec(t, "DROP TABLE t")
 		sqlDB.Exec(t, "IMPORT PGDUMP ($1)", srv.URL)
 		sqlDB.CheckQueryResults(t, `SELECT * from t`, [][]string{{"2", "42", "1"}, {"4", "42", "3"}})
+	})
+	t.Run("import-into-not-supported", func(t *testing.T) {
+		data := `INSERT INTO t VALUES (1, 2), (3, 4)`
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" {
+				_, _ = w.Write([]byte(data))
+			}
+		}))
+		defer srv.Close()
+		defer sqlDB.Exec(t, "DROP TABLE t")
+		sqlDB.Exec(t, "CREATE TABLE t (a INT, b INT)")
+		sqlDB.ExpectErr(t,
+			"PGDUMP file format is currently unsupported by IMPORT INTO",
+			fmt.Sprintf(`IMPORT INTO t (a, b) PGDUMP DATA (%q)`, srv.URL))
 	})
 }
 


### PR DESCRIPTION
As per the [CRDB documentation](https://www.cockroachlabs.com/docs/v20.1/import-into.html), IMPORT INTO is supported only in CSV and AVRO. However, as #51641 points out, calling IMPORT INTO on MYSQLDUMP produces surprising results. 

This PR enforces this restriction by returning an error when IMPORT INTO is done on PGDUMP and MYSQLDUMP data.

Fixes #51641

Release note: None