### PR TITLE
geoindex: make geometry index bounds a square

### DIFF
--- a/pkg/geo/geoindex/s2_geometry_index.go
+++ b/pkg/geo/geoindex/s2_geometry_index.go
@@ -95,6 +95,21 @@ func GeometryIndexConfigForSRID(srid geopb.SRID) (*Config, error) {
 	if maxY-minY < 1 {
 		maxY++
 	}
+	// We are covering shapes using cells that are square. If we have shapes
+	// that start off as well-behaved wrt square cells, we do not wish to
+	// distort them significantly. Hence, we equalize MaxX-MinX and MaxY-MinY
+	// in the index bounds.
+	diffX := maxX - minX
+	diffY := maxY - minY
+	if diffX > diffY {
+		adjustment := (diffX - diffY) / 2
+		minY -= adjustment
+		maxY += adjustment
+	} else {
+		adjustment := (diffY - diffX) / 2
+		minX -= adjustment
+		maxX += adjustment
+	}
 	// Expand the bounds by 2x the clippingBoundsDelta, to
 	// ensure that shapes touching the bounds don't get
 	// clipped.


### PR DESCRIPTION
For SRIDs where the rectangle defined by the dimensions
(maxX-minX, maxY-minY) is not close to a square, the
original shape is distorted when converting the planar
point to an S2 point. This can make shapes that have
good coverings when not distorted to have poor coverings
post-distortion. For example SRID 26918, used in the NYC
dataset, has SRID bounds where the span of the X axis is
~1/10th the span of the Y axis. Before this change, the
average ratio of the cell covering area to the shape
area was ~14 (closer to 1 is good). After this change,
the ratio is ~5.2.

This ratio improvement helps queries. For example, in a
query of the form

SELECT ... FROM nyc_census_blocks@geom_idx AS census
JOIN nyc_subway_stations AS subways
ON ST_Intersects(subways.geom, census.geom)

the false positive row count produced by the inverted
joiner reduced from 6712 to 2615. And the query latency
reduced from ~146ms to ~110ms.
A similar query with ST_DWithin(subways.geom, census.geom, 200)
had a latency reduction from ~410ms to ~275ms, because
the final filtering step done by the joinReader had a
reduction in rows from 48257 to 23183 (of these rows,
only 8608 rows passed the filter).

Release note: None