### PR TITLE
sql: allow escape of any character for COPY

### DIFF
--- a/pkg/sql/copy_test.go
+++ b/pkg/sql/copy_test.go
@@ -24,7 +24,6 @@ func TestDecodeCopy(t *testing.T) {
 	tests := []struct {
 		in     string
 		expect string
-		err    bool
 	}{
 		{
 			in:     `new\nline`,
@@ -46,43 +45,42 @@ func TestDecodeCopy(t *testing.T) {
 			in:     `T\n\07\xEV\x0fA\xb2C\1`,
 			expect: "T\n\007\x0eV\x0fA\xb2C\001",
 		},
-
-		// Error cases.
-
 		{
-			in:  `\x`,
-			err: true,
+			in:     `\\\"`,
+			expect: "\\\"",
 		},
 		{
-			in:  `\xg`,
-			err: true,
+			in:     `\x`,
+			expect: "x",
 		},
 		{
-			in:  `\`,
-			err: true,
+			in:     `\xg`,
+			expect: "xg",
 		},
 		{
-			in:  `\8`,
-			err: true,
+			in:     `\`,
+			expect: "\\",
 		},
 		{
-			in:  `\a`,
-			err: true,
+			in:     `\8`,
+			expect: "8",
+		},
+		{
+			in:     `\a`,
+			expect: "a",
+		},
+		{
+			in:     `\x\xg\8\xH\x32\s\`,
+			expect: "xxg8xH2s\\",
 		},
 	}
 
 	for _, test := range tests {
-		out, err := decodeCopy(test.in)
-		if gotErr := err != nil; gotErr != test.err {
-			if gotErr {
-				t.Errorf("%q: unexpected error: %v", test.in, err)
-				continue
+		t.Run(test.in, func(t *testing.T) {
+			out := decodeCopy(test.in)
+			if out != test.expect {
+				t.Errorf("%q: got %q, expected %q", test.in, out, test.expect)
 			}
-			t.Errorf("%q: expected error", test.in)
-			continue
-		}
-		if out != test.expect {
-			t.Errorf("%q: got %q, expected %q", test.in, out, test.expect)
-		}
+		})
 	}
 }


### PR DESCRIPTION
According to the PostgreSQL docs:
  Any other backslashed character that is not mentioned in the above
  table will be taken to represent itself.

Reflect that change by converting error conditions from decodeCopy into
interpreting the characters as is.

Resolves #52067.

Release note (bug fix): `COPY` previously did not allow a backslash of
any character other than the special table set. CockroachDB would error
in these cases. This is changed to allow in any character after a
backslash and interpret it to mean the character itself as per PostgreSQL
(e.g. now `\a` will be interpreted as `a`). Furthermore, non hex-digits
following a `\x` is now interpreted without the backslash, (e.g. `\xH` as
`xH`). Strings ending with a single backslash will use the backslash
(e.g. `x\\` is interpreted as `x\`).