### PR TITLE
cli: support user defined schemas in cockroach dump

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -403,7 +403,7 @@ CREATE TABLE public.t (
 	FAMILY "primary" (i, rowid)
 );
 
-INSERT INTO t (i) VALUES
+INSERT INTO public.t (i) VALUES
 	(1);
 `
 	if dump1 != want1 {
@@ -419,6 +419,7 @@ INSERT INTO t (i) VALUES
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	const want2 = `dump d t
 CREATE TABLE public.t (
 	i INT8 NULL,
@@ -426,7 +427,7 @@ CREATE TABLE public.t (
 	FAMILY "primary" (i, rowid, j)
 );
 
-INSERT INTO t (i, j) VALUES
+INSERT INTO public.t (i, j) VALUES
 	(1, 2),
 	(3, 4);
 `
@@ -446,7 +447,7 @@ INSERT INTO t (i, j) VALUES
 
 	if out, err := c.RunWithCaptureArgs([]string{"dump", "d", "t", "--as-of", "2000-01-01 00:00:00"}); err != nil {
 		t.Fatal(err)
-	} else if !strings.Contains(out, `relation d.public.t does not exist`) {
+	} else if !strings.Contains(out, `database d does not exist`) {
 		t.Fatalf("unexpected output: %s", out)
 	}
 }
@@ -656,7 +657,7 @@ CREATE TABLE public.t1 (
 	FAMILY "primary" (id, pkey)
 );
 
-INSERT INTO t1 (id, pkey) VALUES
+INSERT INTO public.t1 (id, pkey) VALUES
 	(1, 'db1-aaaa'),
 	(2, 'db1-bbbb');
 
@@ -670,7 +671,7 @@ CREATE TABLE public.t2 (
 	FAMILY "primary" (id, pkey)
 );
 
-INSERT INTO t2 (id, pkey) VALUES
+INSERT INTO public.t2 (id, pkey) VALUES
 	(1, 'db2-aaaa'),
 	(2, 'db2-bbbb');
 `,
@@ -694,11 +695,11 @@ INSERT INTO t2(id, pkey) VALUES(1, 'db2-aaaa');
 INSERT INTO t2(id, pkey) VALUES(2, 'db2-bbbb');
 `,
 			expected: `
-INSERT INTO t1 (id, pkey) VALUES
+INSERT INTO public.t1 (id, pkey) VALUES
 	(1, 'db1-aaaa'),
 	(2, 'db1-bbbb');
 
-INSERT INTO t2 (id, pkey) VALUES
+INSERT INTO public.t2 (id, pkey) VALUES
 	(1, 'db2-aaaa'),
 	(2, 'db2-bbbb');
 `,
@@ -740,7 +741,7 @@ CREATE TABLE public.account (
 	FAMILY "primary" (id, person_id, accountno)
 );
 
-INSERT INTO account (id, person_id, accountno) VALUES
+INSERT INTO public.account (id, person_id, accountno) VALUES
 	(1, 1, 1111),
 	(2, 2, 2222);
 
@@ -754,7 +755,7 @@ CREATE TABLE public.person (
 	FAMILY "primary" (id, name)
 );
 
-INSERT INTO person (id, name) VALUES
+INSERT INTO public.person (id, name) VALUES
 	(1, 'John Smith'),
 	(2, 'Joe Dow');
 
@@ -800,7 +801,7 @@ CREATE TABLE public.bar (
 	FAMILY "primary" (id, rowid)
 );
 
-INSERT INTO bar (id) VALUES
+INSERT INTO public.bar (id) VALUES
 	(1),
 	(2);
 
@@ -812,7 +813,7 @@ CREATE TABLE public.foo (
 	FAMILY "primary" (id, rowid)
 );
 
-INSERT INTO foo (id) VALUES
+INSERT INTO public.foo (id) VALUES
 	(1),
 	(2),
 	(3);
@@ -907,7 +908,7 @@ CREATE TEMP TABLE tmpbar (id int primary key);
 	FAMILY "primary" (id, text)
 );
 
-INSERT INTO bar (id, text) VALUES
+INSERT INTO public.bar (id, text) VALUES
 	(1, 'a');
 `,
 			args: []string{"foo"},
@@ -924,7 +925,7 @@ CREATE TABLE bar (id INT PRIMARY KEY);
 CREATE TEMP TABLE tmpbar (id INT PRIMARY KEY);
 INSERT INTO tmpbar VALUES (1);
 `,
-			expected: "ERROR: cannot dump temp table tmpbar\n",
+			expected: "ERROR: getBasicMetadata: relation foo.public.tmpbar does not exist\n",
 			args:     []string{"foo", "bar", "tmpbar"},
 		},
 		{
@@ -938,7 +939,7 @@ CREATE TABLE bar (id INT PRIMARY KEY);
 		
 CREATE TEMP VIEW tmpview (id) AS SELECT id FROM bar;
 `,
-			expected: "ERROR: cannot dump temp table tmpview\n",
+			expected: "ERROR: getBasicMetadata: relation foo.public.tmpview does not exist\n",
 			args:     []string{"foo", "tmpview"},
 		},
 		{
@@ -950,7 +951,7 @@ USE foo;
 
 CREATE TEMP SEQUENCE tmpseq START 1 INCREMENT 1;
 `,
-			expected: "ERROR: cannot dump temp table tmpseq\n",
+			expected: "ERROR: getBasicMetadata: relation foo.public.tmpseq does not exist\n",
 			args:     []string{"foo", "tmpseq"},
 		},
 		{
@@ -981,7 +982,7 @@ CREATE TABLE public.t1 (
 	FAMILY "primary" (id, pkey)
 );
 
-INSERT INTO t1 (id, pkey) VALUES
+INSERT INTO public.t1 (id, pkey) VALUES
 	(1, 'db1-aaaa');
 
 CREATE DATABASE IF NOT EXISTS db2;
@@ -994,7 +995,7 @@ CREATE TABLE public.t3 (
 	FAMILY "primary" (id, pkey)
 );
 
-INSERT INTO t3 (id, pkey) VALUES
+INSERT INTO public.t3 (id, pkey) VALUES
 	(1, 'db2-aaaa');
 `,
 			args: []string{"--dump-all"},

--- a/pkg/cli/testdata/dump/comments
+++ b/pkg/cli/testdata/dump/comments
@@ -16,6 +16,6 @@ CREATE TABLE public."t   t" (
 	CONSTRAINT "primary" PRIMARY KEY ("x'" ASC),
 	FAMILY "primary" ("x'")
 );
-COMMENT ON TABLE "t   t" IS e'has \' quotes';
-COMMENT ON COLUMN "t   t"."x'" IS e'i \' just \' love \' quotes';
-COMMENT ON INDEX "t   t"@primary IS e'has \' more \' quotes';
+COMMENT ON TABLE public."t   t" IS e'has \' quotes';
+COMMENT ON COLUMN public."t   t"."x'" IS e'i \' just \' love \' quotes';
+COMMENT ON INDEX public."t   t"@primary IS e'has \' more \' quotes';

--- a/pkg/cli/testdata/dump/computed
+++ b/pkg/cli/testdata/dump/computed
@@ -19,7 +19,7 @@ CREATE TABLE public.t (
 	FAMILY "primary" (a, b)
 );
 
-INSERT INTO t (a) VALUES
+INSERT INTO public.t (a) VALUES
 	(1);
 ----
 ----

--- a/pkg/cli/testdata/dump/enums
+++ b/pkg/cli/testdata/dump/enums
@@ -26,7 +26,7 @@ CREATE TABLE public.tt (
 	FAMILY "primary" (x, y, z, rowid)
 );
 
-INSERT INTO tt (x, y, z) VALUES
+INSERT INTO public.tt (x, y, z) VALUES
 	('dump', ARRAY['dump'], 1),
 	('cli', ARRAY['cli'], 2);
 ----
@@ -45,7 +45,7 @@ CREATE TABLE public.tt (
 	FAMILY "primary" (x, y, z, rowid)
 );
 
-INSERT INTO tt (x, y, z) VALUES
+INSERT INTO public.tt (x, y, z) VALUES
 	('dump', ARRAY['dump'], 1),
 	('cli', ARRAY['cli'], 2);
 ----
@@ -56,7 +56,7 @@ noroundtrip
 ----
 ----
 
-INSERT INTO tt (x, y, z) VALUES
+INSERT INTO public.tt (x, y, z) VALUES
 	('dump', ARRAY['dump'], 1),
 	('cli', ARRAY['cli'], 2);
 ----

--- a/pkg/cli/testdata/dump/flags
+++ b/pkg/cli/testdata/dump/flags
@@ -14,7 +14,7 @@ CREATE TABLE public.f (
 	FAMILY "primary" (x, y, rowid)
 );
 
-INSERT INTO f (x, y) VALUES
+INSERT INTO public.f (x, y) VALUES
 	(42, 69);
 ----
 ----
@@ -32,7 +32,7 @@ noroundtrip
 ----
 ----
 
-INSERT INTO f (x, y) VALUES
+INSERT INTO public.f (x, y) VALUES
 	(42, 69);
 ----
 ----

--- a/pkg/cli/testdata/dump/identifiers
+++ b/pkg/cli/testdata/dump/identifiers
@@ -17,7 +17,7 @@ CREATE TABLE public.";" (
 	FAMILY "primary" (";", rowid)
 );
 
-INSERT INTO ";" (";") VALUES
+INSERT INTO public.";" (";") VALUES
 	(1);
 ----
 ----

--- a/pkg/cli/testdata/dump/interleave_index
+++ b/pkg/cli/testdata/dump/interleave_index
@@ -50,10 +50,10 @@ CREATE TABLE public.t2 (
 	FAMILY "primary" (a, b)
 );
 
-INSERT INTO t3 (a, b) VALUES
+INSERT INTO public.t3 (a, b) VALUES
 	(3, 4);
 
-INSERT INTO t2 (a, b) VALUES
+INSERT INTO public.t2 (a, b) VALUES
 	(1, 2);
 
 CREATE INDEX b_idx ON public.t2 (a ASC, b ASC) INTERLEAVE IN PARENT public.t3 (a);

--- a/pkg/cli/testdata/dump/inverted_index
+++ b/pkg/cli/testdata/dump/inverted_index
@@ -40,7 +40,7 @@ CREATE TABLE public.t (
 	FAMILY "primary" (a, b, c, d, e, f, rowid)
 );
 
-INSERT INTO t (a, b, c, d, e, f) VALUES
+INSERT INTO public.t (a, b, c, d, e, f) VALUES
 	('{"a": "b"}', '{"c": "d"}', ARRAY[1], ARRAY[2], '0101000020E6100000000000000000F03F000000000000F03F', '0101000020E6100000000000000000F03F000000000000F03F');
 ----
 ----

--- a/pkg/cli/testdata/dump/multiple
+++ b/pkg/cli/testdata/dump/multiple
@@ -22,10 +22,10 @@ CREATE TABLE public.g (
 	FAMILY "primary" (x, y, rowid)
 );
 
-INSERT INTO f (x, y) VALUES
+INSERT INTO public.f (x, y) VALUES
 	(42, 69);
 
-INSERT INTO g (x, y) VALUES
+INSERT INTO public.g (x, y) VALUES
 	(3, 4);
 ----
 ----
@@ -45,10 +45,10 @@ CREATE TABLE public.g (
 	FAMILY "primary" (x, y, rowid)
 );
 
-INSERT INTO f (x, y) VALUES
+INSERT INTO public.f (x, y) VALUES
 	(42, 69);
 
-INSERT INTO g (x, y) VALUES
+INSERT INTO public.g (x, y) VALUES
 	(3, 4);
 ----
 ----

--- a/pkg/cli/testdata/dump/primary_key
+++ b/pkg/cli/testdata/dump/primary_key
@@ -19,7 +19,7 @@ CREATE TABLE public.t (
 	FAMILY "primary" (i)
 );
 
-INSERT INTO t (i) VALUES
+INSERT INTO public.t (i) VALUES
 	(1);
 ----
 ----

--- a/pkg/cli/testdata/dump/reference_cycle
+++ b/pkg/cli/testdata/dump/reference_cycle
@@ -45,12 +45,12 @@ CREATE TABLE public.loop_a (
 	FAMILY "primary" (id, b_id)
 );
 
-INSERT INTO loop_b (id, a_id) VALUES
+INSERT INTO public.loop_b (id, a_id) VALUES
 	(1, 1),
 	(2, 2),
 	(3, 3);
 
-INSERT INTO loop_a (id, b_id) VALUES
+INSERT INTO public.loop_a (id, b_id) VALUES
 	(1, 3),
 	(2, 1),
 	(3, 2);

--- a/pkg/cli/testdata/dump/reference_order
+++ b/pkg/cli/testdata/dump/reference_order
@@ -87,30 +87,30 @@ CREATE TABLE public.s_tbl (
 	FAMILY "primary" (id, v)
 );
 
-INSERT INTO b (i) VALUES
+INSERT INTO public.b (i) VALUES
 	(1);
 
-INSERT INTO a (i) VALUES
+INSERT INTO public.a (i) VALUES
 	(1);
 
-INSERT INTO e (i) VALUES
+INSERT INTO public.e (i) VALUES
 	(1);
 
-INSERT INTO g (i) VALUES
+INSERT INTO public.g (i) VALUES
 	(1);
 
-INSERT INTO f (i, g) VALUES
+INSERT INTO public.f (i, g) VALUES
 	(1, 1);
 
-INSERT INTO d (i, e, f) VALUES
+INSERT INTO public.d (i, e, f) VALUES
 	(1, 1, 1);
 
-INSERT INTO c (i) VALUES
+INSERT INTO public.c (i) VALUES
 	(1);
 
 SELECT setval('s', 3, false);
 
-INSERT INTO s_tbl (id, v) VALUES
+INSERT INTO public.s_tbl (id, v) VALUES
 	(1, 10),
 	(2, 11);
 
@@ -150,10 +150,10 @@ CREATE TABLE public.d (
 	FAMILY "primary" (i, e, f)
 );
 
-INSERT INTO e (i) VALUES
+INSERT INTO public.e (i) VALUES
 	(1);
 
-INSERT INTO d (i, e, f) VALUES
+INSERT INTO public.d (i, e, f) VALUES
 	(1, 1, 1);
 
 ALTER TABLE public.d ADD CONSTRAINT fk_e_ref_e FOREIGN KEY (e) REFERENCES public.e(i);

--- a/pkg/cli/testdata/dump/reference_self
+++ b/pkg/cli/testdata/dump/reference_self
@@ -27,7 +27,7 @@ CREATE TABLE public.t (
 	FAMILY "primary" (id, next_id)
 );
 
-INSERT INTO t (id, next_id) VALUES
+INSERT INTO public.t (id, next_id) VALUES
 	(1, NULL);
 
 ALTER TABLE public.t ADD CONSTRAINT fk_next_id_ref_t FOREIGN KEY (next_id) REFERENCES public.t(id);
@@ -54,7 +54,7 @@ CREATE TABLE public.t (
 	FAMILY "primary" (id, next_id)
 );
 
-INSERT INTO t (id, next_id) VALUES
+INSERT INTO public.t (id, next_id) VALUES
 	(1, 1);
 
 ALTER TABLE public.t ADD CONSTRAINT fk_next_id_ref_t FOREIGN KEY (next_id) REFERENCES public.t(id);
@@ -82,7 +82,7 @@ CREATE TABLE public."table" (
 	FAMILY "primary" (id, "'")
 );
 
-INSERT INTO "table" (id, "'") VALUES
+INSERT INTO public."table" (id, "'") VALUES
 	(1, 1);
 
 ALTER TABLE public."table" ADD CONSTRAINT fk_next_id_ref_t FOREIGN KEY ("'") REFERENCES public."table"(id);
@@ -118,7 +118,7 @@ noroundtrip
 ----
 ----
 
-INSERT INTO "table" (id, "'") VALUES
+INSERT INTO public."table" (id, "'") VALUES
 	(1, 1);
 ----
 ----

--- a/pkg/cli/testdata/dump/row
+++ b/pkg/cli/testdata/dump/row
@@ -89,7 +89,7 @@ CREATE TABLE public.t (
 	FAMILY fam_3_e (e)
 );
 
-INSERT INTO t (i, f, s, b, d, t, ts, n, o, e, u, ip, j, ary, tz, e1, e2, s1, s2, oi) VALUES
+INSERT INTO public.t (i, f, s, b, d, t, ts, n, o, e, u, ip, j, ary, tz, e1, e2, s1, s2, oi) VALUES
 	(1, 2.3, 'striiing', '\x613162326333', '2016-03-26', '01:02:03.456', '2016-01-25 10:10:10', '02:30:30', true, 1.2345, 'e9716c74-2638-443d-90ed-ffde7bea7d1d', '192.168.0.1', '{"a": "b"}', ARRAY['hello','world'], '2016-01-25 10:10:10+00:00', 3, 4.5, 's', 'hello' COLLATE en_u_ks_level2, 6),
 	(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
 	(NULL, '+Inf', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'Infinity', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),

--- a/pkg/cli/testdata/dump/schemas
+++ b/pkg/cli/testdata/dump/schemas
@@ -1,0 +1,90 @@
+sql
+SET experimental_enable_user_defined_schemas = true;
+CREATE DATABASE d;
+USE d;
+
+CREATE SCHEMA sc1;
+CREATE SCHEMA sc2;
+
+CREATE TABLE sc1.t (x int);
+INSERT INTO sc1.t VALUES (1);
+
+CREATE TABLE sc2.t (x int);
+INSERT INTO sc2.t VALUES (2)
+----
+INSERT 1
+
+dump d
+----
+----
+SET experimental_enable_user_defined_schemas = true;
+CREATE SCHEMA sc1;
+
+CREATE SCHEMA sc2;
+
+CREATE TABLE sc1.t (
+	x INT8 NULL,
+	FAMILY "primary" (x, rowid)
+);
+
+CREATE TABLE sc2.t (
+	x INT8 NULL,
+	FAMILY "primary" (x, rowid)
+);
+
+INSERT INTO sc1.t (x) VALUES
+	(1);
+
+INSERT INTO sc2.t (x) VALUES
+	(2);
+----
+----
+
+# Test just dumping a table. We shouldn't output the schema create statement.
+dump d sc1.t
+noroundtrip
+----
+----
+CREATE TABLE sc1.t (
+	x INT8 NULL,
+	FAMILY "primary" (x, rowid)
+);
+
+INSERT INTO sc1.t (x) VALUES
+	(1);
+----
+----
+
+dump d sc1.t --dump-mode=data
+noroundtrip
+----
+----
+
+INSERT INTO sc1.t (x) VALUES
+	(1);
+----
+----
+
+dump d sc2.t
+noroundtrip
+----
+----
+CREATE TABLE sc2.t (
+	x INT8 NULL,
+	FAMILY "primary" (x, rowid)
+);
+
+INSERT INTO sc2.t (x) VALUES
+	(2);
+----
+----
+
+dump d sc2.t --dump-mode=data
+noroundtrip
+----
+----
+
+INSERT INTO sc2.t (x) VALUES
+	(2);
+----
+----

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -386,6 +386,9 @@ func GetDatabaseDescriptorsFromIDs(
 		if err := result.Rows[0].ValueProto(desc); err != nil {
 			return nil, err
 		}
+		if desc.GetUnion() == nil {
+			return nil, sqlbase.ErrDescriptorNotFound
+		}
 		db := desc.GetDatabase()
 		if db == nil {
 			return nil, errors.AssertionFailedf(

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -60,18 +60,18 @@ CREATE TABLE public.c (
   FAMILY fam_0_a_rowid (a, rowid),
   FAMILY fam_1_b (b)
 );
-COMMENT ON TABLE c IS 'table';
-COMMENT ON COLUMN c.a IS 'column';
-COMMENT ON INDEX c@c_a_b_idx IS 'index'  CREATE TABLE public.c (
-                                         a INT8 NOT NULL,
-                                         b INT8 NULL,
-                                         INDEX c_a_b_idx (a ASC, b ASC),
-                                         FAMILY fam_0_a_rowid (a, rowid),
-                                         FAMILY fam_1_b (b)
+COMMENT ON TABLE public.c IS 'table';
+COMMENT ON COLUMN public.c.a IS 'column';
+COMMENT ON INDEX public.c@c_a_b_idx IS 'index'  CREATE TABLE public.c (
+                                                a INT8 NOT NULL,
+                                                b INT8 NULL,
+                                                INDEX c_a_b_idx (a ASC, b ASC),
+                                                FAMILY fam_0_a_rowid (a, rowid),
+                                                FAMILY fam_1_b (b)
 );
-COMMENT ON TABLE c IS 'table';
-COMMENT ON COLUMN c.a IS 'column';
-COMMENT ON INDEX c@c_a_b_idx IS 'index'  {}  {}
+COMMENT ON TABLE public.c IS 'table';
+COMMENT ON COLUMN public.c.a IS 'column';
+COMMENT ON INDEX public.c@c_a_b_idx IS 'index'  {}  {}
 
 statement error invalid storage parameter "foo"
 CREATE TABLE a (b INT) WITH (foo=100);

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -189,25 +189,25 @@ test           information_schema  tables      public   SELECT
 
 ## information_schema.schemata
 
-query TTTT colnames
+query TTTTT colnames
 SELECT * FROM information_schema.schemata
 ----
-catalog_name  schema_name         default_character_set_name  sql_path
-test          crdb_internal       NULL                        NULL
-test          information_schema  NULL                        NULL
-test          pg_catalog          NULL                        NULL
-test          pg_extension        NULL                        NULL
-test          public              NULL                        NULL
+catalog_name  schema_name         default_character_set_name  sql_path  crdb_is_user_defined
+test          crdb_internal       NULL                        NULL      NO
+test          information_schema  NULL                        NULL      NO
+test          pg_catalog          NULL                        NULL      NO
+test          pg_extension        NULL                        NULL      NO
+test          public              NULL                        NULL      NO
 
-query TTTT colnames
+query TTTTT colnames
 SELECT * FROM INFormaTION_SCHEMa.schemata
 ----
-catalog_name  schema_name         default_character_set_name  sql_path
-test          crdb_internal       NULL                        NULL
-test          information_schema  NULL                        NULL
-test          pg_catalog          NULL                        NULL
-test          pg_extension        NULL                        NULL
-test          public              NULL                        NULL
+catalog_name  schema_name         default_character_set_name  sql_path  crdb_is_user_defined
+test          crdb_internal       NULL                        NULL      NO
+test          information_schema  NULL                        NULL      NO
+test          pg_catalog          NULL                        NULL      NO
+test          pg_extension        NULL                        NULL      NO
+test          public              NULL                        NULL      NO
 
 ## information_schema.tables
 

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -27,6 +27,6 @@ c           CREATE TABLE public.c (
             FAMILY fam_0_a_rowid (a, rowid),
             FAMILY fam_1_b (b)
 );
-COMMENT ON TABLE c IS 'table';
-COMMENT ON COLUMN c.a IS 'column';
-COMMENT ON INDEX c@c_a_b_idx IS 'index'
+COMMENT ON TABLE public.c IS 'table';
+COMMENT ON COLUMN public.c.a IS 'column';
+COMMENT ON INDEX public.c@c_a_b_idx IS 'index'

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -255,3 +255,9 @@ CREATE TABLE persistent_48233(a int)
 
 statement error pq: cannot change schema of table with RENAME
 ALTER TABLE persistent_48233 RENAME TO pg_temp.pers_48233
+
+# Ensure that temporary schemas don't appear as user defined in the
+# information_schema.schemata vtable.
+query T
+SELECT schema_name FROM information_schema.schemata WHERE crdb_is_user_defined = 'YES'
+----

--- a/pkg/sql/opt/exec/execbuilder/testdata/information_schema
+++ b/pkg/sql/opt/exec/execbuilder/testdata/information_schema
@@ -3,10 +3,10 @@
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM system.information_schema.schemata
 ----
-·              distribution  local             ·                                                                  ·
-·              vectorized    false             ·                                                                  ·
-virtual table  ·             ·                 (catalog_name, schema_name, default_character_set_name, sql_path)  ·
-·              source        schemata@primary  ·                                                                  ·
+·              distribution  local             ·                                                                                        ·
+·              vectorized    false             ·                                                                                        ·
+virtual table  ·             ·                 (catalog_name, schema_name, default_character_set_name, sql_path, crdb_is_user_defined)  ·
+·              source        schemata@primary  ·                                                                                        ·
 
 query TTT
 EXPLAIN SELECT * FROM system.information_schema.tables WHERE table_name='foo'

--- a/pkg/sql/opt/memo/testdata/logprops/virtual-scan
+++ b/pkg/sql/opt/memo/testdata/logprops/virtual-scan
@@ -8,38 +8,38 @@ project
  ├── columns: catalog_name:2(string!null) sql_path:5(string)
  ├── prune: (2,5)
  └── left-join (cross)
-      ├── columns: catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string) information_schema.tables.crdb_internal_vtable_pk:6(int) table_catalog:7(string) table_schema:8(string) table_name:9(string) table_type:10(string) is_insertable_into:11(string) version:12(int)
+      ├── columns: catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string) crdb_is_user_defined:6(string) information_schema.tables.crdb_internal_vtable_pk:7(int) table_catalog:8(string) table_schema:9(string) table_name:10(string) table_type:11(string) is_insertable_into:12(string) version:13(int)
       ├── fd: ()-->(3)
-      ├── prune: (4-6,9-12)
-      ├── reject-nulls: (6-12)
-      ├── interesting orderings: (+6)
+      ├── prune: (4-7,10-13)
+      ├── reject-nulls: (7-13)
+      ├── interesting orderings: (+7)
       ├── project
-      │    ├── columns: catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string)
+      │    ├── columns: catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string) crdb_is_user_defined:6(string)
       │    ├── fd: ()-->(3)
-      │    ├── prune: (2-5)
+      │    ├── prune: (2-6)
       │    └── select
-      │         ├── columns: information_schema.schemata.crdb_internal_vtable_pk:1(int!null) catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string)
+      │         ├── columns: information_schema.schemata.crdb_internal_vtable_pk:1(int!null) catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string) crdb_is_user_defined:6(string)
       │         ├── fd: ()-->(3)
