### PR TITLE
release-19.1: build: touch lib/*.so files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ artifacts
 /bin.*
 .buildinfo
 /lib
+/lib.*
 # cockroach-data, cockroach{,.race}-{darwin,linux,windows}-*
 /cockroach*
 /certs

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -149,6 +149,8 @@ vols="${vols} --volume=${cockroach_toplevel}:/go/src/github.com/cockroachdb/cock
 # are nested, as they are here.)
 mkdir -p "${cockroach_toplevel}"/bin{.docker_amd64,}
 vols="${vols} --volume=${cockroach_toplevel}/bin.docker_amd64:/go/src/github.com/cockroachdb/cockroach/bin${delegated_volume_mode}"
+mkdir -p "${cockroach_toplevel}"/lib{.docker_amd64,}
+vols="${vols} --volume=${cockroach_toplevel}/lib.docker_amd64:/go/src/github.com/cockroachdb/cockroach/lib${delegated_volume_mode}"
 
 mkdir -p "${gocache}"/docker/bin
 vols="${vols} --volume=${gocache}/docker/bin:/go/bin${delegated_volume_mode}"

--- a/build/builder/mkrelease.sh
+++ b/build/builder/mkrelease.sh
@@ -100,6 +100,7 @@ if [ $# -ge 1 ]; then
     shift
 fi
 
-# lib is populated in v20.2 or higher, but we make a temporary directory
-# in /lib such that TeamCity can pick up the artifacts.
-(set -x && mkdir -p lib && CGO_ENABLED=1 make BUILDTYPE=release "${args[@]}" "$@")
+# lib is populated in v20.2 or higher, but we make a placeholder for the same
+# files in /lib such that TeamCity can pick up the artifacts.
+# These placeholders are unused in the actual release process.
+(set -x && mkdir -p lib && touch lib/libgeos.so && touch lib/libgeos_c.so && CGO_ENABLED=1 make BUILDTYPE=release "${args[@]}" "$@")


### PR DESCRIPTION
TeamCity can't resolve empty directories as artifacts, so add dummy
files when doing mkrelease.

Release note: None

Release note: None