### PR TITLE
opt: add rules to reject nulls under joins

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -2002,30 +2002,30 @@ inner-join (hash)
 # Case with duplicated referenced columns.
 norm
 SELECT * FROM
-fk INNER JOIN (SELECT * FROM xysd FULL JOIN (VALUES (1), (2)) ON False) ON r1 = x
+fk INNER JOIN (SELECT * FROM xysd FULL JOIN (VALUES (1), (2)) ON True) ON r1 = x
 ----
-inner-join (hash)
- ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int) x:6(int!null) y:7(int) s:8(string) d:9(decimal) column1:11(int)
+inner-join (cross)
+ ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int) x:6(int!null) y:7(int) s:8(string) d:9(decimal!null) column1:11(int!null)
  ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  ├── fd: (1)-->(2-4), (6)-->(7-9), (8,9)~~>(6,7), (3)==(6), (6)==(3)
  ├── prune: (1,2,4,7-9,11)
- ├── reject-nulls: (6-9,11)
  ├── interesting orderings: (+1) (+6) (-8,+9,+6)
- ├── scan fk
- │    ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int)
+ ├── join-size: 2
+ ├── inner-join (hash)
+ │    ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int) x:6(int!null) y:7(int) s:8(string) d:9(decimal!null)
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
- │    ├── prune: (1-4)
- │    ├── interesting orderings: (+1)
- │    └── unfiltered-cols: (1-5)
- ├── full-join (cross)
- │    ├── columns: x:6(int) y:7(int) s:8(string) d:9(decimal) column1:11(int)
- │    ├── cardinality: [2 - ]
- │    ├── fd: (6)-->(7-9), (8,9)~~>(6,7)
- │    ├── prune: (6-9,11)
- │    ├── reject-nulls: (6-9,11)
- │    ├── interesting orderings: (+6) (-8,+9,+6)
- │    ├── unfiltered-cols: (6-10)
+ │    ├── fd: (1)-->(2-4), (6)-->(7-9), (8,9)~~>(6,7), (3)==(6), (6)==(3)
+ │    ├── prune: (1,2,4,7-9)
+ │    ├── interesting orderings: (+1) (+6) (-8,+9,+6)
+ │    ├── unfiltered-cols: (1-5)
+ │    ├── scan fk
+ │    │    ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4)
+ │    │    ├── prune: (1-4)
+ │    │    ├── interesting orderings: (+1)
+ │    │    └── unfiltered-cols: (1-5)
  │    ├── scan xysd
  │    │    ├── columns: x:6(int!null) y:7(int) s:8(string) d:9(decimal!null)
  │    │    ├── key: (6)
@@ -2033,20 +2033,19 @@ inner-join (hash)
  │    │    ├── prune: (6-9)
  │    │    ├── interesting orderings: (+6) (-8,+9,+6)
  │    │    └── unfiltered-cols: (6-10)
- │    ├── values
- │    │    ├── columns: column1:11(int!null)
- │    │    ├── cardinality: [2 - 2]
- │    │    ├── prune: (11)
- │    │    ├── tuple [type=tuple{int}]
- │    │    │    └── const: 1 [type=int]
- │    │    └── tuple [type=tuple{int}]
- │    │         └── const: 2 [type=int]
  │    └── filters
- │         └── false [type=bool]
- └── filters
-      └── eq [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
-           ├── variable: r1:3 [type=int]
-           └── variable: x:6 [type=int]
+ │         └── eq [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+ │              ├── variable: r1:3 [type=int]
+ │              └── variable: x:6 [type=int]
+ ├── values
+ │    ├── columns: column1:11(int!null)
+ │    ├── cardinality: [2 - 2]
+ │    ├── prune: (11)
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 2 [type=int]
+ └── filters (true)
 
 # Case with a self-join in the input of an InnerJoin.
 norm

--- a/pkg/sql/opt/norm/rules/reject_nulls.opt
+++ b/pkg/sql/opt/norm/rules/reject_nulls.opt
@@ -149,3 +149,53 @@
     )
     $filters
 )
