### PR TITLE
backupccl: various user defined types fixes and tests

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1297,8 +1297,7 @@ func TestBackupRestoreUserDefinedTypes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// TODO (rohany): Add tests for backup/restore with revision history and
-	//  incremental backups once types can change.
+	// TODO (rohany): Add some tests for backup/restore with revision history.
 
 	// Test full cluster backup/restore.
 	t.Run("full-cluster", func(t *testing.T) {
@@ -1351,6 +1350,12 @@ INSERT INTO d2.t2 VALUES (ARRAY['bye']), (ARRAY['cya']);
 		sqlDBRestore.ExpectErr(t, `pq: type "d.public._greeting" already exists`, `CREATE TYPE d._greeting AS ENUM ('hello', 'hiya')`)
 		sqlDBRestore.ExpectErr(t, `pq: type "d2.public.farewell" already exists`, `CREATE TYPE d2.farewell AS ENUM ('go', 'away')`)
 		sqlDBRestore.ExpectErr(t, `pq: type "d2.public._farewell" already exists`, `CREATE TYPE d2._farewell AS ENUM ('go', 'away')`)
+
+		// We shouldn't be able to drop the types since there are tables that
+		// depend on them. These tests ensure that the back references from types
+		// to tables that use them are handled correctly by backup and restore.
+		sqlDBRestore.ExpectErr(t, `pq: cannot drop type "greeting" because other objects \(\[d.public.t1 d.public.t2\]\) still depend on it`, `DROP TYPE d.greeting`)
+		sqlDBRestore.ExpectErr(t, `pq: cannot drop type "farewell" because other objects \(\[d2.public.t1 d2.public.t2\]\) still depend on it`, `DROP TYPE d2.farewell`)
 	})
 
 	// Test backup/restore of a database.
@@ -1399,6 +1404,12 @@ CREATE TABLE d.expr (
 		sqlDB.ExpectErr(t, `pq: type "d.public._greeting" already exists`, `CREATE TYPE d._greeting AS ENUM ('hello', 'hiya')`)
 		sqlDB.ExpectErr(t, `pq: type "d.public.farewell" already exists`, `CREATE TYPE d.farewell AS ENUM ('hello', 'hiya')`)
 		sqlDB.ExpectErr(t, `pq: type "d.public._farewell" already exists`, `CREATE TYPE d._farewell AS ENUM ('hello', 'hiya')`)
+
+		// We shouldn't be able to drop the types since there are tables that
+		// depend on them. These tests ensure that the back references from types
+		// to tables that use them are handled correctly by backup and restore.
+		sqlDB.ExpectErr(t, `pq: cannot drop type "greeting" because other objects \(\[d.public.t1 d.public.t2 d.public.expr d.public.t3\]\) still depend on it`, `DROP TYPE d.greeting`)
+		sqlDB.ExpectErr(t, `pq: cannot drop type "farewell" because other objects \(\[d.public.t3\]\) still depend on it`, `DROP TYPE d.farewell`)
 	})
 
 	// Test backup/restore of a single table.
