### PR TITLE
release-20.1: sql: be more strict with validating EXPLAIN

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -2818,6 +2818,49 @@ EXPLAIN EXECUTE a
 HINT: try \h EXPLAIN`,
 		},
 		{
+			`EXPLAIN ANALYZE (PLAN) SELECT 1`,
+			`at or near "EOF": syntax error: EXPLAIN ANALYZE cannot be used with PLAN
+DETAIL: source SQL:
+EXPLAIN ANALYZE (PLAN) SELECT 1
+                               ^`,
+		},
+		{
+			`EXPLAIN (ANALYZE, PLAN) SELECT 1`,
+			`at or near "analyze": syntax error
+DETAIL: source SQL:
+EXPLAIN (ANALYZE, PLAN) SELECT 1
+         ^
+HINT: try \h <SELECTCLAUSE>`,
+		},
+		{
+			`EXPLAIN ANALYZE (OPT) SELECT 1`,
+			`at or near "EOF": syntax error: EXPLAIN ANALYZE cannot be used with OPT
+DETAIL: source SQL:
+EXPLAIN ANALYZE (OPT) SELECT 1
+                              ^`,
+		},
+		{
+			`EXPLAIN ANALYZE (VEC) SELECT 1`,
+			`at or near "EOF": syntax error: EXPLAIN ANALYZE cannot be used with VEC
+DETAIL: source SQL:
+EXPLAIN ANALYZE (VEC) SELECT 1
+                              ^`,
+		},
+		{
+			`EXPLAIN (DEBUG) SELECT 1`,
+			`at or near "EOF": syntax error: DEBUG flag can only be used with EXPLAIN ANALYZE
+DETAIL: source SQL:
+EXPLAIN (DEBUG) SELECT 1
+                        ^`,
+		},
+		{
+			`EXPLAIN (PLAN, DEBUG) SELECT 1`,
+			`at or near "EOF": syntax error: DEBUG flag can only be used with EXPLAIN ANALYZE
+DETAIL: source SQL:
+EXPLAIN (PLAN, DEBUG) SELECT 1
+                              ^`,
+		},
+		{
 			`SELECT $0`,
 			`lexical error: placeholder index must be between 1 and 65536
 DETAIL: source SQL:

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -2017,13 +2017,15 @@ func (node *Export) doc(p *PrettyCfg) pretty.Doc {
 
 func (node *Explain) doc(p *PrettyCfg) pretty.Doc {
 	d := pretty.Keyword("EXPLAIN")
+	showMode := node.Mode != ExplainPlan
 	// ANALYZE is a special case because it is a statement implemented as an
 	// option to EXPLAIN.
 	if node.Flags[ExplainFlagAnalyze] {
 		d = pretty.ConcatSpace(d, pretty.Keyword("ANALYZE"))
+		showMode = true
 	}
 	var opts []pretty.Doc
-	if node.Mode != ExplainPlan {
+	if showMode {
 		opts = append(opts, pretty.Keyword(node.Mode.String()))
 	}
 	for f := ExplainFlag(1); f <= numExplainFlags; f++ {


### PR DESCRIPTION
Backport 1/1 commits from #51477.

/cc @cockroachdb/release

---

#### sql: be more strict with validating EXPLAIN

Verify during paring that we are not specifying an invalid mode for
`EXPLAIN ANALYZE`.

Fixes #51473.

Release note: None
