### PR TITLE
teams: add TEAMS.yaml to repo

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -1,0 +1,68 @@
+# This is a YAML file mapping team aliases from GitHub to
+# metadata about the team.
+# Expected structure is available in pkg/internal/team/team.go.
+
+# Finding triage_column_id:
+#   TriageColumnID is the column id of the project column the team uses to
+#   triage issues. Unfortunately, there appears to be no way to retrieve this
+#   programmatically from the API.
+#
+#   To find the triage column for a project, run the following curl command:
+#     curl -u yourusername:githubaccesstoken -H "Accept: application/vnd.github.inertia-preview+json" \
+#     https://api.github.com/repos/cockroachdb/cockroach/projects
+#
+#   Then, for the project you care about, curl its columns URL, which looks like this:
+#     https://api.github.com/projects/3842382/columns
+#
+#   Find the triage column you want, and pick its ID field.
+#
+#   TODO(otan): make this a tool.
+
+cockroachdb/sql-features:
+  email: sql-features-team@cockroachlabs.com
+  slack: sql-features
+  triage_column_id: 9056630
+cockroachdb/sql-schema:
+  email: sql-schema-team@cockroachlabs.com
+  slack: sql-schema
+  triage_column_id: 8946818
+cockroachdb/sql-execution:
+  email: vectorized-execution-team@cockroachlabs.com
+  slack: sql-execution
+  triage_column_id: 6837155
+cockroachdb/sql-optimizer:
+  email: optimizer-team@cockroachlabs.com
+  slack: sql-optimizer
+  triage_column_id: 3281044
+cockroachdb/kv:
+  email: kv@cockroachlabs.com
+  slack: kv
+  triage_column_id: 3550674
+cockroachdb/geospatial:
+  email: geospatial-team@cockroachlabs.com
+  slack: geospatial
+  triage_column_id: 9487269
+cockroachdb/dev-inf:
+  email: dev-inf@cockroachlabs.com
+  slack: dev-inf
+  triage_column_id: 10210759
+cockroachdb/storage:
+  email: storage-team@cockroachlabs.com
+  slack: storage
+  triage_column_id: 6668367
+cockroachdb/appdev:
+  email: app-dev-team@cockroachlabs.com
+  slack: app-dev
+  triage_column_id: 8532151
+cockroachdb/security:
+  email: security@cockroachlabs.com
+  slack: security
+  triage_column_id: 0 # TODO: create project board.
+cockroachdb/admin-ui-prs:
+  email: observability@cockroachlabs.com
+  slack: product-observability
+  triage_column_id: 6598672
+cockroachdb/bulk-io:
+  email: bulk-io@cockroachlabs.com
+  slack: bulk-io
+  triage_column_id: 3097123

--- a/pkg/internal/team/team.go
+++ b/pkg/internal/team/team.go
@@ -1,0 +1,67 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package team involves processing team information based on a yaml
+// file containing team metadata.
+package team
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+)
+
+// DefaultTeamsYAMLLocation is the default location for the TEAMS.yaml file.
+var DefaultTeamsYAMLLocation string
+
+func init() {
+	DefaultTeamsYAMLLocation = filepath.Join(
+		os.Getenv("GOPATH"),
+		"src/github.com/cockroachdb/cockroach/TEAMS.yaml",
+	)
+}
+
+// Alias is the name of a team.
+type Alias string
+
+// Team is a team in the CockroachDB repo.
+type Team struct {
+	// Alias is the name of the team.
+	// It is populated from using the key of the yaml file.
+	Alias Alias `yaml:"-"`
+	// Email is the email address for this team.
+	Email string `yaml:"email"`
+	// Slack is the slack channel for this team.
+	Slack string `yaml:"slack"`
+	// TriageColumnID is the Github Column ID to assign issues to.
+	TriageColumnID int `yaml:"triage_column_id"`
+}
+
+// LoadTeams loads the teams from an io input.
+// It is expected the input is in YAML format.
+func LoadTeams(f io.Reader) (map[Alias]Team, error) {
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	var ret map[Alias]Team
+	if err := yaml.UnmarshalStrict(b, &ret); err != nil {
+		return nil, err
+	}
+	// Populate the Alias value of each team.
+	for k, v := range ret {
+		v.Alias = k
+		ret[k] = v
+	}
+	return ret, nil
+}

--- a/pkg/internal/team/team_test.go
+++ b/pkg/internal/team/team_test.go
@@ -1,0 +1,64 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package team
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTeams(t *testing.T) {
+	yamlFile := []byte(`
+sql:
+  email: otan@cockroachlabs.com
+  slack: otan
+  triage_column_id: 1
+test-infra-team:
+  email: jlinder@cockroachlabs.com
+  slack: jlinder
+  triage_column_id: 2
+`)
+	ret, err := LoadTeams(bytes.NewReader(yamlFile))
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		map[Alias]Team{
+			"sql": {
+				Alias:          "sql",
+				Email:          "otan@cockroachlabs.com",
+				Slack:          "otan",
+				TriageColumnID: 1,
+			},
+			"test-infra-team": {
+				Alias:          "test-infra-team",
+				Email:          "jlinder@cockroachlabs.com",
+				Slack:          "jlinder",
+				TriageColumnID: 2,
+			},
+		},
+		ret,
+	)
+}
+
+func TestTeamsYAMLValid(t *testing.T) {
+	f, err := os.Open(DefaultTeamsYAMLLocation)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	_, err = LoadTeams(f)
+	require.NoError(t, err)
+
+	// TODO(otan): test other volatile validity conditions, e.g. triage_column_id exists.
+	// Gate this by a flag so this is only tested with certain flags, as these are
+	// not reproducible results in tests.
+}


### PR DESCRIPTION
This commit adds a concept of TEAMS.yaml to the repo, allowing us to
attribute Github aliases to team metadata. This will be useful in the
times to come as we attribute ownership, and map that to contact
information as well as Github board items.

Release note: None