### PR TITLE
codeowners: enrich CODEOWNERS with team info and a debugging tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1718,6 +1718,7 @@ bins = \
   bin/teamcity-trigger \
   bin/uptodate \
   bin/urlcheck \
+	bin/whoownsit \
   bin/workload \
   bin/zerosum
 

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -1,0 +1,92 @@
+# This is a YAML file mapping team aliases from GitHub to
+# metadata about the team.
+# Expected structure is available in pkg/internal/team/team.go.
+
+# Finding triage_column_id:
+#   TriageColumnID is the column id of the project column the team uses to
+#   triage issues. Unfortunately, there appears to be no way to retrieve this
+#   programmatically from the API.
+#
+#   To find the triage column for a project, run the following curl command:
+#     curl -u yourusername:githubaccesstoken -H "Accept: application/vnd.github.inertia-preview+json" \
+#     https://api.github.com/repos/cockroachdb/cockroach/projects
+#
+#   Then, for the project you care about, curl its columns URL, which looks like this:
+#     https://api.github.com/projects/3842382/columns
+#
+#   Find the triage column you want, and pick its ID field.
+#
+#   TODO(otan): make this a tool.
+
+cockroachdb/sql-features:
+  email: sql-features-team@cockroachlabs.com
+  slack: sql-features
+  triage_column_id: 9056630
+cockroachdb/sql-syntax-prs: # TODO: remove
+  email: sql-features-team@cockroachlabs.com
+  slack: sql-features
+  triage_column_id: 9056630
+cockroachdb/sql-api-prs: # TODO: remove
+  email: sql-features-team@cockroachlabs.com
+  slack: sql-features
+  triage_column_id: 9056630
+cockroachdb/sql-schema:
+  email: sql-schema-team@cockroachlabs.com
+  slack: sql-schema
+  triage_column_id: 8946818
+cockroachdb/sql-execution:
+  email: vectorized-execution-team@cockroachlabs.com
+  slack: sql-execution
+  triage_column_id: 6837155
+cockroachdb/sql-optimizer:
+  email: optimizer-team@cockroachlabs.com
+  slack: sql-optimizer
+  triage_column_id: 3281044
+cockroachdb/sql-opt-prs: # TODO: remove
+  email: optimizer-team@cockroachlabs.com
+  slack: sql-optimizer
+  triage_column_id: 3281044
+cockroachdb/kv:
+  email: kv@cockroachlabs.com
+  slack: kv
+  triage_column_id: 3550674
+cockroachdb/geospatial:
+  email: geospatial-team@cockroachlabs.com
+  slack: geospatial
+  triage_column_id: 9487269
+cockroachdb/dev-inf:
+  email: dev-inf@cockroachlabs.com
+  slack: dev-inf
+  triage_column_id: 10210759
+cockroachdb/storage:
+  email: storage-team@cockroachlabs.com
+  slack: storage
+  triage_column_id: 6668367
+cockroachdb/appdev:
+  email: app-dev-team@cockroachlabs.com
+  slack: app-dev
+  triage_column_id: 8532151
+cockroachdb/security:
+  email: security@cockroachlabs.com
+  slack: security
+  triage_column_id: 0 # TODO
+cockroachdb/admin-ui-prs:
+  email: observability@cockroachlabs.com
+  slack: product-observability
+  triage_column_id: 6598672
+cockroachdb/bulk-prs: # TODO: remove
+  email: bulk-io@cockroachlabs.com
+  slack: bulk-io
+  triage_column_id: 3097123
+cockroachdb/bulk-io:
+  email: bulk-io@cockroachlabs.com
+  slack: bulk-io
+  triage_column_id: 3097123
+cockroachdb/cli-prs:
+  email: TODO@cockroachlabs.com
+  slack: cli
+  triage_column_id: 0 # TODO
+cockroachdb/rfc-prs:
+  email: TODO@cockroachlabs.com
+  slack: TODO
+  triage_column_id: 0 # TODO

