### PR TITLE
backupccl: stop blocking backup/restore jobs on client disconnect

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -814,11 +814,7 @@ func backupPlanHook(
 
 		collectTelemetry()
 
-		errCh, err := sj.Start(ctx)
-		if err != nil {
-			return err
-		}
-		return <-errCh
+		return sj.Run(ctx)
 	}
 
 	if backupStmt.Options.Detached {

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -1113,7 +1114,7 @@ func doRestorePlan(
 		}
 	}
 
-	_, errCh, err := p.ExecCfg().JobRegistry.CreateAndStartJob(ctx, resultsCh, jobs.Record{
+	jr := jobs.Record{
 		Description: description,
 		Username:    p.User(),
 		DescriptorIDs: func() (sqlDescIDs []sqlbase.ID) {
@@ -1134,11 +1135,23 @@ func doRestorePlan(
 			Tenants:            tenants,
 		},
 		Progress: jobspb.RestoreProgress{},
-	})
-	if err != nil {
-		return err
 	}
-	return <-errCh
+	var sj *jobs.StartableJob
+	if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
+		sj, err = p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, jr, txn, resultsCh)
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		if sj != nil {
+			if cleanupErr := sj.CleanupOnRollback(ctx); cleanupErr != nil {
+				log.Warningf(ctx, "failed to cleanup StartableJob: %v", cleanupErr)
+			}
+		}
+	}
+
+	return sj.Run(ctx)
 }
 
 func init() {


### PR DESCRIPTION
Previously, a backup/restore job whose client disconnect might have blocked on
sending its results to the resultCh (and thus block forever). This
commit allows these jobs to complete.

Release note (bug fix): Previously, a BACKUP/RESTORE jobs would
sometimes block once it finished executing the job. This is now fixed.

