### PR TITLE
backupccl: include all tenants in full cluster backup

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -900,6 +900,15 @@ func createImportingDescriptors(
 
 	if !details.PrepareCompleted {
 		err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			if len(details.Tenants) > 0 {
+				// TODO(during review): if the txn already has txn.Key set, we get an
+				// eror from AnchorOnSystemConfigRange without this. This is pretty
+				// silly though, can we avoid the system config trigger here? Might not
+				// be worth the hassle though.
+				if err := txn.SetSystemConfigTrigger(p.ExecCfg().Codec.ForSystemTenant()); err != nil {
+					return err
+				}
+			}
 			// Write the new TableDescriptors which are set in the OFFLINE state.
 			if err := WriteDescriptors(ctx, txn, databases, writtenSchemas, tables, writtenTypes, details.DescriptorCoverage, r.settings, nil /* extra */); err != nil {
 				return errors.Wrapf(err, "restoring %d TableDescriptors from %d databases", len(r.tables), len(databases))
@@ -1145,6 +1154,12 @@ func (r *restoreResumer) publishDescriptors(ctx context.Context) error {
 
 	newDescriptorChangeJobs := make([]*jobs.StartableJob, 0)
 	err := r.execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		if len(details.Tenants) > 0 {
+			// TODO(during review): see the other code like this when creating tenants.
+			if err := txn.SetSystemConfigTrigger(r.execCfg.Codec.ForSystemTenant()); err != nil {
+				return err
+			}
+		}
 		// Write the new TableDescriptors and flip state over to public so they can be
 		// accessed.
 		b := txn.NewBatch()
@@ -1247,7 +1262,9 @@ func (r *restoreResumer) OnFailOrCancel(ctx context.Context, phs interface{}) er
 		for _, tenant := range details.Tenants {
 			// TODO(dt): this is a noop since the tenant is already active=false but
 			// that should be fixed in DestroyTenant.
-			if err := sql.DestroyTenant(ctx, r.execCfg, txn, tenant.ID); err != nil {
+			// TODO(during review): why is r.execCfg nil and what's the difference
+			// to execCfg above?
+			if err := sql.DestroyTenant(ctx, execCfg, txn, tenant.ID); err != nil {
 				return err
 			}
 		}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -901,10 +901,9 @@ func createImportingDescriptors(
 	if !details.PrepareCompleted {
 		err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			if len(details.Tenants) > 0 {
-				// TODO(during review): if the txn already has txn.Key set, we get an
-				// eror from AnchorOnSystemConfigRange without this. This is pretty
-				// silly though, can we avoid the system config trigger here? Might not
-				// be worth the hassle though.
+				// TODO(dt): we need to set the system config trigger as the loop below
+				// will make a batch that anchors the txn at '/Table/...', and setting the trigger
+				// later (as we will have to) would fail.
 				if err := txn.SetSystemConfigTrigger(p.ExecCfg().Codec.ForSystemTenant()); err != nil {
 					return err
 				}
@@ -1155,7 +1154,9 @@ func (r *restoreResumer) publishDescriptors(ctx context.Context) error {
 	newDescriptorChangeJobs := make([]*jobs.StartableJob, 0)
 	err := r.execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		if len(details.Tenants) > 0 {
-			// TODO(during review): see the other code like this when creating tenants.
+			// TODO(dt): we need to set the system config trigger as the loop below
+			// will make a batch that anchors the txn at '/Table/...', and setting the trigger
+			// later (as we will have to) would fail.
 			if err := txn.SetSystemConfigTrigger(r.execCfg.Codec.ForSystemTenant()); err != nil {
 				return err
 			}
@@ -1262,8 +1263,6 @@ func (r *restoreResumer) OnFailOrCancel(ctx context.Context, phs interface{}) er
 		for _, tenant := range details.Tenants {
 			// TODO(dt): this is a noop since the tenant is already active=false but
 			// that should be fixed in DestroyTenant.
-			// TODO(during review): why is r.execCfg nil and what's the difference
-			// to execCfg above?
 			if err := sql.DestroyTenant(ctx, execCfg, txn, tenant.ID); err != nil {
 				return err
 			}

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -751,7 +751,7 @@ func CheckObjectExists(
 }
 
 func fullClusterTargetsRestore(
-	allDescs []sqlbase.Descriptor,
+	allDescs []sqlbase.Descriptor, lastBackupManifest BackupManifest,
 ) ([]sqlbase.Descriptor, []sqlbase.DatabaseDescriptor, []jobspb.RestoreDetails_Tenant, error) {
 	fullClusterDescs, fullClusterDBs, err := fullClusterTargets(allDescs)
 	if err != nil {
@@ -770,7 +770,13 @@ func fullClusterTargetsRestore(
 		}
 	}
 
-	return filteredDescs, filteredDBs, nil, nil
+	// Restore all tenants during full-cluster restore.
+	var tenants []jobspb.RestoreDetails_Tenant
+	for _, tenant := range lastBackupManifest.Tenants {
+		tenants = append(tenants, jobspb.RestoreDetails_Tenant{ID: tenant.ID, Info: tenant.Info})
+	}
+
+	return filteredDescs, filteredDBs, tenants, nil
 }
 
 func selectTargets(
@@ -784,7 +790,7 @@ func selectTargets(
 	allDescs, lastBackupManifest := loadSQLDescsFromBackupsAtTime(backupManifests, asOf)
 
 	if descriptorCoverage == tree.AllDescriptors {
-		return fullClusterTargetsRestore(allDescs)
+		return fullClusterTargetsRestore(allDescs, lastBackupManifest)
 	}
 
 	if targets.Tenant != (roachpb.TenantID{}) {

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -344,6 +344,16 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		includedInBootstrap: clusterversion.VersionByKey(
 			clusterversion.VersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTable),
 	},
+	{
+		// Introduced in v20.2.
+		name:   "create new system.tenants table",
+		workFn: createTenantsTable,
+		// NB: no dedicated cluster version was introduced for this table at the
+		// time (4272248e573cbaa4fac436b0ea07195fcd648845). The below is the first
+		// cluster version that was added after the system.tenants table.
+		includedInBootstrap: clusterversion.VersionByKey(clusterversion.VersionAlterColumnTypeGeneral),
+		newDescriptorIDs:    staticIDs(keys.TenantsTableID),
+	},
 }
 
 func staticIDs(
@@ -1923,4 +1933,8 @@ ADD COLUMN IF NOT EXISTS claim_instance_id INT8 FAMILY claim
 		return err
 	}
 	return createSystemTable(ctx, r, sqlbase.SqllivenessTable)
+}
+
+func createTenantsTable(ctx context.Context, r runner) error {
+	return createSystemTable(ctx, r, sqlbase.TenantsTable)
 }


### PR DESCRIPTION
As of this commit, `BACKUP TO x` includes all tenants, and `RESTORE FROM
x` restores them. `WITH REVISION HISTORY` is not yet supported; an error
will result if such a combination is attempted.

Release note: None