-      │         ├── prune: (1,2,4,5)
+      │         ├── prune: (1,2,4-6)
       │         ├── interesting orderings: (+1)
       │         ├── scan information_schema.schemata
-      │         │    ├── columns: information_schema.schemata.crdb_internal_vtable_pk:1(int!null) catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string)
-      │         │    ├── prune: (1-5)
+      │         │    ├── columns: information_schema.schemata.crdb_internal_vtable_pk:1(int!null) catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string) crdb_is_user_defined:6(string)
+      │         │    ├── prune: (1-6)
       │         │    └── interesting orderings: (+1)
       │         └── filters
       │              └── eq [type=bool, outer=(3), constraints=(/3: [/'public' - /'public']; tight), fd=()-->(3)]
       │                   ├── variable: schema_name:3 [type=string]
       │                   └── const: 'public' [type=string]
       ├── scan information_schema.tables
-      │    ├── columns: information_schema.tables.crdb_internal_vtable_pk:6(int!null) table_catalog:7(string!null) table_schema:8(string!null) table_name:9(string!null) table_type:10(string!null) is_insertable_into:11(string!null) version:12(int)
-      │    ├── prune: (6-12)
-      │    ├── interesting orderings: (+6)
-      │    └── unfiltered-cols: (6-12)
+      │    ├── columns: information_schema.tables.crdb_internal_vtable_pk:7(int!null) table_catalog:8(string!null) table_schema:9(string!null) table_name:10(string!null) table_type:11(string!null) is_insertable_into:12(string!null) version:13(int)
+      │    ├── prune: (7-13)
+      │    ├── interesting orderings: (+7)
+      │    └── unfiltered-cols: (7-13)
       └── filters
