### PR TITLE
kvtenant: implement SystemConfigProvider, remove Gossip from SQL-only server

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -141,7 +141,7 @@ func splitAndFilterSpans(
 }
 
 // clusterNodeCount returns the approximate number of nodes in the cluster.
-func clusterNodeCount(gw gossip.DeprecatedGossip) (int, error) {
+func clusterNodeCount(gw gossip.OptionalGossip) (int, error) {
 	g, err := gw.OptionalErr(47970)
 	if err != nil {
 		return 0, err

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -219,7 +219,7 @@ func createBenchmarkChangefeed(
 		Settings:         settings,
 		DB:               s.DB(),
 		Clock:            feedClock,
-		Gossip:           gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		Gossip:           gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
 		Spans:            spans,
 		Targets:          details.Targets,
 		Sink:             buf,

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -38,7 +38,7 @@ type Config struct {
 	Settings           *cluster.Settings
 	DB                 *kv.DB
 	Clock              *hlc.Clock
-	Gossip             gossip.DeprecatedGossip
+	Gossip             gossip.OptionalGossip
 	Spans              []roachpb.Span
 	Targets            jobspb.ChangefeedTargets
 	Sink               EventBufferWriter

--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -36,7 +36,7 @@ type kvScanner interface {
 
 type scanRequestScanner struct {
 	settings *cluster.Settings
-	gossip   gossip.DeprecatedGossip
+	gossip   gossip.OptionalGossip
 	db       *kv.DB
 }
 
@@ -244,7 +244,7 @@ func allRangeDescriptors(ctx context.Context, txn *kv.Txn) ([]roachpb.RangeDescr
 }
 
 // clusterNodeCount returns the approximate number of nodes in the cluster.
-func clusterNodeCount(gw gossip.DeprecatedGossip) (int, error) {
+func clusterNodeCount(gw gossip.OptionalGossip) (int, error) {
 	g, err := gw.OptionalErr(47971)
 	if err != nil {
 		return 0, err

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package config
+
+// SystemConfigProvider is capable of providing the SystemConfig, as well as
+// notifying clients of updates to the SystemConfig.
+type SystemConfigProvider interface {
+	// GetSystemConfig returns the local unmarshaled version of the system
+	// config. Returns nil if the system config hasn't been set yet.
+	GetSystemConfig() *SystemConfig
+
+	// RegisterSystemConfigChannel registers a channel to signify updates for
+	// the system config. It is notified after registration (if a system config
+	// is already set), and whenever a new system config is successfully
+	// unmarshaled.
+	RegisterSystemConfigChannel() <-chan struct{}
+}
+
+// EmptySystemConfigProvider is an implementation of SystemConfigProvider that
+// never provides a system config.
+type EmptySystemConfigProvider struct{}
+
+// GetSystemConfig implements the SystemConfigProvider interface.
+func (EmptySystemConfigProvider) GetSystemConfig() *SystemConfig {
+	return nil
+}
+
+// RegisterSystemConfigChannel implements the SystemConfigProvider interface.
+func (EmptySystemConfigProvider) RegisterSystemConfigChannel() <-chan struct{} {
+	// The system config will never be updated, so return a nil channel.
+	return nil
+}

--- a/pkg/gossip/util.go
+++ b/pkg/gossip/util.go
@@ -15,7 +15,6 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
-	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
 
@@ -27,7 +26,7 @@ import (
 // goroutines.
 type SystemConfigDeltaFilter struct {
 	keyPrefix roachpb.Key
-	lastCfg   *config.SystemConfig
+	lastCfg   config.SystemConfigEntries
 }
 
 // MakeSystemConfigDeltaFilter creates a new SystemConfigDeltaFilter. The filter
@@ -36,7 +35,6 @@ type SystemConfigDeltaFilter struct {
 func MakeSystemConfigDeltaFilter(keyPrefix roachpb.Key) SystemConfigDeltaFilter {
 	return SystemConfigDeltaFilter{
 		keyPrefix: keyPrefix,
-		lastCfg:   config.NewSystemConfig(zonepb.DefaultZoneConfigRef()),
 	}
 }
 
@@ -47,7 +45,6 @@ func (df *SystemConfigDeltaFilter) ForModified(
 ) {
 	// Save newCfg in the filter.
 	lastCfg := df.lastCfg
-	df.lastCfg = config.NewSystemConfig(newCfg.DefaultZoneConfig)
 	df.lastCfg.Values = newCfg.Values
 
 	// SystemConfig values are always sorted by key, so scan over new and old

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1026,6 +1026,14 @@ func (n *Node) GossipSubscription(
 		// and filter system config updates. Luckily, SystemConfigDeltaFilter
 		// supports a "keyPrefix" that should help here. We'll also want to use
 		// RegisterSystemConfigChannel for any SystemConfig patterns.
+		//
+		// UPDATE: the SystemConfig pattern story is even more complicated
+		// because of ZoneConfig inheritance/recursion. We'll also need to
+		// return the default zone config. In that case, it probably makes sense
+		// to perform the filtering here (based on whether a tenant marker is
+		// present in the ctx) without baking it into the protocol itself. So
+		// the request will simply specify "system-db" but we'll only return the
+		// subset of key/values that the tenant is allowed to / needs to see.
 
 		callback := func(key string, content roachpb.Value) {
 			callbackMu.Lock()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -614,6 +614,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		runtime:                  runtimeSampler,
 		rpcContext:               rpcContext,
 		nodeDescs:                g,
+		systemConfigProvider:     g,
 		nodeDialer:               nodeDialer,
 		distSender:               distSender,
 		db:                       db,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -599,7 +599,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		sqlServerOptionalKVArgs: sqlServerOptionalKVArgs{
 			statusServer:           serverpb.MakeOptionalStatusServer(sStatus),
 			nodeLiveness:           sqlbase.MakeOptionalNodeLiveness(nodeLiveness),
-			gossip:                 gossip.MakeExposedGossip(g),
+			gossip:                 gossip.MakeOptionalGossip(g),
 			grpcServer:             grpc.Server,
 			recorder:               recorder,
 			nodeIDContainer:        idContainer,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/blobs/blobspb"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -146,6 +147,9 @@ type sqlServerArgs struct {
 
 	// Used by DistSQLPlanner.
 	nodeDescs kvcoord.NodeDescStore
+
+	// Used by the executor config.
+	systemConfigProvider config.SystemConfigProvider
 
 	// Used by DistSQLPlanner.
 	nodeDialer *nodedialer.Dialer
@@ -397,6 +401,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		AmbientCtx:              cfg.AmbientCtx,
 		DB:                      cfg.db,
 		Gossip:                  cfg.gossip,
+		SystemConfig:            cfg.systemConfigProvider,
 		MetricsRecorder:         cfg.recorder,
 		DistSender:              cfg.distSender,
 		RPCContext:              cfg.rpcContext,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -102,7 +102,7 @@ type sqlServerOptionalKVArgs struct {
 	// Gossip is relied upon by distSQLCfg (execinfra.ServerConfig), the executor
 	// config, the DistSQL planner, the table statistics cache, the statements
 	// diagnostics registry, and the lease manager.
-	gossip gossip.DeprecatedGossip
+	gossip gossip.OptionalGossip
 	// To register blob and DistSQL servers.
 	grpcServer *grpc.Server
 	// Used by executorConfig.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -555,7 +555,7 @@ func makeSQLServerArgs(
 		sqlServerOptionalKVArgs: sqlServerOptionalKVArgs{
 			statusServer: serverpb.MakeOptionalStatusServer(nil),
 			nodeLiveness: sqlbase.MakeOptionalNodeLiveness(nil),
-			gossip:       gossip.MakeUnexposedGossip(nil),
+			gossip:       gossip.MakeOptionalGossip(nil),
 			grpcServer:   dummyRPCServer,
 			recorder:     dummyRecorder,
 			isMeta1Leaseholder: func(_ context.Context, timestamp hlc.Timestamp) (bool, error) {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
-	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -477,33 +476,13 @@ func makeSQLServerArgs(
 	}
 	rpcRetryOptions := base.DefaultRetryOptions()
 
-	// TODO(ajwerner): this use of Gossip needs to go. Tracked in:
-	// https://github.com/cockroachdb/cockroach/issues/47150
-	var g *gossip.Gossip
-	{
-		var nodeID base.NodeIDContainer
-		nodeID.Set(context.Background(), fakeNodeID)
-		var clusterID base.ClusterIDContainer
-		dummyGossipGRPC := rpc.NewServer(rpcContext) // never Serve()s anything
-		g = gossip.New(
-			baseCfg.AmbientCtx,
-			&clusterID,
-			&nodeID,
-			rpcContext,
-			dummyGossipGRPC,
-			stopper,
-			registry,
-			baseCfg.Locality,
-			&baseCfg.DefaultZoneConfig,
-		)
+	tpCfg := kvtenant.ProxyConfig{
+		AmbientCtx:        baseCfg.AmbientCtx,
+		RPCContext:        rpcContext,
+		RPCRetryOptions:   rpcRetryOptions,
+		DefaultZoneConfig: &baseCfg.DefaultZoneConfig,
 	}
-
-	tenantProxy, err := kvtenant.Factory.NewProxy(
-		baseCfg.AmbientCtx,
-		rpcContext,
-		rpcRetryOptions,
-		sqlCfg.TenantKVAddrs,
-	)
+	tenantProxy, err := kvtenant.Factory.NewProxy(tpCfg, sqlCfg.TenantKVAddrs)
 	if err != nil {
 		return sqlServerArgs{}, err
 	}
@@ -572,12 +551,11 @@ func makeSQLServerArgs(
 	// server to register against (but they'll never get RPCs at the time of
 	// writing): the blob service and DistSQL.
 	dummyRPCServer := rpc.NewServer(rpcContext)
-	noStatusServer := serverpb.MakeOptionalStatusServer(nil)
 	return sqlServerArgs{
 		sqlServerOptionalKVArgs: sqlServerOptionalKVArgs{
-			statusServer: noStatusServer,
+			statusServer: serverpb.MakeOptionalStatusServer(nil),
 			nodeLiveness: sqlbase.MakeOptionalNodeLiveness(nil),
-			gossip:       gossip.MakeUnexposedGossip(g),
+			gossip:       gossip.MakeUnexposedGossip(nil),
 			grpcServer:   dummyRPCServer,
 			recorder:     dummyRecorder,
 			isMeta1Leaseholder: func(_ context.Context, timestamp hlc.Timestamp) (bool, error) {
@@ -602,6 +580,7 @@ func makeSQLServerArgs(
 		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),
 		rpcContext:               rpcContext,
 		nodeDescs:                tenantProxy,
+		systemConfigProvider:     tenantProxy,
 		nodeDialer:               nodeDialer,
 		distSender:               ds,
 		db:                       db,
@@ -691,22 +670,6 @@ func StartTenant(
 		socketFile = "" // no unix socket
 	)
 	orphanedLeasesTimeThresholdNanos := args.clock.Now().WallTime
-
-	// TODO(ajwerner): this use of Gossip needs to go. Tracked in:
-	// https://github.com/cockroachdb/cockroach/issues/47150
-	{
-		rs := make([]resolver.Resolver, len(sqlCfg.TenantKVAddrs))
-		for i := range rs {
-			var err error
-			rs[i], err = resolver.NewResolver(sqlCfg.TenantKVAddrs[i])
-			if err != nil {
-				return "", err
-			}
-		}
-		// NB: gossip server is not bound to any address, so the advertise addr does
-		// not matter.
-		args.gossip.Start(pgL.Addr(), rs)
-	}
 
 	if err := s.start(ctx,
 		args.stopper,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -325,12 +325,12 @@ func makeMetrics(internal bool) Metrics {
 // Start starts the Server's background processing.
 func (s *Server) Start(ctx context.Context, stopper *stop.Stopper) {
 	if s.cfg.Codec.ForSystemTenant() {
-		gossipUpdateC := s.cfg.Gossip.DeprecatedRegisterSystemConfigChannel(47150)
+		gossipUpdateC := s.cfg.SystemConfig.RegisterSystemConfigChannel()
 		stopper.RunWorker(ctx, func(ctx context.Context) {
 			for {
 				select {
 				case <-gossipUpdateC:
-					sysCfg := s.cfg.Gossip.DeprecatedSystemConfig(47150)
+					sysCfg := s.cfg.SystemConfig.GetSystemConfig()
 					s.dbCache.updateSystemConfig(sysCfg)
 				case <-stopper.ShouldStop():
 					return

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -256,6 +257,7 @@ func startConnExecutor(
 		Settings:        st,
 		Clock:           clock,
 		DB:              db,
+		SystemConfig:    config.EmptySystemConfigProvider{},
 		SessionRegistry: NewSessionRegistry(),
 		NodeInfo: NodeInfo{
 			NodeID:    nodeID,

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -251,7 +251,7 @@ func startConnExecutor(
 	st := cluster.MakeTestingClusterSettings()
 	nodeID := base.TestingIDContainer
 	distSQLMetrics := execinfra.MakeDistSQLMetrics(time.Hour /* histogramWindow */)
-	gw := gossip.MakeExposedGossip(nil)
+	gw := gossip.MakeOptionalGossip(nil)
 	cfg := &ExecutorConfig{
 		AmbientCtx:      testutils.MakeAmbientCtx(),
 		Settings:        st,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -86,7 +86,7 @@ type DistSQLPlanner struct {
 	runnerChan chan runnerRequest
 
 	// gossip handle used to check node version compatibility.
-	gossip gossip.DeprecatedGossip
+	gossip gossip.OptionalGossip
 
 	nodeDialer *nodedialer.Dialer
 
@@ -128,7 +128,7 @@ func NewDistSQLPlanner(
 	distSQLSrv *distsql.ServerImpl,
 	distSender *kvcoord.DistSender,
 	nodeDescs kvcoord.NodeDescStore,
-	gw gossip.DeprecatedGossip,
+	gw gossip.OptionalGossip,
 	stopper *stop.Stopper,
 	isLive func(roachpb.NodeID) (bool, error),
 	nodeDialer *nodedialer.Dialer,
@@ -716,7 +716,7 @@ type SpanPartition struct {
 }
 
 type distSQLNodeHealth struct {
-	gossip     gossip.DeprecatedGossip
+	gossip     gossip.OptionalGossip
 	isLive     func(roachpb.NodeID) (bool, error)
 	connHealth func(roachpb.NodeID, rpc.ConnectionClass) error
 }

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -820,7 +820,7 @@ func TestPartitionSpans(t *testing.T) {
 				ranges: tc.ranges,
 			}
 
-			gw := gossip.MakeExposedGossip(mockGossip)
+			gw := gossip.MakeOptionalGossip(mockGossip)
 			dsp := DistSQLPlanner{
 				planVersion:   execinfra.Version,
 				st:            cluster.MakeTestingClusterSettings(),
@@ -1008,7 +1008,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				ranges: ranges,
 			}
 
-			gw := gossip.MakeExposedGossip(mockGossip)
+			gw := gossip.MakeOptionalGossip(mockGossip)
 			dsp := DistSQLPlanner{
 				planVersion:   tc.planVersion,
 				st:            cluster.MakeTestingClusterSettings(),
@@ -1107,7 +1107,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		ranges: ranges,
 	}
 
-	gw := gossip.MakeExposedGossip(mockGossip)
+	gw := gossip.MakeOptionalGossip(mockGossip)
 	dsp := DistSQLPlanner{
 		planVersion:   execinfra.Version,
 		st:            cluster.MakeTestingClusterSettings(),
@@ -1213,7 +1213,7 @@ func TestCheckNodeHealth(t *testing.T) {
 		{notLive, "not using n5 due to liveness: node n5 is not live"},
 	}
 
-	gw := gossip.MakeExposedGossip(mockGossip)
+	gw := gossip.MakeOptionalGossip(mockGossip)
 	for _, test := range livenessTests {
 		t.Run("liveness", func(t *testing.T) {
 			h := distSQLNodeHealth{

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -653,6 +653,7 @@ type ExecutorConfig struct {
 	AmbientCtx        log.AmbientContext
 	DB                *kv.DB
 	Gossip            gossip.DeprecatedGossip
+	SystemConfig      config.SystemConfigProvider
 	DistSender        *kvcoord.DistSender
 	RPCContext        *rpc.Context
 	LeaseManager      *lease.Manager

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -652,7 +652,7 @@ type ExecutorConfig struct {
 	Locality          roachpb.Locality
 	AmbientCtx        log.AmbientContext
 	DB                *kv.DB
-	Gossip            gossip.DeprecatedGossip
+	Gossip            gossip.OptionalGossip
 	SystemConfig      config.SystemConfigProvider
 	DistSender        *kvcoord.DistSender
 	RPCContext        *rpc.Context

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -144,7 +144,7 @@ type ServerConfig struct {
 
 	// A handle to gossip used to broadcast the node's DistSQL version and
 	// draining state.
-	Gossip gossip.DeprecatedGossip
+	Gossip gossip.OptionalGossip
 
 	NodeDialer *nodedialer.Dialer
 

--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -126,7 +126,7 @@ func (r schemaChangeGCResumer) Resume(
 			// TTL whenever we get an update on one of the tables/indexes (or the db)
 			// that this job is responsible for, and computing the earliest deadline
 			// from our set of cached TTL values.
-			cfg := execCfg.Gossip.DeprecatedSystemConfig(47150)
+			cfg := execCfg.SystemConfig.GetSystemConfig()
 			zoneConfigUpdated := false
 			zoneCfgFilter.ForModified(cfg, func(kv roachpb.KeyValue) {
 				zoneConfigUpdated = true

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -81,7 +81,7 @@ func updateStatusForGCElements(
 	progress *jobspb.SchemaChangeGCProgress,
 ) (expired bool, timeToNextTrigger time.Time) {
 	defTTL := execCfg.DefaultZoneConfig.GC.TTLSeconds
-	cfg := execCfg.Gossip.DeprecatedSystemConfig(47150)
+	cfg := execCfg.SystemConfig.GetSystemConfig()
 	protectedtsCache := execCfg.ProtectedTimestampProvider
 
 	earliestDeadline := timeutil.Unix(0, int64(math.MaxInt64))
@@ -270,8 +270,8 @@ func isProtected(
 func setupConfigWatcher(
 	execCfg *sql.ExecutorConfig,
 ) (gossip.SystemConfigDeltaFilter, <-chan struct{}) {
-	k := execCfg.Codec.IndexPrefix(uint32(keys.ZonesTableID), uint32(keys.ZonesTablePrimaryIndexID))
+	k := execCfg.Codec.IndexPrefix(keys.ZonesTableID, keys.ZonesTablePrimaryIndexID)
 	zoneCfgFilter := gossip.MakeSystemConfigDeltaFilter(k)
-	gossipUpdateC := execCfg.Gossip.DeprecatedRegisterSystemConfigChannel(47150)
+	gossipUpdateC := execCfg.SystemConfig.RegisterSystemConfigChannel()
 	return zoneCfgFilter, gossipUpdateC
 }

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -76,7 +76,7 @@ func (oc *optCatalog) reset() {
 		oc.dataSources = make(map[*sqlbase.ImmutableTableDescriptor]cat.DataSource)
 	}
 
-	oc.cfg = oc.planner.execCfg.Gossip.DeprecatedSystemConfig(47150)
+	oc.cfg = oc.planner.execCfg.SystemConfig.GetSystemConfig()
 }
 
 // optSchema represents the parent database and schema for an object. It

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -51,7 +51,7 @@ func TestSampleAggregator(t *testing.T) {
 				Settings: st,
 				DB:       kvDB,
 				Executor: server.InternalExecutor().(sqlutil.InternalExecutor),
-				Gossip:   gossip.MakeExposedGossip(server.GossipI().(*gossip.Gossip)),
+				Gossip:   gossip.MakeOptionalGossip(server.GossipI().(*gossip.Gossip)),
 			},
 		}
 		// Override the default memory limit. If memLimitBytes is small but

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -60,7 +60,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	descA := sqlbase.TestingGetTableDescriptor(s.DB(), keys.SystemSQLCodec, "t", "a")
 	cache := NewTableStatisticsCache(
 		10, /* cacheSize */
-		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
 		kvDB,
 		executor,
 		keys.SystemSQLCodec,
@@ -137,7 +137,7 @@ func TestAverageRefreshTime(t *testing.T) {
 	tableID := sqlbase.TestingGetTableDescriptor(s.DB(), keys.SystemSQLCodec, "t", "a").ID
 	cache := NewTableStatisticsCache(
 		10, /* cacheSize */
-		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
 		kvDB,
 		executor,
 		keys.SystemSQLCodec,
@@ -373,7 +373,7 @@ func TestAutoStatsReadOnlyTables(t *testing.T) {
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	cache := NewTableStatisticsCache(
 		10, /* cacheSize */
-		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
 		kvDB,
 		executor,
 		keys.SystemSQLCodec,
@@ -411,7 +411,7 @@ func TestNoRetryOnFailure(t *testing.T) {
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	cache := NewTableStatisticsCache(
 		10, /* cacheSize */
-		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
 		kvDB,
 		executor,
 		keys.SystemSQLCodec,

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -40,7 +40,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 	ex := s.InternalExecutor().(sqlutil.InternalExecutor)
 	cache := NewTableStatisticsCache(
 		10, /* cacheSize */
-		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
 		db,
 		ex,
 		keys.SystemSQLCodec,

--- a/pkg/sql/stats/gossip_invalidation_test.go
+++ b/pkg/sql/stats/gossip_invalidation_test.go
@@ -40,7 +40,7 @@ func TestGossipInvalidation(t *testing.T) {
 
 	sc := stats.NewTableStatisticsCache(
 		10, /* cacheSize */
-		gossip.MakeExposedGossip(tc.Server(0).GossipI().(*gossip.Gossip)),
+		gossip.MakeOptionalGossip(tc.Server(0).GossipI().(*gossip.Gossip)),
 		tc.Server(0).DB(),
 		tc.Server(0).InternalExecutor().(sqlutil.InternalExecutor),
 		keys.SystemSQLCodec,

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -94,7 +94,7 @@ type cacheEntry struct {
 // statistics for <cacheSize> tables.
 func NewTableStatisticsCache(
 	cacheSize int,
-	gw gossip.DeprecatedGossip,
+	gw gossip.OptionalGossip,
 	db *kv.DB,
 	sqlExecutor sqlutil.InternalExecutor,
 	codec keys.SQLCodec,

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -231,7 +231,7 @@ func TestCacheBasic(t *testing.T) {
 	// exceeded, entries should be evicted according to the LRU policy.
 	sc := NewTableStatisticsCache(
 		2, /* cacheSize */
-		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
 		db,
 		ex,
 		keys.SystemSQLCodec,
@@ -323,7 +323,7 @@ CREATE STATISTICS s FROM tt;
 	// Make a stats cache.
 	sc := NewTableStatisticsCache(
 		1,
-		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
 		kvDB,
 		s.InternalExecutor().(sqlutil.InternalExecutor),
 		keys.SystemSQLCodec,
@@ -362,7 +362,7 @@ func TestCacheWait(t *testing.T) {
 	sort.Sort(tableIDs)
 	sc := NewTableStatisticsCache(
 		len(tableIDs), /* cacheSize */
-		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
 		db,
 		ex,
 		keys.SystemSQLCodec,

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -72,7 +72,7 @@ type Registry struct {
 	st     *cluster.Settings
 	ie     sqlutil.InternalExecutor
 	db     *kv.DB
-	gossip gossip.DeprecatedGossip
+	gossip gossip.OptionalGossip
 
 	// gossipUpdateChan is used to notify the polling loop that a diagnostics
 	// request has been added. The gossip callback will not block sending on this
@@ -82,7 +82,7 @@ type Registry struct {
 
 // NewRegistry constructs a new Registry.
 func NewRegistry(
-	ie sqlutil.InternalExecutor, db *kv.DB, gw gossip.DeprecatedGossip, st *cluster.Settings,
+	ie sqlutil.InternalExecutor, db *kv.DB, gw gossip.OptionalGossip, st *cluster.Settings,
 ) *Registry {
 	r := &Registry{
 		ie:               ie,


### PR DESCRIPTION
Fixes #49445.

This commit introduces a new SystemConfigProvider abstraction, which is capable of providing the SystemConfig, as well as notifying clients of updates to the SystemConfig. Gossip already implements this interface. The commit then updates SQL to use this new dependency in place of Gossip whenever it needs to access the SystemConfig.

After making this change, it then updates the kvtenant.Proxy to implement the new SystemConfigProvider interface. This is powered by the GossipSubscription RPC that was added in #50520. The commit updates the subscription to also match on the "system-db" gossip key, and just like that, it can provide the SystemConfig to SQL [*].

Finally, with the kvtenant.Proxy serving the role of a SystemConfigProvider to SQL when applicable, we're able to remove gossip entirely from StartTenant. SQL-only servers will no longer join the gossip network, which is a nice milestone for all of this work.

[*] there are a few remaining questions about how exactly we want to enforce an access control policy on the system config gossip pattern. See the updated comment in `Node.GossipSubscription`. For now, we're just returning the entire SystemConfig to the subscription.