### PR TITLE
vendor: bump Pebble to cfd19d33cdca

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200716211707-073e15ee2ccf
+	github.com/cockroachdb/pebble v0.0.0-20200729202514-cfd19d33cdca
 	github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2
@@ -151,7 +151,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c
 	golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
+	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1
 	golang.org/x/text v0.3.3
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20200702044944-0cc1aa72b347

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200716211707-073e15ee2ccf h1:USQzgQROUOcOtbSGjMuGybOX0oFTzX34qPtOiOGpGyg=
-github.com/cockroachdb/pebble v0.0.0-20200716211707-073e15ee2ccf/go.mod h1:TipC4T/j2WXDHhGHuPue5m00pjk21v7qPMYIVj4Ay+I=
+github.com/cockroachdb/pebble v0.0.0-20200729202514-cfd19d33cdca h1:csqQv8PoYJbaND7PkGOBC48uxoFj9ThZxcRzc1ve618=
+github.com/cockroachdb/pebble v0.0.0-20200729202514-cfd19d33cdca/go.mod h1:TipC4T/j2WXDHhGHuPue5m00pjk21v7qPMYIVj4Ay+I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd h1:KFOt5I9nEKZgCnOSmy8r4Oykh8BYQO8bFOTgHDS8YZA=
@@ -820,8 +820,8 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 h1:sIky/MyNRSHTrdxfsiUSS4WIAMvInbeXljJz+jDjeYE=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -819,7 +819,7 @@ func (p *Pebble) GetEnvStats() (*EnvStats, error) {
 	stats.TotalBytes = m.WAL.Size + m.Table.ZombieSize
 	for _, l := range m.Levels {
 		stats.TotalFiles += uint64(l.NumFiles)
-		stats.TotalBytes += l.Size
+		stats.TotalBytes += uint64(l.Size)
 	}
 
 	sstSizes := make(map[pebble.FileNum]uint64)


### PR DESCRIPTION
```
cfd19d33 db: compute file count and size metrics incrementally
e34d759c internal/rangedel: format keys in Fragmenter panics
06a3fb73 internal/mkbench: fix dropped walkfunc error
61c629af internal/manifest: unexport LevelMetadata files
8fdce959 vfs: Add FS.GetFreeSpace, IsNoSpaceError
24bd87a5 db: fix tombstone elision, grandparent limit bug
a9d18a23 *: Update comment on Ingest() on callers needing to Sync()
42cb6336 internal/manifest: take a LevelSlice in L0Sublevels.PickBaseCompaction
887d40ba db: use manifest.NewVersion constructor in tests
2f3fb56c internal/rangedel: Skip range tombstones outside a file's bounds
1a5f7680 record: propagate WAL sync errors to queued writers
cc76c76e db: update L0 compaction-picking to use manifest.LevelIterator
69961893 pebble: fix dropped test error
5edc4f5b db: use LevelSlice.SizeSum where applicable
d524d342 db: use manifest.LevelIterator in compaction, levelIter
049c566a db: capture stack trace of closed call for ErrClosed
```

Release note: None