### PR TITLE
[wip]: filter tenant labels on prometheus output rather than scrape

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -254,7 +254,8 @@ func (mr *MetricsRecorder) scrapeIntoPrometheus(pm *metric.PrometheusExporter) {
 			log.Warning(context.TODO(), "MetricsRecorder asked to scrape metrics before NodeID allocation")
 		}
 	}
-	includeChildMetrics := childMetricsEnabled.Get(&mr.settings.SV)
+	// TODO(tbg): clean this up.
+	includeChildMetrics := true || childMetricsEnabled.Get(&mr.settings.SV)
 	pm.ScrapeRegistry(mr.mu.nodeRegistry, includeChildMetrics)
 	for _, reg := range mr.mu.storeRegistries {
 		pm.ScrapeRegistry(reg, includeChildMetrics)

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1157,11 +1157,14 @@ func TestStatusVars(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
-	if body, err := getText(s, s.AdminURL()+statusPrefix+"vars"); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Contains(body, []byte("# TYPE sql_bytesout counter\nsql_bytesout")) {
+	s.StartTenant(base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+
+	body, err := getText(s, s.AdminURL()+statusPrefix+"vars")
+	require.NoError(t, err)
+	if !bytes.Contains(body, []byte("# TYPE sql_bytesout counter\nsql_bytesout")) {
 		t.Errorf("expected sql_bytesout, got: %s", body)
 	}
+	t.Error(string(body))
 }
 
 func TestSpanStatsResponse(t *testing.T) {


### PR DESCRIPTION
    If we use metrics labels more pervasively down the road as I hope we
    will, it will be
    important to be able to fetch them all in a debug zip. To that end,
    `/_stats/vars` should be able to expose them when requested via query
    string (for example `?extra_labels=true`).

    The current code (prior to this commit) removes the measurements
    corresponding to extra labels when populating the prometheus exporter,
    meaning that by the time the `vars` renders it, the data has been
    stripped.

    This commit (still wip) changes things around so that we always fully
    populate the exporter, but skip child measurements during rendering.
    What's missing is testing and plumbing a parameter through. When
    all is said and done, we should be comfortable removing the cluster
    setting.

    Release note: None