### PR TITLE
sql: use a structured error to detect roachpb.BatchTimestampBeforeGCE…

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -134,10 +134,7 @@ func isPermanentSchemaChangeError(err error) bool {
 	// Ignore error thrown because of a read at a very old timestamp.
 	// The Backfill will grab a new timestamp to read at for the rest
 	// of the backfill.
-	// TODO(knz): this should really use errors.Is(). However until/unless
-	// we are not receiving errors from 19.1 any more, a string
-	// comparison must remain.
-	if strings.Contains(err.Error(), "must be after replica GC threshold") {
+	if errors.HasType(err, (*roachpb.BatchTimestampBeforeGCError)(nil)) {
 		return false
 	}
 


### PR DESCRIPTION
…rror

Fixes #50198.

See the issue for more details. This issue is so obscure it does not deserve
a release note.

Release note: None