### PR TITLE
opt: update query planning cache to consider used types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -224,3 +224,47 @@ f
 
 statement error pq: enum label \"g\" is not yet public
 INSERT INTO new_enum_values VALUES ('g')
+
+statement ok
+ROLLBACK
+
+# Ensure that optimizer plan caching takes into account changes in types.
+statement ok
+CREATE TYPE cache AS ENUM ('lru', 'clock')
+
+# Run the statement once to put it into the cache.
+query T
+SELECT 'clock'::cache
+----
+clock
+
+# Now alter the type.
+statement ok
+ALTER TYPE cache RENAME VALUE 'clock' TO 'clock-pro'
+
+statement error pq: invalid input value for enum cache: "clock"
+SELECT 'clock'::cache
+
+# Put another query into the cache.
+query T
+SELECT 'lru'::cache
+----
+lru
+
+statement ok
+ALTER TYPE cache RENAME TO store
+
+statement error pq: type "cache" does not exist
+SELECT 'lru'::cache
+
+# Lastly, ensure that we error out in planning when trying to use a dropped type.
+query T
+SELECT 'lru'::store
+----
+lru
+
+statement ok
+DROP TYPE store
+
+statement error pq: type "store" does not exist
+SELECT 'lru'::store

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
 // StableID permanently and uniquely identifies a catalog object (table, view,