--- a/go.mod
+++ b/go.mod
@@ -143,6 +143,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/twpayne/go-geom v1.3.2
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
+	github.com/zabawaba99/go-gitignore v0.0.0-20200117185801-39e6bddfb292
 	go.etcd.io/etcd v0.0.0-00010101000000-000000000000
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/exp v0.0.0-20200513190911-00229845015e

--- a/go.sum
+++ b/go.sum
@@ -736,6 +736,8 @@ github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FB
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/zabawaba99/go-gitignore v0.0.0-20200117185801-39e6bddfb292 h1:vpcCVk+pSR/6zcurmlGFD3jC5I/7RMl+GwGAPLxvX18=
+github.com/zabawaba99/go-gitignore v0.0.0-20200117185801-39e6bddfb292/go.mod h1:qcqv8IHwbR0JmjY1LZy4PeytlwxDPn1vUkjX7Wq0VaY=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=

--- a/pkg/cmd/whoownsit/whoownsit.go
+++ b/pkg/cmd/whoownsit/whoownsit.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// whoownsit looks for OWNERS in the directory and parenting directories
+// until it finds an owner for a given file.
+//
+// Usage: ./whoownsit [<file_or_dir> ...]
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/codeowners"
+)
+
+func main() {
+	flag.Parse()
+
+	codeOwners, err := codeowners.DefaultLoadCodeOwners()
+	if err != nil {
+		log.Fatalf("failing to load code owners: %v", err)
+	}
+
+	for _, path := range flag.Args() {
+		owners, err := codeOwners.Match(path)
+		if err != nil {
+			log.Fatalf("failed finding owner for %q: %v", path, err)
+		}
+		if len(flag.Args()) > 1 {
+			fmt.Printf("%s: ", path)
+		}
+		if len(owners) == 0 {
+			fmt.Printf("no owners")
+		} else {
+			for i, owner := range owners {
+				if i > 0 {
+					fmt.Printf(", ")
+				}
+				fmt.Print(owner.Alias)
+			}
+		}
+		fmt.Printf("\n")
+	}
+}

--- a/pkg/internal/codeowners/codeowners.go
+++ b/pkg/internal/codeowners/codeowners.go
@@ -1,0 +1,135 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package codeowners
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/gopath"
+	"github.com/cockroachdb/cockroach/pkg/internal/team"
+	"github.com/cockroachdb/errors"
+	"github.com/zabawaba99/go-gitignore"
+)
+
+// DefaultCodeOwnersLocation is the default location for the CODEOWNERS file.
+var DefaultCodeOwnersLocation string
+
+func init() {
+	DefaultCodeOwnersLocation = filepath.Join(
+		gopath.Get(),
+		"src",
+		"github.com",
+		"cockroachdb",
+		"cockroach",
+		".github",
+		"CODEOWNERS",
+	)
+}
+
+// Rule is a single rule within a CODEOWNERS file.
+type Rule struct {
+	Pattern string
+	Owners  []team.Alias
+}
+
+// CodeOwners is a struct encapsulating a CODEOWNERS file.
+type CodeOwners struct {
+	rules []Rule
+	teams map[team.Alias]team.Team
+}
+
+// LoadCodeOwners parses a CODEOWNERS file and returns the CodeOwners struct.
+func LoadCodeOwners(r io.Reader, teams map[team.Alias]team.Team) (*CodeOwners, error) {
+	s := bufio.NewScanner(r)
+	ret := &CodeOwners{
+		teams: teams,
+	}
+	lineNum := 1
+	for s.Scan() {
+		lineNum++
+		if s.Err() != nil {
+			return nil, s.Err()
+		}
+		t := s.Text()
+		if strings.HasPrefix(t, "#") {
+			continue
+		}
+		t = strings.TrimSpace(t)
+		if len(t) == 0 {
+			continue
+		}
+
+		fields := strings.Fields(t)
+		rule := Rule{Pattern: fields[0]}
+		for _, field := range fields[1:] {
+			owner := team.Alias(strings.TrimPrefix(field, "@"))
+			if _, ok := teams[owner]; !ok {
+				return nil, errors.Newf("owner %s does not exist", owner)
+			}
+			rule.Owners = append(rule.Owners, owner)
+		}
+		ret.rules = append(ret.rules, rule)
+	}
+	return ret, nil
+}
+
+// DefaultLoadCodeOwners loads teams from the DefaultCodeOwnersLocation.
+func DefaultLoadCodeOwners() (*CodeOwners, error) {
+	teams, err := team.DefaultLoadTeams()
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(DefaultCodeOwnersLocation)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return LoadCodeOwners(f, teams)
+}
+
+// Match matches the given file to the rules and returns the owning team(s).
+// Returns empty if there are no owning teams.
+func (co *CodeOwners) Match(inPath string) ([]team.Team, error) {
+	// Hack for now to get the same format as CODEOWNERS
+	fullPath, err := filepath.Abs(inPath)
+	if err != nil {
+		return nil, err
+	}
+	filePath := strings.TrimPrefix(
+		fullPath,
+		filepath.Join(gopath.Get(), "src", "github.com", "cockroachdb", "cockroach"),
+	)
+
+	// Keep matching until we hit the root directory.
+	lastFilePath := ""
+	for filePath != lastFilePath {
+		// Rules are matched backwards.
+		for i := len(co.rules) - 1; i >= 0; i-- {
+			rule := co.rules[i]
+			// For subdirectories, CODEOWNERS will add ** automatically for matches.
+			// As such, if the pattern ends with a directory (i.e. '/'), add the ** operator implicitly.
+			if gitignore.Match(rule.Pattern, filePath) {
+				teams := make([]team.Team, len(rule.Owners))
+				for i, owner := range rule.Owners {
+					teams[i] = co.teams[owner]
+				}
+				return teams, nil
+			}
+		}
+		lastFilePath = filePath
+		filePath = filepath.Dir(filePath)
+	}
+	return nil, nil
+}

