### PR TITLE
sql: parse and recognize `ALTER SCHEMA` and `DROP SCHEMA`

### DIFF
--- a/docs/generated/sql/bnf/drop_stmt.bnf
+++ b/docs/generated/sql/bnf/drop_stmt.bnf
@@ -4,6 +4,7 @@ drop_stmt ::=
 	| drop_table_stmt
 	| drop_view_stmt
 	| drop_sequence_stmt
+	| drop_schema_stmt
 	| drop_type_stmt
 	| drop_role_stmt
 	| drop_schedule_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -310,6 +310,7 @@ alter_ddl_stmt ::=
 	| alter_database_stmt
 	| alter_range_stmt
 	| alter_partition_stmt
+	| alter_schema_stmt
 	| alter_type_stmt
 
 alter_role_stmt ::=
@@ -406,6 +407,7 @@ drop_ddl_stmt ::=
 	| drop_table_stmt
 	| drop_view_stmt
 	| drop_sequence_stmt
+	| drop_schema_stmt
 	| drop_type_stmt
 
 drop_role_stmt ::=
@@ -1064,6 +1066,9 @@ alter_range_stmt ::=
 alter_partition_stmt ::=
 	alter_zone_partition_stmt
 
+alter_schema_stmt ::=
+	'ALTER' 'SCHEMA' schema_name 'RENAME' 'TO' schema_name
+
 alter_type_stmt ::=
 	'ALTER' 'TYPE' type_name 'ADD' 'VALUE' 'SCONST' opt_add_val_placement
 	| 'ALTER' 'TYPE' type_name 'ADD' 'VALUE' 'IF' 'NOT' 'EXISTS' 'SCONST' opt_add_val_placement
@@ -1202,6 +1207,10 @@ drop_view_stmt ::=
 drop_sequence_stmt ::=
 	'DROP' 'SEQUENCE' table_name_list opt_drop_behavior
 	| 'DROP' 'SEQUENCE' 'IF' 'EXISTS' table_name_list opt_drop_behavior
+
+drop_schema_stmt ::=
+	'DROP' 'SCHEMA' schema_name_list opt_drop_behavior
+	| 'DROP' 'SCHEMA' 'IF' 'EXISTS' schema_name_list opt_drop_behavior
 
 drop_type_stmt ::=
 	'DROP' 'TYPE' type_name_list opt_drop_behavior
@@ -1455,6 +1464,9 @@ alter_zone_partition_stmt ::=
 	| 'ALTER' 'PARTITION' partition_name 'OF' 'INDEX' table_index_name set_zone_config
 	| 'ALTER' 'PARTITION' partition_name 'OF' 'INDEX' table_name '@' '*' set_zone_config
 
+schema_name ::=
+	name
+
 type_name ::=
 	db_object_name
 
@@ -1462,9 +1474,6 @@ opt_add_val_placement ::=
 	'BEFORE' 'SCONST'
 	| 'AFTER' 'SCONST'
 	| 
-
-schema_name ::=
-	name
 
 opt_with ::=
 	'WITH'
@@ -1644,6 +1653,9 @@ table_index_name_list ::=
 
 table_name_list ::=
 	( table_name ) ( ( ',' table_name ) )*
+
+schema_name_list ::=
+	( schema_name ) ( ( ',' schema_name ) )*
 
 type_name_list ::=
 	( type_name ) ( ( ',' type_name ) )*

--- a/pkg/sql/alter_schema.go
+++ b/pkg/sql/alter_schema.go
@@ -1,0 +1,39 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/errors"
+)
+
+type alterSchemaNode struct {
+	n *tree.AlterSchema
+}
+
+// Use to satisfy the linter.
+var _ planNode = &alterSchemaNode{n: nil}
+
+func (p *planner) AlterSchema(ctx context.Context, n *tree.AlterSchema) (planNode, error) {
+	return nil, unimplemented.NewWithIssue(50880, "ALTER SCHEMA")
+}
+
+func (n *alterSchemaNode) startExec(params runParams) error {
+	return errors.AssertionFailedf("unimplemented")
+}
+
+func (n *alterSchemaNode) Next(params runParams) (bool, error) { return false, nil }
+func (n *alterSchemaNode) Values() tree.Datums                 { return tree.Datums{} }
+func (n *alterSchemaNode) Close(ctx context.Context)           {}
+func (n *alterSchemaNode) ReadingOwnWrites()                   {}