+
+# RejectNullsUnderJoinLeft adds "col IS NOT NULL" null-rejecting filters to the
+# left input of a join for each column that is both in the NullRejectCols ColSet
+# and is null-rejected by the join's filters. Note that a left join cannot be
+# matched even if its filters reject nulls on a column because left joins add
+# back unmatched columns to the output. RejectNullsUnderJoinLeft is low priority
+# to allow filters to be pushed down entirely, if possible.
+[RejectNullsUnderJoinLeft, Normalize, LowPriority]
+(InnerJoin | InnerJoinApply | SemiJoin | SemiJoinApply
+    $left:* & ^(ColsAreEmpty $rejectCols:(RejectNullCols $left))
+    $right:*
+    $on:* &
+        ^(ColsAreEmpty
+            $nullRejectedCols:(IntersectionCols
+                $rejectCols
+                (GetNullRejectedCols $on)
+            )
+        )
+    $private:*
+)
+=>
+((OpName)
+    (Select $left (MakeNullRejectFilters $nullRejectedCols))
+    $right
+    $on
+    $private
+)
+
+# RejectNullsUnderJoinRight mirrors RejectNullsUnderJoinLeft.
+[RejectNullsUnderJoinRight, Normalize, LowPriority]
+(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply
+    $left:*
+    $right:* &
+        ^(ColsAreEmpty $rejectCols:(RejectNullCols $right))
+    $on:* &
+        ^(ColsAreEmpty
+            $nullRejectedCols:(IntersectionCols
+                $rejectCols
+                (GetNullRejectedCols $on)
+            )
+        )
+    $private:*
+)
+=>
+((OpName)
+    $left
+    (Select $right (MakeNullRejectFilters $nullRejectedCols))
+    $on
+    $private
+)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -821,8 +821,8 @@ project
  │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
  │    │    │    ├── immutable
  │    │    │    ├── fd: (5)==(11), (11)==(5)
- │    │    │    ├── full-join (cross)
- │    │    │    │    ├── columns: b.x:5
+ │    │    │    ├── left-join (cross)
+ │    │    │    │    ├── columns: b.x:5!null
  │    │    │    │    ├── outer: (1)
  │    │    │    │    ├── scan b
  │    │    │    │    │    ├── columns: b.x:5!null
@@ -874,32 +874,34 @@ project
  │    │    ├── scan c
  │    │    │    ├── columns: c.x:1!null
  │    │    │    └── key: (1)
- │    │    ├── inner-join (hash)
+ │    │    ├── left-join (cross)
  │    │    │    ├── columns: k:5!null b.x:11!null
  │    │    │    ├── outer: (1)
- │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
  │    │    │    ├── immutable
  │    │    │    ├── fd: (5)==(11), (11)==(5)
- │    │    │    ├── select
- │    │    │    │    ├── columns: k:5!null
+ │    │    │    ├── inner-join (hash)
+ │    │    │    │    ├── columns: k:5!null b.x:11!null
+ │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
  │    │    │    │    ├── immutable
- │    │    │    │    ├── key: (5)
- │    │    │    │    ├── scan a
+ │    │    │    │    ├── key: (11)
+ │    │    │    │    ├── fd: (5)==(11), (11)==(5)
+ │    │    │    │    ├── select
  │    │    │    │    │    ├── columns: k:5!null
- │    │    │    │    │    └── key: (5)
- │    │    │    │    └── filters
- │    │    │    │         └── (k:5 + k:5) < 5 [outer=(5), immutable]
- │    │    │    ├── full-join (cross)
- │    │    │    │    ├── columns: b.x:11
- │    │    │    │    ├── outer: (1)
+ │    │    │    │    │    ├── immutable
+ │    │    │    │    │    ├── key: (5)
+ │    │    │    │    │    ├── scan a
+ │    │    │    │    │    │    ├── columns: k:5!null
+ │    │    │    │    │    │    └── key: (5)
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         └── (k:5 + k:5) < 5 [outer=(5), immutable]
  │    │    │    │    ├── scan b
  │    │    │    │    │    ├── columns: b.x:11!null
  │    │    │    │    │    └── key: (11)
