### PR TITLE
sql: remove local execution of projectSetNode and implement ConstructProjectSet in the new factory

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2951,7 +2951,7 @@ func (dsp *DistSQLPlanner) createPlanForOrdinality(
 }
 
 func createProjectSetSpec(
-	planCtx *PlanningCtx, n *projectSetNode, indexVarMap []int,
+	planCtx *PlanningCtx, n *projectSetPlanningInfo, indexVarMap []int,
 ) (*execinfrapb.ProjectSetSpec, error) {
 	spec := execinfrapb.ProjectSetSpec{
 		Exprs:            make([]execinfrapb.Expression, len(n.exprs)),
@@ -2981,12 +2981,21 @@ func (dsp *DistSQLPlanner) createPlanForProjectSet(
 	if err != nil {
 		return nil, err
 	}
+	err = dsp.addProjectSet(plan, planCtx, &n.projectSetPlanningInfo)
+	return plan, err
+}
+
+// addProjectSet adds a grouping stage consisting of a single
+// projectSetProcessor that is planned on the gateway.
+func (dsp *DistSQLPlanner) addProjectSet(
+	plan *PhysicalPlan, planCtx *PlanningCtx, info *projectSetPlanningInfo,
+) error {
 	numResults := len(plan.ResultTypes)
 
 	// Create the project set processor spec.
-	projectSetSpec, err := createProjectSetSpec(planCtx, n, plan.PlanToStreamColMap)
+	projectSetSpec, err := createProjectSetSpec(planCtx, info, plan.PlanToStreamColMap)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	spec := execinfrapb.ProcessorCoreUnion{
 		ProjectSet: projectSetSpec,
@@ -3004,8 +3013,7 @@ func (dsp *DistSQLPlanner) createPlanForProjectSet(
 	for i := range projectSetSpec.GeneratedColumns {
 		plan.PlanToStreamColMap = append(plan.PlanToStreamColMap, numResults+i)
 	}
-
-	return plan, nil
+	return nil
 }
 
 // isOnlyOnGateway returns true if a physical plan is executed entirely on the

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2983,11 +2983,8 @@ func (dsp *DistSQLPlanner) createPlanForProjectSet(
 	}
 	numResults := len(plan.ResultTypes)
 
-	indexVarMap := makePlanToStreamColMap(len(n.columns))
-	copy(indexVarMap, plan.PlanToStreamColMap)
-
 	// Create the project set processor spec.
-	projectSetSpec, err := createProjectSetSpec(planCtx, n, indexVarMap)
+	projectSetSpec, err := createProjectSetSpec(planCtx, n, plan.PlanToStreamColMap)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
@@ -100,3 +100,12 @@ SELECT v FROM kv ORDER BY v DESC
 1
 1
 NULL
+
+# Check that an SRF is supported.
+query I colnames
+SELECT * FROM generate_series(1, 3)
+----
+generate_series
+1
+2
+3

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -922,11 +922,13 @@ func (ef *execFactory) ConstructProjectSet(
 	src := asDataSource(n)
 	cols := append(src.columns, zipCols...)
 	return &projectSetNode{
-		source:          src.plan,
-		columns:         cols,
-		numColsInSource: len(src.columns),
-		exprs:           exprs,
-		numColsPerGen:   numColsPerGen,
+		source: src.plan,
+		projectSetPlanningInfo: projectSetPlanningInfo{
+			columns:         cols,
+			numColsInSource: len(src.columns),
+			exprs:           exprs,
+			numColsPerGen:   numColsPerGen,
+		},
 	}, nil
 }
 

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -921,29 +921,13 @@ func (ef *execFactory) ConstructProjectSet(
 ) (exec.Node, error) {
 	src := asDataSource(n)
 	cols := append(src.columns, zipCols...)
-	p := &projectSetNode{
+	return &projectSetNode{
 		source:          src.plan,
-		sourceCols:      src.columns,
 		columns:         cols,
 		numColsInSource: len(src.columns),
 		exprs:           exprs,
-		funcs:           make([]*tree.FuncExpr, len(exprs)),
 		numColsPerGen:   numColsPerGen,
-		run: projectSetRun{
-			gens:      make([]tree.ValueGenerator, len(exprs)),
-			done:      make([]bool, len(exprs)),
-			rowBuffer: make(tree.Datums, len(cols)),
-		},
-	}
-
-	for i, expr := range exprs {
-		if tFunc, ok := expr.(*tree.FuncExpr); ok && tFunc.IsGeneratorApplication() {
-			// Set-generating functions: generate_series() etc.
-			p.funcs[i] = tFunc
-		}
-	}
-
-	return p, nil
+	}, nil
 }
 
 // ConstructWindow is part of the exec.Factory interface.

--- a/pkg/sql/plan_ordering.go
+++ b/pkg/sql/plan_ordering.go
@@ -38,8 +38,6 @@ func planReqOrdering(plan planNode) ReqOrdering {
 		if n.run.rowsNeeded {
 			return planReqOrdering(n.source)
 		}
-	case *projectSetNode:
-		return n.reqOrdering
 
 	case *filterNode:
 		return n.reqOrdering

--- a/pkg/sql/project_set.go
+++ b/pkg/sql/project_set.go
@@ -33,7 +33,12 @@ import (
 // with zip(a,b,c).
 type projectSetNode struct {
 	source planNode
+	projectSetPlanningInfo
+}
 
+// projectSetPlanningInfo is a helper struct that is extracted from
+// projectSetNode to be reused during physical planning.
+type projectSetPlanningInfo struct {
 	// columns contains all the columns from the source, and then
 	// the columns from the generators.
 	columns sqlbase.ResultColumns

--- a/pkg/sql/project_set.go
+++ b/pkg/sql/project_set.go
@@ -13,10 +13,8 @@ package sql
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
 // projectSetNode zips through a list of generators for every row of
@@ -34,8 +32,7 @@ import (
 // of R prefixed. Formally, this performs a lateral cross join of R
 // with zip(a,b,c).
 type projectSetNode struct {
-	source     planNode
-	sourceCols sqlbase.ResultColumns
+	source planNode
 
 	// columns contains all the columns from the source, and then
 	// the columns from the generators.
@@ -52,170 +49,23 @@ type projectSetNode struct {
 	// SRFs.
 	exprs tree.TypedExprs
 
-	// funcs contains a valid pointer to a SRF FuncExpr for every entry
-	// in `exprs` that is actually a SRF function application.
-	// The size of the slice is the same as `exprs` though.
-	funcs []*tree.FuncExpr
-
 	// numColsPerGen indicates how many columns are produced by
 	// each entry in `exprs`.
 	numColsPerGen []int
-
-	reqOrdering ReqOrdering
-
-	run projectSetRun
-}
-
-func (n *projectSetNode) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum, error) {
-	return n.run.rowBuffer[idx].Eval(ctx)
-}
-
-func (n *projectSetNode) IndexedVarResolvedType(idx int) *types.T {
-	return n.columns[idx].Typ
-}
-
-func (n *projectSetNode) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return n.columns.NodeFormatter(idx)
-}
-
-type projectSetRun struct {
-	// inputRowReady is set when there was a row of input data available
-	// from the source.
-	inputRowReady bool
-
-	// rowBuffer will contain the current row of results.
-	rowBuffer tree.Datums
-
-	// gens contains the current "active" ValueGenerators for each entry
-	// in `funcs`. They are initialized anew for every new row in the source.
-	gens []tree.ValueGenerator
-
-	// done indicates for each `expr` whether the values produced by
-	// either the SRF or the scalar expressions are fully consumed and
-	// thus also whether NULLs should be emitted instead.
-	done []bool
 }
 
 func (n *projectSetNode) startExec(runParams) error {
-	return nil
+	panic("projectSetNode can't be run in local mode")
 }
 
 func (n *projectSetNode) Next(params runParams) (bool, error) {
-	for {
-		// If there's a cancellation request or a timeout, process it here.
-		if err := params.p.cancelChecker.Check(); err != nil {
-			return false, err
-		}
-
-		// Start of a new row of input?
-		if !n.run.inputRowReady {
-			// Read the row from the source.
-			hasRow, err := n.source.Next(params)
-			if err != nil || !hasRow {
-				return false, err
-			}
-
-			// Keep the values for later.
-			copy(n.run.rowBuffer, n.source.Values())
-
-			// Initialize a round of SRF generators or scalar values.
-			colIdx := n.numColsInSource
-			evalCtx := params.EvalContext()
-			evalCtx.IVarContainer = n
-			for i := range n.exprs {
-				if fn := n.funcs[i]; fn != nil {
-					// A set-generating function. Prepare its ValueGenerator.
-					gen, err := fn.EvalArgsAndGetGenerator(evalCtx)
-					if err != nil {
-						return false, err
-					}
-					if gen == nil {
-						gen = builtins.EmptyGenerator()
-					}
-					if err := gen.Start(params.ctx, params.extendedEvalCtx.Txn); err != nil {
-						return false, err
-					}
-					n.run.gens[i] = gen
-				}
-				n.run.done[i] = false
-				colIdx += n.numColsPerGen[i]
-			}
-
-			// Mark the row ready for further iterations.
-			n.run.inputRowReady = true
-		}
-
-		// Try to find some data on the generator side.
-		colIdx := n.numColsInSource
-		newValAvail := false
-		for i := range n.exprs {
-			numCols := n.numColsPerGen[i]
-
-			// Do we have a SRF?
-			if gen := n.run.gens[i]; gen != nil {
-				// Yes. Is there still work to do for the current row?
-				if !n.run.done[i] {
-					// Yes; heck whether this source still has some values available.
-					hasVals, err := gen.Next(params.ctx)
-					if err != nil {
-						return false, err
-					}
-					if hasVals {
-						// This source has values, use them.
-						values, err := gen.Values()
-						if err != nil {
-							return false, err
-						}
-						copy(n.run.rowBuffer[colIdx:colIdx+numCols], values)
-						newValAvail = true
-					} else {
-						n.run.done[i] = true
-						// No values left. Fill the buffer with NULLs for future
-						// results.
-						for j := 0; j < numCols; j++ {
-							n.run.rowBuffer[colIdx+j] = tree.DNull
-						}
-					}
-				}
-			} else {
-				// A simple scalar result.
-				// Do we still need to produce the scalar value? (first row)
-				if !n.run.done[i] {
-					// Yes. Produce it once, then indicate it's "done".
-					var err error
-					n.run.rowBuffer[colIdx], err = n.exprs[i].Eval(params.EvalContext())
-					if err != nil {
-						return false, err
-					}
-					newValAvail = true
-					n.run.done[i] = true
-				} else {
-					// Ensure that every row after the first returns a NULL value.
-					n.run.rowBuffer[colIdx] = tree.DNull
-				}
-			}
-
-			// Advance to the next column group.
-			colIdx += numCols
-		}
-
-		if newValAvail {
-			return true, nil
-		}
-
-		// The current batch of SRF values was exhausted. Advance
-		// to the next input row.
-		n.run.inputRowReady = false
-	}
+	panic("projectSetNode can't be run in local mode")
 }
 
-func (n *projectSetNode) Values() tree.Datums { return n.run.rowBuffer }
+func (n *projectSetNode) Values() tree.Datums {
+	panic("projectSetNode can't be run in local mode")
+}
 
 func (n *projectSetNode) Close(ctx context.Context) {
 	n.source.Close(ctx)
-	for _, gen := range n.run.gens {
-		if gen != nil {
-			gen.Close()
-		}
-	}
 }


### PR DESCRIPTION
Depends on #52108.

**sql: remove local execution of projectSetNode**

We have project set processor which is always planned for
`projectSetNode`, so this commit removes the dead code of its local
execution. Additionally, it removes some unused fields and cleans up
cancellation check of the processor.

Release note: None

**sql: implement ConstructProjectSet in the new factory**

Addresses: #47473.

Release note: None