--- a/pkg/internal/codeowners/codeowners_test.go
+++ b/pkg/internal/codeowners/codeowners_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package codeowners
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/team"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatch(t *testing.T) {
+	owners := `
+/a/ @cockroachdb/team-a
+/b/ @cockroachdb/team-b
+/a/b* @cockroachdb/team-b @cockroachdb/team-a
+**/c/ @cockroachdb/team-c
+`
+	teams := map[team.Alias]team.Team{
+		"cockroachdb/team-a": {Alias: "cockroachdb/team-a"},
+		"cockroachdb/team-b": {Alias: "cockroachdb/team-c"},
+		"cockroachdb/team-c": {Alias: "cockroachdb/team-c"},
+	}
+
+	codeOwners, err := LoadCodeOwners(strings.NewReader(owners), teams)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		path     string
+		expected []team.Team
+	}{
+		{"/a", []team.Team{teams["cockroachdb/team-a"]}},
+		{"/a/file.txt", []team.Team{teams["cockroachdb/team-a"]}},
+		{"/a/b", []team.Team{teams["cockroachdb/team-b"], teams["cockroachdb/team-a"]}},
+		{"/a/bob", []team.Team{teams["cockroachdb/team-b"], teams["cockroachdb/team-a"]}},
+		{"/no/owner/", nil},
+		{"/hmm/what/about/c/file", []team.Team{teams["cockroachdb/team-c"]}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.path, func(t *testing.T) {
+			ret, err := codeOwners.Match(tc.path)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, ret)
+		})
+	}
+}
+
+func TestCodeOwnersValid(t *testing.T) {
+	_, err := DefaultLoadCodeOwners()
+	require.NoError(t, err)
+}

--- a/pkg/internal/gopath/gopath.go
+++ b/pkg/internal/gopath/gopath.go
@@ -1,0 +1,32 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package gopath contains utilities to get the current GOPATH.
+package gopath
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+)
+
+// Get returns the guessed GOPATH.
+func Get() string {
+	p := os.Getenv("GOPATH")
+	if p != "" {
+		return p
+	}
+	home, err := envutil.HomeDir()
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(home, "go")
+}

