### PR TITLE
roachtest: fetch dmesg also in local runs

### DIFF
--- a/build/teamcity-local-roachtest.sh
+++ b/build/teamcity-local-roachtest.sh
@@ -38,7 +38,7 @@ env \
     TC_SERVER_URL="${TC_SERVER_URL-}" \
     TC_BUILD_BRANCH="${TC_BUILD_BRANCH-}" \
   stdbuf -oL -eL \
-  ./bin/roachtest run acceptance kv/splits cdc/bank \
+  ./bin.docker_amd64/roachtest run acceptance kv/splits cdc/bank \
   --local \
   --parallelism=1 \
   --cockroach "cockroach" \

--- a/build/teamcity-local-roachtest.sh
+++ b/build/teamcity-local-roachtest.sh
@@ -26,7 +26,11 @@ tc_start_block "Run local roachtests"
 # NB: roachtest has its own teamcity output format and posts issues (whenever
 # GITHUB_API_TOKEN) is set, so it doesn't fit into the streamlined process
 # around the run_json_test helper.
-build/builder.sh env \
+#
+# NB: we intentionally don't go through the builder to remove a layer of
+# complexity. For example, roachtest can't retrieve dmesg for us when run
+# through the builder.
+env \
     COCKROACH_DEV_LICENSE="${COCKROACH_DEV_LICENSE}" \
     GITHUB_API_TOKEN="${GITHUB_API_TOKEN-}" \
     BUILD_VCS_NUMBER="${BUILD_VCS_NUMBER-}" \

--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -23,49 +23,50 @@ func registerAcceptance(r *testRegistry) {
 		minVersion string
 		timeout    time.Duration
 	}{
-		// Sorted. Please keep it that way.
 		{name: "bank/cluster-recovery", fn: runBankClusterRecovery},
-		{name: "bank/node-restart", fn: runBankNodeRestart},
-		{
-			name: "bank/zerosum-splits", fn: runBankNodeZeroSum,
-			skip: "https://github.com/cockroachdb/cockroach/issues/33683 (runs into " +
-				" various errors during its rebalances, see isExpectedRelocateError)",
-		},
-		// {"bank/zerosum-restart", runBankZeroSumRestart},
-		{name: "build-info", fn: runBuildInfo},
-		{name: "build-analyze", fn: runBuildAnalyze},
-		{name: "cli/node-status", fn: runCLINodeStatus},
-		{name: "cluster-init", fn: runClusterInit},
-		{name: "event-log", fn: runEventLog},
-		{name: "gossip/peerings", fn: runGossipPeerings},
-		{name: "gossip/restart", fn: runGossipRestart},
-		{name: "gossip/restart-node-one", fn: runGossipRestartNodeOne},
-		{name: "gossip/locality-address", fn: runCheckLocalityIPAddress},
-		{
-			name:       "multitenant",
-			minVersion: "v20.2.0", // multitenancy is introduced in this cycle
-			fn:         runAcceptanceMultitenant,
-		},
-		{name: "rapid-restart", fn: runRapidRestart},
-		{
-			name: "many-splits", fn: runManySplits,
-			minVersion: "v19.2.0", // SQL syntax unsupported on 19.1.x
-			skip:       "https://github.com/cockroachdb/cockroach/issues/47325",
-		},
-		{name: "status-server", fn: runStatusServer},
-		{
-			name: "version-upgrade",
-			fn: func(ctx context.Context, t *test, c *cluster) {
-				runVersionUpgrade(ctx, t, c, r.buildVersion)
-			},
-			// This test doesn't like running on old versions because it upgrades to
-			// the latest released version and then it tries to "head", where head is
-			// the cockroach binary built from the branch on which the test is
-			// running. If that branch corresponds to an older release, then upgrading
-			// to head after 19.2 fails.
-			minVersion: "v19.2.0",
-			timeout:    30 * time.Minute,
-		},
+		//// Sorted. Please keep it that way.
+		//{name: "bank/cluster-recovery", fn: runBankClusterRecovery},
+		//{name: "bank/node-restart", fn: runBankNodeRestart},
+		//{
+		//	name: "bank/zerosum-splits", fn: runBankNodeZeroSum,
+		//	skip: "https://github.com/cockroachdb/cockroach/issues/33683 (runs into " +
+		//		" various errors during its rebalances, see isExpectedRelocateError)",
+		//},
+		//// {"bank/zerosum-restart", runBankZeroSumRestart},
+		//{name: "build-info", fn: runBuildInfo},
+		//{name: "build-analyze", fn: runBuildAnalyze},
+		//{name: "cli/node-status", fn: runCLINodeStatus},
+		//{name: "cluster-init", fn: runClusterInit},
+		//{name: "event-log", fn: runEventLog},
+		//{name: "gossip/peerings", fn: runGossipPeerings},
+		//{name: "gossip/restart", fn: runGossipRestart},
+		//{name: "gossip/restart-node-one", fn: runGossipRestartNodeOne},
+		//{name: "gossip/locality-address", fn: runCheckLocalityIPAddress},
+		//{
+		//	name:       "multitenant",
+		//	minVersion: "v20.2.0", // multitenancy is introduced in this cycle
+		//	fn:         runAcceptanceMultitenant,
+		//},
+		//{name: "rapid-restart", fn: runRapidRestart},
+		//{
+		//	name: "many-splits", fn: runManySplits,
+		//	minVersion: "v19.2.0", // SQL syntax unsupported on 19.1.x
+		//	skip:       "https://github.com/cockroachdb/cockroach/issues/47325",
+		//},
+		//{name: "status-server", fn: runStatusServer},
+		//{
+		//	name: "version-upgrade",
+		//	fn: func(ctx context.Context, t *test, c *cluster) {
+		//		runVersionUpgrade(ctx, t, c, r.buildVersion)
+		//	},
+		//	// This test doesn't like running on old versions because it upgrades to
+		//	// the latest released version and then it tries to "head", where head is
+		//	// the cockroach binary built from the branch on which the test is
+		//	// running. If that branch corresponds to an older release, then upgrading
+		//	// to head after 19.2 fails.
+		//	minVersion: "v19.2.0",
+		//	timeout:    30 * time.Minute,
+		//},
 	}
 	tags := []string{"default", "quick"}
 	const numNodes = 4

