### PR TITLE
rowexec: skip the vectorized config in a test

### DIFF
--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -226,6 +226,11 @@ func (s *ParallelUnorderedSynchronizer) init(ctx context.Context) {
 				ctxCanceled := errors.Is(err, context.Canceled)
 				grpcCtxCanceled := grpcutil.IsContextCanceled(err)
 				queryCanceled := errors.Is(err, sqlbase.QueryCanceledError)
+				// TODO(yuzefovich): should we be swallowing flow and stream
+				// context cancellation errors regardless whether the
+				// cancellation is internal? The reasoning is that if another
+				// operator encounters an error, the context is likely to get
+				// canceled with this synchronizer seeing the "fallout".
 				if atomic.LoadInt32(&internalCancellation) == 1 && (ctxCanceled || grpcCtxCanceled || queryCanceled) {
 					// If the synchronizer performed the internal cancellation,
 					// we need to swallow context cancellation and "query

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -850,6 +850,11 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 		vectorizeOpt := "off"
 		if vectorize {
 			vectorizeOpt = "on"
+			// Occasionally, the vectorized engine propagates either flow's or
+			// stream's context canceled error instead of the expected one, so
+			// we temporarily skip such config.
+			// TODO(yuzefovich): remove this.
+			skip.WithIssue(t, 52057)
 		}
 		for _, testCase := range testCases {
 			t.Run(testCase.query, func(t *testing.T) {


### PR DESCRIPTION
Occasionally, the vectorized engine propagates either flow's or
stream's context canceled error instead of the expected one in
`TestUncertaintyErrorIsReturned`, so we temporarily skip such
config.

Addresses: #52057.

Release note: None