### PR TITLE
roachtest: fetch confluent tarball from mirror

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -55,8 +55,6 @@ type cdcTestArgs struct {
 }
 
 func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
-	t.Skip("flaky #51543", "https://github.com/cockroachdb/cockroach/issues/51543")
-
 	// Skip the poller test on v19.2. After 19.2 is out, we should likely delete
 	// the test entirely.
 	if !args.rangefeed && t.buildVersion.Compare(version.MustParse(`v19.1.0-0`)) > 0 {
@@ -227,7 +225,6 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 }
 
 func runCDCBank(ctx context.Context, t *test, c *cluster) {
-	t.Skip("flaky #51543", "https://github.com/cockroachdb/cockroach/issues/51543")
 
 	// Make the logs dir on every node to work around the `roachprod get logs`
 	// spam.
@@ -378,7 +375,6 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 // end-to-end (including the schema registry default of requiring backward
 // compatibility within a topic).
 func runCDCSchemaRegistry(ctx context.Context, t *test, c *cluster) {
-	t.Skip("flaky #51543", "https://github.com/cockroachdb/cockroach/issues/51543")
 
 	crdbNodes, kafkaNode := c.Node(1), c.Node(1)
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
@@ -682,7 +678,7 @@ func (k kafkaManager) install(ctx context.Context) {
 	k.c.status("installing kafka")
 	folder := k.basePath()
 	k.c.Run(ctx, k.nodes, `mkdir -p `+folder)
-	k.c.Run(ctx, k.nodes, `curl -s https://packages.confluent.io/archive/4.0/confluent-oss-4.0.0-2.11.tar.gz | tar -xz -C `+folder)
+	k.c.Run(ctx, k.nodes, `curl https://storage.googleapis.com/cockroach-fixtures/tools/confluent-oss-4.0.0-2.11.tar.gz | tar -xz -C `+folder)
 	if !k.c.isLocal() {
 		k.c.Run(ctx, k.nodes, `mkdir -p logs`)
 		k.c.Run(ctx, k.nodes, `sudo apt-get -q update 2>&1 > logs/apt-get-update.log`)


### PR DESCRIPTION
This switches out CDC roachtests to fetch the confluent tarball from a
copy mirrored in one of our GS buckets instead of directly from confluent's
download site on each run, to reduce the chance a build flakes due to their
download server's response or lack thereof.

Ideally we'd go futher and bake this into our image and/or cache it
somewhere in the agent, but just using the mirrored artifact is
enough to get these tests re-enabled as it should be at least as
stable as it was for the past several months when it was going to
the external download site directly.

Release note: none.