@@ -1465,8 +1476,6 @@ INSERT INTO d.t3 VALUES ('hi');
 	// Test cases where we attempt to remap types in the backup to types that
 	// already exist in the cluster.
 	t.Run("backup-remap", func(t *testing.T) {
-		// TODO (rohany): Add a test for remapping to enums that are compatible
-		//  but not the same once ALTER TYPE is possibe.
 		_, _, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, 0, InitNone)
 		defer cleanupFn()
 		sqlDB.Exec(t, `
@@ -1488,6 +1497,9 @@ INSERT INTO d.t2 VALUES (ARRAY['hello']);
 			// Check that the table data is restored correctly and the types aren't touched.
 			sqlDB.CheckQueryResults(t, `SELECT 'hello'::d.greeting, ARRAY['hello']::d.greeting[]`, [][]string{{"hello", "{hello}"}})
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d.t ORDER BY x`, [][]string{{"hello"}, {"howdy"}})
+
+			// d.t should be added as a back reference to greeting.
+			sqlDB.ExpectErr(t, `pq: cannot drop type "greeting" because other objects \(\[d.public.t2 d.public.t\]\) still depend on it`, `DROP TYPE d.greeting`)
 		}
 
 		{
@@ -1514,6 +1526,9 @@ INSERT INTO d.t2 VALUES (ARRAY['hello']);
 			sqlDB.Exec(t, `RESTORE TABLE d.t2 FROM 'nodelocal://0/test2/' WITH into_db = 'd2'`)
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d2.t2 ORDER BY x`, [][]string{{"{hello}"}})
 			sqlDB.Exec(t, `INSERT INTO d2.t2 VALUES (ARRAY['hi'::d2.greeting])`)
+
+			// d2.t and d2.t2 should both have back references to d2.greeting.
+			sqlDB.ExpectErr(t, `pq: cannot drop type "greeting" because other objects \(\[d2.public.t d2.public.t2\]\) still depend on it`, `DROP TYPE d2.greeting`)
 		}
 
 		{
@@ -1553,6 +1568,23 @@ INSERT INTO d.t2 VALUES (ARRAY['hello']);
 			sqlDB.Exec(t, `RESTORE TABLE d5.tb1 FROM 'nodelocal://0/test3/' WITH into_db = 'd6'`)
 			sqlDB.Exec(t, `INSERT INTO d6.tb1 VALUES (ARRAY['v1']::d6._typ1)`)
 		}
+
+		{
+			// Test a case where we restore to an existing enum that is compatible with,
+			// but not the same as greeting.
+			sqlDB.Exec(t, `CREATE DATABASE d7`)
+			sqlDB.Exec(t, `CREATE TYPE d7.greeting AS ENUM ('hello', 'howdy', 'hi')`)
+			// Now add a value to greeting -- this will keep the internal representations
+			// of the existing enum members the same.
+			sqlDB.Exec(t, `ALTER TYPE d7.greeting ADD VALUE 'greetings' BEFORE 'howdy'`)
+
+			// We should be able to restore d.greeting using d7.greeting.
+			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://0/test/' WITH into_db = 'd7'`)
+			sqlDB.Exec(t, `INSERT INTO d7.t VALUES ('greetings')`)
+			sqlDB.CheckQueryResults(t, `SELECT * FROM d7.t ORDER BY x`, [][]string{{"hello"}, {"greetings"}, {"howdy"}})
+			// d7.t should have a back reference from d7.greeting.
+			sqlDB.ExpectErr(t, `pq: cannot drop type "greeting" because other objects \(\[d7.public.t\]\) still depend on it`, `DROP TYPE d7.greeting`)
+		}
 	})
 
 	t.Run("incremental", func(t *testing.T) {
@@ -1577,6 +1609,37 @@ INSERT INTO d.t VALUES ('hello'), ('howdy');
 			sqlDB.Exec(t, `CREATE DATABASE d2`)
 			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://0/test/' WITH into_db = 'd2'`)
 			sqlDB.CheckQueryResults(t, `SELECT 'hello'::d2.newname`, [][]string{{"hello"}})
+		}
+
+		{
+			// Create a database with a type, and take a backup.
+			sqlDB.Exec(t, `CREATE DATABASE d3`)
+			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/test2/'`)
+
+			// Now create a new type in that database.
+			sqlDB.Exec(t, `CREATE TYPE d3.farewell AS ENUM ('bye', 'cya')`)
+
+			// Perform an incremental backup, which should pick up the new type.
+			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/test2/'`)
+
+			// Until #51362 lands we have to manually clean up this type before the
+			// DROP DATABASE statement otherwise we'll leave behind an orphaned desc.
+			sqlDB.Exec(t, `DROP TYPE d3.farewell`)
+
+			// Now restore it.
+			sqlDB.Exec(t, `DROP DATABASE d3`)
+			sqlDB.Exec(t, `RESTORE DATABASE d3 FROM 'nodelocal://0/test2/'`)
+			// Check that we are able to use the type.
+			sqlDB.Exec(t, `CREATE TABLE d3.t (x d3.farewell)`)
+			sqlDB.Exec(t, `DROP TABLE d3.t`)
+
+			// If we drop the type and back up again, it should be gone.
+			sqlDB.Exec(t, `DROP TYPE d3.farewell`)
+
+			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/test2/'`)
+			sqlDB.Exec(t, `DROP DATABASE d3`)
+			sqlDB.Exec(t, `RESTORE DATABASE d3 FROM 'nodelocal://0/test2/'`)
+			sqlDB.ExpectErr(t, `pq: type "d3.farewell" does not exist`, `CREATE TABLE d3.t (x d3.farewell)`)
 		}
 	})
 }

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -995,9 +995,14 @@ func createImportingDescriptors(
 	// case, we don't want to create namespace and descriptor entries for those
 	// types. So collect only the types that we need to write here.
 	var typesToWrite []sqlbase.TypeDescriptorInterface
+	// We need to know what existing types we are remapping to, so collect them.
+	existingTypeIDs := make(map[sqlbase.ID]struct{})
 	for i := range types {
 		typ := types[i]
-		if !details.DescriptorRewrites[typ.GetID()].ToExisting {
+		rewrite := details.DescriptorRewrites[typ.GetID()]
+		if rewrite.ToExisting {
+			existingTypeIDs[rewrite.ID] = struct{}{}
+		} else {
 			typesToWrite = append(typesToWrite, typ)
 		}
 	}
@@ -1017,11 +1022,61 @@ func createImportingDescriptors(
 		desc.OfflineReason = "restoring"
 	}
 
+	// Collect all types after they have had their ID's rewritten.
+	typesByID := make(map[sqlbase.ID]*sqlbase.TypeDescriptor)
+	for i := range types {
+		typ := types[i].TypeDesc()
+		typesByID[typ.ID] = typ
+	}
+
 	if !details.PrepareCompleted {
 		err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			// Write the new TableDescriptors which are set in the OFFLINE state.
 			if err := WriteDescriptors(ctx, txn, databases, tables, typesToWrite, details.DescriptorCoverage, r.settings, nil /* extra */); err != nil {
 				return errors.Wrapf(err, "restoring %d TableDescriptors from %d databases", len(r.tables), len(databases))
+			}
+
+			// We could be restoring tables that point to existing types. We need to
+			// ensure that those existing types are updated with back references pointing
+			// to the new tables being restored.
+			b := txn.NewBatch()
+			for _, table := range tables {
+				// Collect all types used by this table.
+				typeIDs, err := table.TableDesc().GetAllReferencedTypeIDs(func(id sqlbase.ID) (*sqlbase.TypeDescriptor, error) {
+					return typesByID[id], nil
+				})
+				if err != nil {
+					return err
+				}
+				for _, id := range typeIDs {
+					// If the type was restored as part of the backup, then the backreference
+					// already exists.
+					_, ok := existingTypeIDs[id]
+					if !ok {
+						continue
+					}
+					// Otherwise, add a backreference to this table.
+					desc, err := catalogkv.GetMutableDescriptorByID(ctx, txn, keys.SystemSQLCodec, id)
+					if err != nil {
+						return err
+					}
+					typDesc := desc.(*sqlbase.MutableTypeDescriptor)
+					typDesc.AddReferencingDescriptorID(table.GetID())
+					if err := catalogkv.WriteDescToBatch(
+						ctx,
+						false, /* kvTrace */
+						p.ExecCfg().Settings,
+						b,
+						keys.SystemSQLCodec,
+						typDesc.ID,
+						typDesc,
+					); err != nil {
+						return err
+					}
+				}
+			}
+			if err := txn.Run(ctx, b); err != nil {
+				return err
 			}
 
 			for _, tenant := range details.Tenants {
@@ -1041,6 +1096,13 @@ func createImportingDescriptors(
 		})
 		if err != nil {
 			return nil, nil, nil, nil, err
+		}
+
+		// Wait for one version on any existing changed types.
+		for existing := range existingTypeIDs {
+			if err := sql.WaitToUpdateLeases(ctx, p.ExecCfg().LeaseManager, existing); err != nil {
+				return nil, nil, nil, nil, err
+			}
 		}
 	}
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -653,6 +653,12 @@ func rewriteTypeDescs(types []*sqlbase.TypeDescriptor, descriptorRewrites DescRe
 		}
 		typ.ID = rewrite.ID
 		typ.ParentID = rewrite.ParentID
+		for i := range typ.ReferencingDescriptorIDs {
+			id := typ.ReferencingDescriptorIDs[i]
+			if rw, ok := descriptorRewrites[id]; ok {
+				typ.ReferencingDescriptorIDs[i] = rw.ID
+			}
+		}
 		switch t := typ.Kind; t {
 		case sqlbase.TypeDescriptor_ENUM:
 			if rw, ok := descriptorRewrites[typ.ArrayTypeID]; ok {

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -169,7 +169,9 @@ func newDescriptorResolver(descs []sqlbase.Descriptor) (*descriptorResolver, err
 			}
 		}
 		if typDesc := desc.GetType(); typDesc != nil {
-			// TODO (rohany): Add a .Dropped() check here once we can drop types.
+			if typDesc.Dropped() {
+				continue
+			}
 			if err := registerDesc(typDesc.ParentID, typDesc, "type"); err != nil {
 				return nil, err
 			}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -382,11 +382,11 @@ func (sc *SchemaChanger) dropConstraints(
 	if err != nil {
 		return nil, err
 	}
-	if err := waitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID); err != nil {
+	if err := WaitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID); err != nil {
 		return nil, err
 	}
 	for id := range fksByBackrefTable {
-		if err := waitToUpdateLeases(ctx, sc.leaseMgr, id); err != nil {
+		if err := WaitToUpdateLeases(ctx, sc.leaseMgr, id); err != nil {
 			return nil, err
 		}
 	}
@@ -489,11 +489,11 @@ func (sc *SchemaChanger) addConstraints(
 	if _, err := sc.leaseMgr.PublishMultiple(ctx, tableIDsToUpdate, update, nil); err != nil {
 		return err
 	}
-	if err := waitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID); err != nil {
+	if err := WaitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID); err != nil {
 		return err
 	}
 	for id := range fksByBackrefTable {
-		if err := waitToUpdateLeases(ctx, sc.leaseMgr, id); err != nil {
+		if err := WaitToUpdateLeases(ctx, sc.leaseMgr, id); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -93,7 +93,7 @@ func makeTypeLookupFunc(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec,
 ) sqlbase.TypeLookupFunc {
 	return func(ctx context.Context, id sqlbase.ID) (*tree.TypeName, sqlbase.TypeDescriptorInterface, error) {
-		return resolver.ResolveTypeDescByID(ctx, txn, codec, id, tree.ObjectLookupFlags{})
+		return resolver.ResolveTypeDescByID(ctx, txn, codec, id, tree.ObjectLookupFlagsWithRequired())
 	}
 }
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -319,7 +319,7 @@ func (sc *SchemaChanger) maybeMakeAddTablePublic(
 
 		fks := table.AllActiveAndInactiveForeignKeys()
 		for _, fk := range fks {
-			if err := waitToUpdateLeases(ctx, sc.leaseMgr, fk.ReferencedTableID); err != nil {
+			if err := WaitToUpdateLeases(ctx, sc.leaseMgr, fk.ReferencedTableID); err != nil {
 				return err
 			}
 		}
@@ -499,7 +499,7 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 	// returns, so that the new schema is live everywhere. This is not needed for
 	// correctness but is done to make the UI experience/tests predictable.
 	waitToUpdateLeases := func(refreshStats bool) error {
-		if err := waitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID); err != nil {
+		if err := WaitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID); err != nil {
 			if errors.Is(err, sqlbase.ErrDescriptorNotFound) {
 				return err
 			}
@@ -577,7 +577,7 @@ func (sc *SchemaChanger) handlePermanentSchemaChangeError(
 	// returns, so that the new schema is live everywhere. This is not needed for
 	// correctness but is done to make the UI experience/tests predictable.
 	waitToUpdateLeases := func(refreshStats bool) error {
-		if err := waitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID); err != nil {
+		if err := WaitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID); err != nil {
 			if errors.Is(err, sqlbase.ErrDescriptorNotFound) {
 				return err
 			}
@@ -735,12 +735,12 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill(ctx context.Context) erro
 	log.Info(ctx, "finished stepping through state machine")
 
 	// wait for the state change to propagate to all leases.
-	return waitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID)
+	return WaitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID)
 }
 
-// Wait until the entire cluster has been updated to the latest version
-// of the descriptor.
-func waitToUpdateLeases(ctx context.Context, leaseMgr *lease.Manager, descID sqlbase.ID) error {
+// WaitToUpdateLeases until the entire cluster has been updated to the latest
+// version of the descriptor.
+func WaitToUpdateLeases(ctx context.Context, leaseMgr *lease.Manager, descID sqlbase.ID) error {
 	// Aggressively retry because there might be a user waiting for the
 	// schema change to complete.
 	retryOpts := retry.Options{
@@ -1332,11 +1332,11 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 		return err
 	}
 
-	if err := waitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID); err != nil {
+	if err := WaitToUpdateLeases(ctx, sc.leaseMgr, sc.tableID); err != nil {
 		return err
 	}
 	for id := range fksByBackrefTable {
-		if err := waitToUpdateLeases(ctx, sc.leaseMgr, id); err != nil {
+		if err := WaitToUpdateLeases(ctx, sc.leaseMgr, id); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -192,7 +192,7 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 	}
 
 	// Finally, make sure all of the leases are updated.
-	if err := waitToUpdateLeases(ctx, leaseMgr, t.typeID); err != nil {
+	if err := WaitToUpdateLeases(ctx, leaseMgr, t.typeID); err != nil {
 		if errors.Is(err, sqlbase.ErrDescriptorNotFound) {
 			return nil
 		}


### PR DESCRIPTION
This commit fixes some bugs introduced with the ability to change and
drop types, and adds some more tests. In particular it
* Ensures that backup+restore maintain type backreferences to tables
  that use them, as well as ensuring that backups that use existing
  types get those backreferences installed on the existing descriptors.
* Adds a test to restore to an existing type that is a logical
  "superset" of an existing type.
* Adds test to ensure created and dropped types are reflected in
  incremenetal backups and restore of those backups.

Fixes #50321.
Fixes #51787.

Release note: None