### PR TITLE
release-20.1: sql: fix UPSERT in some cases

### DIFF
--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -148,6 +148,7 @@ func (tu *optTableUpserter) init(
 
 // flushAndStartNewBatch is part of the tableWriter interface.
 func (tu *optTableUpserter) flushAndStartNewBatch(ctx context.Context) error {
+	tu.resultCount = 0
 	if tu.collectRows {
 		tu.rowsUpserted.Clear(ctx)
 	}


### PR DESCRIPTION
`optTableUpserter.resultCount` tracks the number of rows in the current
batch (and mirrors `rowsUpserted.Len()` if it's collecting rows).
Previously, `resultCount` was never reset although `rowsUpserted` was.
This resulted in a "unsynchronization" of `BatchedCount` and
`BatchedValues` methods which - I think - could lead to incorrect
results being returned by RETURNING clause of UPSERT statement (possibly
attempting to request a "value" that is "out of bounds").

This is a "backport" of the fix in #51631 without other cleanup stuff.

Release note: None