### PR TITLE
colexec: bugfix to builtins with 0 args

### DIFF
--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -145,14 +145,17 @@ func NewMaterializer(
 	outputStatsToTrace func(),
 	cancelFlow func() context.CancelFunc,
 ) (*Materializer, error) {
+	vecIdxsToConvert := make([]int, len(typs))
+	for i := range vecIdxsToConvert {
+		vecIdxsToConvert[i] = i
+	}
 	m := &Materializer{
 		input:       input,
 		typs:        typs,
 		drainHelper: newDrainHelper(metadataSourcesQueue),
-		// nil vecIdxsToConvert indicates that we want to convert all vectors.
-		converter: newVecToDatumConverter(len(typs), nil /* vecIdxsToConvert */),
-		row:       make(sqlbase.EncDatumRow, len(typs)),
-		closers:   toClose,
+		converter:   newVecToDatumConverter(len(typs), vecIdxsToConvert),
+		row:         make(sqlbase.EncDatumRow, len(typs)),
+		closers:     toClose,
 	}
 
 	if err := m.ProcessorBase.Init(

--- a/pkg/sql/colexec/vec_to_datum.eg.go
+++ b/pkg/sql/colexec/vec_to_datum.eg.go
@@ -48,15 +48,8 @@ type vecToDatumConverter struct {
 
 // newVecToDatumConverter creates a new vecToDatumConverter.
 // - batchWidth determines the width of the batches that it will be converting.
-// - vecIdxsToConvert determines which vectors need to be converted. It can be
-// nil indicating that all vectors need to be converted.
+// - vecIdxsToConvert determines which vectors need to be converted.
 func newVecToDatumConverter(batchWidth int, vecIdxsToConvert []int) *vecToDatumConverter {
-	if vecIdxsToConvert == nil {
-		vecIdxsToConvert = make([]int, batchWidth)
-		for i := range vecIdxsToConvert {
-			vecIdxsToConvert[i] = i
-		}
-	}
 	return &vecToDatumConverter{
 		convertedVecs:    make([]tree.Datums, batchWidth),
 		vecIdxsToConvert: vecIdxsToConvert,

--- a/pkg/sql/colexec/vec_to_datum_tmpl.go
+++ b/pkg/sql/colexec/vec_to_datum_tmpl.go
@@ -51,15 +51,8 @@ type vecToDatumConverter struct {
 
 // newVecToDatumConverter creates a new vecToDatumConverter.
 // - batchWidth determines the width of the batches that it will be converting.
-// - vecIdxsToConvert determines which vectors need to be converted. It can be
-// nil indicating that all vectors need to be converted.
+// - vecIdxsToConvert determines which vectors need to be converted.
 func newVecToDatumConverter(batchWidth int, vecIdxsToConvert []int) *vecToDatumConverter {
-	if vecIdxsToConvert == nil {
-		vecIdxsToConvert = make([]int, batchWidth)
-		for i := range vecIdxsToConvert {
-			vecIdxsToConvert[i] = i
-		}
-	}
 	return &vecToDatumConverter{
 		convertedVecs:    make([]tree.Datums, batchWidth),
 		vecIdxsToConvert: vecIdxsToConvert,

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1270,3 +1270,14 @@ query B
 SELECT crdb_internal_mvcc_timestamp IS NOT NULL FROM mvcc@i
 ----
 true
+
+# Regression test for builtin funcs that take no arguments, combined with
+# data that can't be safely decoded as input.
+
+statement ok
+RESET vectorize;
+CREATE TABLE t51841 (a) AS SELECT gen_random_uuid();
+SET vectorize = experimental_always
+
+statement ok
+SELECT random() from t51841


### PR DESCRIPTION
Previously, builtins with 0 args that had no vectorized implementations
caused the engine to materialize all columns of their input instead of
none of them. This could cause issues in some circumstances.

Fixes #51841.

Release note (bug fix): resolve an internal error that occurred with
0-arg builtin functions in the vectorized engine.