### PR TITLE
kvserver: remove bogus `lastupdatenanos` metric

### DIFF
--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -760,12 +760,6 @@ var charts = []sectionDescription{
 		Organization: [][]string{{KVTransactionLayer, "Storage"}},
 		Charts: []chartDescription{
 			{
-				Rate:        DescribeDerivative_DERIVATIVE,
-				Percentiles: false,
-				Title:       "Metric Update Frequency",
-				Metrics:     []string{"lastupdatenanos"},
-			},
-			{
 				Title:     "Counts",
 				AxisLabel: "MVCC Keys & Values",
 				Metrics: []string{
@@ -2041,10 +2035,6 @@ var charts = []sectionDescription{
 			{
 				Title:   "Cumultative Intent Age",
 				Metrics: []string{"intentage"},
-			},
-			{
-				Title:   "Metric Update Frequency",
-				Metrics: []string{"lastupdatenanos"},
 			},
 			{
 				Title: "Size",

--- a/pkg/ui/src/util/proto.ts
+++ b/pkg/ui/src/util/proto.ts
@@ -66,7 +66,6 @@ export namespace MetricConstants {
   export const intentCount: string = "intentcount";
   export const intentAge: string = "intentage";
   export const gcBytesAge: string = "gcbytesage";
-  export const lastUpdateNano: string = "lastupdatenanos";
   export const capacity: string = "capacity";
   export const availableCapacity: string = "capacity.available";
   export const usedCapacity: string = "capacity.used";


### PR DESCRIPTION
This metric was nonsense because in the MVCCStats deltas we didn't record a
delta but rather had the whole timestamp. This leads to the value just
overflowing constantly. FWIW, even if we did have the delta, it'd be a hard
to use metric.

Release note: None