### PR TITLE
jobs: propagate tracing to StartableJobs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -667,10 +667,30 @@ INSERT INTO users (user_profile) VALUES
   ('{"first_name": "Carl", "last_name": "Kimball", "location": "NYC", "breed": "Boston Terrier"}'
 )
 
+statement ok
+SET tracing=on
+
 # Ensure that trying to create statistics with default columns does not fail
 # when there is an inverted index.
 statement ok
 CREATE STATISTICS s FROM users
+
+# Ensure that the trace includes the job by observing the job move through
+# the 'succeeded' state in the trace.
+
+query I
+SELECT count(*)
+  FROM [SHOW TRACE FOR SESSION]
+ WHERE message
+       LIKE '%job%: stepping through state succeeded with error: <nil>%'
+   AND message
+       NOT LIKE '%SELECT message%'
+----
+1
+
+statement ok
+SET tracing=off
+
 
 query TTIIIB colnames
 SELECT


### PR DESCRIPTION
Prior to this commit, jobs which were resumed using a StartableJob did
not carry tracing spans. We want the job to carry a tracing span that
will show up in the parent's trace, at least upon success. We also need
to make sure that this trace span follows from the parent but is not the
parent in order to deal with cases where the client disconnects.

Fixes #51104

Release note: None