-           └── and [type=bool, outer=(2,3,7,8), constraints=(/2: (/NULL - ]; /3: (/NULL - ]; /7: (/NULL - ]; /8: (/NULL - ])]
+           └── and [type=bool, outer=(2,3,8,9), constraints=(/2: (/NULL - ]; /3: (/NULL - ]; /8: (/NULL - ]; /9: (/NULL - ])]
                 ├── eq [type=bool]
                 │    ├── variable: catalog_name:2 [type=string]
-                │    └── variable: table_catalog:7 [type=string]
+                │    └── variable: table_catalog:8 [type=string]
                 └── eq [type=bool]
                      ├── variable: schema_name:3 [type=string]
-                     └── variable: table_schema:8 [type=string]
+                     └── variable: table_schema:9 [type=string]

--- a/pkg/sql/opt/optbuilder/testdata/delegate
+++ b/pkg/sql/opt/optbuilder/testdata/delegate
@@ -8,8 +8,8 @@ sort
  └── project
       ├── columns: schema_name:3!null
       └── select
-           ├── columns: crdb_internal_vtable_pk:1!null catalog_name:2!null schema_name:3!null default_character_set_name:4 sql_path:5
+           ├── columns: crdb_internal_vtable_pk:1!null catalog_name:2!null schema_name:3!null default_character_set_name:4 sql_path:5 crdb_is_user_defined:6
            ├── scan t.information_schema.schemata
