### PR TITLE
release-20.1: stats: don't delete stale cache entries, update them asynchronously instead

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1170,6 +1170,7 @@ func injectTableStats(
 	// update is handled asynchronously).
 	params.extendedEvalCtx.ExecCfg.TableStatsCache.InvalidateTableStats(params.ctx, desc.ID)
 
+	// Use Gossip to refresh the caches on other nodes.
 	return stats.GossipTableStatAdded(params.extendedEvalCtx.ExecCfg.Gossip, desc.ID)
 }
 

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -411,11 +411,6 @@ func (r *createStatsResumer) Resume(
 		return err
 	}
 
-	// Invalidate the local cache synchronously; this guarantees that the next
-	// statement in the same session won't use a stale cache (whereas the gossip
-	// update is handled asynchronously).
-	evalCtx.ExecCfg.TableStatsCache.InvalidateTableStats(ctx, r.tableID)
-
 	// Record this statistics creation in the event log.
 	if !createStatsPostEvents.Get(&evalCtx.Settings.SV) {
 		return nil

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -11,11 +11,26 @@ statement ok
 CREATE STATISTICS u ON u FROM uv;
 CREATE STATISTICS v ON v FROM uv
 
+query TTIIIB colnames
+SELECT
+  statistics_name,
+  column_names,
+  row_count,
+  distinct_count,
+  null_count,
+  histogram_id IS NOT NULL AS has_histogram
+FROM
+  [SHOW STATISTICS FOR TABLE uv]
+----
+statistics_name  column_names  row_count  distinct_count  null_count  has_histogram
+u                {u}           8          2               0           true
+v                {v}           8          7               0           true
+
 statement ok
 set enable_zigzag_join = false
 
 # Verify we scan index v which has the more selective constraint.
-query TTTTT
+query TTTTT retry
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
 ·     distributed  true         ·       ·

--- a/pkg/sql/plan_opt_test.go
+++ b/pkg/sql/plan_opt_test.go
@@ -88,6 +88,20 @@ func (h *queryCacheTestHelper) AssertStats(tb *testing.T, expHits, expMisses int
 	assert.Equal(tb, expMisses, misses, "misses")
 }
 
+// CheckStats is similar to AssertStats, but returns an error instead of
+// failing the test if the actual stats don't match the expected stats.
+func (h *queryCacheTestHelper) CheckStats(tb *testing.T, expHits, expMisses int) error {
+	tb.Helper()
+	hits, misses := h.GetStats()
+	if expHits != hits {
+		return errors.Errorf("expected %d hits but found %d", expHits, hits)
+	}
+	if expMisses != misses {
+		return errors.Errorf("expected %d misses but found %d", expMisses, misses)
+	}
+	return nil
+}
+
 func TestQueryCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -328,8 +342,17 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 			h.AssertStats(t, 1 /* hits */, 1 /* misses */)
 			r0.Exec(t, "CREATE STATISTICS s FROM t")
 			h.AssertStats(t, 1 /* hits */, 1 /* misses */)
-			r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
-			h.AssertStats(t, 1 /* hits */, 2 /* misses */)
+			hits := 1
+			testutils.SucceedsSoon(t, func() error {
+				// The stats cache is updated asynchronously, so we may get some hits
+				// before we get a miss.
+				r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
+				if err := h.CheckStats(t, hits, 2 /* misses */); err != nil {
+					hits++
+					return err
+				}
+				return nil
+			})
 		})
 
 		// Test that a schema change triggers cache invalidation.

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -388,7 +388,7 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 		return err
 	}
 