@@ -113,6 +114,9 @@ type Catalog interface {
 	ResolveDataSourceByID(
 		ctx context.Context, flags Flags, id StableID,
 	) (_ DataSource, isAdding bool, _ error)
+
+	// ResolveTypeByID is used to look up a user defined type by ID.
+	ResolveTypeByID(ctx context.Context, id uint32) (*types.T, error)
 
 	// CheckPrivilege verifies that the current user has the given privilege on
 	// the given catalog object. If not, then CheckPrivilege returns an error.

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -118,6 +120,15 @@ type Metadata struct {
 	// sequences stores information about each metadata sequence, indexed by SequenceID.
 	sequences []cat.Sequence
 
+	// userDefinedTypes contains all user defined types present in expressions
+	// in this query.
+	// TODO (rohany): This only contains user defined types present in the query
+	//  because the installation of type metadata in tables doesn't go through
+	//  the type resolver that the optimizer hijacks. However, we could update
+	//  this map when adding a table via metadata.AddTable.
+	userDefinedTypes      map[uint32]struct{}
+	userDefinedTypesSlice []*types.T
+
 	// deps stores information about all data source objects depended on by the
 	// query, as well as the privileges required to access them. The objects are
 	// deduplicated: any name/object pair shows up at most once.
@@ -203,6 +214,8 @@ func (md *Metadata) Init() {
 	md.currUniqueID = 0
 
 	md.withBindings = nil
+	md.userDefinedTypes = nil
+	md.userDefinedTypesSlice = nil
 }
 
 // CopyFrom initializes the metadata with a copy of the provided metadata.
@@ -212,12 +225,22 @@ func (md *Metadata) Init() {
 // the copy.
 func (md *Metadata) CopyFrom(from *Metadata) {
 	if len(md.schemas) != 0 || len(md.cols) != 0 || len(md.tables) != 0 ||
-		len(md.sequences) != 0 || len(md.deps) != 0 || len(md.views) != 0 {
+		len(md.sequences) != 0 || len(md.deps) != 0 || len(md.views) != 0 ||
+		len(md.userDefinedTypes) != 0 || len(md.userDefinedTypesSlice) != 0 {
 		panic(errors.AssertionFailedf("CopyFrom requires empty destination"))
 	}
 	md.schemas = append(md.schemas, from.schemas...)
 	md.cols = append(md.cols, from.cols...)
 	md.tables = append(md.tables, from.tables...)
+
+	if (md.userDefinedTypes) == nil {
+		md.userDefinedTypes = make(map[uint32]struct{})
+	}
+	for i := range from.userDefinedTypesSlice {
+		typ := from.userDefinedTypesSlice[i]
+		md.userDefinedTypes[typ.StableTypeID()] = struct{}{}
+		md.userDefinedTypesSlice = append(md.userDefinedTypesSlice, typ)
+	}
 
 	// Clear table annotations. These objects can be mutable and can't be safely
 	// shared between different metadata instances.
@@ -315,6 +338,20 @@ func (md *Metadata) CheckDependencies(
 			privs &= ^(1 << priv)
 		}
 	}
+	// Check that all of the user defined types present have not changed.
+	for _, typ := range md.AllUserDefinedTypes() {
+		toCheck, err := catalog.ResolveTypeByID(ctx, typ.StableTypeID())
+		if err != nil {
+			// Handle when the type no longer exists.
+			if pgerror.GetPGCode(err) == pgcode.UndefinedObject {
+				return false, nil
+			}
+			return false, err
+		}
+		if typ.TypeMeta.Version != toCheck.TypeMeta.Version {
+			return false, nil
+		}
+	}
 	return true, nil
 }
 
@@ -328,6 +365,25 @@ func (md *Metadata) AddSchema(sch cat.Schema) SchemaID {
 // id.
 func (md *Metadata) Schema(schID SchemaID) cat.Schema {
 	return md.schemas[schID-1]
+}
+
+// AddUserDefinedType adds a user defined type to the metadata for this query.
+func (md *Metadata) AddUserDefinedType(typ *types.T) {
+	if !typ.UserDefined() {
+		return
+	}
+	if md.userDefinedTypes == nil {
+		md.userDefinedTypes = make(map[uint32]struct{})
+	}
+	if _, ok := md.userDefinedTypes[typ.StableTypeID()]; !ok {
+		md.userDefinedTypes[typ.StableTypeID()] = struct{}{}
+		md.userDefinedTypesSlice = append(md.userDefinedTypesSlice, typ)
+	}
+}
+
+// AllUserDefinedTypes returns all user defined types contained in this query.
+func (md *Metadata) AllUserDefinedTypes() []*types.T {
+	return md.userDefinedTypesSlice
 }
 
 // AddTable indexes a new reference to a table within the query. Separate

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -30,6 +30,7 @@ func TestMetadata(t *testing.T) {
 	tabID := md.AddTable(&testcat.Table{}, &tree.TableName{})
 	seqID := md.AddSequence(&testcat.Sequence{})
 	md.AddView(&testcat.View{})
+	md.AddUserDefinedType(types.MakeEnum(15210, 15418))
 
 	// Call Init and add objects from catalog, verifying that IDs have been reset.
 	testCat := testcat.New()
@@ -53,6 +54,11 @@ func TestMetadata(t *testing.T) {
 	md.AddView(&testcat.View{ViewID: 101})
 	if len(md.AllViews()) != 1 {
 		t.Fatalf("unexpected views")
+	}
+
+	md.AddUserDefinedType(types.MakeEnum(15150, 15251))
+	if len(md.AllUserDefinedTypes()) != 1 {
+		t.Fatalf("unexpected types")
 	}
 
 	md.AddDependency(opt.DepByName(&tab.TabName), tab, privilege.CREATE)
@@ -83,6 +89,10 @@ func TestMetadata(t *testing.T) {
 
 	if v := mdNew.AllViews(); len(v) != 1 && v[0].(*testcat.View).ViewID != 101 {
 		t.Fatalf("unexpected view")
+	}
+
+	if ts := mdNew.AllUserDefinedTypes(); len(ts) != 1 && ts[15150].Equal(types.MakeEnum(15150, 15251)) {
+		t.Fatalf("unexpected type")
 	}
 
 	depsUpToDate, err = md.CheckDependencies(context.Background(), testCat)

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -170,6 +170,11 @@ func (tc *Catalog) ResolveDataSourceByID(
 		"relation [%d] does not exist", id)
 }
 
+// ResolveTypeByID is part of the cat.Catalog interface.
+func (tc *Catalog) ResolveTypeByID(context.Context, uint32) (*types.T, error) {
+	return nil, errors.Newf("test catalog cannot handle user defined types")
+}
+
 // CheckPrivilege is part of the cat.Catalog interface.
 func (tc *Catalog) CheckPrivilege(ctx context.Context, o cat.Object, priv privilege.Kind) error {
 	return tc.CheckAnyPrivilege(ctx, o)

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -232,6 +232,11 @@ func (oc *optCatalog) ResolveDataSourceByID(
 	return ds, false, err
 }
 
+// ResolveTypeByID is part of the cat.Catalog interface.
+func (oc *optCatalog) ResolveTypeByID(ctx context.Context, id uint32) (*types.T, error) {
+	return oc.planner.ResolveTypeByID(ctx, id)
+}
+
 func getDescFromCatalogObjectForPermissions(o cat.Object) (sqlbase.DescriptorInterface, error) {
 	switch t := o.(type) {
 	case *optSchema:


### PR DESCRIPTION
Fixes #52037.

This commit updates the optimizer's logic for deciding when a query plan
is stale or not to include the set of user defined types present in the
query. This ensures that queries that use types are replanned once those
types change.

Release note: None