### PR TITLE
logictest: de-flake a logic test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/txn_stats
+++ b/pkg/sql/logictest/testdata/logic_test/txn_stats
@@ -40,14 +40,16 @@ SELECT txn_count - implicit_count = 1
 true
 
 # All transactions so far should be extremely fast, so we check that the
-# average transaction time is in [0s, 0.1s] range.
+# average transaction time is in [0s, 1s] range.
+# Note: if this query flakes again, you should remove it - it's a sanity check
+# on txn_time_avg_sec field.
 query B
 SELECT count(*) = 0
   FROM crdb_internal.node_txn_stats
  WHERE application_name = 'test'
    AND (
         txn_time_avg_sec < 0
-        OR txn_time_avg_sec > 0.1
+        OR txn_time_avg_sec > 1
        )
 ----
 true


### PR DESCRIPTION
This commit increases the expected range of the average txn time in
`txn_stats` logic test from [0s, 0.1s] to [0s, 1s] in order to de-flake
it.

Fixes: #52143.

Release note: None