### PR TITLE
colexec: re-enable short-circuiting in the hash joiner

### DIFF
--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -256,11 +256,7 @@ func (hj *hashJoiner) Next(ctx context.Context) coldata.Batch {
 					hj.spec.joinType == sqlbase.RightOuterJoin ||
 					hj.spec.joinType == sqlbase.LeftSemiJoin ||
 					hj.spec.joinType == sqlbase.IntersectAllJoin {
-					// The short-circuiting behavior is temporarily disabled
-					// because it causes flakiness of some tests due to #48785
-					// (concurrent calls to DrainMeta and Next).
-					// TODO(asubiotto): remove this once the issue is resolved.
-					// hj.state = hjDone
+					hj.state = hjDone
 					continue
 				}
 			}


### PR DESCRIPTION
This commit re-enables short-circuiting logic in the hash joiner when
the build side is empty (it was temporarily disabled because of #48785
which has been fixed).

Fixes: #49631.

Release note: None