-           │    └── columns: crdb_internal_vtable_pk:1!null catalog_name:2!null schema_name:3!null default_character_set_name:4 sql_path:5
+           │    └── columns: crdb_internal_vtable_pk:1!null catalog_name:2!null schema_name:3!null default_character_set_name:4 sql_path:5 crdb_is_user_defined:6
            └── filters
                 └── catalog_name:2 = 't'

--- a/pkg/sql/opt/xform/testdata/coster/virtual-scan
+++ b/pkg/sql/opt/xform/testdata/coster/virtual-scan
@@ -2,13 +2,13 @@ opt
 SELECT * FROM information_schema.schemata WHERE SCHEMA_NAME='public'
 ----
 select
- ├── columns: catalog_name:2!null schema_name:3!null default_character_set_name:4 sql_path:5
+ ├── columns: catalog_name:2!null schema_name:3!null default_character_set_name:4 sql_path:5 crdb_is_user_defined:6
  ├── stats: [rows=10, distinct(3)=1, null(3)=0]
- ├── cost: 1100.04
+ ├── cost: 1120.04
  ├── fd: ()-->(3)
  ├── scan information_schema.schemata
- │    ├── columns: catalog_name:2!null schema_name:3!null default_character_set_name:4 sql_path:5
+ │    ├── columns: catalog_name:2!null schema_name:3!null default_character_set_name:4 sql_path:5 crdb_is_user_defined:6
  │    ├── stats: [rows=1000, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0]
