### PR TITLE
sql: allow " as an escape character for COPY

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -513,4 +513,5 @@ var decodeMap = map[byte]byte{
 	't':  '\t',
 	'v':  '\v',
 	'\\': '\\',
+	'"':  '"',
 }

--- a/pkg/sql/copy_test.go
+++ b/pkg/sql/copy_test.go
@@ -46,6 +46,10 @@ func TestDecodeCopy(t *testing.T) {
 			in:     `T\n\07\xEV\x0fA\xb2C\1`,
 			expect: "T\n\007\x0eV\x0fA\xb2C\001",
 		},
+		{
+			in:     `\\\"`,
+			expect: "\\\"",
+		},
 
 		// Error cases.
 


### PR DESCRIPTION
PostgreSQL allows `\\\"` as an escape for `\"`. However, we seem to not
allow it at all. This was a blocker for osm2pgsql.

In general, I think we should be allowing any non-captured escape to be
used as is, as PostgreSQL does:
```
otan=# \copy copytest from stdin
Enter data to be copied followed by a newline.
End with a backslash and a period on a line by itself, or an EOF signal.
>> \1\2
>> COPY 1
otan=# select * from copytest
;
    t
----------
 \"
 \x01\x02
(2 rows)

otan=# \copy copytest from stdin
Enter data to be copied followed by a newline.
End with a backslash and a period on a line by itself, or an EOF signal.
>> \a
>> COPY 1
otan=# select * from copytest
;
    t
----------
 \"
 \x01\x02
 a
(3 rows)

otan=# \copy copytest from stdin
Enter data to be copied followed by a newline.
End with a backslash and a period on a line by itself, or an EOF signal.
>> \b
>> COPY 1
otan=# select * from copytest
;
    t
----------
 \"
 \x01\x02
 a
 \x08
(4 rows)
```

If you think we should change our code to follow this, let me know.

Release note: None