--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -1,0 +1,39 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/errors"
+)
+
+type dropSchemaNode struct {
+	n *tree.DropSchema
+}
+
+// Use to satisfy the linter.
+var _ planNode = &dropSchemaNode{n: nil}
+
+func (p *planner) DropSchema(ctx context.Context, n *tree.DropSchema) (planNode, error) {
+	return nil, unimplemented.NewWithIssue(50884, "DROP SCHEMA")
+}
+
+func (n *dropSchemaNode) startExec(params runParams) error {
+	return errors.AssertionFailedf("unimplemented")
+}
+
+func (n *dropSchemaNode) Next(params runParams) (bool, error) { return false, nil }
+func (n *dropSchemaNode) Values() tree.Datums                 { return tree.Datums{} }
+func (n *dropSchemaNode) Close(ctx context.Context)           {}
+func (n *dropSchemaNode) ReadingOwnWrites()                   {}

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -102,3 +102,9 @@ CREATE TEMP TABLE myschema.tmp (x int)
 # We should error out trying to modify any virtual schemas.
 statement error pq: schema cannot be modified: "pg_catalog"
 CREATE TABLE pg_catalog.bad (x int)
+
+statement error pq: unimplemented: DROP SCHEMA
+DROP SCHEMA myschema
+
+statement error pq: unimplemented: ALTER SCHEMA
+ALTER SCHEMA myschema RENAME TO yourschema

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -49,6 +49,8 @@ func buildOpaque(
 	switch n := stmt.(type) {
 	case *tree.AlterIndex:
 		plan, err = p.AlterIndex(ctx, n)
+	case *tree.AlterSchema:
+		plan, err = p.AlterSchema(ctx, n)
 	case *tree.AlterTable:
 		plan, err = p.AlterTable(ctx, n)
 	case *tree.AlterTableSetSchema:
@@ -93,6 +95,8 @@ func buildOpaque(
 		plan, err = p.DropIndex(ctx, n)
 	case *tree.DropRole:
 		plan, err = p.DropRole(ctx, n)
+	case *tree.DropSchema:
+		plan, err = p.DropSchema(ctx, n)
 	case *tree.DropTable:
 		plan, err = p.DropTable(ctx, n)
 	case *tree.DropType:
@@ -169,6 +173,7 @@ func buildOpaque(
 func init() {
 	for _, stmt := range []tree.Statement{
 		&tree.AlterIndex{},
+		&tree.AlterSchema{},
 		&tree.AlterTable{},
 		&tree.AlterTableSetSchema{},
 		&tree.AlterType{},
@@ -190,6 +195,7 @@ func init() {
 		&tree.Discard{},
 		&tree.DropDatabase{},
 		&tree.DropIndex{},
+		&tree.DropSchema{},
 		&tree.DropTable{},
 		&tree.DropType{},
 		&tree.DropView{},

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -69,6 +69,10 @@ func TestContextualHelp(t *testing.T) {
 		{`ALTER SEQUENCE blah RENAME ??`, `ALTER SEQUENCE`},
 		{`ALTER SEQUENCE blah RENAME TO blih ??`, `ALTER SEQUENCE`},
 
+		{`ALTER SCHEMA ??`, `ALTER SCHEMA`},
+		{`ALTER SCHEMA x RENAME ??`, `ALTER SCHEMA`},
+		{`ALTER SCHEMA x OWNER ??`, `ALTER SCHEMA`},
+
 		{`ALTER USER IF ??`, `ALTER ROLE`},
 		{`ALTER USER foo WITH PASSWORD ??`, `ALTER ROLE`},
 
@@ -181,6 +185,8 @@ func TestContextualHelp(t *testing.T) {
 
 		{`DROP SCHEDULE ???`, `DROP SCHEDULES`},
 		{`DROP SCHEDULES ???`, `DROP SCHEDULES`},
+
+		{`DROP SCHEMA ??`, `DROP SCHEMA`},
 
 		{`EXPLAIN (??`, `EXPLAIN`},
 		{`EXPLAIN SELECT 1 ??`, `SELECT`},

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -356,6 +356,13 @@ func TestParse(t *testing.T) {
 		{`CREATE TYPE a.b AS ENUM ('a', 'b', 'c')`},
 		{`CREATE TYPE a.b.c AS ENUM ('a', 'b', 'c')`},
 
+		{`DROP SCHEMA a`},
+		{`DROP SCHEMA a, b`},
+		{`DROP SCHEMA IF EXISTS a, b, c`},
+		{`DROP SCHEMA IF EXISTS a, b CASCADE`},
+		{`DROP SCHEMA IF EXISTS a, b RESTRICT`},
+		{`DROP SCHEMA a RESTRICT`},
+
 		{`DROP TYPE a`},
 		{`DROP TYPE a, b, c`},
 		{`DROP TYPE db.sc.a, sc.a`},
@@ -1243,6 +1250,8 @@ func TestParse(t *testing.T) {
 		{`ALTER INDEX IF EXISTS b RENAME TO b`},
 		{`ALTER INDEX IF EXISTS a@b RENAME TO b`},
 		{`ALTER INDEX IF EXISTS a@primary RENAME TO like`},
+
+		{`ALTER SCHEMA s RENAME TO s2`},
 
 		{`ALTER TABLE a RENAME TO b`},
 		{`EXPLAIN ALTER TABLE a RENAME TO b`},
@@ -2814,7 +2823,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`DROP OPERATOR a`, 0, `drop operator`, ``},
 		{`DROP PUBLICATION a`, 0, `drop publication`, ``},
 		{`DROP RULE a`, 0, `drop rule`, ``},
-		{`DROP SCHEMA a`, 26443, `drop`, ``},
 		{`DROP SERVER a`, 0, `drop server`, ``},
 		{`DROP SUBSCRIPTION a`, 0, `drop subscription`, ``},
 		{`DROP TEXT SEARCH a`, 7821, `drop text`, ``},

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -136,6 +136,7 @@ type planNodeReadingOwnWrites interface {
 }
 
 var _ planNode = &alterIndexNode{}
+var _ planNode = &alterSchemaNode{}
 var _ planNode = &alterSequenceNode{}
 var _ planNode = &alterTableNode{}
 var _ planNode = &alterTableSetSchemaNode{}
@@ -158,6 +159,7 @@ var _ planNode = &deleteRangeNode{}
 var _ planNode = &distinctNode{}
 var _ planNode = &dropDatabaseNode{}
 var _ planNode = &dropIndexNode{}
+var _ planNode = &dropSchemaNode{}
 var _ planNode = &dropSequenceNode{}
 var _ planNode = &dropTableNode{}
 var _ planNode = &dropTypeNode{}
@@ -217,6 +219,7 @@ var _ planNodeFastPath = &controlJobsNode{}
 var _ planNodeFastPath = &controlSchedulesNode{}
 
 var _ planNodeReadingOwnWrites = &alterIndexNode{}
+var _ planNodeReadingOwnWrites = &alterSchemaNode{}
 var _ planNodeReadingOwnWrites = &alterSequenceNode{}
 var _ planNodeReadingOwnWrites = &alterTableNode{}
 var _ planNodeReadingOwnWrites = &alterTypeNode{}
@@ -226,6 +229,7 @@ var _ planNodeReadingOwnWrites = &createTableNode{}
 var _ planNodeReadingOwnWrites = &createTypeNode{}
 var _ planNodeReadingOwnWrites = &createViewNode{}
 var _ planNodeReadingOwnWrites = &changePrivilegesNode{}
+var _ planNodeReadingOwnWrites = &dropSchemaNode{}
 var _ planNodeReadingOwnWrites = &dropTypeNode{}
 var _ planNodeReadingOwnWrites = &setZoneConfigNode{}
 

--- a/pkg/sql/sem/tree/alter_schema.go
+++ b/pkg/sql/sem/tree/alter_schema.go
@@ -1,0 +1,45 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// AlterSchema represents an ALTER SCHEMA statement.
+type AlterSchema struct {
+	Schema string
+	Cmd    AlterSchemaCmd
+}
+
+var _ Statement = &AlterSchema{}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterSchema) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER SCHEMA ")
+	ctx.FormatNameP(&node.Schema)
+	ctx.FormatNode(node.Cmd)
+}
+
+// AlterSchemaCmd represents a schema modification operation.
+type AlterSchemaCmd interface {
+	NodeFormatter
+	alterSchemaCmd()
+}
+
+func (*AlterSchemaRename) alterSchemaCmd() {}
+
+// AlterSchemaRename represents an ALTER SCHEMA RENAME command.
+type AlterSchemaRename struct {
+	NewName string
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterSchemaRename) Format(ctx *FmtCtx) {
+	ctx.WriteString(" RENAME TO ")
+	ctx.FormatNameP(&node.NewName)
+}

--- a/pkg/sql/sem/tree/drop.go
+++ b/pkg/sql/sem/tree/drop.go
@@ -190,3 +190,30 @@ func (node *DropType) Format(ctx *FmtCtx) {
 		ctx.WriteString(node.DropBehavior.String())
 	}
 }
+
+// DropSchema represents a DROP SCHEMA command.
+type DropSchema struct {
+	Names        []string
+	IfExists     bool
+	DropBehavior DropBehavior
+}
+
+var _ Statement = &DropSchema{}
+
+// Format implements the NodeFormatter interface.
+func (node *DropSchema) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP SCHEMA ")
+	if node.IfExists {
+		ctx.WriteString("IF EXISTS ")
+	}
+	for i := range node.Names {
+		if i > 0 {
+			ctx.WriteString(", ")
+		}
+		ctx.FormatNameP(&node.Names[i])
+	}
+	if node.DropBehavior != DropDefault {
+		ctx.WriteString(" ")
+		ctx.WriteString(node.DropBehavior.String())
+	}
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -195,6 +195,14 @@ func (*AlterTableSetSchema) StatementTag() string { return "ALTER TABLE SET SCHE
 func (*AlterTableSetSchema) hiddenFromShowQueries() {}
 
 // StatementType implements the Statement interface.
+func (*AlterSchema) StatementType() StatementType { return DDL }
+
+// StatementTag implements the Statement interface.
+func (*AlterSchema) StatementTag() string { return "ALTER SCHEMA" }
+
+func (*AlterSchema) hiddenFromShowQueries() {}
+
+// StatementType implements the Statement interface.
 func (*AlterType) StatementType() StatementType { return DDL }
 
 // StatementTag implements the Statement interface.
@@ -481,6 +489,12 @@ func (*DropType) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*DropType) StatementTag() string { return "DROP TYPE" }
+
+// StatementType implements the Statement interface.
+func (*DropSchema) StatementType() StatementType { return DDL }
+
+// StatementTag implements the Statement interface.
+func (*DropSchema) StatementTag() string { return "DROP SCHEMA" }
 
 // StatementType implements the Statement interface.
 func (*Execute) StatementType() StatementType { return Unknown }
@@ -951,6 +965,7 @@ func (*ValuesClause) StatementType() StatementType { return Rows }
 func (*ValuesClause) StatementTag() string { return "VALUES" }
 
 func (n *AlterIndex) String() string                     { return AsString(n) }
+func (n *AlterSchema) String() string                    { return AsString(n) }
 func (n *AlterTable) String() string                     { return AsString(n) }
 func (n *AlterTableCmds) String() string                 { return AsString(n) }
 func (n *AlterTableAddColumn) String() string            { return AsString(n) }
@@ -994,6 +1009,7 @@ func (n *Deallocate) String() string                     { return AsString(n) }
 func (n *Delete) String() string                         { return AsString(n) }
 func (n *DropDatabase) String() string                   { return AsString(n) }
 func (n *DropIndex) String() string                      { return AsString(n) }
+func (n *DropSchema) String() string                     { return AsString(n) }
 func (n *DropTable) String() string                      { return AsString(n) }
 func (n *DropType) String() string                       { return AsString(n) }
 func (n *DropView) String() string                       { return AsString(n) }


### PR DESCRIPTION
Touches #50880.
Touches #50884.

This commit adds the boilerplate for adding the `ALTER SCHEMA` and `DROP
SCHEMA` statements.

Release note: None