### PR TITLE
sql: support synchronous_commit and enable_seqscan as dummy no-op

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2036,6 +2036,14 @@ func (m *sessionDataMutator) SetDefaultReadOnly(val bool) {
 	m.data.DefaultReadOnly = val
 }
 
+func (m *sessionDataMutator) SetEnableSeqScan(val bool) {
+	m.data.EnableSeqScan = val
+}
+
+func (m *sessionDataMutator) SetSynchronousCommit(val bool) {
+	m.data.SynchronousCommit = val
+}
+
 func (m *sessionDataMutator) SetDistSQLMode(val sessiondata.DistSQLExecMode) {
 	m.data.DistSQLMode = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1760,6 +1760,7 @@ enable_experimental_alter_column_type_general  off                 NULL      NUL
 enable_implicit_select_for_update              on                  NULL      NULL        NULL        string
 enable_insert_fast_path                        on                  NULL      NULL        NULL        string
 enable_interleaved_joins                       on                  NULL      NULL        NULL        string
+enable_seqscan                                 on                  NULL      NULL        NULL        string
 enable_zigzag_join                             on                  NULL      NULL        NULL        string
 experimental_distsql_planning                  off                 NULL      NULL        NULL        string
 experimental_enable_enums                      on                  NULL      NULL        NULL        string
@@ -1795,6 +1796,7 @@ sql_safe_updates                               off                 NULL      NUL
 standard_conforming_strings                    on                  NULL      NULL        NULL        string
 statement_timeout                              0                   NULL      NULL        NULL        string
 synchronize_seqscans                           on                  NULL      NULL        NULL        string
+synchronous_commit                             on                  NULL      NULL        NULL        string
 timezone                                       UTC                 NULL      NULL        NULL        string
 tracing                                        off                 NULL      NULL        NULL        string
 transaction_isolation                          serializable        NULL      NULL        NULL        string
@@ -1830,6 +1832,7 @@ enable_experimental_alter_column_type_general  off                 NULL  user   
 enable_implicit_select_for_update              on                  NULL  user     NULL      on                  on
 enable_insert_fast_path                        on                  NULL  user     NULL      on                  on
 enable_interleaved_joins                       on                  NULL  user     NULL      on                  on
+enable_seqscan                                 on                  NULL  user     NULL      on                  on
 enable_zigzag_join                             on                  NULL  user     NULL      on                  on
 experimental_distsql_planning                  off                 NULL  user     NULL      off                 off
 experimental_enable_enums                      on                  NULL  user     NULL      off                 off
@@ -1865,6 +1868,7 @@ sql_safe_updates                               off                 NULL  user   
 standard_conforming_strings                    on                  NULL  user     NULL      on                  on
 statement_timeout                              0                   NULL  user     NULL      0                   0
 synchronize_seqscans                           on                  NULL  user     NULL      on                  on
+synchronous_commit                             on                  NULL  user     NULL      on                  on
 timezone                                       UTC                 NULL  user     NULL      UTC                 UTC
 tracing                                        off                 NULL  user     NULL      off                 off
 transaction_isolation                          serializable        NULL  user     NULL      serializable        serializable
@@ -1896,6 +1900,7 @@ enable_experimental_alter_column_type_general  NULL    NULL     NULL     NULL   
 enable_implicit_select_for_update              NULL    NULL     NULL     NULL        NULL
 enable_insert_fast_path                        NULL    NULL     NULL     NULL        NULL
 enable_interleaved_joins                       NULL    NULL     NULL     NULL        NULL
+enable_seqscan                                 NULL    NULL     NULL     NULL        NULL
 enable_zigzag_join                             NULL    NULL     NULL     NULL        NULL
 experimental_distsql_planning                  NULL    NULL     NULL     NULL        NULL
 experimental_enable_enums                      NULL    NULL     NULL     NULL        NULL
@@ -1933,6 +1938,7 @@ sql_safe_updates                               NULL    NULL     NULL     NULL   
 standard_conforming_strings                    NULL    NULL     NULL     NULL        NULL
 statement_timeout                              NULL    NULL     NULL     NULL        NULL
 synchronize_seqscans                           NULL    NULL     NULL     NULL        NULL
+synchronous_commit                             NULL    NULL     NULL     NULL        NULL
 timezone                                       NULL    NULL     NULL     NULL        NULL
 tracing                                        NULL    NULL     NULL     NULL        NULL
 transaction_isolation                          NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -355,3 +355,41 @@ statement ok
 SET experimental_distsql_planning = always;
 SET experimental_distsql_planning = on;
 SET experimental_distsql_planning = off
+
+subtest dummy_session_vars
+
+query T noticetrace
+SET synchronous_commit = off; SET enable_seqscan = false
+----
+WARNING: setting session var "synchronous_commit" is a no-op
+WARNING: setting session var "enable_seqscan" is a no-op
+
+query T colnames
+SHOW synchronous_commit
+----
+synchronous_commit
+off
+
+query T colnames
+SHOW enable_seqscan
+----
+enable_seqscan
+off
+
+query T noticetrace
+SET synchronous_commit = on; SET enable_seqscan = true
+----
+WARNING: setting session var "synchronous_commit" is a no-op
+WARNING: setting session var "enable_seqscan" is a no-op
+
+query T colnames
+SHOW synchronous_commit
+----
+synchronous_commit
+on
+
+query T colnames
+SHOW enable_seqscan
+----
+enable_seqscan
+on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -43,6 +43,7 @@ enable_experimental_alter_column_type_general  off
 enable_implicit_select_for_update              on
 enable_insert_fast_path                        on
 enable_interleaved_joins                       on
+enable_seqscan                                 on
 enable_zigzag_join                             on
 experimental_distsql_planning                  off
 experimental_enable_enums                      off
@@ -78,6 +79,7 @@ sql_safe_updates                               off
 standard_conforming_strings                    on
 statement_timeout                              0
 synchronize_seqscans                           on
+synchronous_commit                             on
 timezone                                       UTC
 tracing                                        off
 transaction_isolation                          serializable

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -141,6 +141,11 @@ type SessionData struct {
 	// AlterColumnTypeGeneralEnabled is true if ALTER TABLE ... ALTER COLUMN ...
 	// TYPE x may be used for general conversions requiring online schema change/
 	AlterColumnTypeGeneralEnabled bool
+
+	// SynchronousCommit is a dummy setting for the synchronous_commit var.
+	SynchronousCommit bool
+	// EnableSeqScan is a dummy setting for the enable_seqscan var.
+	EnableSeqScan bool
 }
 
 // DataConversionConfig contains the parameters that influence

--- a/pkg/sql/sqltelemetry/session.go
+++ b/pkg/sql/sqltelemetry/session.go
@@ -31,3 +31,10 @@ var ForceSavepointRestartCounter = telemetry.GetCounterOnce("sql.force_savepoint
 func UnimplementedSessionVarValueCounter(varName, val string) telemetry.Counter {
 	return telemetry.GetCounter(fmt.Sprintf("unimplemented.sql.session_var.%s.%s", varName, val))
 }
+
+// DummySessionVarValueCounter is to be incremented every time
+// a client attempts to set a compatitibility session var to a
+// dummy value.
+func DummySessionVarValueCounter(varName string) telemetry.Counter {
+	return telemetry.GetCounter(fmt.Sprintf("sql.session_var.dummy.%s", varName))
+}

--- a/pkg/sql/testdata/telemetry/set
+++ b/pkg/sql/testdata/telemetry/set
@@ -1,0 +1,9 @@
+feature-allowlist
+sql.session_var.dummy.*
+----
+
+feature-usage
+SET synchronous_commit = off; SET enable_seqscan = false
+----
+sql.session_var.dummy.enable_seqscan
+sql.session_var.dummy.synchronous_commit

--- a/pkg/sql/unsupported_vars.go
+++ b/pkg/sql/unsupported_vars.go
@@ -10,6 +10,35 @@
 
 package sql
 
+import "github.com/cockroachdb/cockroach/pkg/settings"
+
+// DummyVars contains a list of dummy vars we do not support that
+// PostgreSQL does, but are required as an easy fix to make certain
+// tooling/ORMs work. These vars should not affect the correctness
+// of results.
+var DummyVars = map[string]sessionVar{
+	"enable_seqscan": makeDummyBooleanSessionVar(
+		"enable_seqscan",
+		func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.EnableSeqScan)
+		},
+		func(m *sessionDataMutator, v bool) {
+			m.SetEnableSeqScan(v)
+		},
+		func(sv *settings.Values) string { return "on" },
+	),
+	"synchronous_commit": makeDummyBooleanSessionVar(
+		"synchronous_commit",
+		func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.SynchronousCommit)
+		},
+		func(m *sessionDataMutator, v bool) {
+			m.SetSynchronousCommit(v)
+		},
+		func(sv *settings.Values) string { return "on" },
+	),
+}
+
 // UnsupportedVars contains the set of PostgreSQL session variables
 // and client parameters that are not supported in CockroachDB.
 // These are used to produce error messages and telemetry.
@@ -70,7 +99,7 @@ var UnsupportedVars = func(ss ...string) map[string]struct{} {
 	"enable_material",
 	"enable_mergejoin",
 	"enable_nestloop",
-	"enable_seqscan",
+	// "enable_seqscan",
 	"enable_sort",
 	"enable_tidscan",
 	"escape_string_warning",
@@ -135,8 +164,8 @@ var UnsupportedVars = func(ss ...string) map[string]struct{} {
 	// "ssl_renegotiation_limit",
 	// "standard_conforming_strings",
 	// "statement_timeout",
-	//	"synchronize_seqscans",
-	"synchronous_commit",
+	// "synchronize_seqscans",
+	// "synchronous_commit",
 	"tcp_keepalives_count",
 	"tcp_keepalives_idle",
 	"tcp_keepalives_interval",


### PR DESCRIPTION
These vars are set by `osm2pgsql` and `ogr2ogr` respectively. These
default to the ON state, the OFF state affects performance but not
correctness.

Touches #51818.

Release note (sql change): Support the setting and getting of the
`synchronous_commit` and `enable_seqscan` variables, which do not affect
any performance characteristics. These are no-ops enabled to allow
certain tools to work.