### PR TITLE
opt: fix internal error due to nested correlated aggregate functions

### DIFF
--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -681,10 +681,12 @@ func translateAggName(name string) string {
 // buildAggregateFunction returns a pointer to the aggregateInfo containing
 // the function definition, fully built arguments, and the aggregate output
 // column.
+//
+// tempScope is a temporary scope which is used for building the aggregate
+// function arguments before the correct scope is determined.
 func (b *Builder) buildAggregateFunction(
-	f *tree.FuncExpr, def *memo.FunctionPrivate, fromScope *scope,
+	f *tree.FuncExpr, def *memo.FunctionPrivate, tempScope, fromScope *scope,
 ) *aggregateInfo {
-	tempScope := fromScope.startAggFunc()
 	tempScopeColsBefore := len(tempScope.cols)
 
 	info := aggregateInfo{

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3995,3 +3995,9 @@ project
            └── ne [type=bool]
                 ├── variable: min:5 [type=float]
                 └── const: NaN [type=float]
+
+# Regression test for #51877.
+build
+SELECT max((SELECT jsonb_agg(v))) FROM kv
+----
+error (42803): aggregate function calls cannot be nested


### PR DESCRIPTION
Prior to this commit, the query `SELECT max((SELECT count(v))) FROM kv;`
caused an internal error. This query is invalid, but instead of causing an
internal error, the optimizer should have rejected it for containing nested
aggregates (that's what Postgres does). However, the optimizer could not
recognize that the aggregates were nested in this case.

This commit fixes the error by ensuring that the optimizer can detect
that the aggregate functions are nested. It does so by updating the outer
scope earlier to indicate the start of an aggregate function so that any
nested aggregates referencing the outer scope from a subquery in the aggregate
function arguments will return an appropriate error.

Fixes #41820
Fixes #51877

Release note (bug fix): Fixed an internal error that could occur when
an aggregate function argument contained a correlated subquery with another
aggregate function referencing the outer scope. This now returns an appropriate
user-friendly error, "aggregate function calls cannot be nested".