### PR TITLE
build: mkdir /lib for older release branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ artifacts
 /lib
 /lib.*
 .buildinfo
+/lib
 # cockroach-data, cockroach{,.race}-{darwin,linux,windows}-*
 /cockroach*
 /certs

--- a/build/builder/mkrelease.sh
+++ b/build/builder/mkrelease.sh
@@ -96,4 +96,6 @@ if [ $# -ge 1 ]; then
     shift
 fi
 
-(set -x && CGO_ENABLED=1 make BUILDTYPE=release "${args[@]}" "$@")
+# lib is populated in v20.2 or higher, but we make a temporary directory
+# in /lib such that TeamCity can pick up the artifacts.
+(set -x && mkdir -p lib && CGO_ENABLED=1 make BUILDTYPE=release "${args[@]}" "$@")


### PR DESCRIPTION
TeamCity does not support optional artifacts. However, we use the `lib/`
artifact in Publish Bleeding Edge for Docker to include the GEOS files
in the artifacts when Publishing Artifacts for Docker. Unfortunately TC
artifact settings are not versioned by SHA, so the artifacts  need to be
a global setting.

As such, for older versions, add a /lib directory so that they can be put
as artifacts and not error pre-v20.2.

Release note: None