- │    └── cost: 1090.02
+ │    └── cost: 1110.02
  └── filters
       └── schema_name:3 = 'public' [outer=(3), constraints=(/3: [/'public' - /'public']; tight), fd=()-->(3)]

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestParse verifies that we can parse the supplied SQL and regenerate the SQL
@@ -2574,6 +2575,23 @@ func TestParseDatadriven(t *testing.T) {
 			return ""
 		})
 	})
+}
+
+func TestParseTableNameWithQualifiedNames(t *testing.T) {
+	testdata := []struct {
+		name     string
+		expected string
+	}{
+		{"unique", `"unique"`},
+		{"unique.index", `"unique".index`},
+		{"table.index.primary", `"table".index.primary`},
+	}
+
+	for _, tc := range testdata {
+		name, err := parser.ParseTableNameWithQualifiedNames(tc.name)
+		require.NoError(t, err)
+		require.Equal(t, tc.expected, name.String())
+	}
 }
 
 func TestParsePanic(t *testing.T) {

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1906,7 +1906,7 @@ CREATE TABLE pg_catalog.pg_namespace (
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
 			func(db *sqlbase.ImmutableDatabaseDescriptor) error {
-				return forEachSchemaName(ctx, p, db, func(s string) error {
+				return forEachSchemaName(ctx, p, db, func(s string, _ bool) error {
 					return addRow(
 						h.NamespaceOid(db, s), // oid
 						tree.NewDString(s),    // nspname

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -567,10 +567,6 @@ func newInternalLookupCtx(
 			}
 		case *sqlbase.ImmutableSchemaDescriptor:
 			schemaDescs[desc.GetID()] = desc
-			if prefix == nil || prefix.GetID() == desc.ParentID {
-				// Only make the schema visible for iteration if the prefix was included.
-				typIDs = append(typIDs, desc.GetID())
-			}
 		}
 	}
 	return &internalLookupCtx{

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -177,7 +177,7 @@ func ShowCreateTable(
 	}
 
 	if !displayOptions.IgnoreComments {
-		if err := showComments(desc, selectComment(ctx, p, desc.ID), &f.Buffer); err != nil {
+		if err := showComments(tn, desc, selectComment(ctx, p, desc.ID), &f.Buffer); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -100,13 +100,12 @@ func ShowCreateView(
 // showComments prints out the COMMENT statements sufficient to populate a
 // table's comments, including its index and column comments.
 func showComments(
-	table *sqlbase.ImmutableTableDescriptor, tc *tableComments, buf *bytes.Buffer,
+	tn *tree.TableName, table *sqlbase.ImmutableTableDescriptor, tc *tableComments, buf *bytes.Buffer,
 ) error {
 	if tc == nil {
 		return nil
 	}
 	f := tree.NewFmtCtx(tree.FmtSimple)
-	tn := tree.MakeUnqualifiedTableName(tree.Name(table.Name))
 	un := tn.ToUnresolvedObjectName()
 	if tc.comment != nil {
 		f.WriteString(";\n")
@@ -141,7 +140,7 @@ func showComments(
 		f.WriteString(";\n")
 		f.FormatNode(&tree.CommentOnIndex{
 			Index: tree.TableIndexName{
-				Table: tn,
+				Table: *tn,
 				Index: tree.UnrestrictedName(idx.Name),
 			},
 			Comment: &indexComment.comment,

--- a/pkg/sql/vtable/information_schema.go
+++ b/pkg/sql/vtable/information_schema.go
@@ -121,7 +121,8 @@ CREATE TABLE information_schema.schemata (
 	CATALOG_NAME               STRING NOT NULL,
 	SCHEMA_NAME                STRING NOT NULL,
 	DEFAULT_CHARACTER_SET_NAME STRING,
-	SQL_PATH                   STRING
+	SQL_PATH                   STRING,
+	CRDB_IS_USER_DEFINED       STRING
 )`
 
 // InformationSchemaTables describes the schema of the


### PR DESCRIPTION
Fixes #50874.

Release note (cli change): `cockroach dump` now supports dumping
databases that contain user defined schemas, as well as accepting schema
qualified table names as arguments.