### PR TITLE
release-20.1: opt: fix internal error due to nested correlated aggregate functions

### DIFF
--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -645,10 +645,12 @@ func (b *Builder) buildAggArg(
 // buildAggregateFunction returns a pointer to the aggregateInfo containing
 // the function definition, fully built arguments, and the aggregate output
 // column.
+//
+// tempScope is a temporary scope which is used for building the aggregate
+// function arguments before the correct scope is determined.
 func (b *Builder) buildAggregateFunction(
-	f *tree.FuncExpr, def *memo.FunctionPrivate, fromScope *scope,
+	f *tree.FuncExpr, def *memo.FunctionPrivate, tempScope, fromScope *scope,
 ) *aggregateInfo {
-	tempScope := fromScope.startAggFunc()
 	tempScopeColsBefore := len(tempScope.cols)
 
 	info := aggregateInfo{

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -636,6 +636,10 @@ func (s *scope) endAggFunc(cols opt.ColSet) (g *groupby) {
 // verifyAggregateContext checks that the current scope is allowed to contain
 // aggregate functions.
 func (s *scope) verifyAggregateContext() {
+	if s.inAgg {
+		panic(sqlbase.NewAggInAggError())
+	}
+
 	switch s.context {
 	case exprKindLateralJoin:
 		panic(pgerror.Newf(pgcode.Grouping,
@@ -1044,6 +1048,12 @@ func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.FunctionDefinition)
 
 	expr := f.Walk(s)
 
+	// Update this scope to indicate that we are now inside an aggregate function
+	// so that any nested aggregates referencing this scope from a subquery will
+	// return an appropriate error. The returned tempScope will be used for
+	// building aggregate function arguments below in buildAggregateFunction.
+	tempScope := s.startAggFunc()
+
 	// We need to do this check here to ensure that we check the usage of special
 	// functions with the right error message.
 	if f.Filter != nil {
@@ -1075,7 +1085,7 @@ func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.FunctionDefinition)
 		Overload:   f.ResolvedOverload(),
 	}
 
-	return s.builder.buildAggregateFunction(f, &private, s)
+	return s.builder.buildAggregateFunction(f, &private, tempScope, s)
 }
 
 func (s *scope) lookupWindowDef(name tree.Name) *tree.WindowDef {

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3855,3 +3855,9 @@ scalar-group-by
  └── aggregations
       └── max [as=max:3, type=string]
            └── column2:2 [type=string]
+
+# Regression test for #51877.
+build
+SELECT max((SELECT jsonb_agg(v))) FROM kv
+----
+error (42803): aggregate function calls cannot be nested


### PR DESCRIPTION
Backport 1/1 commits from #52092.

/cc @cockroachdb/release

---

Prior to this commit, the query `SELECT max((SELECT count(v))) FROM kv;`
caused an internal error. This query is invalid, but instead of causing an
internal error, the optimizer should have rejected it for containing nested
aggregates (that's what Postgres does). However, the optimizer could not
recognize that the aggregates were nested in this case.

This commit fixes the error by ensuring that the optimizer can detect
that the aggregate functions are nested. It does so by updating the outer
scope earlier to indicate the start of an aggregate function so that any
nested aggregates referencing the outer scope from a subquery in the aggregate
function arguments will return an appropriate error.

Fixes #41820
Fixes #51877

Release note (bug fix): Fixed an internal error that could occur when
an aggregate function argument contained a correlated subquery with another
aggregate function referencing the outer scope. This now returns an appropriate
user-friendly error, "aggregate function calls cannot be nested".