- │    │    │    │    ├── scan b2
  │    │    │    │    └── filters
- │    │    │    │         └── c.x:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    │    │    │         └── k:5 = b.x:11 [outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
+ │    │    │    ├── scan b2
  │    │    │    └── filters
- │    │    │         └── k:5 = b.x:11 [outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
+ │    │    │         └── c.x:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
  │    │    └── filters (true)
  │    └── aggregations
  │         └── const-agg [as=b.x:11, outer=(11)]

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1427,7 +1427,7 @@ norm expect-not=(AssociateLimitJoinsLeft,AssociateLimitJoinsRight) format=hide-a
 SELECT *
 FROM (SELECT * FROM b LEFT JOIN uv ON x = u)
 INNER JOIN ab
-ON a = y AND b = v
+ON a = y AND (b = v OR v IS NULL)
 LIMIT 10
 ----
 limit
@@ -1440,7 +1440,7 @@ limit
  │    ├── scan ab
  │    └── filters
  │         ├── a = y
- │         └── b = v
+ │         └── (b = v) OR (v IS NULL)
  └── 10
 
 # No-op case because one of the joins has a join hint.

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -759,3 +759,409 @@ select
  │              └── z:7
  └── filters
       └── sum:8 = 10 [outer=(8), constraints=(/8: [/10 - /10]; tight), fd=()-->(8)]
+
+# ----------------------------------------------------------
+# RejectNullsUnderJoinLeft + RejectNullsUnderJoinRight
+# ----------------------------------------------------------
+
+# InnerJoin case.
+norm expect=RejectNullsUnderJoinLeft
+SELECT * FROM a
+LEFT JOIN xy ON k = x
+INNER JOIN uv ON u = y
+----
+inner-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 x:6!null y:7!null u:9!null v:10
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── key: (6)
+ ├── fd: (1)-->(2-4), (6)-->(7), (1)==(6), (6)==(1), (9)-->(10), (7)==(9), (9)==(7)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null i:2 f:3 s:4 x:6!null y:7!null
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: (6)
+ │    ├── fd: (1)-->(2-4), (6)-->(7), (1)==(6), (6)==(1)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 f:3 s:4
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    ├── select
+ │    │    ├── columns: x:6!null y:7!null
+ │    │    ├── key: (6)
+ │    │    ├── fd: (6)-->(7)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:6!null y:7
+ │    │    │    ├── key: (6)
+ │    │    │    └── fd: (6)-->(7)
+ │    │    └── filters
+ │    │         └── y:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ │    └── filters
+ │         └── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ ├── scan uv
+ │    ├── columns: u:9!null v:10
+ │    ├── key: (9)
+ │    └── fd: (9)-->(10)
+ └── filters
+      └── u:9 = y:7 [outer=(7,9), constraints=(/7: (/NULL - ]; /9: (/NULL - ]), fd=(7)==(9), (9)==(7)]
+
+# InnerJoin case.
+norm expect=RejectNullsUnderJoinRight
+SELECT * FROM uv
+INNER JOIN
+(
+  SELECT * FROM a
+  LEFT JOIN xy ON k = x
+)
+ON u = y
+----
+inner-join (hash)
+ ├── columns: u:1!null v:2 k:4!null i:5 f:6 s:7 x:9!null y:10!null
+ ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ ├── key: (9)
+ ├── fd: (1)-->(2), (4)-->(5-7), (9)-->(10), (4)==(9), (9)==(4), (1)==(10), (10)==(1)
+ ├── scan uv
+ │    ├── columns: u:1!null v:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── inner-join (hash)
+ │    ├── columns: k:4!null i:5 f:6 s:7 x:9!null y:10!null
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: (9)
+ │    ├── fd: (4)-->(5-7), (9)-->(10), (4)==(9), (9)==(4)
+ │    ├── scan a
+ │    │    ├── columns: k:4!null i:5 f:6 s:7
+ │    │    ├── key: (4)
+ │    │    └── fd: (4)-->(5-7)
+ │    ├── select
+ │    │    ├── columns: x:9!null y:10!null
+ │    │    ├── key: (9)
+ │    │    ├── fd: (9)-->(10)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:9!null y:10
+ │    │    │    ├── key: (9)
+ │    │    │    └── fd: (9)-->(10)
+ │    │    └── filters
+ │    │         └── y:10 IS NOT NULL [outer=(10), constraints=(/10: (/NULL - ]; tight)]
+ │    └── filters
+ │         └── k:4 = x:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
+ └── filters
+      └── u:1 = y:10 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+
+# No-op case because null-rejection is not requested for null-rejected column.
+norm expect-not=(RejectNullsUnderJoinLeft, RejectNullsUnderJoinRight)
+SELECT * FROM a
+INNER JOIN xy ON k = x
+INNER JOIN uv ON u = y
+----
+inner-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 x:6!null y:7!null u:9!null v:10
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── key: (6)
+ ├── fd: (1)-->(2-4), (6)-->(7), (1)==(6), (6)==(1), (9)-->(10), (7)==(9), (9)==(7)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null i:2 f:3 s:4 x:6!null y:7
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: (6)
+ │    ├── fd: (1)-->(2-4), (6)-->(7), (1)==(6), (6)==(1)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 f:3 s:4
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    ├── scan xy
+ │    │    ├── columns: x:6!null y:7
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ ├── scan uv
+ │    ├── columns: u:9!null v:10
+ │    ├── key: (9)
+ │    └── fd: (9)-->(10)
+ └── filters
+      └── u:9 = y:7 [outer=(7,9), constraints=(/7: (/NULL - ]; /9: (/NULL - ]), fd=(7)==(9), (9)==(7)]
+
+# No-op case because null-rejection is not requested for null-rejected column.
+norm expect-not=(RejectNullsUnderJoinLeft, RejectNullsUnderJoinRight)
+SELECT * FROM uv
+INNER JOIN
+(
+  SELECT * FROM a
+  INNER JOIN xy ON k = x
+)
+ON u = y
+----
+inner-join (hash)
+ ├── columns: u:1!null v:2 k:4!null i:5 f:6 s:7 x:9!null y:10!null
+ ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ ├── key: (9)
+ ├── fd: (1)-->(2), (4)-->(5-7), (9)-->(10), (4)==(9), (9)==(4), (1)==(10), (10)==(1)
+ ├── scan uv
+ │    ├── columns: u:1!null v:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── inner-join (hash)
+ │    ├── columns: k:4!null i:5 f:6 s:7 x:9!null y:10
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: (9)
+ │    ├── fd: (4)-->(5-7), (9)-->(10), (4)==(9), (9)==(4)
+ │    ├── scan a
+ │    │    ├── columns: k:4!null i:5 f:6 s:7
+ │    │    ├── key: (4)
+ │    │    └── fd: (4)-->(5-7)
+ │    ├── scan xy
+ │    │    ├── columns: x:9!null y:10
+ │    │    ├── key: (9)
+ │    │    └── fd: (9)-->(10)
+ │    └── filters
+ │         └── k:4 = x:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
+ └── filters
+      └── u:1 = y:10 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+
+# InnerJoinApply case.
+norm expect=RejectNullsUnderJoinLeft
+SELECT * FROM a
+LEFT JOIN xy ON k = x
+INNER JOIN LATERAL (VALUES (x)) f(v) ON v = y
+----
+inner-join-apply
+ ├── columns: k:1!null i:2 f:3 s:4 x:6!null y:7!null v:9
+ ├── key: (6)
+ ├── fd: (1)-->(2-4), (6)-->(7,9), (1)==(6), (6)==(1), (7)==(9), (9)==(7)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null i:2 f:3 s:4 x:6!null y:7!null
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: (6)
+ │    ├── fd: (1)-->(2-4), (6)-->(7), (1)==(6), (6)==(1)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 f:3 s:4
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    ├── select
+ │    │    ├── columns: x:6!null y:7!null
+ │    │    ├── key: (6)
+ │    │    ├── fd: (6)-->(7)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:6!null y:7
+ │    │    │    ├── key: (6)
+ │    │    │    └── fd: (6)-->(7)
+ │    │    └── filters
+ │    │         └── y:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ │    └── filters
+ │         └── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ ├── values
+ │    ├── columns: column1:9
+ │    ├── outer: (6)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(9)
+ │    └── (x:6,)
+ └── filters
+      └── column1:9 = y:7 [outer=(7,9), constraints=(/7: (/NULL - ]; /9: (/NULL - ]), fd=(7)==(9), (9)==(7)]
+
+# InnerJoinApply case.
+norm expect=RejectNullsUnderJoinRight
+SELECT * FROM xy
+INNER JOIN LATERAL
+(
+  SELECT * FROM (VALUES (y)) f(v)
+  LEFT JOIN a ON k = v
+)
+ON x = i
+----
+inner-join-apply
+ ├── columns: x:1!null y:2 v:4!null k:5!null i:6!null f:7 s:8
+ ├── key: (1)
+ ├── fd: (1)-->(2,4,5,7,8), (1)==(6), (6)==(1)
+ ├── scan xy
+ │    ├── columns: x:1!null y:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── inner-join (hash)
+ │    ├── columns: column1:4!null k:5!null i:6!null f:7 s:8
+ │    ├── outer: (2)
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: ()
+ │    ├── fd: ()-->(4-8)
+ │    ├── values
+ │    │    ├── columns: column1:4
+ │    │    ├── outer: (2)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(4)
+ │    │    └── (y:2,)
+ │    ├── select
+ │    │    ├── columns: k:5!null i:6!null f:7 s:8
+ │    │    ├── key: (5)
+ │    │    ├── fd: (5)-->(6-8)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:5!null i:6 f:7 s:8
+ │    │    │    ├── key: (5)
+ │    │    │    └── fd: (5)-->(6-8)
+ │    │    └── filters
+ │    │         └── i:6 IS NOT NULL [outer=(6), constraints=(/6: (/NULL - ]; tight)]
+ │    └── filters
+ │         └── k:5 = column1:4 [outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
+ └── filters
+      └── x:1 = i:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+
+# SemiJoin case.
+norm expect=RejectNullsUnderJoinLeft
+SELECT * FROM a
+LEFT JOIN xy ON k = x
+WHERE EXISTS (SELECT * FROM uv WHERE u = y)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 x:6!null y:7!null
+ ├── key: (6)
+ ├── fd: (1)-->(2-4), (6)-->(7), (1)==(6), (6)==(1)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null i:2 f:3 s:4 x:6!null y:7!null
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: (6)
+ │    ├── fd: (1)-->(2-4), (6)-->(7), (1)==(6), (6)==(1)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 f:3 s:4
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    ├── select
+ │    │    ├── columns: x:6!null y:7!null
+ │    │    ├── key: (6)
+ │    │    ├── fd: (6)-->(7)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:6!null y:7
+ │    │    │    ├── key: (6)
+ │    │    │    └── fd: (6)-->(7)
+ │    │    └── filters
+ │    │         └── y:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ │    └── filters
+ │         └── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ ├── scan uv
+ │    ├── columns: u:9!null
+ │    └── key: (9)
+ └── filters
+      └── u:9 = y:7 [outer=(7,9), constraints=(/7: (/NULL - ]; /9: (/NULL - ]), fd=(7)==(9), (9)==(7)]
+
+# SemiJoinApply case.
+norm expect=RejectNullsUnderJoinLeft
+SELECT * FROM a
+LEFT JOIN xy ON k = x
+WHERE EXISTS (SELECT * FROM (VALUES (y)) f(v) WHERE v = x)
+----
+semi-join-apply
+ ├── columns: k:1!null i:2 f:3 s:4 x:6!null y:7
+ ├── key: (6)
+ ├── fd: (1)-->(2-4), (6)-->(7), (1)==(6), (6)==(1)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null i:2 f:3 s:4 x:6!null y:7
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: (6)
+ │    ├── fd: (1)-->(2-4), (6)-->(7), (1)==(6), (6)==(1)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 f:3 s:4
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    ├── scan xy
+ │    │    ├── columns: x:6!null y:7
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ ├── values
+ │    ├── columns: column1:9
+ │    ├── outer: (7)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(9)
+ │    └── (y:7,)
+ └── filters
+      └── column1:9 = x:6 [outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
+
+# LeftJoin case.
+norm expect=RejectNullsUnderJoinRight
+SELECT * FROM uv
+LEFT JOIN
+(
+  SELECT * FROM a
+  LEFT JOIN xy ON k = x
+)
+ON u = y
+----
+left-join (hash)
+ ├── columns: u:1!null v:2 k:4 i:5 f:6 s:7 x:9 y:10
+ ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+ ├── key: (1,9)
+ ├── fd: (1)-->(2), (4)-->(5-7), (9)-->(10), (4)==(9), (9)==(4)
+ ├── scan uv
+ │    ├── columns: u:1!null v:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── inner-join (hash)
+ │    ├── columns: k:4!null i:5 f:6 s:7 x:9!null y:10!null
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: (9)
+ │    ├── fd: (4)-->(5-7), (9)-->(10), (4)==(9), (9)==(4)
+ │    ├── scan a
+ │    │    ├── columns: k:4!null i:5 f:6 s:7
+ │    │    ├── key: (4)
+ │    │    └── fd: (4)-->(5-7)
+ │    ├── select
+ │    │    ├── columns: x:9!null y:10!null
+ │    │    ├── key: (9)
+ │    │    ├── fd: (9)-->(10)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:9!null y:10
+ │    │    │    ├── key: (9)
+ │    │    │    └── fd: (9)-->(10)
+ │    │    └── filters
+ │    │         └── y:10 IS NOT NULL [outer=(10), constraints=(/10: (/NULL - ]; tight)]
+ │    └── filters
+ │         └── k:4 = x:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
+ └── filters
+      └── u:1 = y:10 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+
+# LeftJoinApply case.
+norm expect=RejectNullsUnderJoinRight
+SELECT * FROM uv
+LEFT JOIN LATERAL
+(
+  SELECT * FROM (VALUES (u)) f(v)
+  LEFT JOIN xy ON v = x
+)
+ON u = y
+----
+left-join-apply
+ ├── columns: u:1!null v:2 v:4 x:5 y:6
+ ├── key: (1)
+ ├── fd: (1)-->(2,4-6)
+ ├── scan uv
+ │    ├── columns: u:1!null v:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── inner-join (hash)
+ │    ├── columns: column1:4!null x:5!null y:6!null
+ │    ├── outer: (1)
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: ()
+ │    ├── fd: ()-->(4-6)
+ │    ├── values
+ │    │    ├── columns: column1:4
+ │    │    ├── outer: (1)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(4)
+ │    │    └── (u:1,)
+ │    ├── select
+ │    │    ├── columns: x:5!null y:6!null
+ │    │    ├── key: (5)
+ │    │    ├── fd: (5)-->(6)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:5!null y:6
+ │    │    │    ├── key: (5)
+ │    │    │    └── fd: (5)-->(6)
+ │    │    └── filters
+ │    │         └── y:6 IS NOT NULL [outer=(6), constraints=(/6: (/NULL - ]; tight)]
+ │    └── filters
+ │         └── column1:4 = x:5 [outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
+ └── filters
+      └── u:1 = y:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -243,30 +243,30 @@ limit
  │         ├── key: (1)
  │         ├── fd: (1)-->(20,21)
  │         ├── group-by
- │         │    ├── columns: ca_id:1!null customer_account.ca_bal:6!null sum:19
+ │         │    ├── columns: ca_id:1!null customer_account.ca_bal:6!null sum:19!null
  │         │    ├── grouping columns: ca_id:1!null
  │         │    ├── internal-ordering: +1
  │         │    ├── immutable
  │         │    ├── key: (1)
  │         │    ├── fd: (1)-->(6,19)
  │         │    ├── project
- │         │    │    ├── columns: column18:18 ca_id:1!null customer_account.ca_bal:6!null
+ │         │    │    ├── columns: column18:18!null ca_id:1!null customer_account.ca_bal:6!null
  │         │    │    ├── immutable
  │         │    │    ├── fd: (1)-->(6)
  │         │    │    ├── ordering: +1
  │         │    │    ├── inner-join (lookup last_trade)
- │         │    │    │    ├── columns: ca_id:1!null ca_c_id:3!null customer_account.ca_bal:6!null hs_ca_id:8 hs_s_symb:9!null hs_qty:10 lt_s_symb:12!null lt_price:14!null
+ │         │    │    │    ├── columns: ca_id:1!null ca_c_id:3!null customer_account.ca_bal:6!null hs_ca_id:8!null hs_s_symb:9!null hs_qty:10!null lt_s_symb:12!null lt_price:14!null
  │         │    │    │    ├── key columns: [9] = [12]
  │         │    │    │    ├── lookup columns are key
- │         │    │    │    ├── key: (1,8,12)
- │         │    │    │    ├── fd: ()-->(3), (1)-->(6), (8,9)-->(10), (12)-->(14), (9)==(12), (12)==(9)
- │         │    │    │    ├── ordering: +1 opt(3) [actual: +1]
- │         │    │    │    ├── left-join (lookup holding_summary)
- │         │    │    │    │    ├── columns: ca_id:1!null ca_c_id:3!null customer_account.ca_bal:6!null hs_ca_id:8 hs_s_symb:9 hs_qty:10
+ │         │    │    │    ├── key: (8,12)
+ │         │    │    │    ├── fd: ()-->(3), (1)-->(6), (8,9)-->(10), (1)==(8), (8)==(1), (12)-->(14), (9)==(12), (12)==(9)
+ │         │    │    │    ├── ordering: +(1|8) opt(3) [actual: +1]
+ │         │    │    │    ├── inner-join (lookup holding_summary)
+ │         │    │    │    │    ├── columns: ca_id:1!null ca_c_id:3!null customer_account.ca_bal:6!null hs_ca_id:8!null hs_s_symb:9!null hs_qty:10!null
  │         │    │    │    │    ├── key columns: [1] = [8]
- │         │    │    │    │    ├── key: (1,8,9)
- │         │    │    │    │    ├── fd: ()-->(3), (1)-->(6), (8,9)-->(10)
- │         │    │    │    │    ├── ordering: +1 opt(3) [actual: +1]
+ │         │    │    │    │    ├── key: (8,9)
+ │         │    │    │    │    ├── fd: ()-->(3), (1)-->(6), (8,9)-->(10), (1)==(8), (8)==(1)
+ │         │    │    │    │    ├── ordering: +(1|8) opt(3) [actual: +1]
  │         │    │    │    │    ├── select
  │         │    │    │    │    │    ├── columns: ca_id:1!null ca_c_id:3!null customer_account.ca_bal:6!null
  │         │    │    │    │    │    ├── key: (1)


### PR DESCRIPTION
Previously, join filters could not be used to reject nulls on input
expressions. This patch adds two rules that will push an `IS NOT NULL`
filter into the input of a join for columns which are NULL-rejected by
the join's ON condition.

Release note: None