--- a/pkg/cmd/roachtest/bank.go
+++ b/pkg/cmd/roachtest/bank.go
@@ -413,6 +413,8 @@ func (s *bankState) waitClientsStop(
 }
 
 func runBankClusterRecovery(ctx context.Context, t *test, c *cluster) {
+	t.Fatal("boom")
+	return
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, t)
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1681,7 +1681,7 @@ func (c *cluster) FetchDmesg(ctx context.Context) error {
 		if err := execCmd(
 			ctx, c.l, roachprod, "ssh", c.name, "--",
 			// NB: -n is for --non-interactive.
-			"/bin/bash", "-c", "'sudo -n dmesg > "+name+"'", /* src */
+			"/bin/bash", "-c", "'sudo -n dmesg > "+name+"'; env; ls /usr/bin", /* src */
 		); err != nil {
 			// Don't error out because it might've worked on some nodes. Fetching will
 			// error out below but will get everything it can first.

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1662,7 +1662,7 @@ func (c *cluster) FailOnReplicaDivergence(ctx context.Context, t *test) {
 // FetchDmesg grabs the dmesg logs if possible. This requires being able to run
 // `sudo dmesg` on the remote nodes.
 func (c *cluster) FetchDmesg(ctx context.Context) error {
-	if c.spec.NodeCount == 0 || c.isLocal() {
+	if c.spec.NodeCount == 0 {
 		// No nodes can happen during unit tests and implies nothing to do.
 		// Also, don't grab dmesg on local runs.
 		return nil
@@ -1680,7 +1680,8 @@ func (c *cluster) FetchDmesg(ctx context.Context) error {
 		}
 		if err := execCmd(
 			ctx, c.l, roachprod, "ssh", c.name, "--",
-			"/bin/bash", "-c", "'sudo dmesg > "+name+"'", /* src */
+			// NB: -n is for --non-interactive.
+			"/bin/bash", "-c", "'sudo -n dmesg > "+name+"'", /* src */
 		); err != nil {
 			// Don't error out because it might've worked on some nodes. Fetching will
 			// error out below but will get everything it can first.


### PR DESCRIPTION
Over the last few weeks, we've regularly seen test failures in local
mode (i.e. acceptance) in which a `*monitor` claims that a node is dead,
without evidence in the logs. One explanation for this is OOM killing,
so make sure we fetch dmesg in local runs to be able to look into this.

Touches #47325.

Release note: None
