### PR TITLE
util: add iterutil to create consistent iterators

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -1234,9 +1235,13 @@ func IterateIDPrefixKeys(
 	reader storage.Reader,
 	keyFn func(roachpb.RangeID) roachpb.Key,
 	msg protoutil.Message,
-	f func(_ roachpb.RangeID) (more bool, _ error),
+	f func(c iterutil.Cur) error,
 ) error {
 	rangeID := roachpb.RangeID(1)
+
+	iterState := iterutil.NewState()
+	iterState.Elem = new(roachpb.RangeID)
+
 	iter := reader.NewIterator(storage.IterOptions{
 		UpperBound: keys.LocalRangeIDPrefix.PrefixEnd().AsRawKey(),
 	})
@@ -1291,9 +1296,12 @@ func IterateIDPrefixKeys(
 			return errors.Errorf("unable to unmarshal %s into %T", unsafeKey.Key, msg)
 		}
 
-		more, err := f(rangeID)
-		if !more || err != nil {
+		*iterState.Elem.(*roachpb.RangeID) = rangeID
+		if err := f(iterState.Current()); err != nil {
 			return err
+		}
+		if iterState.Done() {
+			return nil
 		}
 		rangeID++
 	}

--- a/pkg/util/iterutil/iterutil.go
+++ b/pkg/util/iterutil/iterutil.go
@@ -1,0 +1,77 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package iterutil
+
+// Cur is the current element of the iteration.
+type Cur struct {
+	Elem  interface{}
+	Index int
+	done  *bool
+}
+
+// Stop halts the iteration, i.e., sets the `done` flag to true.
+func (c *Cur) Stop() error {
+	*c.done = true
+	return nil
+}
+
+// State iterates over the values.
+//
+// This can be used to create iterators that use closures, like:
+//
+// 	s := iterutil.NewState()
+//	s.Elem = new(my.Thing)
+// 	for _, thing := range myThings {
+// 		*s.Elem.(*my.Thing) = thing // set the current element
+// 		if err := f(s.Current()); err != nil {
+// 			return err
+// 		}
+// 		if s.Done() {
+// 			break
+// 		}
+// 	}
+//
+// where `f` is something like:
+//
+// 	f := func(c iterutil.Cur) error {
+// 		repl := c.Elem.(*my.Thing)
+// 		if something(repl) {
+// 			return errors.New("something is not good!")
+// 		} else if somethingElse(repl) {
+// 			return c.Stop() // that's it, won't be called again, even if Stop returns non-nil error
+// 		}
+// 		return nil
+// 	}
+//
+type State struct {
+	Cur
+	done bool
+}
+
+// NewState creates a new iterator state.
+func NewState() *State {
+	s := State{}
+	s.Cur.done = &s.done
+	s.Cur.Index = -1 // will become 0 when Current is called the first time
+	return &s
+}
+
+// Current returns the current element of the iteration state.
+//
+// Once the closure returns, it must not retain or access Elem any more.
+// It is preferred to be used over accessing Cur since it increments the index.
+func (s *State) Current() Cur {
+	s.Cur.Index++
+	return s.Cur
+}
+
+// Done tells if the iteration is complete or not.
+func (s *State) Done() bool { return s.done }

--- a/pkg/util/iterutil/iterutil_test.go
+++ b/pkg/util/iterutil/iterutil_test.go
@@ -1,0 +1,65 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package iterutil
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIter(t *testing.T) {
+	input := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+
+	var output []string
+	fn := func(c Cur) error {
+		str, ok := c.Elem.(*string)
+		if !ok {
+			return errors.Newf("extpected type *string; got %T", c.Elem)
+		}
+		output = append(output, *str)
+		return nil
+	}
+	require.NoError(t, sampleIter(input, fn))
+	require.Len(t, output, len(input))
+	require.ElementsMatch(t, input, output)
+
+	output = []string{}
+	stopAt := 4
+	fn = func(c Cur) error {
+		str := c.Elem.(*string)
+		if c.Index == stopAt {
+			return c.Stop()
+		}
+		output = append(output, *str)
+		return nil
+	}
+	require.NoError(t, sampleIter(input, fn))
+	require.Len(t, output, stopAt)
+	require.ElementsMatch(t, input[:stopAt], output)
+}
+
+// sampleIter iterates over the slice and applies the closure.
+func sampleIter(list []string, closure func(c Cur) error) error {
+	it := NewState()
+	it.Elem = new(string)
+	for _, elem := range list {
+		*it.Elem.(*string) = elem
+		if err := closure(it.Current()); err != nil {
+			return err
+		}
+		if it.Done() {
+			break
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Previously, all the iterators were implemented using closures that returned a bool and an error. The behaviour of bool was dependent on the documentation, i.e., whether it represented presence of "more" elements or the iteration was "done".

This was prone to errors as evident by fix in #48681.

This change introduces a type that can be commonly used by all closure based iterators to implement them. Package iterutil declares State which defines the following listed methods:

 - Current: returns the current element of the iteration
 - Done: checks if the iteration is over

Now, closures can take the "cur" as a parameter to get the current element. Cur returns a wrapper which can be used to access the element associated with the state of iteration and the index. This "cur" can also be used to stop the iteration using Stop method.

Resolves: #48709

Release note: None

Signed-off-by: Vaibhav <vrongmeal@gmail.com>