### PR TITLE
sql: crdb_version & version() are the same

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2780,3 +2780,8 @@ system
 
 query error pq: crdb_internal.pb_to_json\(\): unknown proto message type cockroach.sql.sqlbase.descriptor
 select crdb_internal.pb_to_json('cockroach.sql.sqlbase.descriptor', descriptor)->'database'->>'name' from system.descriptor where id=1
+
+query B
+SELECT (SELECT * FROM [SHOW crdb_version]) = version()
+----
+true

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -914,7 +914,9 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
-	`crdb_version`: makeReadOnlyVar(build.GetInfo().Short()),
+	`crdb_version`: makeReadOnlyVarWithFn(func() string {
+		return build.GetInfo().Short()
+	}),
 
 	// CockroachDB extension
 	`session_id`: {
@@ -1177,6 +1179,13 @@ func makeReadOnlyVar(value string) sessionVar {
 	return sessionVar{
 		Get:           func(_ *extendedEvalContext) string { return value },
 		GlobalDefault: func(_ *settings.Values) string { return value },
+	}
+}
+
+func makeReadOnlyVarWithFn(fn func() string) sessionVar {
+	return sessionVar{
+		Get:           func(_ *extendedEvalContext) string { return fn() },
+		GlobalDefault: func(_ *settings.Values) string { return fn() },
 	}
 }
 


### PR DESCRIPTION
Fixes #51655

Before this change License (info.Distribution) was not the same returned
by "show crdb_version" and "select version();".

Added function sql.makeReadOnlyVarWithFn to init "crdb_version" read
only variables after "init" block.

Release note (bug fix): crdb_version & version() return the same result