-	// Gossip invalidation of the stat caches for this table.
+	// Gossip refresh of the stat caches for this table.
 	return stats.GossipTableStatAdded(s.FlowCtx.Cfg.Gossip, s.tableID)
 }
 

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -128,41 +129,45 @@ func TestAverageRefreshTime(t *testing.T) {
 	refresher := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
 	checkAverageRefreshTime := func(expected time.Duration) error {
-		cache.InvalidateTableStats(ctx, tableID)
-		stats, err := cache.GetTableStats(ctx, tableID)
-		if err != nil {
-			return err
-		}
-		if actual := avgRefreshTime(stats).Round(time.Minute); actual != expected {
-			return fmt.Errorf("expected avgRefreshTime %s but found %s",
-				expected.String(), actual.String())
-		}
-		return nil
+		cache.RefreshTableStats(ctx, tableID)
+		return testutils.SucceedsSoonError(func() error {
+			stats, err := cache.GetTableStats(ctx, tableID)
+			if err != nil {
+				return err
+			}
+			if actual := avgRefreshTime(stats).Round(time.Minute); actual != expected {
+				return fmt.Errorf("expected avgRefreshTime %s but found %s",
+					expected.String(), actual.String())
+			}
+			return nil
+		})
 	}
 
 	// Checks that the most recent statistic was created less than (greater than)
 	// expectedAge time ago if lessThan is true (false).
 	checkMostRecentStat := func(expectedAge time.Duration, lessThan bool) error {
-		cache.InvalidateTableStats(ctx, tableID)
-		stats, err := cache.GetTableStats(ctx, tableID)
-		if err != nil {
-			return err
-		}
-		stat := mostRecentAutomaticStat(stats)
-		if stat == nil {
-			return fmt.Errorf("no recent automatic statistic found")
-		}
-		if !lessThan && stat.CreatedAt.After(timeutil.Now().Add(-1*expectedAge)) {
-			return fmt.Errorf("most recent stat is less than %s old. Created at: %s Current time: %s",
-				expectedAge, stat.CreatedAt, timeutil.Now(),
-			)
-		}
-		if lessThan && stat.CreatedAt.Before(timeutil.Now().Add(-1*expectedAge)) {
-			return fmt.Errorf("most recent stat is more than %s old. Created at: %s Current time: %s",
-				expectedAge, stat.CreatedAt, timeutil.Now(),
-			)
-		}
-		return nil
+		cache.RefreshTableStats(ctx, tableID)
+		return testutils.SucceedsSoonError(func() error {
+			stats, err := cache.GetTableStats(ctx, tableID)
+			if err != nil {
+				return err
+			}
+			stat := mostRecentAutomaticStat(stats)
+			if stat == nil {
+				return fmt.Errorf("no recent automatic statistic found")
+			}
+			if !lessThan && stat.CreatedAt.After(timeutil.Now().Add(-1*expectedAge)) {
+				return fmt.Errorf("most recent stat is less than %s old. Created at: %s Current time: %s",
+					expectedAge, stat.CreatedAt, timeutil.Now(),
+				)
+			}
+			if lessThan && stat.CreatedAt.Before(timeutil.Now().Add(-1*expectedAge)) {
+				return fmt.Errorf("most recent stat is more than %s old. Created at: %s Current time: %s",
+					expectedAge, stat.CreatedAt, timeutil.Now(),
+				)
+			}
+			return nil
+		})
 	}
 
 	// Since there are no stats yet, avgRefreshTime should return the default
@@ -446,13 +451,15 @@ func TestDefaultColumns(t *testing.T) {
 func checkStatsCount(
 	ctx context.Context, cache *TableStatisticsCache, tableID sqlbase.ID, expected int,
 ) error {
-	cache.InvalidateTableStats(ctx, tableID)
-	stats, err := cache.GetTableStats(ctx, tableID)
-	if err != nil {
-		return err
-	}
-	if len(stats) != expected {
-		return fmt.Errorf("expected %d stat(s) but found %d", expected, len(stats))
-	}
-	return nil
+	cache.RefreshTableStats(ctx, tableID)
+	return testutils.SucceedsSoonError(func() error {
+		stats, err := cache.GetTableStats(ctx, tableID)
+		if err != nil {
+			return err
+		}
+		if len(stats) != expected {
+			return fmt.Errorf("expected %d stat(s) but found %d", expected, len(stats))
+		}
+		return nil
+	})
 }

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -257,37 +258,45 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 			return err
 		}
 
-		cache.InvalidateTableStats(ctx, tableID)
-		tableStats, err := cache.GetTableStats(ctx, tableID)
-		if err != nil {
-			return err
-		}
-
+		cache.RefreshTableStats(ctx, tableID)
 		for i := range testData {
 			stat := &testData[i]
 			if stat.TableID != tableID {
-				cache.InvalidateTableStats(ctx, stat.TableID)
-				stats, err := cache.GetTableStats(ctx, stat.TableID)
-				if err != nil {
-					return err
-				}
-				// No stats from other tables should be deleted.
-				if err := findStat(
-					stats, stat.TableID, stat.StatisticID, false, /* expectDeleted */
-				); err != nil {
-					return err
-				}
-				continue
-			}
-
-			// Check whether this stat should have been deleted.
-			_, expectDeleted := expectDeleted[stat.StatisticID]
-			if err := findStat(tableStats, tableID, stat.StatisticID, expectDeleted); err != nil {
-				return err
+				cache.RefreshTableStats(ctx, stat.TableID)
 			}
 		}
 
-		return nil
+		return testutils.SucceedsSoonError(func() error {
+			tableStats, err := cache.GetTableStats(ctx, tableID)
+			if err != nil {
+				return err
+			}
+
+			for i := range testData {
+				stat := &testData[i]
+				if stat.TableID != tableID {
+					stats, err := cache.GetTableStats(ctx, stat.TableID)
+					if err != nil {
+						return err
+					}
+					// No stats from other tables should be deleted.
+					if err := findStat(
+						stats, stat.TableID, stat.StatisticID, false, /* expectDeleted */
+					); err != nil {
+						return err
+					}
+					continue
+				}
+
+				// Check whether this stat should have been deleted.
+				_, expectDeleted := expectDeleted[stat.StatisticID]
+				if err := findStat(tableStats, tableID, stat.StatisticID, expectDeleted); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
 	}
 
 	expectDeleted := make(map[uint64]struct{}, len(testData))

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -106,7 +106,7 @@ func (sc *TableStatisticsCache) tableStatAddedGossipUpdate(key string, value roa
 		log.Errorf(context.Background(), "tableStatAddedGossipUpdate(%s) error: %v", key, err)
 		return
 	}
-	sc.InvalidateTableStats(context.Background(), sqlbase.ID(tableID))
+	sc.RefreshTableStats(context.Background(), sqlbase.ID(tableID))
 }
 
 // GetTableStats looks up statistics for the requested table ID in the cache,
@@ -130,8 +130,8 @@ func (sc *TableStatisticsCache) GetTableStats(
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
-	if found, stats, err := sc.lookupStatsLocked(ctx, tableID); found {
-		return stats, err
+	if found, e := sc.lookupStatsLocked(ctx, tableID); found {
+		return e.stats, e.err
 	}
 
 	return sc.addCacheEntryLocked(ctx, tableID)
@@ -146,12 +146,12 @@ func (sc *TableStatisticsCache) GetTableStats(
 // locked again if we need to wait (this can only happen when found=true).
 func (sc *TableStatisticsCache) lookupStatsLocked(
 	ctx context.Context, tableID sqlbase.ID,
-) (found bool, _ []*TableStatistic, _ error) {
+) (found bool, e *cacheEntry) {
 	eUntyped, ok := sc.mu.cache.Get(tableID)
 	if !ok {
-		return false, nil, nil
+		return false, nil
 	}
-	e := eUntyped.(*cacheEntry)
+	e = eUntyped.(*cacheEntry)
 
 	if e.mustWait {
 		// We are in the process of grabbing stats for this table. Wait until
@@ -165,7 +165,7 @@ func (sc *TableStatisticsCache) lookupStatsLocked(
 			log.Infof(ctx, "statistics for table %d found in cache", tableID)
 		}
 	}
-	return true, e.stats, e.err
+	return true, e
 }
 
 // addCacheEntryLocked creates a new cache entry and retrieves table statistics
@@ -213,7 +213,65 @@ func (sc *TableStatisticsCache) addCacheEntryLocked(
 	return stats, err
 }
 
+// refreshCacheEntry retrieves table statistics from the database and updates
+// an existing cache entry. It does this in a way so that the other goroutines
+// can continue using the stale stats from the existing entry until the new
+// stats are added:
+//  - the existing cache entry is retrieved;
+//  - mutex is unlocked;
+//  - stats are retrieved from database:
+//  - mutex is locked again and the entry is updated.
+//
+func (sc *TableStatisticsCache) refreshCacheEntry(ctx context.Context, tableID sqlbase.ID) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	if log.V(1) {
+		log.Infof(ctx, "reading statistics for table %d", tableID)
+	}
+
+	// If the stats don't already exist in the cache, don't bother performing
+	// the refresh. If e.err is not nil, the stats are in the process of being
+	// removed from the cache (see addCacheEntryLocked), so don't refresh in this
+	// case either.
+	found, e := sc.lookupStatsLocked(ctx, tableID)
+	if !found || e.err != nil {
+		return
+	}
+	sc.mu.numInternalQueries++
+
+	var stats []*TableStatistic
+	var err error
+	func() {
+		sc.mu.Unlock()
+		defer sc.mu.Lock()
+
+		stats, err = sc.getTableStatsFromDB(ctx, tableID)
+	}()
+
+	e.stats, e.err = stats, err
+
+	if err != nil {
+		// Don't keep the cache entry around, so that we retry the query.
+		sc.mu.cache.Del(tableID)
+	}
+}
+
+// RefreshTableStats refreshes the cached statistics for the given table ID
+// by fetching the new stats from the database.
+func (sc *TableStatisticsCache) RefreshTableStats(ctx context.Context, tableID sqlbase.ID) {
+	if log.V(1) {
+		log.Infof(ctx, "refreshing statistics for table %d", tableID)
+	}
+	// Perform an asynchronous refresh of the cache.
+	go sc.refreshCacheEntry(ctx, tableID)
+}
+
 // InvalidateTableStats invalidates the cached statistics for the given table ID.
+//
+// Note that RefreshTableStats should normally be used instead of this function.
+// This function is used only when we want to guarantee that the next query
+// uses updated stats.
 func (sc *TableStatisticsCache) InvalidateTableStats(ctx context.Context, tableID sqlbase.ID) {
 	if log.V(1) {
 		log.Infof(ctx, "evicting statistics for table %d", tableID)

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -63,10 +63,24 @@ type TableStatisticsCache struct {
 // The cache stores *cacheEntry objects. The fields are protected by the
 // cache-wide mutex.
 type cacheEntry struct {
-	// If true, we are in the process of updating the statistics for this
-	// table. Other callers can wait on the waitCond until this is false.
+	// If mustWait is true, we do not have any statistics for this table and we
+	// are in the process of fetching the stats from the database. Other callers
+	// can wait on the waitCond until this is false.
 	mustWait bool
 	waitCond sync.Cond
+
+	// If refreshing is true, the current statistics for this table are stale,
+	// and we are in the process of fetching the updated stats from the database.
+	// In the mean time, other callers can use the stale stats and do not need to
+	// wait.
+	//
+	// If a goroutine tries to perform a refresh when a refresh is already
+	// in progress, it will see that refreshing=true and will set the
+	// mustRefreshAgain flag to true before returning. When the original
+	// goroutine that was performing the refresh returns from the database and
+	// sees that mustRefreshAgain=true, it will trigger another refresh.
+	refreshing       bool
+	mustRefreshAgain bool
 
 	stats []*TableStatistic
 
@@ -238,18 +252,33 @@ func (sc *TableStatisticsCache) refreshCacheEntry(ctx context.Context, tableID s
 	if !found || e.err != nil {
 		return
 	}
-	sc.mu.numInternalQueries++
+
+	// Don't perform a refresh if a refresh is already in progress, but let that
+	// goroutine know it needs to refresh again.
+	if e.refreshing {
+		e.mustRefreshAgain = true
+		return
+	}
+	e.refreshing = true
 
 	var stats []*TableStatistic
 	var err error
-	func() {
-		sc.mu.Unlock()
-		defer sc.mu.Lock()
+	for {
+		func() {
+			sc.mu.numInternalQueries++
+			sc.mu.Unlock()
+			defer sc.mu.Lock()
 
-		stats, err = sc.getTableStatsFromDB(ctx, tableID)
-	}()
+			stats, err = sc.getTableStatsFromDB(ctx, tableID)
+		}()
+		if !e.mustRefreshAgain {
+			break
+		}
+		e.mustRefreshAgain = false
+	}
 
 	e.stats, e.err = stats, err
+	e.refreshing = false
 
 	if err != nil {
 		// Don't keep the cache entry around, so that we retry the query.

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -326,7 +326,7 @@ func TestCacheWait(t *testing.T) {
 		before := sc.mu.numInternalQueries
 
 		id := tableIDs[rand.Intn(len(tableIDs))]
-		sc.RefreshTableStats(ctx, id)
+		sc.InvalidateTableStats(ctx, id)
 		// Run GetTableStats multiple times in parallel.
 		var wg sync.WaitGroup
 		for n := 0; n < 10; n++ {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "stats: don't delete stale cache entries, update them asynchronously instead" (#51616)
  * 1/1 commits from "opt: fix flake in TestExecBuild due to new stats cache refresh mechanism" (#51780)
  * 1/1 commits from "stats: fix race condition when refreshing cache" (#51805)
  * 2/2 commits from "sql,stats: fix flakes in TestCacheWait and TestQueryCache" (#51828)

Please see individual PRs for details.

/cc @cockroachdb/release