--- a/pkg/internal/team/team.go
+++ b/pkg/internal/team/team.go
@@ -1,0 +1,82 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package team involves processing team information based on a yaml
+// file containing team metadata.
+package team
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/gopath"
+	"gopkg.in/yaml.v2"
+)
+
+// DefaultTeamsYAMLLocation is the default location for the TEAMS.yaml file.
+var DefaultTeamsYAMLLocation string
+
+func init() {
+	DefaultTeamsYAMLLocation = filepath.Join(
+		gopath.Get(),
+		"src",
+		"github.com",
+		"cockroachdb",
+		"cockroach",
+		"TEAMS.yaml",
+	)
+}
+
+// Alias is the name of a team.
+type Alias string
+
+// Team is a team in the CockroachDB repo.
+type Team struct {
+	// Alias is the name of the team.
+	// It is populated from using the key of the yaml file.
+	Alias Alias `yaml:"-"`
+	// Email is the email address for this team.
+	Email string `yaml:"email"`
+	// Slack is the slack channel for this team.
+	Slack string `yaml:"slack"`
+	// TriageColumnID is the Github Column ID to assign issues to.
+	TriageColumnID int `yaml:"triage_column_id"`
+}
+
+// DefaultLoadTeams loads teams from the DefaultTeamsYAMLLocation.
+func DefaultLoadTeams() (map[Alias]Team, error) {
+	f, err := os.Open(DefaultTeamsYAMLLocation)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return LoadTeams(f)
+}
+
+// LoadTeams loads the teams from an io input.
+// It is expected the input is in YAML format.
+func LoadTeams(f io.Reader) (map[Alias]Team, error) {
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	var ret map[Alias]Team
+	if err := yaml.UnmarshalStrict(b, &ret); err != nil {
+		return nil, err
+	}
+	// Populate the Alias value of each team.
+	for k, v := range ret {
+		v.Alias = k
+		ret[k] = v
+	}
+	return ret, nil
+}

--- a/pkg/internal/team/team_test.go
+++ b/pkg/internal/team/team_test.go
@@ -1,0 +1,60 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package team
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTeams(t *testing.T) {
+	yamlFile := []byte(`
+sql:
+  email: otan@cockroachlabs.com
+  slack: otan
+  triage_column_id: 1
+test-infra-team:
+  email: jlinder@cockroachlabs.com
+  slack: jlinder
+  triage_column_id: 2
+`)
+	ret, err := LoadTeams(bytes.NewReader(yamlFile))
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		map[Alias]Team{
+			"sql": {
+				Alias:          "sql",
+				Email:          "otan@cockroachlabs.com",
+				Slack:          "otan",
+				TriageColumnID: 1,
+			},
+			"test-infra-team": {
+				Alias:          "test-infra-team",
+				Email:          "jlinder@cockroachlabs.com",
+				Slack:          "jlinder",
+				TriageColumnID: 2,
+			},
+		},
+		ret,
+	)
+}
+
+func TestTeamsYAMLValid(t *testing.T) {
+	_, err := DefaultLoadTeams()
+	require.NoError(t, err)
+
+	// TODO(otan): test other volatile validity conditions, e.g. triage_column_id exists.
+	// Gate this by a flag so this is only tested with certain flags, as these are
+	// not reproducible results in tests.
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -444,6 +444,7 @@ func TestLint(t *testing.T) {
 					":!ccl/backupccl/backup_test.go",
 					":!storage/cloudimpl",
 					":!ccl/workloadccl/fixture_test.go",
+					":!internal/gopath/gopath.go",
 					":!cmd",
 					":!nightly",
 					":!testutils/lint",


### PR DESCRIPTION
Expand the CODEOWNERS functionality by adding a TEAMS.yaml file which
contains useful metadata about each given team.

The changes are as follows:
* Add a `team` package, which infers team information from a TEAMS.yaml
  file in root. This TEAMS.yaml file is enriched with a few more teams.
* Add a `codeowners` package which can interpret CODEOWNERS files and
  match a filepath to a set of teams which own a given file.
* Add a `whoownsit` tool which given any number of files or directories
  attempts to decipher the owner from CODEOWNERS.

Release note: None