### PR TITLE
geogfn: use bounding box intersection fast paths for Geography

### DIFF
--- a/pkg/geo/geogfn/dwithin.go
+++ b/pkg/geo/geogfn/dwithin.go
@@ -54,7 +54,14 @@ func DWithin(
 		}
 		return false, err
 	}
-	maybeClosestDistance, err := distanceGeographyRegions(spheroid, useSphereOrSpheroid, aRegions, bRegions, distance)
+	maybeClosestDistance, err := distanceGeographyRegions(
+		spheroid,
+		useSphereOrSpheroid,
+		aRegions,
+		bRegions,
+		a.BoundingRect().Intersects(b.BoundingRect()),
+		distance,
+	)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
There are shortcuts in the distance algorithm which involving whether
the bounding boxes intersects. Since we have that for Geography, include
the logic.

Release note: None