### PR TITLE
sql: copy partial indexes from source table in CREATE TABLE LIKE

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2007,6 +2007,12 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 						PrimaryKey:    isPK,
 					}
 				}
+				if idx.IsPartial() {
+					indexDef.Predicate, err = parser.ParseExpr(idx.Predicate)
+					if err != nil {
+						return nil, err
+					}
+				}
 				defs = append(defs, def)
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -178,6 +178,25 @@ t7  CREATE TABLE public.t7 (
     FAMILY "primary" (b, rowid)
 )
 
+#### CREATE TABLE LIKE ... INCLUDING INDEXES copies partial index predicate
+#### expressions to the new table.
+
+statement ok
+CREATE TABLE t9 (a INT, b INT, INDEX (a) WHERE b > 1)
+
+statement ok
+CREATE TABLE t10 (LIKE t9 INCLUDING INDEXES)
+
+query TT
+SHOW CREATE TABLE t10
+----
+t10  CREATE TABLE public.t10 (
+     a INT8 NULL,
+     b INT8 NULL,
+     INDEX t9_a_idx (a ASC) WHERE b > 1:::INT8,
+     FAMILY "primary" (a, b, rowid)
+)
+
 #### Update a non-indexed column referenced by the predicate.
 
 statement ok


### PR DESCRIPTION
Previously, issuing a `CREATE TABLE ... LIKE` command would copy indexes
of the table, but not copy the partial index predicates of those
indexes. For example:

    CREATE TABLE t (a INT, b INT, INDEX (a) WHERE b > 1)
    CREATE TABLE u (LIKE t INCLUDING INDEXES)

Table u had a copy of t's secondary index, but the partial index
predicate was missing.

This commit fixes the issue so that the predicates of partial indexes
are copied.

Fixes #51849 

Release note: None