### PR TITLE
sql: don't allocate strings in COPY if there were no escaped chars

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -483,6 +483,11 @@ func decodeCopy(in string) string {
 		}
 		start = i + 1
 	}
+	// If there were no backslashes in the input string, we can simply
+	// return it.
+	if start == 0 {
+		return in
+	}
 	if start < len(in) {
 		buf.WriteString(in[start:])
 	}

--- a/pkg/sql/copy_test.go
+++ b/pkg/sql/copy_test.go
@@ -26,6 +26,10 @@ func TestDecodeCopy(t *testing.T) {
 		expect string
 	}{
 		{
+			in:     "simple",
+			expect: "simple",
+		},
+		{
 			in:     `new\nline`,
 			expect: "new\nline",
 		},
@@ -82,5 +86,17 @@ func TestDecodeCopy(t *testing.T) {
 				t.Errorf("%q: got %q, expected %q", test.in, out, test.expect)
 			}
 		})
+	}
+}
+
+func BenchmarkDecodeCopySimple(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		decodeCopy("test string")
+	}
+}
+
+func BenchmarkDecodeCopyEscaped(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		decodeCopy(`string \x1 with escape`)
 	}
 }


### PR DESCRIPTION
Previously we would always write to a buffer and allocate a string.

```
name                  old time/op    new time/op    delta
DecodeCopySimple-12      156ns ± 2%      10ns ± 2%   -93.35%  (p=0.008 n=5+5)
DecodeCopyEscaped-12     244ns ± 4%     245ns ± 3%      ~     (p=0.905 n=5+5)

name                  old alloc/op   new alloc/op   delta
DecodeCopySimple-12      80.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
DecodeCopyEscaped-12     96.0B ± 0%     96.0B ± 0%      ~     (all equal)

name                  old allocs/op  new allocs/op  delta
DecodeCopySimple-12       2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
DecodeCopyEscaped-12      2.00 ± 0%      2.00 ± 0%      ~     (all equal)
```

Release note: None