### PR TITLE
sql: clean up EXPLAIN node names

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -383,7 +383,7 @@ SELECT index_id, index_name FROM crdb_internal.table_indexes WHERE descriptor_na
 query TTT
 SELECT * FROM [EXPLAIN SELECT * FROM t@i1] OFFSET 2
 ----
-index-join  ·            ·
+index join  ·            ·
  │          table        t@primary
  │          key columns  y
  └── scan   ·            ·
@@ -398,7 +398,7 @@ SELECT * FROM t@i1
 query TTT
 SELECT * FROM [EXPLAIN SELECT * FROM t@i2] OFFSET 2
 ----
-index-join  ·            ·
+index join  ·            ·
  │          table        t@primary
  │          key columns  y
  └── scan   ·            ·
@@ -413,7 +413,7 @@ SELECT * FROM t@i2
 query TTT
 SELECT * FROM [EXPLAIN SELECT * FROM t@i3] OFFSET 2
 ----
-index-join  ·            ·
+index join  ·            ·
  │          table        t@primary
  │          key columns  y
  └── scan   ·            ·
@@ -428,7 +428,7 @@ SELECT * FROM t@i3
 query TTT
 SELECT * FROM [EXPLAIN SELECT * FROM t@i4] OFFSET 2
 ----
-index-join  ·            ·
+index join  ·            ·
  │          table        t@primary
  │          key columns  y
  └── scan   ·            ·
@@ -443,7 +443,7 @@ SELECT * FROM t@i4
 query TTT
 SELECT * FROM [EXPLAIN SELECT * FROM t@i5] OFFSET 2
 ----
-index-join  ·            ·
+index join  ·            ·
  │          table        t@primary
  │          key columns  y
  └── scan   ·            ·
@@ -458,7 +458,7 @@ SELECT * FROM t@i5
 query TTT
 SELECT * FROM [EXPLAIN SELECT * FROM t@i7] OFFSET 2
 ----
-index-join  ·            ·
+index join  ·            ·
  │          table        t@primary
  │          key columns  y
  └── scan   ·            ·
@@ -501,7 +501,7 @@ query TTT
 SELECT * FROM [EXPLAIN INSERT INTO t VALUES (4, 5, 6)] OFFSET 2
 ----
 count                  ·            ·
- └── insert-fast-path  ·            ·
+ └── insert fast path  ·            ·
 ·                      into         t(x, y, z, crdb_internal_z_shard_5, crdb_internal_y_shard_10)
 ·                      strategy     inserter
 ·                      auto commit  ·

--- a/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_explain_local
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial_explain_local
@@ -32,11 +32,11 @@ EXPLAIN SELECT k, k_plus_one FROM geo_table2 WHERE ST_Intersects('POINT(3.0 3.0)
 render                               ·                ·
  └── filter                          ·                ·
       │                              filter           st_intersects('010100000000000000000008400000000000000840', geom)
-      └── index-join                 ·                ·
+      └── index join                 ·                ·
            │                         table            geo_table2@primary
            │                         key columns      k, k_plus_one
            └── render                ·                ·
-                └── inverted-filter  ·                ·
+                └── inverted filter  ·                ·
                      │               inverted column  2
                      │               num spans        31
                      └── scan        ·                ·
@@ -51,11 +51,11 @@ EXPLAIN SELECT k, k_plus_one FROM geo_table2 WHERE ST_DFullyWithin('POINT(3.0 3.
 render                               ·                ·
  └── filter                          ·                ·
       │                              filter           st_dfullywithin('010100000000000000000008400000000000000840', geom, 1.0)
-      └── index-join                 ·                ·
+      └── index join                 ·                ·
            │                         table            geo_table2@primary
            │                         key columns      k, k_plus_one
            └── render                ·                ·
-                └── inverted-filter  ·                ·
+                └── inverted filter  ·                ·
                      │               inverted column  2
                      │               num spans        20
                      └── scan        ·                ·

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_explain
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_explain
@@ -30,7 +30,7 @@ FROM ltable JOIN rtable@geom_index ON ST_Intersects(ltable.geom, rtable.geom)
 ·                             distribution           local
 ·                             vectorized             true
 render                        ·                      ·
- └── lookup-join              ·                      ·
+ └── lookup join              ·                      ·
       │                       table                  rtable@primary
       │                       type                   inner
       │                       equality               (rk1, rk2) = (rk1, rk2)
@@ -38,7 +38,7 @@ render                        ·                      ·
       │                       parallel               ·
       │                       pred                   st_intersects(geom, geom)
       └── render              ·                      ·
-           └── inverted-join  ·                      ·
+           └── inverted join  ·                      ·
                 │             table                  rtable@geom_index
                 │             type                   inner
                 │             ·                      st_intersects(@2, @4)
@@ -54,7 +54,7 @@ FROM ltable JOIN rtable@geom_index ON ST_DWithin(ltable.geom, rtable.geom, 5)
 ·                             distribution           local
 ·                             vectorized             true
 render                        ·                      ·
- └── lookup-join              ·                      ·
+ └── lookup join              ·                      ·
       │                       table                  rtable@primary
       │                       type                   inner
       │                       equality               (rk1, rk2) = (rk1, rk2)
@@ -62,7 +62,7 @@ render                        ·                      ·
       │                       parallel               ·
       │                       pred                   st_dwithin(geom, geom, 5.0)
       └── render              ·                      ·
-           └── inverted-join  ·                      ·
+           └── inverted join  ·                      ·
                 │             table                  rtable@geom_index
                 │             type                   inner
                 │             ·                      st_dwithin(@2, @4, 5.0)

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -222,7 +222,7 @@ group                      ·             ·                             (count)
       │                    distinct on   column11                      ·             ·
       └── render           ·             ·                             (column11)    ·
            │               render 0      ((k, v, w, s) AS k, v, w, s)  ·             ·
-           └── cross-join  ·             ·                             (k, v, w, s)  ·
+           └── cross join  ·             ·                             (k, v, w, s)  ·
                 │          type          cross                         ·             ·
                 ├── scan   ·             ·                             (k, v, w, s)  ·
                 │          table         kv@primary                    ·             ·
@@ -244,7 +244,7 @@ render                ·             ·
       │               aggregate 0   k
       │               aggregate 1   min(k)
       │               group by      k
-      └── cross-join  ·             ·
+      └── cross join  ·             ·
            │          type          cross
            ├── scan   ·             ·
            │          table         kv@primary
@@ -266,7 +266,7 @@ render                ·             ·
       │               aggregate 0   k
       │               aggregate 1   min(k)
       │               group by      k
-      └── cross-join  ·             ·
+      └── cross join  ·             ·
            │          type          cross
            ├── scan   ·             ·
            │          table         kv@primary
@@ -289,7 +289,7 @@ render                ·             ·
       │               aggregate 0   k
       │               aggregate 1   min(k)
       │               group by      k
-      └── cross-join  ·             ·
+      └── cross join  ·             ·
            │          type          cross
            ├── scan   ·             ·
            │          table         kv@primary
@@ -310,7 +310,7 @@ render                ·             ·
  │                    render 0      v
  └── distinct         ·             ·
       │               distinct on   v, w, s
-      └── cross-join  ·             ·
+      └── cross join  ·             ·
            │          type          cross
            ├── scan   ·             ·
            │          table         kv@primary
@@ -726,7 +726,7 @@ render                ·             ·                                 (sum dec
       │               aggregate 0   k                                 ·                     ·
       │               aggregate 1   sum(d)                            ·                     ·
       │               group by      k                                 ·                     ·
-      └── cross-join  ·             ·                                 (k int, d decimal)    ·
+      └── cross join  ·             ·                                 (k int, d decimal)    ·
            │          type          inner                             ·                     ·
            │          pred          ((k)[int] >= (d)[decimal])[bool]  ·                     ·
            ├── scan   ·             ·                                 (k int)               ·
@@ -836,7 +836,7 @@ render                ·             ·                                         
       │               aggregate 2   min(y)                                              ·                                                ·
       │               aggregate 3   any_not_null(b)                                     ·                                                ·
       │               group by      a, x                                                ·                                                ·
-      └── cross-join  ·             ·                                                   (a int, b int, x string, y string)               ·
+      └── cross join  ·             ·                                                   (a int, b int, x string, y string)               ·
            │          type          cross                                               ·                                                ·
            ├── scan   ·             ·                                                   (a int, b int)                                   ·
            │          table         ab@primary                                          ·                                                ·
@@ -1097,7 +1097,7 @@ group                ·             ·             (count)  ·
  │                   aggregate 0   count_rows()  ·        ·
  │                   scalar        ·             ·        ·
  └── render          ·             ·             ()       ·
-      └── hash-join  ·             ·             (y, v)   ·
+      └── hash join  ·             ·             (y, v)   ·
            │         type          inner         ·        ·
            │         equality      (y) = (v)     ·        ·
            ├── scan  ·             ·             (y)      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -337,24 +337,24 @@ CREATE TABLE external_ref (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                           distribution  local
-·                           vectorized    false
-root                        ·             ·
- ├── count                  ·             ·
- │    └── delete            ·             ·
- │         │                from          parent
- │         │                strategy      deleter
- │         └── buffer node  ·             ·
- │              │           label         buffer 1
- │              └── scan    ·             ·
- │                          table         parent@primary
- │                          spans         /11-
- ├── fk-cascade             ·             ·
- │                          fk            fk_pid_ref_parent
- │                          input         buffer 1
- └── fk-cascade             ·             ·
-·                           fk            fk_pid_ref_parent
-·                           input         buffer 1
+·                         distribution  local
+·                         vectorized    false
+root                      ·             ·
+ ├── count                ·             ·
+ │    └── delete          ·             ·
+ │         │              from          parent
+ │         │              strategy      deleter
+ │         └── buffer     ·             ·
+ │              │         label         buffer 1
+ │              └── scan  ·             ·
+ │                        table         parent@primary
+ │                        spans         /11-
+ ├── fk-cascade           ·             ·
+ │                        fk            fk_pid_ref_parent
+ │                        input         buffer 1
+ └── fk-cascade           ·             ·
+·                         fk            fk_pid_ref_parent
+·                         input         buffer 1
 
 statement ok
 DROP TABLE external_ref
@@ -373,40 +373,40 @@ CREATE TABLE child_with_index (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                                          distribution        local
-·                                          vectorized          false
-root                                       ·                   ·
- ├── count                                 ·                   ·
- │    └── delete                           ·                   ·
- │         │                               from                parent
- │         │                               strategy            deleter
- │         └── buffer node                 ·                   ·
- │              │                          label               buffer 1
- │              └── scan                   ·                   ·
- │                                         table               parent@primary
- │                                         spans               /11-
- ├── fk-cascade                            ·                   ·
- │                                         fk                  fk_pid_ref_parent
- │                                         input               buffer 1
- ├── fk-cascade                            ·                   ·
- │                                         fk                  fk_pid_ref_parent
- │                                         input               buffer 1
- └── fk-check                              ·                   ·
-      └── error if rows                    ·                   ·
-           └── render                      ·                   ·
-                └── hash-join              ·                   ·
-                     │                     type                inner
-                     │                     equality            (id) = (pid)
-                     │                     left cols are key   ·
-                     │                     right cols are key  ·
-                     ├── scan buffer node  ·                   ·
-                     │                     label               buffer 1
-                     └── distinct          ·                   ·
-                          │                distinct on         pid
-                          │                order key           pid
-                          └── scan         ·                   ·
-·                                          table               child_with_index@primary
-·                                          spans               FULL SCAN
+·                                     distribution        local
+·                                     vectorized          false
+root                                  ·                   ·
+ ├── count                            ·                   ·
+ │    └── delete                      ·                   ·
+ │         │                          from                parent
+ │         │                          strategy            deleter
+ │         └── buffer                 ·                   ·
+ │              │                     label               buffer 1
+ │              └── scan              ·                   ·
+ │                                    table               parent@primary
+ │                                    spans               /11-
+ ├── fk-cascade                       ·                   ·
+ │                                    fk                  fk_pid_ref_parent
+ │                                    input               buffer 1
+ ├── fk-cascade                       ·                   ·
+ │                                    fk                  fk_pid_ref_parent
+ │                                    input               buffer 1
+ └── fk-check                         ·                   ·
+      └── error if rows               ·                   ·
+           └── render                 ·                   ·
+                └── hash join         ·                   ·
+                     │                type                inner
+                     │                equality            (id) = (pid)
+                     │                left cols are key   ·
+                     │                right cols are key  ·
+                     ├── scan buffer  ·                   ·
+                     │                label               buffer 1
+                     └── distinct     ·                   ·
+                          │           distinct on         pid
+                          │           order key           pid
+                          └── scan    ·                   ·
+·                                     table               child_with_index@primary
+·                                     spans               FULL SCAN
 
 statement ok
 DROP TABLE child_with_index
@@ -423,40 +423,40 @@ CREATE TABLE child_without_cascade (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                                          distribution        local
-·                                          vectorized          false
-root                                       ·                   ·
- ├── count                                 ·                   ·
- │    └── delete                           ·                   ·
- │         │                               from                parent
- │         │                               strategy            deleter
- │         └── buffer node                 ·                   ·
- │              │                          label               buffer 1
- │              └── scan                   ·                   ·
- │                                         table               parent@primary
- │                                         spans               /11-
- ├── fk-cascade                            ·                   ·
- │                                         fk                  fk_pid_ref_parent
- │                                         input               buffer 1
- ├── fk-cascade                            ·                   ·
- │                                         fk                  fk_pid_ref_parent
- │                                         input               buffer 1
- └── fk-check                              ·                   ·
-      └── error if rows                    ·                   ·
-           └── render                      ·                   ·
-                └── hash-join              ·                   ·
-                     │                     type                inner
-                     │                     equality            (id) = (pid)
-                     │                     left cols are key   ·
-                     │                     right cols are key  ·
-                     ├── scan buffer node  ·                   ·
-                     │                     label               buffer 1
-                     └── distinct          ·                   ·
-                          │                distinct on         pid
-                          │                order key           pid
-                          └── scan         ·                   ·
-·                                          table               child_without_cascade@primary
-·                                          spans               FULL SCAN
+·                                     distribution        local
+·                                     vectorized          false
+root                                  ·                   ·
+ ├── count                            ·                   ·
+ │    └── delete                      ·                   ·
+ │         │                          from                parent
+ │         │                          strategy            deleter
+ │         └── buffer                 ·                   ·
+ │              │                     label               buffer 1
+ │              └── scan              ·                   ·
+ │                                    table               parent@primary
+ │                                    spans               /11-
+ ├── fk-cascade                       ·                   ·
+ │                                    fk                  fk_pid_ref_parent
+ │                                    input               buffer 1
+ ├── fk-cascade                       ·                   ·
+ │                                    fk                  fk_pid_ref_parent
+ │                                    input               buffer 1
+ └── fk-check                         ·                   ·
+      └── error if rows               ·                   ·
+           └── render                 ·                   ·
+                └── hash join         ·                   ·
+                     │                type                inner
+                     │                equality            (id) = (pid)
+                     │                left cols are key   ·
+                     │                right cols are key  ·
+                     ├── scan buffer  ·                   ·
+                     │                label               buffer 1
+                     └── distinct     ·                   ·
+                          │           distinct on         pid
+                          │           order key           pid
+                          └── scan    ·                   ·
+·                                     table               child_without_cascade@primary
+·                                     spans               FULL SCAN
 
 statement ok
 DROP TABLE child_without_cascade
@@ -472,24 +472,24 @@ CREATE TABLE child_without_fk (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                           distribution  local
-·                           vectorized    false
-root                        ·             ·
- ├── count                  ·             ·
- │    └── delete            ·             ·
- │         │                from          parent
- │         │                strategy      deleter
- │         └── buffer node  ·             ·
- │              │           label         buffer 1
- │              └── scan    ·             ·
- │                          table         parent@primary
- │                          spans         /11-
- ├── fk-cascade             ·             ·
- │                          fk            fk_pid_ref_parent
- │                          input         buffer 1
- └── fk-cascade             ·             ·
-·                           fk            fk_pid_ref_parent
-·                           input         buffer 1
+·                         distribution  local
+·                         vectorized    false
+root                      ·             ·
+ ├── count                ·             ·
+ │    └── delete          ·             ·
+ │         │              from          parent
+ │         │              strategy      deleter
+ │         └── buffer     ·             ·
+ │              │         label         buffer 1
+ │              └── scan  ·             ·
+ │                        table         parent@primary
+ │                        spans         /11-
+ ├── fk-cascade           ·             ·
+ │                        fk            fk_pid_ref_parent
+ │                        input         buffer 1
+ └── fk-cascade           ·             ·
+·                         fk            fk_pid_ref_parent
+·                         input         buffer 1
 
 statement ok
 DROP TABLE child_without_fk
@@ -511,18 +511,18 @@ CREATE TABLE abc (
 query TTT
 EXPLAIN DELETE FROM ab WHERE a = 1
 ----
-·                           distribution  local
-·                           vectorized    false
-root                        ·             ·
- ├── count                  ·             ·
- │    └── delete            ·             ·
- │         │                from          ab
- │         │                strategy      deleter
- │         └── buffer node  ·             ·
- │              │           label         buffer 1
- │              └── scan    ·             ·
- │                          table         ab@primary
- │                          spans         /1-/2
- └── fk-cascade             ·             ·
-·                           fk            fk_b_ref_ab
-·                           input         buffer 1
+·                         distribution  local
+·                         vectorized    false
+root                      ·             ·
+ ├── count                ·             ·
+ │    └── delete          ·             ·
+ │         │              from          ab
+ │         │              strategy      deleter
+ │         └── buffer     ·             ·
+ │              │         label         buffer 1
+ │              └── scan  ·             ·
+ │                        table         ab@primary
+ │                        spans         /1-/2
+ └── fk-cascade           ·             ·
+·                         fk            fk_b_ref_ab
+·                         input         buffer 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -195,7 +195,7 @@ EXPLAIN SELECT * FROM parent1 JOIN child1 USING(pid1)
 ·                distribution       full
 ·                vectorized         true
 render           ·                  ·
- └── merge-join  ·                  ·
+ └── merge join  ·                  ·
       │          type               inner
       │          equality           (pid1) = (pid1)
       │          left cols are key  ·
@@ -216,7 +216,7 @@ EXPLAIN SELECT * FROM parent1 JOIN child1 USING(pid1)
 ·                      distribution  full
 ·                      vectorized    true
 render                 ·             ·
- └── interleaved-join  ·             ·
+ └── interleaved join  ·             ·
 ·                      type          inner
 ·                      left table    parent1@primary
 ·                      left spans    FULL SCAN
@@ -239,7 +239,7 @@ render                 ·             ·                    (pid1, pa1, cid1, ca
  │                     render 1      pa1                  ·                             ·
  │                     render 2      cid1                 ·                             ·
  │                     render 3      ca1                  ·                             ·
- └── interleaved-join  ·             ·                    (pid1, pa1, pid1, cid1, ca1)  ·
+ └── interleaved join  ·             ·                    (pid1, pa1, pid1, cid1, ca1)  ·
 ·                      type          inner                ·                             ·
 ·                      left table    parent1@primary      ·                             ·
 ·                      left spans    /3-/5/#              ·                             ·
@@ -263,7 +263,7 @@ render                 ·             ·                    (pid1, cid1, ca1, pa
  │                     render 1      cid1                 ·                             ·
  │                     render 2      ca1                  ·                             ·
  │                     render 3      pa1                  ·                             ·
- └── interleaved-join  ·             ·                    (pid1, cid1, ca1, pid1, pa1)  ·
+ └── interleaved join  ·             ·                    (pid1, cid1, ca1, pid1, pa1)  ·
 ·                      type          inner                ·                             ·
 ·                      left table    child1@primary       ·                             ·
 ·                      left spans    /3/#/55/1-/5/#/55/2  ·                             ·
@@ -284,7 +284,7 @@ EXPLAIN (VERBOSE) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid
 ----
 ·                 distribution  full                   ·                             ·
 ·                 vectorized    true                   ·                             ·
-interleaved-join  ·             ·                      (pid1, pa1, pid1, cid1, ca1)  +pid1
+interleaved join  ·             ·                      (pid1, pa1, pid1, cid1, ca1)  +pid1
 ·                 type          inner                  ·                             ·
 ·                 left table    parent1@primary        ·                             ·
 ·                 left spans    /29-/31/#              ·                             ·
@@ -315,7 +315,7 @@ render                 ·             ·                (pid1, pa1, cid2, cid3, 
  │                     render 2      cid2             ·                                   ·
  │                     render 3      cid3             ·                                   ·
  │                     render 4      ca2              ·                                   ·
- └── interleaved-join  ·             ·                (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
+ └── interleaved join  ·             ·                (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
 ·                      type          inner            ·                                   ·
 ·                      left table    parent1@primary  ·                                   ·
 ·                      left spans    /12-             ·                                   ·
@@ -340,7 +340,7 @@ render                 ·             ·                                        
  │                     render 2      cid2                                                                                   ·                                   ·
  │                     render 3      cid3                                                                                   ·                                   ·
  │                     render 4      ca2                                                                                    ·                                   ·
- └── interleaved-join  ·             ·                                                                                      (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
+ └── interleaved join  ·             ·                                                                                      (pid1, pa1, pid1, cid2, cid3, ca2)  +pid1
 ·                      type          inner                                                                                  ·                                   ·
 ·                      left table    parent1@primary                                                                        ·                                   ·
 ·                      left spans    /1-/1/# /11-/11/# /21-/21/# /31-/31/#                                                  ·                                   ·
@@ -372,7 +372,7 @@ render                 ·             ·                                        
  │                     render 3      cid3                                                                                                                    ·                                           ·
  │                     render 4      gcid2                                                                                                                   ·                                           ·
  │                     render 5      gca2                                                                                                                    ·                                           ·
- └── interleaved-join  ·             ·                                                                                                                       (pid1, pa1, pid1, cid2, cid3, gcid2, gca2)  ·
+ └── interleaved join  ·             ·                                                                                                                       (pid1, pa1, pid1, cid2, cid3, gcid2, gca2)  ·
 ·                      type          inner                                                                                                                   ·                                           ·
 ·                      left table    parent1@primary                                                                                                         ·                                           ·
 ·                      left spans    FULL SCAN                                                                                                               ·                                           ·
@@ -409,7 +409,7 @@ render                 ·             ·                                        
  │                     render 3      gcid2                                                                                                                   ·                                           ·
  │                     render 4      gca2                                                                                                                    ·                                           ·
  │                     render 5      pa1                                                                                                                     ·                                           ·
- └── interleaved-join  ·             ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2, pid1, pa1)  ·
+ └── interleaved join  ·             ·                                                                                                                       (pid1, cid2, cid3, gcid2, gca2, pid1, pa1)  ·
 ·                      type          inner                                                                                                                   ·                                           ·
 ·                      left table    grandchild2@primary                                                                                                     ·                                           ·
 ·                      left spans    FULL SCAN                                                                                                               ·                                           ·
@@ -439,7 +439,7 @@ EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
 ·                      distribution  full
 ·                      vectorized    true
 render                 ·             ·
- └── interleaved-join  ·             ·
+ └── interleaved join  ·             ·
 ·                      type          inner
 ·                      left table    grandchild2@primary
 ·                      left spans    FULL SCAN
@@ -478,7 +478,7 @@ EXPLAIN
 ----
 ·                 distribution  full
 ·                 vectorized    true
-interleaved-join  ·             ·
+interleaved join  ·             ·
 ·                 type          inner
 ·                 left table    child2@primary
 ·                 left spans    FULL SCAN
@@ -576,7 +576,7 @@ render                 ·             ·                     (pid1, pa1, cid1, c
  │                     render 2      cid1                  ·                                   ·
  │                     render 3      cid2                  ·                                   ·
  │                     render 4      ca1                   ·                                   ·
- └── interleaved-join  ·             ·                     (pid1, pa1, pid1, cid1, cid2, ca1)  ·
+ └── interleaved join  ·             ·                     (pid1, pa1, pid1, cid1, cid2, ca1)  ·
 ·                      type          full outer            ·                                   ·
 ·                      left table    outer_p1@primary      ·                                   ·
 ·                      left spans    FULL SCAN             ·                                   ·
@@ -601,7 +601,7 @@ render                 ·             ·                     (pid1, cid1, cid2, 
  │                     render 3      gcid1                 ·                                                       ·
  │                     render 4      gca1                  ·                                                       ·
  │                     render 5      ca1                   ·                                                       ·
- └── interleaved-join  ·             ·                     (pid1, cid1, cid2, gcid1, gca1, pid1, cid1, cid2, ca1)  ·
+ └── interleaved join  ·             ·                     (pid1, cid1, cid2, gcid1, gca1, pid1, cid1, cid2, ca1)  ·
 ·                      type          full outer            ·                                                       ·
 ·                      left table    outer_gc1@primary     ·                                                       ·
 ·                      left spans    FULL SCAN             ·                                                       ·
@@ -625,7 +625,7 @@ render                 ·             ·                     (pid1, cid1, cid2, 
  │                     render 2      cid2                  ·                                   ·
  │                     render 3      ca1                   ·                                   ·
  │                     render 4      pa1                   ·                                   ·
- └── interleaved-join  ·             ·                     (pid1, cid1, cid2, ca1, pid1, pa1)  ·
+ └── interleaved join  ·             ·                     (pid1, cid1, cid2, ca1, pid1, pa1)  ·
 ·                      type          left outer            ·                                   ·
 ·                      left table    outer_c1@primary      ·                                   ·
 ·                      left spans    /0/#/60/1-/39/#/60/2  ·                                   ·
@@ -650,7 +650,7 @@ render                 ·             ·                     (pid1, pa1, cid1, c
  │                     render 3      cid2                  ·                                           ·
  │                     render 4      gcid1                 ·                                           ·
  │                     render 5      gca1                  ·                                           ·
- └── interleaved-join  ·             ·                     (pid1, cid1, cid2, gcid1, gca1, pid1, pa1)  ·
+ └── interleaved join  ·             ·                     (pid1, cid1, cid2, gcid1, gca1, pid1, pa1)  ·
 ·                      type          left outer            ·                                           ·
 ·                      left table    outer_gc1@primary     ·                                           ·
 ·                      left spans    /1/#/60/1-/20/#/60/2  ·                                           ·
@@ -727,14 +727,14 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM (SELECT * FROM parent1 ORDER BY pid1 LIMIT 2) AS parent1 INNER MERGE JOIN child1 USING(pid1)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN (SELECT * FROM child1 ORDER BY pid1 LIMIT 10) AS child1 USING(pid1)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 statement ok
 DROP TABLE grandchild2, grandchild1, child1, child2, parent1, parent2
@@ -764,21 +764,21 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN child1 USING (pid1)
 ] WHERE node_type LIKE '%join'
 ----
-interleaved-join
+interleaved join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN child1 USING (pid1, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN child1 USING (v)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 # Parent-grandchild cases.
 # parent1-grandchild1 share interleave prefix (pid1).
@@ -787,21 +787,21 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN grandchild1 USING (pid1)
 ] WHERE node_type LIKE '%join'
 ----
-interleaved-join
+interleaved join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN grandchild1 USING (pid1, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM parent1 INNER MERGE JOIN grandchild1 USING (v)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 # Multiple-column interleave prefix.
 # child1-grandchild1 share interleave prefix (pid1, cid1, cid2).
@@ -810,21 +810,21 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1, cid2)
 ] WHERE node_type LIKE '%join'
 ----
-interleaved-join
+interleaved join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1, cid2, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (v)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 # TODO(richardwu): update these once prefix/subset of
 # interleave prefixes are permitted.
@@ -833,70 +833,70 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid2)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid2, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1, cid2)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (cid1, cid2, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid2)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid1, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 query T
 SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN grandchild1 USING (pid1, cid2, v)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 # Common ancestor example.
 # TODO(richardwu): update this when common ancestor interleaved joins are possible.
@@ -905,7 +905,7 @@ SELECT node_type FROM [ EXPLAIN (VERBOSE)
   SELECT * FROM child1 INNER MERGE JOIN child2 USING (pid1)
 ] WHERE node_type LIKE '%join'
 ----
-merge-join
+merge join
 
 # Case where the merge join ordering includes a non-interleaved column (this is
 # possible if that column is constrained to a constant value). We shouldn't
@@ -916,7 +916,7 @@ EXPLAIN (VERBOSE) SELECT * FROM parent1 INNER MERGE JOIN child1 ON parent1.pid1 
 ----
 ·               distribution       full                     ·                               ·
 ·               vectorized         true                     ·                               ·
-merge-join      ·                  ·                        (pid1, v, pid1, cid1, cid2, v)  ·
+merge join      ·                  ·                        (pid1, v, pid1, cid1, cid2, v)  ·
  │              type               inner                    ·                               ·
  │              equality           (pid1, v) = (pid1, v)    ·                               ·
  │              left cols are key  ·                        ·                               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -37,7 +37,7 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data) NATURAL JOIN (SELECT a,b
 render           ·               ·                  (a, b)        ·
  │               render 0        a                  ·             ·
  │               render 1        b                  ·             ·
- └── merge-join  ·               ·                  (a, b, a, b)  ·
+ └── merge join  ·               ·                  (a, b, a, b)  ·
       │          type            inner              ·             ·
       │          equality        (a, b) = (a, b)    ·             ·
       │          mergeJoinOrder  +"(a=a)",+"(b=b)"  ·             ·
@@ -116,7 +116,7 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,
 ·               vectorized    true             ·             ·
 sort            ·             ·                (a, b, c, d)  +b,+a
  │              order         +b,+a            ·             ·
- └── hash-join  ·             ·                (a, b, c, d)  ·
+ └── hash join  ·             ·                (a, b, c, d)  ·
       │         type          inner            ·             ·
       │         equality      (a, b) = (c, d)  ·             ·
       ├── scan  ·             ·                (a, b)        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -85,7 +85,7 @@ EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x 
 render               ·                   ·                    (x, str)     ·
  │                   render 0            x                    ·            ·
  │                   render 1            str                  ·            ·
- └── merge-join      ·                   ·                    (x, y, str)  ·
+ └── merge join      ·                   ·                    (x, y, str)  ·
       │              type                inner                ·            ·
       │              equality            (x) = (y)            ·            ·
       │              left cols are key   ·                    ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -186,7 +186,7 @@ render                                       ·             ·
  └── sort                                    ·             ·
       │                                      order         +nspname,+relname
       └── render                             ·             ·
-           └── hash-join                     ·             ·
+           └── hash join                     ·             ·
                 │                            type          inner
                 │                            equality      (oid) = (relnamespace)
                 ├── filter                   ·             ·
@@ -209,7 +209,7 @@ render                                            ·                  ·
  └── sort                                         ·                  ·
       │                                           order              +nspname,+relname
       └── render                                  ·                  ·
-           └── hash-join                          ·                  ·
+           └── hash join                          ·                  ·
                 │                                 type               inner
                 │                                 equality           (oid) = (relnamespace)
                 ├── filter                        ·                  ·
@@ -217,7 +217,7 @@ render                                            ·                  ·
                 │    └── render                   ·                  ·
                 │         └── virtual table       ·                  ·
                 │                                 source             pg_namespace@primary
-                └── hash-join                     ·                  ·
+                └── hash join                     ·                  ·
                      │                            type               left outer
                      │                            equality           (oid) = (objoid)
                      │                            left cols are key  ·
@@ -324,7 +324,7 @@ render                                            ·             ·
       └── render                                  ·             ·
            └── sort                               ·             ·
                 │                                 order         +ordinal_position
-                └── hash-join                     ·             ·
+                └── hash join                     ·             ·
                      │                            type          left outer
                      │                            equality      (column_name) = (column_name)
                      ├── filter                   ·             ·
@@ -373,7 +373,7 @@ render                                            ·             ·
  └── sort                                         ·             ·
       │                                           order         +conname
       └── render                                  ·             ·
-           └── hash-join                          ·             ·
+           └── hash join                          ·             ·
                 │                                 type          inner
                 │                                 equality      (oid) = (relnamespace)
                 ├── filter                        ·             ·
@@ -381,7 +381,7 @@ render                                            ·             ·
                 │    └── render                   ·             ·
                 │         └── virtual table       ·             ·
                 │                                 source        pg_namespace@primary
-                └── virtual-table-lookup-join     ·             ·
+                └── virtual table lookup join     ·             ·
                      │                            table         pg_constraint@pg_constraint_conrelid_idx
                      │                            type          inner
                      │                            equality      (oid) = (conrelid)
@@ -409,7 +409,7 @@ render                                                             ·           
                 └── render                                         ·                  ·
                      └── sort                                      ·                  ·
                           │                                        order              +role
-                          └── hash-join                            ·                  ·
+                          └── hash join                            ·                  ·
                                │                                   type               left outer
                                │                                   equality           (username) = (member)
                                │                                   left cols are key  ·
@@ -420,7 +420,7 @@ render                                                             ·           
                                │    └── render                     ·                  ·
                                │         └── window                ·                  ·
                                │              └── render           ·                  ·
-                               │                   └── merge-join  ·                  ·
+                               │                   └── merge join  ·                  ·
                                │                        │          type               left outer
                                │                        │          equality           (username) = (username)
                                │                        │          left cols are key  ·
@@ -470,7 +470,7 @@ EXPLAIN INSERT INTO t VALUES (1, 2)
 ·                      distribution  local
 ·                      vectorized    false
 count                  ·             ·
- └── insert-fast-path  ·             ·
+ └── insert fast path  ·             ·
 ·                      into          t(k, v)
 ·                      strategy      inserter
 ·                      auto commit   ·
@@ -520,7 +520,7 @@ EXPLAIN (PLAN) SELECT * FROM t INNER LOOKUP JOIN t2 ON t.k = t2.x
 ----
 ·            distribution           local
 ·            vectorized             true
-lookup-join  ·                      ·
+lookup join  ·                      ·
  │           table                  t2@primary
  │           type                   inner
  │           equality               (k) = (x)
@@ -606,7 +606,7 @@ EXPLAIN (VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ·                vectorized    true        ·           ·
 sort             ·             ·           (a, b)      +b
  │               order         +b          ·           ·
- └── index-join  ·             ·           (a, b)      ·
+ └── index join  ·             ·           (a, b)      ·
       │          table         tc@primary  ·           ·
       │          key columns   rowid       ·           ·
       └── scan   ·             ·           (a, rowid)  ·
@@ -620,7 +620,7 @@ tree                   field          description       columns  ordering
 ·                      distribution   local             ·        ·
 ·                      vectorized     false             ·        ·
 count                  ·              ·                 ()       ·
- └── insert-fast-path  ·              ·                 ()       ·
+ └── insert fast path  ·              ·                 ()       ·
 ·                      into           t(k, v)           ·        ·
 ·                      strategy       inserter          ·        ·
 ·                      auto commit    ·                 ·        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -15,28 +15,28 @@ CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p), FAMI
 query TTT
 EXPLAIN INSERT INTO child VALUES (1,1), (2,2)
 ----
-·                                          distribution           local
-·                                          vectorized             false
-root                                       ·                      ·
- ├── count                                 ·                      ·
- │    └── insert                           ·                      ·
- │         │                               into                   child(c, p)
- │         │                               strategy               inserter
- │         └── buffer node                 ·                      ·
- │              │                          label                  buffer 1
- │              └── values                 ·                      ·
- │                                         size                   2 columns, 2 rows
- └── fk-check                              ·                      ·
-      └── error if rows                    ·                      ·
-           └── lookup-join                 ·                      ·
-                │                          table                  parent@primary
-                │                          type                   anti
-                │                          equality               (column2) = (p)
-                │                          equality cols are key  ·
-                │                          parallel               ·
-                └── render                 ·                      ·
-                     └── scan buffer node  ·                      ·
-·                                          label                  buffer 1
+·                                     distribution           local
+·                                     vectorized             false
+root                                  ·                      ·
+ ├── count                            ·                      ·
+ │    └── insert                      ·                      ·
+ │         │                          into                   child(c, p)
+ │         │                          strategy               inserter
+ │         └── buffer                 ·                      ·
+ │              │                     label                  buffer 1
+ │              └── values            ·                      ·
+ │                                    size                   2 columns, 2 rows
+ └── fk-check                         ·                      ·
+      └── error if rows               ·                      ·
+           └── lookup join            ·                      ·
+                │                     table                  parent@primary
+                │                     type                   anti
+                │                     equality               (column2) = (p)
+                │                     equality cols are key  ·
+                │                     parallel               ·
+                └── render            ·                      ·
+                     └── scan buffer  ·                      ·
+·                                     label                  buffer 1
 
 # Use data from a different table as input.
 statement ok
@@ -45,30 +45,30 @@ CREATE TABLE xy (x INT, y INT)
 query TTT
 EXPLAIN INSERT INTO child SELECT x,y FROM xy
 ----
-·                                          distribution        local
-·                                          vectorized          false
-root                                       ·                   ·
- ├── count                                 ·                   ·
- │    └── insert                           ·                   ·
- │         │                               into                child(c, p)
- │         │                               strategy            inserter
- │         └── buffer node                 ·                   ·
- │              │                          label               buffer 1
- │              └── scan                   ·                   ·
- │                                         table               xy@primary
- │                                         spans               FULL SCAN
- └── fk-check                              ·                   ·
-      └── error if rows                    ·                   ·
-           └── hash-join                   ·                   ·
-                │                          type                anti
-                │                          equality            (y) = (p)
-                │                          right cols are key  ·
-                ├── render                 ·                   ·
-                │    └── scan buffer node  ·                   ·
-                │                          label               buffer 1
-                └── scan                   ·                   ·
-·                                          table               parent@primary
-·                                          spans               FULL SCAN
+·                                     distribution        local
+·                                     vectorized          false
+root                                  ·                   ·
+ ├── count                            ·                   ·
+ │    └── insert                      ·                   ·
+ │         │                          into                child(c, p)
+ │         │                          strategy            inserter
+ │         └── buffer                 ·                   ·
+ │              │                     label               buffer 1
+ │              └── scan              ·                   ·
+ │                                    table               xy@primary
+ │                                    spans               FULL SCAN
+ └── fk-check                         ·                   ·
+      └── error if rows               ·                   ·
+           └── hash join              ·                   ·
+                │                     type                anti
+                │                     equality            (y) = (p)
+                │                     right cols are key  ·
+                ├── render            ·                   ·
+                │    └── scan buffer  ·                   ·
+                │                     label               buffer 1
+                └── scan              ·                   ·
+·                                     table               parent@primary
+·                                     spans               FULL SCAN
 
 statement ok
 CREATE TABLE child_nullable (c INT PRIMARY KEY, p INT REFERENCES parent(p), INDEX (p));
@@ -78,30 +78,30 @@ CREATE TABLE child_nullable (c INT PRIMARY KEY, p INT REFERENCES parent(p), INDE
 query TTT
 EXPLAIN INSERT INTO child_nullable VALUES (100, 1), (200, NULL)
 ----
-·                                               distribution           local
-·                                               vectorized             false
-root                                            ·                      ·
- ├── count                                      ·                      ·
- │    └── insert                                ·                      ·
- │         │                                    into                   child_nullable(c, p)
- │         │                                    strategy               inserter
- │         └── buffer node                      ·                      ·
- │              │                               label                  buffer 1
- │              └── values                      ·                      ·
- │                                              size                   2 columns, 2 rows
- └── fk-check                                   ·                      ·
-      └── error if rows                         ·                      ·
-           └── lookup-join                      ·                      ·
-                │                               table                  parent@primary
-                │                               type                   anti
-                │                               equality               (column2) = (p)
-                │                               equality cols are key  ·
-                │                               parallel               ·
-                └── filter                      ·                      ·
-                     │                          filter                 column2 IS NOT NULL
-                     └── render                 ·                      ·
-                          └── scan buffer node  ·                      ·
-·                                               label                  buffer 1
+·                                          distribution           local
+·                                          vectorized             false
+root                                       ·                      ·
+ ├── count                                 ·                      ·
+ │    └── insert                           ·                      ·
+ │         │                               into                   child_nullable(c, p)
+ │         │                               strategy               inserter
+ │         └── buffer                      ·                      ·
+ │              │                          label                  buffer 1
+ │              └── values                 ·                      ·
+ │                                         size                   2 columns, 2 rows
+ └── fk-check                              ·                      ·
+      └── error if rows                    ·                      ·
+           └── lookup join                 ·                      ·
+                │                          table                  parent@primary
+                │                          type                   anti
+                │                          equality               (column2) = (p)
+                │                          equality cols are key  ·
+                │                          parallel               ·
+                └── filter                 ·                      ·
+                     │                     filter                 column2 IS NOT NULL
+                     └── render            ·                      ·
+                          └── scan buffer  ·                      ·
+·                                          label                  buffer 1
 
 # Tests with multicolumn FKs.
 statement ok
@@ -118,30 +118,30 @@ CREATE TABLE multi_col_child  (
 query TTT
 EXPLAIN INSERT INTO multi_col_child VALUES (2, NULL, 20, 20), (3, 20, NULL, 20)
 ----
-·                                               distribution           local
-·                                               vectorized             false
-root                                            ·                      ·
- ├── count                                      ·                      ·
- │    └── insert                                ·                      ·
- │         │                                    into                   multi_col_child(c, p, q, r)
- │         │                                    strategy               inserter
- │         └── buffer node                      ·                      ·
- │              │                               label                  buffer 1
- │              └── values                      ·                      ·
- │                                              size                   4 columns, 2 rows
- └── fk-check                                   ·                      ·
-      └── error if rows                         ·                      ·
-           └── lookup-join                      ·                      ·
-                │                               table                  multi_col_parent@primary
-                │                               type                   anti
-                │                               equality               (column2, column3, column4) = (p, q, r)
-                │                               equality cols are key  ·
-                │                               parallel               ·
-                └── filter                      ·                      ·
-                     │                          filter                 (column2 IS NOT NULL) AND (column3 IS NOT NULL)
-                     └── render                 ·                      ·
-                          └── scan buffer node  ·                      ·
-·                                               label                  buffer 1
+·                                          distribution           local
+·                                          vectorized             false
+root                                       ·                      ·
+ ├── count                                 ·                      ·
+ │    └── insert                           ·                      ·
+ │         │                               into                   multi_col_child(c, p, q, r)
+ │         │                               strategy               inserter
+ │         └── buffer                      ·                      ·
+ │              │                          label                  buffer 1
+ │              └── values                 ·                      ·
+ │                                         size                   4 columns, 2 rows
+ └── fk-check                              ·                      ·
+      └── error if rows                    ·                      ·
+           └── lookup join                 ·                      ·
+                │                          table                  multi_col_parent@primary
+                │                          type                   anti
+                │                          equality               (column2, column3, column4) = (p, q, r)
+                │                          equality cols are key  ·
+                │                          parallel               ·
+                └── filter                 ·                      ·
+                     │                     filter                 (column2 IS NOT NULL) AND (column3 IS NOT NULL)
+                     └── render            ·                      ·
+                          └── scan buffer  ·                      ·
+·                                          label                  buffer 1
 
 statement ok
 CREATE TABLE multi_ref_parent_a (a INT PRIMARY KEY, other INT)
@@ -162,43 +162,43 @@ CREATE TABLE multi_ref_child (
 query TTT
 EXPLAIN INSERT INTO multi_ref_child VALUES (1, NULL, NULL, NULL), (2, 3, 4, 5)
 ----
-·                                               distribution           local
-·                                               vectorized             false
-root                                            ·                      ·
- ├── count                                      ·                      ·
- │    └── insert                                ·                      ·
- │         │                                    into                   multi_ref_child(k, a, b, c)
- │         │                                    strategy               inserter
- │         └── buffer node                      ·                      ·
- │              │                               label                  buffer 1
- │              └── values                      ·                      ·
- │                                              size                   4 columns, 2 rows
- ├── fk-check                                   ·                      ·
- │    └── error if rows                         ·                      ·
- │         └── lookup-join                      ·                      ·
- │              │                               table                  multi_ref_parent_a@primary
- │              │                               type                   anti
- │              │                               equality               (column2) = (a)
- │              │                               equality cols are key  ·
- │              │                               parallel               ·
- │              └── filter                      ·                      ·
- │                   │                          filter                 column2 IS NOT NULL
- │                   └── render                 ·                      ·
- │                        └── scan buffer node  ·                      ·
- │                                              label                  buffer 1
- └── fk-check                                   ·                      ·
-      └── error if rows                         ·                      ·
-           └── lookup-join                      ·                      ·
-                │                               table                  multi_ref_parent_bc@primary
-                │                               type                   anti
-                │                               equality               (column3, column4) = (b, c)
-                │                               equality cols are key  ·
-                │                               parallel               ·
-                └── filter                      ·                      ·
-                     │                          filter                 (column3 IS NOT NULL) AND (column4 IS NOT NULL)
-                     └── render                 ·                      ·
-                          └── scan buffer node  ·                      ·
-·                                               label                  buffer 1
+·                                          distribution           local
+·                                          vectorized             false
+root                                       ·                      ·
+ ├── count                                 ·                      ·
+ │    └── insert                           ·                      ·
+ │         │                               into                   multi_ref_child(k, a, b, c)
+ │         │                               strategy               inserter
+ │         └── buffer                      ·                      ·
+ │              │                          label                  buffer 1
+ │              └── values                 ·                      ·
+ │                                         size                   4 columns, 2 rows
+ ├── fk-check                              ·                      ·
+ │    └── error if rows                    ·                      ·
+ │         └── lookup join                 ·                      ·
+ │              │                          table                  multi_ref_parent_a@primary
+ │              │                          type                   anti
+ │              │                          equality               (column2) = (a)
+ │              │                          equality cols are key  ·
+ │              │                          parallel               ·
+ │              └── filter                 ·                      ·
+ │                   │                     filter                 column2 IS NOT NULL
+ │                   └── render            ·                      ·
+ │                        └── scan buffer  ·                      ·
+ │                                         label                  buffer 1
+ └── fk-check                              ·                      ·
+      └── error if rows                    ·                      ·
+           └── lookup join                 ·                      ·
+                │                          table                  multi_ref_parent_bc@primary
+                │                          type                   anti
+                │                          equality               (column3, column4) = (b, c)
+                │                          equality cols are key  ·
+                │                          parallel               ·
+                └── filter                 ·                      ·
+                     │                     filter                 (column3 IS NOT NULL) AND (column4 IS NOT NULL)
+                     └── render            ·                      ·
+                          └── scan buffer  ·                      ·
+·                                          label                  buffer 1
 
 # FK check can be omitted when we are inserting only NULLs.
 query TTT
@@ -219,36 +219,36 @@ count             ·             ·
 query TTT
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
-·                                          distribution  local
-·                                          vectorized    false
-root                                       ·             ·
- ├── count                                 ·             ·
- │    └── delete                           ·             ·
- │         │                               from          parent
- │         │                               strategy      deleter
- │         └── buffer node                 ·             ·
- │              │                          label         buffer 1
- │              └── scan                   ·             ·
- │                                         table         parent@primary
- │                                         spans         /3-/3/#
- ├── fk-check                              ·             ·
- │    └── error if rows                    ·             ·
- │         └── lookup-join                 ·             ·
- │              │                          table         child@child_p_idx
- │              │                          type          semi
- │              │                          equality      (p) = (p)
- │              └── render                 ·             ·
- │                   └── scan buffer node  ·             ·
- │                                         label         buffer 1
- └── fk-check                              ·             ·
-      └── error if rows                    ·             ·
-           └── lookup-join                 ·             ·
-                │                          table         child_nullable@child_nullable_p_idx
-                │                          type          semi
-                │                          equality      (p) = (p)
-                └── render                 ·             ·
-                     └── scan buffer node  ·             ·
-·                                          label         buffer 1
+·                                     distribution  local
+·                                     vectorized    false
+root                                  ·             ·
+ ├── count                            ·             ·
+ │    └── delete                      ·             ·
+ │         │                          from          parent
+ │         │                          strategy      deleter
+ │         └── buffer                 ·             ·
+ │              │                     label         buffer 1
+ │              └── scan              ·             ·
+ │                                    table         parent@primary
+ │                                    spans         /3-/3/#
+ ├── fk-check                         ·             ·
+ │    └── error if rows               ·             ·
+ │         └── lookup join            ·             ·
+ │              │                     table         child@child_p_idx
+ │              │                     type          semi
+ │              │                     equality      (p) = (p)
+ │              └── render            ·             ·
+ │                   └── scan buffer  ·             ·
+ │                                    label         buffer 1
+ └── fk-check                         ·             ·
+      └── error if rows               ·             ·
+           └── lookup join            ·             ·
+                │                     table         child_nullable@child_nullable_p_idx
+                │                     type          semi
+                │                     equality      (p) = (p)
+                └── render            ·             ·
+                     └── scan buffer  ·             ·
+·                                     label         buffer 1
 
 statement ok
 CREATE TABLE child2 (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(other), INDEX (p))
@@ -256,45 +256,45 @@ CREATE TABLE child2 (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(other),
 query TTT
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
-·                                          distribution  local
-·                                          vectorized    false
-root                                       ·             ·
- ├── count                                 ·             ·
- │    └── delete                           ·             ·
- │         │                               from          parent
- │         │                               strategy      deleter
- │         └── buffer node                 ·             ·
- │              │                          label         buffer 1
- │              └── scan                   ·             ·
- │                                         table         parent@primary
- │                                         spans         /3-/3/#
- ├── fk-check                              ·             ·
- │    └── error if rows                    ·             ·
- │         └── lookup-join                 ·             ·
- │              │                          table         child@child_p_idx
- │              │                          type          semi
- │              │                          equality      (p) = (p)
- │              └── render                 ·             ·
- │                   └── scan buffer node  ·             ·
- │                                         label         buffer 1
- ├── fk-check                              ·             ·
- │    └── error if rows                    ·             ·
- │         └── lookup-join                 ·             ·
- │              │                          table         child_nullable@child_nullable_p_idx
- │              │                          type          semi
- │              │                          equality      (p) = (p)
- │              └── render                 ·             ·
- │                   └── scan buffer node  ·             ·
- │                                         label         buffer 1
- └── fk-check                              ·             ·
-      └── error if rows                    ·             ·
-           └── lookup-join                 ·             ·
-                │                          table         child2@child2_p_idx
-                │                          type          semi
-                │                          equality      (other) = (p)
-                └── render                 ·             ·
-                     └── scan buffer node  ·             ·
-·                                          label         buffer 1
+·                                     distribution  local
+·                                     vectorized    false
+root                                  ·             ·
+ ├── count                            ·             ·
+ │    └── delete                      ·             ·
+ │         │                          from          parent
+ │         │                          strategy      deleter
+ │         └── buffer                 ·             ·
+ │              │                     label         buffer 1
+ │              └── scan              ·             ·
+ │                                    table         parent@primary
+ │                                    spans         /3-/3/#
+ ├── fk-check                         ·             ·
+ │    └── error if rows               ·             ·
+ │         └── lookup join            ·             ·
+ │              │                     table         child@child_p_idx
+ │              │                     type          semi
+ │              │                     equality      (p) = (p)
+ │              └── render            ·             ·
+ │                   └── scan buffer  ·             ·
+ │                                    label         buffer 1
+ ├── fk-check                         ·             ·
+ │    └── error if rows               ·             ·
+ │         └── lookup join            ·             ·
+ │              │                     table         child_nullable@child_nullable_p_idx
+ │              │                     type          semi
+ │              │                     equality      (p) = (p)
+ │              └── render            ·             ·
+ │                   └── scan buffer  ·             ·
+ │                                    label         buffer 1
+ └── fk-check                         ·             ·
+      └── error if rows               ·             ·
+           └── lookup join            ·             ·
+                │                     table         child2@child2_p_idx
+                │                     type          semi
+                │                     equality      (other) = (p)
+                └── render            ·             ·
+                     └── scan buffer  ·             ·
+·                                     label         buffer 1
 
 statement ok
 CREATE TABLE doubleparent (p1 INT, p2 INT, other INT, PRIMARY KEY (p1, p2))
@@ -311,195 +311,195 @@ CREATE TABLE doublechild (
 query TTT
 EXPLAIN DELETE FROM doubleparent WHERE p1 = 10
 ----
-·                                     distribution  local
-·                                     vectorized    false
-root                                  ·             ·
- ├── count                            ·             ·
- │    └── delete                      ·             ·
- │         │                          from          doubleparent
- │         │                          strategy      deleter
- │         └── buffer node            ·             ·
- │              │                     label         buffer 1
- │              └── scan              ·             ·
- │                                    table         doubleparent@primary
- │                                    spans         /10-/11
- └── fk-check                         ·             ·
-      └── error if rows               ·             ·
-           └── lookup-join            ·             ·
-                │                     table         doublechild@doublechild_p1_p2_idx
-                │                     type          semi
-                │                     equality      (p1, p2) = (p1, p2)
-                └── scan buffer node  ·             ·
-·                                     label         buffer 1
+·                                distribution  local
+·                                vectorized    false
+root                             ·             ·
+ ├── count                       ·             ·
+ │    └── delete                 ·             ·
+ │         │                     from          doubleparent
+ │         │                     strategy      deleter
+ │         └── buffer            ·             ·
+ │              │                label         buffer 1
+ │              └── scan         ·             ·
+ │                               table         doubleparent@primary
+ │                               spans         /10-/11
+ └── fk-check                    ·             ·
+      └── error if rows          ·             ·
+           └── lookup join       ·             ·
+                │                table         doublechild@doublechild_p1_p2_idx
+                │                type          semi
+                │                equality      (p1, p2) = (p1, p2)
+                └── scan buffer  ·             ·
+·                                label         buffer 1
 
 # -- Tests with UPDATE --
 
 query TTT
 EXPLAIN UPDATE child SET p = 4
 ----
-·                                          distribution        local
-·                                          vectorized          false
-root                                       ·                   ·
- ├── count                                 ·                   ·
- │    └── update                           ·                   ·
- │         │                               table               child
- │         │                               set                 p
- │         │                               strategy            updater
- │         └── buffer node                 ·                   ·
- │              │                          label               buffer 1
- │              └── render                 ·                   ·
- │                   └── scan              ·                   ·
- │                                         table               child@primary
- │                                         spans               FULL SCAN
- │                                         locking strength    for update
- └── fk-check                              ·                   ·
-      └── error if rows                    ·                   ·
-           └── hash-join                   ·                   ·
-                │                          type                anti
-                │                          equality            (p_new) = (p)
-                │                          right cols are key  ·
-                ├── render                 ·                   ·
-                │    └── scan buffer node  ·                   ·
-                │                          label               buffer 1
-                └── scan                   ·                   ·
-·                                          table               parent@primary
-·                                          spans               FULL SCAN
+·                                     distribution        local
+·                                     vectorized          false
+root                                  ·                   ·
+ ├── count                            ·                   ·
+ │    └── update                      ·                   ·
+ │         │                          table               child
+ │         │                          set                 p
+ │         │                          strategy            updater
+ │         └── buffer                 ·                   ·
+ │              │                     label               buffer 1
+ │              └── render            ·                   ·
+ │                   └── scan         ·                   ·
+ │                                    table               child@primary
+ │                                    spans               FULL SCAN
+ │                                    locking strength    for update
+ └── fk-check                         ·                   ·
+      └── error if rows               ·                   ·
+           └── hash join              ·                   ·
+                │                     type                anti
+                │                     equality            (p_new) = (p)
+                │                     right cols are key  ·
+                ├── render            ·                   ·
+                │    └── scan buffer  ·                   ·
+                │                     label               buffer 1
+                └── scan              ·                   ·
+·                                     table               parent@primary
+·                                     spans               FULL SCAN
 
 query TTT
 EXPLAIN UPDATE child SET p = 4 WHERE c = 10
 ----
-·                                          distribution           local
-·                                          vectorized             false
-root                                       ·                      ·
- ├── count                                 ·                      ·
- │    └── update                           ·                      ·
- │         │                               table                  child
- │         │                               set                    p
- │         │                               strategy               updater
- │         └── buffer node                 ·                      ·
- │              │                          label                  buffer 1
- │              └── render                 ·                      ·
- │                   └── scan              ·                      ·
- │                                         table                  child@primary
- │                                         spans                  /10-/10/#
- │                                         locking strength       for update
- └── fk-check                              ·                      ·
-      └── error if rows                    ·                      ·
-           └── lookup-join                 ·                      ·
-                │                          table                  parent@primary
-                │                          type                   anti
-                │                          equality               (p_new) = (p)
-                │                          equality cols are key  ·
-                │                          parallel               ·
-                └── render                 ·                      ·
-                     └── scan buffer node  ·                      ·
-·                                          label                  buffer 1
+·                                     distribution           local
+·                                     vectorized             false
+root                                  ·                      ·
+ ├── count                            ·                      ·
+ │    └── update                      ·                      ·
+ │         │                          table                  child
+ │         │                          set                    p
+ │         │                          strategy               updater
+ │         └── buffer                 ·                      ·
+ │              │                     label                  buffer 1
+ │              └── render            ·                      ·
+ │                   └── scan         ·                      ·
+ │                                    table                  child@primary
+ │                                    spans                  /10-/10/#
+ │                                    locking strength       for update
+ └── fk-check                         ·                      ·
+      └── error if rows               ·                      ·
+           └── lookup join            ·                      ·
+                │                     table                  parent@primary
+                │                     type                   anti
+                │                     equality               (p_new) = (p)
+                │                     equality cols are key  ·
+                │                     parallel               ·
+                └── render            ·                      ·
+                     └── scan buffer  ·                      ·
+·                                     label                  buffer 1
 
 query TTT
 EXPLAIN UPDATE parent SET p = p+1
 ----
-·                                                    distribution        local
-·                                                    vectorized          false
-root                                                 ·                   ·
- ├── count                                           ·                   ·
- │    └── update                                     ·                   ·
- │         │                                         table               parent
- │         │                                         set                 p
- │         │                                         strategy            updater
- │         └── buffer node                           ·                   ·
- │              │                                    label               buffer 1
- │              └── render                           ·                   ·
- │                   └── scan                        ·                   ·
- │                                                   table               parent@primary
- │                                                   spans               FULL SCAN
- │                                                   locking strength    for update
- ├── fk-check                                        ·                   ·
- │    └── error if rows                              ·                   ·
- │         └── render                                ·                   ·
- │              └── hash-join                        ·                   ·
- │                   │                               type                inner
- │                   │                               equality            (p) = (p)
- │                   │                               left cols are key   ·
- │                   │                               right cols are key  ·
- │                   ├── union                       ·                   ·
- │                   │    ├── render                 ·                   ·
- │                   │    │    └── scan buffer node  ·                   ·
- │                   │    │                          label               buffer 1
- │                   │    └── render                 ·                   ·
- │                   │         └── scan buffer node  ·                   ·
- │                   │                               label               buffer 1
- │                   └── distinct                    ·                   ·
- │                        │                          distinct on         p
- │                        │                          order key           p
- │                        └── scan                   ·                   ·
- │                                                   table               child@child_p_idx
- │                                                   spans               FULL SCAN
- └── fk-check                                        ·                   ·
-      └── error if rows                              ·                   ·
-           └── render                                ·                   ·
-                └── hash-join                        ·                   ·
-                     │                               type                inner
-                     │                               equality            (p) = (p)
-                     │                               left cols are key   ·
-                     │                               right cols are key  ·
-                     ├── union                       ·                   ·
-                     │    ├── render                 ·                   ·
-                     │    │    └── scan buffer node  ·                   ·
-                     │    │                          label               buffer 1
-                     │    └── render                 ·                   ·
-                     │         └── scan buffer node  ·                   ·
-                     │                               label               buffer 1
-                     └── distinct                    ·                   ·
-                          │                          distinct on         p
-                          │                          order key           p
-                          └── scan                   ·                   ·
-·                                                    table               child_nullable@child_nullable_p_idx
-·                                                    spans               FULL SCAN
+·                                               distribution        local
+·                                               vectorized          false
+root                                            ·                   ·
+ ├── count                                      ·                   ·
+ │    └── update                                ·                   ·
+ │         │                                    table               parent
+ │         │                                    set                 p
+ │         │                                    strategy            updater
+ │         └── buffer                           ·                   ·
+ │              │                               label               buffer 1
+ │              └── render                      ·                   ·
+ │                   └── scan                   ·                   ·
+ │                                              table               parent@primary
+ │                                              spans               FULL SCAN
+ │                                              locking strength    for update
+ ├── fk-check                                   ·                   ·
+ │    └── error if rows                         ·                   ·
+ │         └── render                           ·                   ·
+ │              └── hash join                   ·                   ·
+ │                   │                          type                inner
+ │                   │                          equality            (p) = (p)
+ │                   │                          left cols are key   ·
+ │                   │                          right cols are key  ·
+ │                   ├── union                  ·                   ·
+ │                   │    ├── render            ·                   ·
+ │                   │    │    └── scan buffer  ·                   ·
+ │                   │    │                     label               buffer 1
+ │                   │    └── render            ·                   ·
+ │                   │         └── scan buffer  ·                   ·
+ │                   │                          label               buffer 1
+ │                   └── distinct               ·                   ·
+ │                        │                     distinct on         p
+ │                        │                     order key           p
+ │                        └── scan              ·                   ·
+ │                                              table               child@child_p_idx
+ │                                              spans               FULL SCAN
+ └── fk-check                                   ·                   ·
+      └── error if rows                         ·                   ·
+           └── render                           ·                   ·
+                └── hash join                   ·                   ·
+                     │                          type                inner
+                     │                          equality            (p) = (p)
+                     │                          left cols are key   ·
+                     │                          right cols are key  ·
+                     ├── union                  ·                   ·
+                     │    ├── render            ·                   ·
+                     │    │    └── scan buffer  ·                   ·
+                     │    │                     label               buffer 1
+                     │    └── render            ·                   ·
+                     │         └── scan buffer  ·                   ·
+                     │                          label               buffer 1
+                     └── distinct               ·                   ·
+                          │                     distinct on         p
+                          │                     order key           p
+                          └── scan              ·                   ·
+·                                               table               child_nullable@child_nullable_p_idx
+·                                               spans               FULL SCAN
 
 query TTT
 EXPLAIN UPDATE parent SET p = p+1 WHERE other = 10
 ----
-·                                               distribution      local
-·                                               vectorized        false
-root                                            ·                 ·
- ├── count                                      ·                 ·
- │    └── update                                ·                 ·
- │         │                                    table             parent
- │         │                                    set               p
- │         │                                    strategy          updater
- │         └── buffer node                      ·                 ·
- │              │                               label             buffer 1
- │              └── render                      ·                 ·
- │                   └── scan                   ·                 ·
- │                                              table             parent@parent_other_key
- │                                              spans             /10-/11
- │                                              locking strength  for update
- ├── fk-check                                   ·                 ·
- │    └── error if rows                         ·                 ·
- │         └── lookup-join                      ·                 ·
- │              │                               table             child@child_p_idx
- │              │                               type              semi
- │              │                               equality          (p) = (p)
- │              └── union                       ·                 ·
- │                   ├── render                 ·                 ·
- │                   │    └── scan buffer node  ·                 ·
- │                   │                          label             buffer 1
- │                   └── render                 ·                 ·
- │                        └── scan buffer node  ·                 ·
- │                                              label             buffer 1
- └── fk-check                                   ·                 ·
-      └── error if rows                         ·                 ·
-           └── lookup-join                      ·                 ·
-                │                               table             child_nullable@child_nullable_p_idx
-                │                               type              semi
-                │                               equality          (p) = (p)
-                └── union                       ·                 ·
-                     ├── render                 ·                 ·
-                     │    └── scan buffer node  ·                 ·
-                     │                          label             buffer 1
-                     └── render                 ·                 ·
-                          └── scan buffer node  ·                 ·
-·                                               label             buffer 1
+·                                          distribution      local
+·                                          vectorized        false
+root                                       ·                 ·
+ ├── count                                 ·                 ·
+ │    └── update                           ·                 ·
+ │         │                               table             parent
+ │         │                               set               p
+ │         │                               strategy          updater
+ │         └── buffer                      ·                 ·
+ │              │                          label             buffer 1
+ │              └── render                 ·                 ·
+ │                   └── scan              ·                 ·
+ │                                         table             parent@parent_other_key
+ │                                         spans             /10-/11
+ │                                         locking strength  for update
+ ├── fk-check                              ·                 ·
+ │    └── error if rows                    ·                 ·
+ │         └── lookup join                 ·                 ·
+ │              │                          table             child@child_p_idx
+ │              │                          type              semi
+ │              │                          equality          (p) = (p)
+ │              └── union                  ·                 ·
+ │                   ├── render            ·                 ·
+ │                   │    └── scan buffer  ·                 ·
+ │                   │                     label             buffer 1
+ │                   └── render            ·                 ·
+ │                        └── scan buffer  ·                 ·
+ │                                         label             buffer 1
+ └── fk-check                              ·                 ·
+      └── error if rows                    ·                 ·
+           └── lookup join                 ·                 ·
+                │                          table             child_nullable@child_nullable_p_idx
+                │                          type              semi
+                │                          equality          (p) = (p)
+                └── union                  ·                 ·
+                     ├── render            ·                 ·
+                     │    └── scan buffer  ·                 ·
+                     │                     label             buffer 1
+                     └── render            ·                 ·
+                          └── scan buffer  ·                 ·
+·                                          label             buffer 1
 
 statement ok
 CREATE TABLE grandchild (g INT PRIMARY KEY, c INT NOT NULL REFERENCES child(c))
@@ -507,155 +507,155 @@ CREATE TABLE grandchild (g INT PRIMARY KEY, c INT NOT NULL REFERENCES child(c))
 query TTT
 EXPLAIN UPDATE child SET c = 4
 ----
-·                                                    distribution        local
-·                                                    vectorized          false
-root                                                 ·                   ·
- ├── count                                           ·                   ·
- │    └── update                                     ·                   ·
- │         │                                         table               child
- │         │                                         set                 c
- │         │                                         strategy            updater
- │         └── buffer node                           ·                   ·
- │              │                                    label               buffer 1
- │              └── render                           ·                   ·
- │                   └── scan                        ·                   ·
- │                                                   table               child@primary
- │                                                   spans               FULL SCAN
- │                                                   locking strength    for update
- └── fk-check                                        ·                   ·
-      └── error if rows                              ·                   ·
-           └── render                                ·                   ·
-                └── hash-join                        ·                   ·
-                     │                               type                inner
-                     │                               equality            (c) = (c)
-                     │                               left cols are key   ·
-                     │                               right cols are key  ·
-                     ├── union                       ·                   ·
-                     │    ├── render                 ·                   ·
-                     │    │    └── scan buffer node  ·                   ·
-                     │    │                          label               buffer 1
-                     │    └── render                 ·                   ·
-                     │         └── scan buffer node  ·                   ·
-                     │                               label               buffer 1
-                     └── distinct                    ·                   ·
-                          │                          distinct on         c
-                          └── scan                   ·                   ·
-·                                                    table               grandchild@primary
-·                                                    spans               FULL SCAN
+·                                               distribution        local
+·                                               vectorized          false
+root                                            ·                   ·
+ ├── count                                      ·                   ·
+ │    └── update                                ·                   ·
+ │         │                                    table               child
+ │         │                                    set                 c
+ │         │                                    strategy            updater
+ │         └── buffer                           ·                   ·
+ │              │                               label               buffer 1
+ │              └── render                      ·                   ·
+ │                   └── scan                   ·                   ·
+ │                                              table               child@primary
+ │                                              spans               FULL SCAN
+ │                                              locking strength    for update
+ └── fk-check                                   ·                   ·
+      └── error if rows                         ·                   ·
+           └── render                           ·                   ·
+                └── hash join                   ·                   ·
+                     │                          type                inner
+                     │                          equality            (c) = (c)
+                     │                          left cols are key   ·
+                     │                          right cols are key  ·
+                     ├── union                  ·                   ·
+                     │    ├── render            ·                   ·
+                     │    │    └── scan buffer  ·                   ·
+                     │    │                     label               buffer 1
+                     │    └── render            ·                   ·
+                     │         └── scan buffer  ·                   ·
+                     │                          label               buffer 1
+                     └── distinct               ·                   ·
+                          │                     distinct on         c
+                          └── scan              ·                   ·
+·                                               table               grandchild@primary
+·                                               spans               FULL SCAN
 
 # This update shouldn't emit checks for c, since it's unchanged.
 query TTT
 EXPLAIN UPDATE child SET p = 4
 ----
-·                                          distribution        local
-·                                          vectorized          false
-root                                       ·                   ·
- ├── count                                 ·                   ·
- │    └── update                           ·                   ·
- │         │                               table               child
- │         │                               set                 p
- │         │                               strategy            updater
- │         └── buffer node                 ·                   ·
- │              │                          label               buffer 1
- │              └── render                 ·                   ·
- │                   └── scan              ·                   ·
- │                                         table               child@primary
- │                                         spans               FULL SCAN
- │                                         locking strength    for update
- └── fk-check                              ·                   ·
-      └── error if rows                    ·                   ·
-           └── hash-join                   ·                   ·
-                │                          type                anti
-                │                          equality            (p_new) = (p)
-                │                          right cols are key  ·
-                ├── render                 ·                   ·
-                │    └── scan buffer node  ·                   ·
-                │                          label               buffer 1
-                └── scan                   ·                   ·
-·                                          table               parent@primary
-·                                          spans               FULL SCAN
+·                                     distribution        local
+·                                     vectorized          false
+root                                  ·                   ·
+ ├── count                            ·                   ·
+ │    └── update                      ·                   ·
+ │         │                          table               child
+ │         │                          set                 p
+ │         │                          strategy            updater
+ │         └── buffer                 ·                   ·
+ │              │                     label               buffer 1
+ │              └── render            ·                   ·
+ │                   └── scan         ·                   ·
+ │                                    table               child@primary
+ │                                    spans               FULL SCAN
+ │                                    locking strength    for update
+ └── fk-check                         ·                   ·
+      └── error if rows               ·                   ·
+           └── hash join              ·                   ·
+                │                     type                anti
+                │                     equality            (p_new) = (p)
+                │                     right cols are key  ·
+                ├── render            ·                   ·
+                │    └── scan buffer  ·                   ·
+                │                     label               buffer 1
+                └── scan              ·                   ·
+·                                     table               parent@primary
+·                                     spans               FULL SCAN
 
 query TTT
 EXPLAIN UPDATE child SET p = p
 ----
-·                                          distribution        local
-·                                          vectorized          false
-root                                       ·                   ·
- ├── count                                 ·                   ·
- │    └── update                           ·                   ·
- │         │                               table               child
- │         │                               set                 p
- │         │                               strategy            updater
- │         └── buffer node                 ·                   ·
- │              │                          label               buffer 1
- │              └── render                 ·                   ·
- │                   └── scan              ·                   ·
- │                                         table               child@primary
- │                                         spans               FULL SCAN
- │                                         locking strength    for update
- └── fk-check                              ·                   ·
-      └── error if rows                    ·                   ·
-           └── hash-join                   ·                   ·
-                │                          type                anti
-                │                          equality            (p) = (p)
-                │                          right cols are key  ·
-                ├── render                 ·                   ·
-                │    └── scan buffer node  ·                   ·
-                │                          label               buffer 1
-                └── scan                   ·                   ·
-·                                          table               parent@primary
-·                                          spans               FULL SCAN
+·                                     distribution        local
+·                                     vectorized          false
+root                                  ·                   ·
+ ├── count                            ·                   ·
+ │    └── update                      ·                   ·
+ │         │                          table               child
+ │         │                          set                 p
+ │         │                          strategy            updater
+ │         └── buffer                 ·                   ·
+ │              │                     label               buffer 1
+ │              └── render            ·                   ·
+ │                   └── scan         ·                   ·
+ │                                    table               child@primary
+ │                                    spans               FULL SCAN
+ │                                    locking strength    for update
+ └── fk-check                         ·                   ·
+      └── error if rows               ·                   ·
+           └── hash join              ·                   ·
+                │                     type                anti
+                │                     equality            (p) = (p)
+                │                     right cols are key  ·
+                ├── render            ·                   ·
+                │    └── scan buffer  ·                   ·
+                │                     label               buffer 1
+                └── scan              ·                   ·
+·                                     table               parent@primary
+·                                     spans               FULL SCAN
 
 query TTT
 EXPLAIN UPDATE child SET p = p+1, c = c+1
 ----
-·                                                    distribution        local
-·                                                    vectorized          false
-root                                                 ·                   ·
- ├── count                                           ·                   ·
- │    └── update                                     ·                   ·
- │         │                                         table               child
- │         │                                         set                 c, p
- │         │                                         strategy            updater
- │         └── buffer node                           ·                   ·
- │              │                                    label               buffer 1
- │              └── render                           ·                   ·
- │                   └── scan                        ·                   ·
- │                                                   table               child@primary
- │                                                   spans               FULL SCAN
- │                                                   locking strength    for update
- ├── fk-check                                        ·                   ·
- │    └── error if rows                              ·                   ·
- │         └── hash-join                             ·                   ·
- │              │                                    type                anti
- │              │                                    equality            (p_new) = (p)
- │              │                                    right cols are key  ·
- │              ├── render                           ·                   ·
- │              │    └── scan buffer node            ·                   ·
- │              │                                    label               buffer 1
- │              └── scan                             ·                   ·
- │                                                   table               parent@primary
- │                                                   spans               FULL SCAN
- └── fk-check                                        ·                   ·
-      └── error if rows                              ·                   ·
-           └── render                                ·                   ·
-                └── hash-join                        ·                   ·
-                     │                               type                inner
-                     │                               equality            (c) = (c)
-                     │                               left cols are key   ·
-                     │                               right cols are key  ·
-                     ├── union                       ·                   ·
-                     │    ├── render                 ·                   ·
-                     │    │    └── scan buffer node  ·                   ·
-                     │    │                          label               buffer 1
-                     │    └── render                 ·                   ·
-                     │         └── scan buffer node  ·                   ·
-                     │                               label               buffer 1
-                     └── distinct                    ·                   ·
-                          │                          distinct on         c
-                          └── scan                   ·                   ·
-·                                                    table               grandchild@primary
-·                                                    spans               FULL SCAN
+·                                               distribution        local
+·                                               vectorized          false
+root                                            ·                   ·
+ ├── count                                      ·                   ·
+ │    └── update                                ·                   ·
+ │         │                                    table               child
+ │         │                                    set                 c, p
+ │         │                                    strategy            updater
+ │         └── buffer                           ·                   ·
+ │              │                               label               buffer 1
+ │              └── render                      ·                   ·
+ │                   └── scan                   ·                   ·
+ │                                              table               child@primary
+ │                                              spans               FULL SCAN
+ │                                              locking strength    for update
+ ├── fk-check                                   ·                   ·
+ │    └── error if rows                         ·                   ·
+ │         └── hash join                        ·                   ·
+ │              │                               type                anti
+ │              │                               equality            (p_new) = (p)
+ │              │                               right cols are key  ·
+ │              ├── render                      ·                   ·
+ │              │    └── scan buffer            ·                   ·
+ │              │                               label               buffer 1
+ │              └── scan                        ·                   ·
+ │                                              table               parent@primary
+ │                                              spans               FULL SCAN
+ └── fk-check                                   ·                   ·
+      └── error if rows                         ·                   ·
+           └── render                           ·                   ·
+                └── hash join                   ·                   ·
+                     │                          type                inner
+                     │                          equality            (c) = (c)
+                     │                          left cols are key   ·
+                     │                          right cols are key  ·
+                     ├── union                  ·                   ·
+                     │    ├── render            ·                   ·
+                     │    │    └── scan buffer  ·                   ·
+                     │    │                     label               buffer 1
+                     │    └── render            ·                   ·
+                     │         └── scan buffer  ·                   ·
+                     │                          label               buffer 1
+                     └── distinct               ·                   ·
+                          │                     distinct on         c
+                          └── scan              ·                   ·
+·                                               table               grandchild@primary
+·                                               spans               FULL SCAN
 
 # Multiple grandchild tables
 statement ok
@@ -664,33 +664,33 @@ CREATE TABLE grandchild2 (g INT PRIMARY KEY, c INT NOT NULL REFERENCES child(c))
 query TTT
 EXPLAIN UPDATE child SET p = 4
 ----
-·                                          distribution        local
-·                                          vectorized          false
-root                                       ·                   ·
- ├── count                                 ·                   ·
- │    └── update                           ·                   ·
- │         │                               table               child
- │         │                               set                 p
- │         │                               strategy            updater
- │         └── buffer node                 ·                   ·
- │              │                          label               buffer 1
- │              └── render                 ·                   ·
- │                   └── scan              ·                   ·
- │                                         table               child@primary
- │                                         spans               FULL SCAN
- │                                         locking strength    for update
- └── fk-check                              ·                   ·
-      └── error if rows                    ·                   ·
-           └── hash-join                   ·                   ·
-                │                          type                anti
-                │                          equality            (p_new) = (p)
-                │                          right cols are key  ·
-                ├── render                 ·                   ·
-                │    └── scan buffer node  ·                   ·
-                │                          label               buffer 1
-                └── scan                   ·                   ·
-·                                          table               parent@primary
-·                                          spans               FULL SCAN
+·                                     distribution        local
+·                                     vectorized          false
+root                                  ·                   ·
+ ├── count                            ·                   ·
+ │    └── update                      ·                   ·
+ │         │                          table               child
+ │         │                          set                 p
+ │         │                          strategy            updater
+ │         └── buffer                 ·                   ·
+ │              │                     label               buffer 1
+ │              └── render            ·                   ·
+ │                   └── scan         ·                   ·
+ │                                    table               child@primary
+ │                                    spans               FULL SCAN
+ │                                    locking strength    for update
+ └── fk-check                         ·                   ·
+      └── error if rows               ·                   ·
+           └── hash join              ·                   ·
+                │                     type                anti
+                │                     equality            (p_new) = (p)
+                │                     right cols are key  ·
+                ├── render            ·                   ·
+                │    └── scan buffer  ·                   ·
+                │                     label               buffer 1
+                └── scan              ·                   ·
+·                                     table               parent@primary
+·                                     spans               FULL SCAN
 
 statement ok
 CREATE TABLE self (x INT PRIMARY KEY, y INT NOT NULL REFERENCES self(x))
@@ -698,72 +698,72 @@ CREATE TABLE self (x INT PRIMARY KEY, y INT NOT NULL REFERENCES self(x))
 query TTT
 EXPLAIN UPDATE self SET y = 3
 ----
-·                                          distribution        local
-·                                          vectorized          false
-root                                       ·                   ·
- ├── count                                 ·                   ·
- │    └── update                           ·                   ·
- │         │                               table               self
- │         │                               set                 y
- │         │                               strategy            updater
- │         └── buffer node                 ·                   ·
- │              │                          label               buffer 1
- │              └── render                 ·                   ·
- │                   └── scan              ·                   ·
- │                                         table               self@primary
- │                                         spans               FULL SCAN
- │                                         locking strength    for update
- └── fk-check                              ·                   ·
-      └── error if rows                    ·                   ·
-           └── hash-join                   ·                   ·
-                │                          type                anti
-                │                          equality            (y_new) = (x)
-                │                          right cols are key  ·
-                ├── render                 ·                   ·
-                │    └── scan buffer node  ·                   ·
-                │                          label               buffer 1
-                └── scan                   ·                   ·
-·                                          table               self@primary
-·                                          spans               FULL SCAN
+·                                     distribution        local
+·                                     vectorized          false
+root                                  ·                   ·
+ ├── count                            ·                   ·
+ │    └── update                      ·                   ·
+ │         │                          table               self
+ │         │                          set                 y
+ │         │                          strategy            updater
+ │         └── buffer                 ·                   ·
+ │              │                     label               buffer 1
+ │              └── render            ·                   ·
+ │                   └── scan         ·                   ·
+ │                                    table               self@primary
+ │                                    spans               FULL SCAN
+ │                                    locking strength    for update
+ └── fk-check                         ·                   ·
+      └── error if rows               ·                   ·
+           └── hash join              ·                   ·
+                │                     type                anti
+                │                     equality            (y_new) = (x)
+                │                     right cols are key  ·
+                ├── render            ·                   ·
+                │    └── scan buffer  ·                   ·
+                │                     label               buffer 1
+                └── scan              ·                   ·
+·                                     table               self@primary
+·                                     spans               FULL SCAN
 
 query TTT
 EXPLAIN UPDATE self SET x = 3
 ----
-·                                                    distribution        local
-·                                                    vectorized          false
-root                                                 ·                   ·
- ├── count                                           ·                   ·
- │    └── update                                     ·                   ·
- │         │                                         table               self
- │         │                                         set                 x
- │         │                                         strategy            updater
- │         └── buffer node                           ·                   ·
- │              │                                    label               buffer 1
- │              └── render                           ·                   ·
- │                   └── scan                        ·                   ·
- │                                                   table               self@primary
- │                                                   spans               FULL SCAN
- │                                                   locking strength    for update
- └── fk-check                                        ·                   ·
-      └── error if rows                              ·                   ·
-           └── render                                ·                   ·
-                └── hash-join                        ·                   ·
-                     │                               type                inner
-                     │                               equality            (x) = (y)
-                     │                               left cols are key   ·
-                     │                               right cols are key  ·
-                     ├── union                       ·                   ·
-                     │    ├── render                 ·                   ·
-                     │    │    └── scan buffer node  ·                   ·
-                     │    │                          label               buffer 1
-                     │    └── render                 ·                   ·
-                     │         └── scan buffer node  ·                   ·
-                     │                               label               buffer 1
-                     └── distinct                    ·                   ·
-                          │                          distinct on         y
-                          └── scan                   ·                   ·
-·                                                    table               self@primary
-·                                                    spans               FULL SCAN
+·                                               distribution        local
+·                                               vectorized          false
+root                                            ·                   ·
+ ├── count                                      ·                   ·
+ │    └── update                                ·                   ·
+ │         │                                    table               self
+ │         │                                    set                 x
+ │         │                                    strategy            updater
+ │         └── buffer                           ·                   ·
+ │              │                               label               buffer 1
+ │              └── render                      ·                   ·
+ │                   └── scan                   ·                   ·
+ │                                              table               self@primary
+ │                                              spans               FULL SCAN
+ │                                              locking strength    for update
+ └── fk-check                                   ·                   ·
+      └── error if rows                         ·                   ·
+           └── render                           ·                   ·
+                └── hash join                   ·                   ·
+                     │                          type                inner
+                     │                          equality            (x) = (y)
+                     │                          left cols are key   ·
+                     │                          right cols are key  ·
+                     ├── union                  ·                   ·
+                     │    ├── render            ·                   ·
+                     │    │    └── scan buffer  ·                   ·
+                     │    │                     label               buffer 1
+                     │    └── render            ·                   ·
+                     │         └── scan buffer  ·                   ·
+                     │                          label               buffer 1
+                     └── distinct               ·                   ·
+                          │                     distinct on         y
+                          └── scan              ·                   ·
+·                                               table               self@primary
+·                                               spans               FULL SCAN
 
 # Tests for the insert fast path.
 statement ok
@@ -776,7 +776,7 @@ EXPLAIN (VERBOSE) INSERT INTO child VALUES (1,1), (2,2)
 ·                      distribution   local              ·   ·
 ·                      vectorized     false              ·   ·
 count                  ·              ·                  ()  ·
- └── insert-fast-path  ·              ·                  ()  ·
+ └── insert fast path  ·              ·                  ()  ·
 ·                      into           child(c, p)        ·   ·
 ·                      strategy       inserter           ·   ·
 ·                      auto commit    ·                  ·   ·
@@ -856,7 +856,7 @@ EXPLAIN INSERT INTO nonunique_idx_child VALUES (0, 1, 10)
 ·                      distribution  local
 ·                      vectorized    false
 count                  ·             ·
- └── insert-fast-path  ·             ·
+ └── insert fast path  ·             ·
 ·                      into          nonunique_idx_child(k, ref1, ref2)
 ·                      strategy      inserter
 ·                      auto commit   ·
@@ -899,21 +899,21 @@ CREATE TABLE cascadechild (
 query TTTTT
 EXPLAIN (VERBOSE) DELETE FROM cascadeparent WHERE p > 1
 ----
-·                           distribution  local                   ·    ·
-·                           vectorized    false                   ·    ·
-root                        ·             ·                       ()   ·
- ├── count                  ·             ·                       ()   ·
- │    └── delete            ·             ·                       ()   ·
- │         │                from          cascadeparent           ·    ·
- │         │                strategy      deleter                 ·    ·
- │         └── buffer node  ·             ·                       (p)  ·
- │              │           label         buffer 1                ·    ·
- │              └── scan    ·             ·                       (p)  ·
- │                          table         cascadeparent@primary   ·    ·
- │                          spans         /2-                     ·    ·
- └── fk-cascade             ·             ·                       ·    ·
-·                           fk            fk_p_ref_cascadeparent  ·    ·
-·                           input         buffer 1                ·    ·
+·                         distribution  local                   ·    ·
+·                         vectorized    false                   ·    ·
+root                      ·             ·                       ()   ·
+ ├── count                ·             ·                       ()   ·
+ │    └── delete          ·             ·                       ()   ·
+ │         │              from          cascadeparent           ·    ·
+ │         │              strategy      deleter                 ·    ·
+ │         └── buffer     ·             ·                       (p)  ·
+ │              │         label         buffer 1                ·    ·
+ │              └── scan  ·             ·                       (p)  ·
+ │                        table         cascadeparent@primary   ·    ·
+ │                        spans         /2-                     ·    ·
+ └── fk-cascade           ·             ·                       ·    ·
+·                         fk            fk_p_ref_cascadeparent  ·    ·
+·                         input         buffer 1                ·    ·
 
 statement ok
 CREATE TABLE a (
@@ -950,7 +950,7 @@ tree                      field               description
 render                    ·                   ·
  └── filter               ·                   ·
       │                   filter              z IS NULL
-      └── merge-join      ·                   ·
+      └── merge join      ·                   ·
            │              type                left outer
            │              equality            (a_z, a_y, a_x) = (z, y, x)
            │              right cols are key  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -467,7 +467,7 @@ EXPLAIN (VERBOSE) INSERT INTO mutation(x) VALUES (2) RETURNING *
 render                      ·              ·                      (x)         ·
  │                          render 0       x                      ·           ·
  └── run                    ·              ·                      (x, rowid)  ·
-      └── insert-fast-path  ·              ·                      (x, rowid)  ·
+      └── insert fast path  ·              ·                      (x, rowid)  ·
 ·                           into           mutation(x, rowid, y)  ·           ·
 ·                           strategy       inserter               ·           ·
 ·                           size           3 columns, 1 row       ·           ·
@@ -488,7 +488,7 @@ EXPLAIN (VERBOSE) INSERT INTO mutation(x, y) VALUES (2, 2)
 ·                      distribution   local                  ·   ·
 ·                      vectorized     false                  ·   ·
 count                  ·              ·                      ()  ·
- └── insert-fast-path  ·              ·                      ()  ·
+ └── insert fast path  ·              ·                      ()  ·
 ·                      into           mutation(x, y, rowid)  ·   ·
 ·                      strategy       inserter               ·   ·
 ·                      size           3 columns, 1 row       ·   ·
@@ -516,13 +516,13 @@ EXPLAIN (VERBOSE) SELECT * FROM [INSERT INTO xyz SELECT a, b, c FROM abc RETURNI
 root                                          ·             ·                                                    (z)                  +z
  ├── sort                                     ·             ·                                                    (z)                  +z
  │    │                                       order         +z                                                   ·                    ·
- │    └── scan buffer node                    ·             ·                                                    (z)                  ·
+ │    └── scan buffer                         ·             ·                                                    (z)                  ·
  │                                            label         buffer 1                                             ·                    ·
  └── subquery                                 ·             ·                                                    ·                    ·
       │                                       id            @S1                                                  ·                    ·
       │                                       original sql  INSERT INTO xyz SELECT a, b, c FROM abc RETURNING z  ·                    ·
       │                                       exec mode     all rows                                             ·                    ·
-      └── buffer node                         ·             ·                                                    (z)                  ·
+      └── buffer                              ·             ·                                                    (z)                  ·
            │                                  label         buffer 1                                             ·                    ·
            └── spool                          ·             ·                                                    (z)                  ·
                 └── render                    ·             ·                                                    (z)                  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -166,7 +166,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
 ·           distribution  local                        ·       ·
 ·           vectorized    true                         ·       ·
-index-join  ·             ·                            (a, b)  ·
+index join  ·             ·                            (a, b)  ·
  │          table         d@primary                    ·       ·
  │          key columns   a                            ·       ·
  └── scan   ·             ·                            (a)     ·
@@ -178,7 +178,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
 ----
 ·           distribution  local                                    ·       ·
 ·           vectorized    true                                     ·       ·
-index-join  ·             ·                                        (a, b)  ·
+index join  ·             ·                                        (a, b)  ·
  │          table         d@primary                                ·       ·
  │          key columns   a                                        ·       ·
  └── scan   ·             ·                                        (a)     ·
@@ -190,7 +190,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
 ----
 ·           distribution  local                                            ·       ·
 ·           vectorized    true                                             ·       ·
-index-join  ·             ·                                                (a, b)  ·
+index join  ·             ·                                                (a, b)  ·
  │          table         d@primary                                        ·       ·
  │          key columns   a                                                ·       ·
  └── scan   ·             ·                                                (a)     ·
@@ -202,7 +202,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
 ----
 ·           distribution  local                         ·       ·
 ·           vectorized    true                          ·       ·
-index-join  ·             ·                             (a, b)  ·
+index join  ·             ·                             (a, b)  ·
  │          table         d@primary                     ·       ·
  │          key columns   a                             ·       ·
  └── scan   ·             ·                             (a)     ·
@@ -214,7 +214,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
 ----
 ·           distribution  local                    ·       ·
 ·           vectorized    true                     ·       ·
-index-join  ·             ·                        (a, b)  ·
+index join  ·             ·                        (a, b)  ·
  │          table         d@primary                ·       ·
  │          key columns   a                        ·       ·
  └── scan   ·             ·                        (a)     ·
@@ -226,7 +226,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
 ----
 ·           distribution  local                                            ·       ·
 ·           vectorized    true                                             ·       ·
-index-join  ·             ·                                                (a, b)  ·
+index join  ·             ·                                                (a, b)  ·
  │          table         d@primary                                        ·       ·
  │          key columns   a                                                ·       ·
  └── scan   ·             ·                                                (a)     ·
@@ -262,7 +262,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 ----
 ·           distribution  local                        ·       ·
 ·           vectorized    true                         ·       ·
-index-join  ·             ·                            (a, b)  ·
+index join  ·             ·                            (a, b)  ·
  │          table         d@primary                    ·       ·
  │          key columns   a                            ·       ·
  └── scan   ·             ·                            (a)     ·
@@ -274,7 +274,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
 ----
 ·           distribution  local                                ·       ·
 ·           vectorized    true                                 ·       ·
-index-join  ·             ·                                    (a, b)  ·
+index join  ·             ·                                    (a, b)  ·
  │          table         d@primary                            ·       ·
  │          key columns   a                                    ·       ·
  └── scan   ·             ·                                    (a)     ·
@@ -293,7 +293,7 @@ EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ----
 ·           distribution  local                        ·       ·
 ·           vectorized    true                         ·       ·
-index-join  ·             ·                            (a, b)  ·
+index join  ·             ·                            (a, b)  ·
  │          table         d@primary                    ·       ·
  │          key columns   a                            ·       ·
  └── scan   ·             ·                            (a)     ·
@@ -341,14 +341,14 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
 ·                 distribution           local                               ·       ·
 ·                 vectorized             true                                ·       ·
-lookup-join       ·                      ·                                   (a, b)  ·
+lookup join       ·                      ·                                   (a, b)  ·
  │                table                  d@primary                           ·       ·
  │                type                   inner                               ·       ·
  │                equality               (a) = (a)                           ·       ·
  │                equality cols are key  ·                                   ·       ·
  │                parallel               ·                                   ·       ·
  │                pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
- └── zigzag-join  ·                      ·                                   (a)     ·
+ └── zigzag join  ·                      ·                                   (a)     ·
       │           type                   inner                               ·       ·
       ├── scan    ·                      ·                                   (a)     ·
       │           table                  d@foo_inv                           ·       ·
@@ -362,14 +362,14 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "
 ----
 ·                 distribution           local                                         ·       ·
 ·                 vectorized             true                                          ·       ·
-lookup-join       ·                      ·                                             (a, b)  ·
+lookup join       ·                      ·                                             (a, b)  ·
  │                table                  d@primary                                     ·       ·
  │                type                   inner                                         ·       ·
  │                equality               (a) = (a)                                     ·       ·
  │                equality cols are key  ·                                             ·       ·
  │                parallel               ·                                             ·       ·
  │                pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
- └── zigzag-join  ·                      ·                                             (a)     ·
+ └── zigzag join  ·                      ·                                             (a)     ·
       │           type                   inner                                         ·       ·
       ├── scan    ·                      ·                                             (a)     ·
       │           table                  d@foo_inv                                     ·       ·
@@ -383,14 +383,14 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
 ·                 distribution           local                              ·       ·
 ·                 vectorized             true                               ·       ·
-lookup-join       ·                      ·                                  (a, b)  ·
+lookup join       ·                      ·                                  (a, b)  ·
  │                table                  d@primary                          ·       ·
  │                type                   inner                              ·       ·
  │                equality               (a) = (a)                          ·       ·
  │                equality cols are key  ·                                  ·       ·
  │                parallel               ·                                  ·       ·
  │                pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
- └── zigzag-join  ·                      ·                                  (a)     ·
+ └── zigzag join  ·                      ·                                  (a)     ·
       │           type                   inner                              ·       ·
       ├── scan    ·                      ·                                  (a)     ·
       │           table                  d@foo_inv                          ·       ·
@@ -407,14 +407,14 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
 ·                 distribution           local                               ·       ·
 ·                 vectorized             true                                ·       ·
-lookup-join       ·                      ·                                   (a, b)  ·
+lookup join       ·                      ·                                   (a, b)  ·
  │                table                  d@primary                           ·       ·
  │                type                   inner                               ·       ·
  │                equality               (a) = (a)                           ·       ·
  │                equality cols are key  ·                                   ·       ·
  │                parallel               ·                                   ·       ·
  │                pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
- └── zigzag-join  ·                      ·                                   (a)     ·
+ └── zigzag join  ·                      ·                                   (a)     ·
       │           type                   inner                               ·       ·
       ├── scan    ·                      ·                                   (a)     ·
       │           table                  d@foo_inv                           ·       ·
@@ -428,14 +428,14 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "
 ----
 ·                 distribution           local                                         ·       ·
 ·                 vectorized             true                                          ·       ·
-lookup-join       ·                      ·                                             (a, b)  ·
+lookup join       ·                      ·                                             (a, b)  ·
  │                table                  d@primary                                     ·       ·
  │                type                   inner                                         ·       ·
  │                equality               (a) = (a)                                     ·       ·
  │                equality cols are key  ·                                             ·       ·
  │                parallel               ·                                             ·       ·
  │                pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
- └── zigzag-join  ·                      ·                                             (a)     ·
+ └── zigzag join  ·                      ·                                             (a)     ·
       │           type                   inner                                         ·       ·
       ├── scan    ·                      ·                                             (a)     ·
       │           table                  d@foo_inv                                     ·       ·
@@ -449,14 +449,14 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
 ·                 distribution           local                              ·       ·
 ·                 vectorized             true                               ·       ·
-lookup-join       ·                      ·                                  (a, b)  ·
+lookup join       ·                      ·                                  (a, b)  ·
  │                table                  d@primary                          ·       ·
  │                type                   inner                              ·       ·
  │                equality               (a) = (a)                          ·       ·
  │                equality cols are key  ·                                  ·       ·
  │                parallel               ·                                  ·       ·
  │                pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
- └── zigzag-join  ·                      ·                                  (a)     ·
+ └── zigzag join  ·                      ·                                  (a)     ·
       │           type                   inner                              ·       ·
       ├── scan    ·                      ·                                  (a)     ·
       │           table                  d@foo_inv                          ·       ·
@@ -472,7 +472,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
 ·                vectorized    true                      ·       ·
 filter           ·             ·                         (a, b)  ·
  │               filter        b @> '{"a": {}, "b": 2}'  ·       ·
- └── index-join  ·             ·                         (a, b)  ·
+ └── index join  ·             ·                         (a, b)  ·
       │          table         d@primary                 ·       ·
       │          key columns   a                         ·       ·
       └── scan   ·             ·                         (a)     ·
@@ -498,7 +498,7 @@ EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1]
 ----
 ·           distribution  local      ·       ·
 ·           vectorized    true       ·       ·
-index-join  ·             ·          (a, b)  ·
+index join  ·             ·          (a, b)  ·
  │          table         e@primary  ·       ·
  │          key columns   a          ·       ·
  └── scan   ·             ·          (a)     ·
@@ -522,7 +522,7 @@ EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[NULL]::INT[]
 ----
 ·            distribution  local      ·       ·
 ·            vectorized    true       ·       ·
-index-join   ·             ·          (a, b)  ·
+index join   ·             ·          (a, b)  ·
  │           table         e@primary  ·       ·
  │           key columns   a          ·       ·
  └── norows  ·             ·          (a)     ·
@@ -550,14 +550,14 @@ EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1,2]
 ----
 ·                 distribution           local            ·       ·
 ·                 vectorized             true             ·       ·
-lookup-join       ·                      ·                (a, b)  ·
+lookup join       ·                      ·                (a, b)  ·
  │                table                  e@primary        ·       ·
  │                type                   inner            ·       ·
  │                equality               (a) = (a)        ·       ·
  │                equality cols are key  ·                ·       ·
  │                parallel               ·                ·       ·
  │                pred                   b @> ARRAY[1,2]  ·       ·
- └── zigzag-join  ·                      ·                (a)     ·
+ └── zigzag join  ·                      ·                (a)     ·
       │           type                   inner            ·       ·
       ├── scan    ·                      ·                (a)     ·
       │           table                  e@e_b_idx        ·       ·
@@ -571,14 +571,14 @@ EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1] AND b @> ARRAY[2]
 ----
 ·                 distribution           local                                ·       ·
 ·                 vectorized             true                                 ·       ·
-lookup-join       ·                      ·                                    (a, b)  ·
+lookup join       ·                      ·                                    (a, b)  ·
  │                table                  e@primary                            ·       ·
  │                type                   inner                                ·       ·
  │                equality               (a) = (a)                            ·       ·
  │                equality cols are key  ·                                    ·       ·
  │                parallel               ·                                    ·       ·
  │                pred                   (b @> ARRAY[1]) AND (b @> ARRAY[2])  ·       ·
- └── zigzag-join  ·                      ·                                    (a)     ·
+ └── zigzag join  ·                      ·                                    (a)     ·
       │           type                   inner                                ·       ·
       ├── scan    ·                      ·                                    (a)     ·
       │           table                  e@e_b_idx                            ·       ·
@@ -617,12 +617,12 @@ render                               ·                ·                       
  │                                   render 0         k                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ·          ·
  └── filter                          ·                ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      (k, geom)  ·
       │                              filter           st_intersects('010100000000000000000008400000000000000840', geom)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ·          ·
-      └── index-join                 ·                ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      (k, geom)  ·
+      └── index join                 ·                ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      (k, geom)  ·
            │                         table            geo_table@primary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ·          ·
            │                         key columns      k                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ·          ·
            └── render                ·                ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      (k)        ·
                 │                    render 0         k                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ·          ·
-                └── inverted-filter  ·                ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      (k, geom)  ·
+                └── inverted filter  ·                ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      (k, geom)  ·
                      │               inverted column  2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ·          ·
                      │               num spans        31                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     ·          ·
                      └── scan        ·                ·                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      (k, geom)  ·
@@ -641,7 +641,7 @@ ON ST_Intersects(geo_table2.geom, geo_table.geom)
 ----
 ·                        distribution           local                      ·                   ·
 ·                        vectorized             true                       ·                   ·
-lookup-join              ·                      ·                          (k, geom, k, geom)  ·
+lookup join              ·                      ·                          (k, geom, k, geom)  ·
  │                       table                  geo_table@primary          ·                   ·
  │                       type                   inner                      ·                   ·
  │                       equality               (k) = (k)                  ·                   ·
@@ -652,7 +652,7 @@ lookup-join              ·                      ·                          (k,
       │                  render 0               k                          ·                   ·
       │                  render 1               geom                       ·                   ·
       │                  render 2               k                          ·                   ·
-      └── inverted-join  ·                      ·                          (k, geom, k, geom)  ·
+      └── inverted join  ·                      ·                          (k, geom, k, geom)  ·
            │             table                  geo_table@geom_index       ·                   ·
            │             type                   inner                      ·                   ·
            │             ·                      st_intersects(@2, @4)      ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -14,7 +14,7 @@ EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ·               distribution  local
 ·               vectorized    true
 render          ·             ·
- └── hash-join  ·             ·
+ └── hash join  ·             ·
       │         type          inner
       │         equality      (x) = (x)
       ├── scan  ·             ·
@@ -29,7 +29,7 @@ EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
 ·          distribution  local
 ·          vectorized    true
-hash-join  ·             ·
+hash join  ·             ·
  │         type          inner
  │         equality      (x) = (y)
  ├── scan  ·             ·
@@ -45,7 +45,7 @@ EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ·                    distribution  local
 ·                    vectorized    true
 render               ·             ·
- └── cross-join      ·             ·
+ └── cross join      ·             ·
       │              type          cross
       ├── scan       ·             ·
       │              table         twocolumn@primary
@@ -61,7 +61,7 @@ EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
 ·          distribution  local
 ·          vectorized    true
-hash-join  ·             ·
+hash join  ·             ·
  │         type          inner
  │         equality      (x) = (y)
  ├── scan  ·             ·
@@ -76,7 +76,7 @@ EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
 ·          distribution  local
 ·          vectorized    true
-hash-join  ·             ·
+hash join  ·             ·
  │         type          inner
  │         equality      (x) = (y)
  ├── scan  ·             ·
@@ -98,10 +98,10 @@ LIMIT 1
 ·                    vectorized    true
 limit                ·             ·
  │                   count         1
- └── hash-join       ·             ·
+ └── hash join       ·             ·
       │              type          inner
       │              equality      (x) = (x)
-      ├── hash-join  ·             ·
+      ├── hash join  ·             ·
       │    │         type          inner
       │    │         equality      (x) = (x)
       │    ├── scan  ·             ·
@@ -110,7 +110,7 @@ limit                ·             ·
       │    └── scan  ·             ·
       │              table         twocolumn@primary
       │              spans         FULL SCAN
-      └── hash-join  ·             ·
+      └── hash join  ·             ·
            │         type          inner
            │         equality      (x) = (x)
            ├── scan  ·             ·
@@ -126,7 +126,7 @@ EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
 ·           distribution  local              ·       ·
 ·           vectorized    true               ·       ·
-cross-join  ·             ·                  (x, y)  ·
+cross join  ·             ·                  (x, y)  ·
  │          type          cross              ·       ·
  ├── scan   ·             ·                  (x)     ·
  │          table         twocolumn@primary  ·       ·
@@ -142,7 +142,7 @@ EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ·               vectorized    true               ·          ·
 render          ·             ·                  (y)        ·
  │              render 0      y                  ·          ·
- └── hash-join  ·             ·                  (x, x, y)  ·
+ └── hash join  ·             ·                  (x, x, y)  ·
       │         type          inner              ·          ·
       │         equality      (x) = (x)          ·          ·
       ├── scan  ·             ·                  (x)        ·
@@ -159,7 +159,7 @@ EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b
 ·               vectorized    true               ·          ·
 render          ·             ·                  (y)        ·
  │              render 0      y                  ·          ·
- └── hash-join  ·             ·                  (x, x, y)  ·
+ └── hash join  ·             ·                  (x, x, y)  ·
       │         type          inner              ·          ·
       │         equality      (x) = (x)          ·          ·
       ├── scan  ·             ·                  (x)        ·
@@ -176,7 +176,7 @@ EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b
 ·                vectorized    true               ·       ·
 render           ·             ·                  (x)     ·
  │               render 0      x                  ·       ·
- └── cross-join  ·             ·                  (x, y)  ·
+ └── cross join  ·             ·                  (x, y)  ·
       │          type          inner              ·       ·
       │          pred          x < y              ·       ·
       ├── scan   ·             ·                  (x)     ·
@@ -195,7 +195,7 @@ render               ·             ·                  (x, two, plus1)     ·
  │                   render 0      COALESCE(x, x)     ·                   ·
  │                   render 1      two                ·                   ·
  │                   render 2      plus1              ·                   ·
- └── hash-join       ·             ·                  (two, x, plus1, x)  ·
+ └── hash join       ·             ·                  (two, x, plus1, x)  ·
       │              type          full outer         ·                   ·
       │              equality      (x) = (x)          ·                   ·
       ├── render     ·             ·                  (two, x)            ·
@@ -228,7 +228,7 @@ render                      ·              ·                      (k, u, w)   
            │                render 0       column1                ·                                     ·
            │                render 1       column2                ·                                     ·
            │                render 2       column2                ·                                     ·
-           └── hash-join    ·              ·                      (column1, column2, column1, column2)  ·
+           └── hash join    ·              ·                      (column1, column2, column1, column2)  ·
                 │           type           inner                  ·                                     ·
                 │           equality       (column2) = (column1)  ·                                     ·
                 ├── values  ·              ·                      (column1, column2)                    ·
@@ -346,11 +346,11 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 2   ·                          render 10           conname
 2   ·                          render 11           generate_series
 2   ·                          render 12           relname
-3   hash-join                  ·                   ·
+3   hash join                  ·                   ·
 3   ·                          type                inner
 3   ·                          equality            (refobjid) = (oid)
 3   ·                          right cols are key  ·
-4   hash-join                  ·                   ·
+4   hash join                  ·                   ·
 4   ·                          type                inner
 4   ·                          equality            (oid) = (relnamespace)
 5   render                     ·                   ·
@@ -358,7 +358,7 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 5   ·                          render 1            nspname
 6   virtual table              ·                   ·
 6   ·                          source              pg_namespace@primary
-5   hash-join                  ·                   ·
+5   hash join                  ·                   ·
 5   ·                          type                inner
 5   ·                          equality            (objid) = (oid)
 6   render                     ·                   ·
@@ -366,28 +366,28 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 6   ·                          render 1            refobjid
 7   virtual table              ·                   ·
 7   ·                          source              pg_depend@primary
-6   hash-join                  ·                   ·
+6   hash join                  ·                   ·
 6   ·                          type                inner
 6   ·                          equality            (relnamespace) = (oid)
-7   cross-join                 ·                   ·
+7   cross join                 ·                   ·
 7   ·                          type                inner
 7   ·                          pred                (attnum = confkey[generate_series]) AND (attnum = conkey[generate_series])
 8   project set                ·                   ·
 8   ·                          render 0            generate_series(1, 32)
 9   emptyrow                   ·                   ·
-8   virtual-table-lookup-join  ·                   ·
+8   virtual table lookup join  ·                   ·
 8   ·                          table               pg_attribute@pg_attribute_attrelid_idx
 8   ·                          type                inner
 8   ·                          equality            (oid) = (attrelid)
-9   virtual-table-lookup-join  ·                   ·
+9   virtual table lookup join  ·                   ·
 9   ·                          table               pg_class@pg_class_oid_idx
 9   ·                          type                inner
 9   ·                          equality            (attrelid) = (oid)
-10  virtual-table-lookup-join  ·                   ·
+10  virtual table lookup join  ·                   ·
 10  ·                          table               pg_attribute@pg_attribute_attrelid_idx
 10  ·                          type                inner
 10  ·                          equality            (confrelid) = (attrelid)
-11  virtual-table-lookup-join  ·                   ·
+11  virtual table lookup join  ·                   ·
 11  ·                          table               pg_constraint@pg_constraint_conrelid_idx
 11  ·                          type                inner
 11  ·                          equality            (oid) = (conrelid)
@@ -425,7 +425,7 @@ EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cu
 ----
 ·           distribution        local
 ·           vectorized          true
-merge-join  ·                   ·
+merge join  ·                   ·
  │          type                inner
  │          equality            (cust) = (id)
  │          right cols are key  ·
@@ -451,7 +451,7 @@ EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
 ·          distribution        local
 ·          vectorized          true
-hash-join  ·                   ·
+hash join  ·                   ·
  │         type                inner
  │         equality            (b) = (n)
  │         right cols are key  ·
@@ -473,7 +473,7 @@ render               ·             ·                 (a, b, n, sq)           �
  │                   render 1      b                 ·                       ·
  │                   render 2      n                 ·                       ·
  │                   render 3      sq                ·                       ·
- └── hash-join       ·             ·                 (column8, a, b, n, sq)  ·
+ └── hash join       ·             ·                 (column8, a, b, n, sq)  ·
       │              type          inner             ·                       ·
       │              equality      (column8) = (sq)  ·                       ·
       ├── render     ·             ·                 (column8, a, b)         ·
@@ -507,7 +507,7 @@ render                     ·             ·               (a, b, n, sq)       �
            │               render 2      b               ·                   ·
            │               render 3      n               ·                   ·
            │               render 4      sq              ·                   ·
-           └── cross-join  ·             ·               (a, b, n, sq)       ·
+           └── cross join  ·             ·               (a, b, n, sq)       ·
                 │          type          cross           ·                   ·
                 ├── scan   ·             ·               (a, b)              ·
                 │          table         pairs@primary   ·                   ·
@@ -527,7 +527,7 @@ render               ·             ·                 (a, b, n, sq)           �
  │                   render 1      b                 ·                       ·
  │                   render 2      n                 ·                       ·
  │                   render 3      sq                ·                       ·
- └── hash-join       ·             ·                 (column8, a, b, n, sq)  ·
+ └── hash join       ·             ·                 (column8, a, b, n, sq)  ·
       │              type          full outer        ·                       ·
       │              equality      (column8) = (sq)  ·                       ·
       ├── render     ·             ·                 (column8, a, b)         ·
@@ -553,7 +553,7 @@ render                    ·             ·                    (a, b, n, sq)    
  │                        render 3      sq                   ·                       ·
  └── filter               ·             ·                    (column8, a, b, n, sq)  ·
       │                   filter        (b % 2) != (sq % 2)  ·                       ·
-      └── hash-join       ·             ·                    (column8, a, b, n, sq)  ·
+      └── hash join       ·             ·                    (column8, a, b, n, sq)  ·
            │              type          full outer           ·                       ·
            │              equality      (column8) = (sq)     ·                       ·
            ├── render     ·             ·                    (column8, a, b)         ·
@@ -581,7 +581,7 @@ SELECT *
 ·                    vectorized    true
 filter               ·             ·
  │                   filter        ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
- └── hash-join       ·             ·
+ └── hash join       ·             ·
       │              type          left outer
       │              equality      (b) = (sq)
       │              pred          a > 1
@@ -613,7 +613,7 @@ render                    ·             ·
  │                        render 3      sq
  └── filter               ·             ·
       │                   filter        ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
-      └── hash-join       ·             ·
+      └── hash join       ·             ·
            │              type          left outer
            │              equality      (sq) = (b)
            │              pred          n < 6
@@ -637,7 +637,7 @@ SELECT *
 ----
 ·               distribution  local
 ·               vectorized    true
-hash-join       ·             ·
+hash join       ·             ·
  │              type          inner
  │              equality      (b) = (sq)
  ├── filter     ·             ·
@@ -664,7 +664,7 @@ EXPLAIN (VERBOSE) SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ·               vectorized    true             ·             ·
 render          ·             ·                (x)           ·
  │              render 0      x                ·             ·
- └── hash-join  ·             ·                (x, y, y, x)  ·
+ └── hash join  ·             ·                (x, y, y, x)  ·
       │         type          inner            ·             ·
       │         equality      (x, y) = (x, y)  ·             ·
       ├── scan  ·             ·                (x, y)        ·
@@ -692,7 +692,7 @@ EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = 
 ----
 ·          distribution        local                  ·                         ·
 ·          vectorized          true                   ·                         ·
-hash-join  ·                   ·                      (a, b, c, d, a, b, c, d)  ·
+hash join  ·                   ·                      (a, b, c, d, a, b, c, d)  ·
  │         type                inner                  ·                         ·
  │         equality            (a, b, c) = (a, b, c)  ·                         ·
  │         left cols are key   ·                      ·                         ·
@@ -714,7 +714,7 @@ render          ·                   ·                            (a, b, c, d) 
  │              render 1            b                            ·                         ·
  │              render 2            c                            ·                         ·
  │              render 3            d                            ·                         ·
- └── hash-join  ·                   ·                            (a, b, c, d, a, b, c, d)  ·
+ └── hash join  ·                   ·                            (a, b, c, d, a, b, c, d)  ·
       │         type                inner                        ·                         ·
       │         equality            (a, b, c, d) = (a, b, c, d)  ·                         ·
       │         left cols are key   ·                            ·                         ·
@@ -737,7 +737,7 @@ render           ·                   ·                           (a, b, c, d, 
  │               render 2            c                           ·                         ·
  │               render 3            d                           ·                         ·
  │               render 4            d                           ·                         ·
- └── merge-join  ·                   ·                           (a, b, c, d, a, b, c, d)  ·
+ └── merge join  ·                   ·                           (a, b, c, d, a, b, c, d)  ·
       │          type                inner                       ·                         ·
       │          equality            (b, a, c) = (b, a, c)       ·                         ·
       │          left cols are key   ·                           ·                         ·
@@ -755,7 +755,7 @@ EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a 
 ----
 ·           distribution        local                       ·                         ·
 ·           vectorized          true                        ·                         ·
-merge-join  ·                   ·                           (a, b, c, d, a, b, c, d)  ·
+merge join  ·                   ·                           (a, b, c, d, a, b, c, d)  ·
  │          type                inner                       ·                         ·
  │          equality            (b, a, c) = (b, a, d)       ·                         ·
  │          left cols are key   ·                           ·                         ·
@@ -784,7 +784,7 @@ render          ·             ·             (s, s, s)  ·
  │              render 0      s             ·          ·
  │              render 1      s             ·          ·
  │              render 2      s             ·          ·
- └── hash-join  ·             ·             (s, s)     ·
+ └── hash join  ·             ·             (s, s)     ·
       │         type          inner         ·          ·
       │         equality      (s) = (s)     ·          ·
       ├── scan  ·             ·             (s)        ·
@@ -803,7 +803,7 @@ render          ·             ·             (s, s, s)  ·
  │              render 0      s             ·          ·
  │              render 1      s             ·          ·
  │              render 2      s             ·          ·
- └── hash-join  ·             ·             (s, s)     ·
+ └── hash join  ·             ·             (s, s)     ·
       │         type          left outer    ·          ·
       │         equality      (s) = (s)     ·          ·
       ├── scan  ·             ·             (s)        ·
@@ -822,7 +822,7 @@ render          ·             ·               (s, s, s)  ·
  │              render 0      COALESCE(s, s)  ·          ·
  │              render 1      s               ·          ·
  │              render 2      s               ·          ·
- └── hash-join  ·             ·               (s, s)     ·
+ └── hash join  ·             ·               (s, s)     ·
       │         type          left outer      ·          ·
       │         equality      (s) = (s)       ·          ·
       ├── scan  ·             ·               (s)        ·
@@ -841,7 +841,7 @@ render          ·             ·               (s, s, s)  ·
  │              render 0      COALESCE(s, s)  ·          ·
  │              render 1      s               ·          ·
  │              render 2      s               ·          ·
- └── hash-join  ·             ·               (s, s)     ·
+ └── hash join  ·             ·               (s, s)     ·
       │         type          full outer      ·          ·
       │         equality      (s) = (s)       ·          ·
       ├── scan  ·             ·               (s)        ·
@@ -861,7 +861,7 @@ EXPLAIN (VERBOSE) SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 render          ·                   ·                (a, s)        ·
  │              render 0            a                ·             ·
  │              render 1            COALESCE(s, s)   ·             ·
- └── hash-join  ·                   ·                (a, s, a, s)  ·
+ └── hash join  ·                   ·                (a, s, a, s)  ·
       │         type                left outer       ·             ·
       │         equality            (a, s) = (a, s)  ·             ·
       │         left cols are key   ·                ·             ·
@@ -890,7 +890,7 @@ render           ·               ·                  (x, y, u, v)        ·
  │               render 1        y                  ·                   ·
  │               render 2        u                  ·                   ·
  │               render 3        v                  ·                   ·
- └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+ └── merge join  ·               ·                  (x, y, u, x, y, v)  ·
       │          type            inner              ·                   ·
       │          equality        (x, y) = (x, y)    ·                   ·
       │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -911,7 +911,7 @@ render           ·               ·                  (x, y, u, v)        ·
  │               render 1        y                  ·                   ·
  │               render 2        u                  ·                   ·
  │               render 3        v                  ·                   ·
- └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+ └── merge join  ·               ·                  (x, y, u, x, y, v)  ·
       │          type            left outer         ·                   ·
       │          equality        (x, y) = (x, y)    ·                   ·
       │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -932,7 +932,7 @@ render           ·               ·                  (x, y, u, v)        ·
  │               render 1        y                  ·                   ·
  │               render 2        u                  ·                   ·
  │               render 3        v                  ·                   ·
- └── merge-join  ·               ·                  (x, y, v, x, y, u)  ·
+ └── merge join  ·               ·                  (x, y, v, x, y, u)  ·
       │          type            left outer         ·                   ·
       │          equality        (x, y) = (x, y)    ·                   ·
       │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -955,7 +955,7 @@ filter                ·               ·                  (x, y, u, v)        �
       │               render 1        COALESCE(y, y)     ·                   ·
       │               render 2        u                  ·                   ·
       │               render 3        v                  ·                   ·
-      └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+      └── merge join  ·               ·                  (x, y, u, x, y, v)  ·
            │          type            full outer         ·                   ·
            │          equality        (x, y) = (x, y)    ·                   ·
            │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -972,7 +972,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = 
 ----
 ·           distribution    local              ·                   ·
 ·           vectorized      true               ·                   ·
-merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+merge join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            inner              ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
  │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -988,7 +988,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = 
 ----
 ·           distribution    local              ·                   ·
 ·           vectorized      true               ·                   ·
-merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+merge join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            inner              ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
  │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -1004,7 +1004,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu
 ----
 ·           distribution    local              ·                   ·
 ·           vectorized      true               ·                   ·
-merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+merge join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            left outer         ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
  │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -1027,7 +1027,7 @@ render           ·               ·                  (x, y, u, x, y, v)  ·
  │               render 3        x                  ·                   ·
  │               render 4        y                  ·                   ·
  │               render 5        v                  ·                   ·
- └── merge-join  ·               ·                  (x, y, v, x, y, u)  ·
+ └── merge join  ·               ·                  (x, y, v, x, y, u)  ·
       │          type            left outer         ·                   ·
       │          equality        (x, y) = (x, y)    ·                   ·
       │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -1051,7 +1051,7 @@ render           ·               ·                  (x, y, u, v)        ·
  │               render 1        y                  ·                   ·
  │               render 2        u                  ·                   ·
  │               render 3        v                  ·                   ·
- └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+ └── merge join  ·               ·                  (x, y, u, x, y, v)  ·
       │          type            left outer         ·                   ·
       │          equality        (x, y) = (x, y)    ·                   ·
       │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -1072,7 +1072,7 @@ render           ·               ·                  (x, y, u, v)        ·
  │               render 1        y                  ·                   ·
  │               render 2        u                  ·                   ·
  │               render 3        v                  ·                   ·
- └── merge-join  ·               ·                  (x, y, v, x, y, u)  ·
+ └── merge join  ·               ·                  (x, y, v, x, y, u)  ·
       │          type            left outer         ·                   ·
       │          equality        (x, y) = (x, y)    ·                   ·
       │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -1095,7 +1095,7 @@ filter                ·               ·                  (x, y, u, v)        �
       │               render 1        COALESCE(y, y)     ·                   ·
       │               render 2        u                  ·                   ·
       │               render 3        v                  ·                   ·
-      └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+      └── merge join  ·               ·                  (x, y, u, x, y, v)  ·
            │          type            full outer         ·                   ·
            │          equality        (x, y) = (x, y)    ·                   ·
            │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -1111,7 +1111,7 @@ EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OU
 ----
 ·           distribution    local              ·                   ·
 ·           vectorized      true               ·                   ·
-merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+merge join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            left outer         ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
  │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -1134,7 +1134,7 @@ render           ·               ·                  (x, y, u, x, y, v)  ·
  │               render 3        x                  ·                   ·
  │               render 4        y                  ·                   ·
  │               render 5        v                  ·                   ·
- └── merge-join  ·               ·                  (x, y, v, x, y, u)  ·
+ └── merge join  ·               ·                  (x, y, v, x, y, u)  ·
       │          type            left outer         ·                   ·
       │          equality        (x, y) = (x, y)    ·                   ·
       │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -1156,7 +1156,7 @@ render           ·               ·                  (x, y, u, v)        ·
  │               render 1        y                  ·                   ·
  │               render 2        u                  ·                   ·
  │               render 3        v                  ·                   ·
- └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+ └── merge join  ·               ·                  (x, y, u, x, y, v)  ·
       │          type            inner              ·                   ·
       │          equality        (x, y) = (x, y)    ·                   ·
       │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
@@ -1187,7 +1187,7 @@ render           ·                   ·           (a, b1, b2)     ·
  │               render 0            a           ·               ·
  │               render 1            b1          ·               ·
  │               render 2            b2          ·               ·
- └── merge-join  ·                   ·           (a, b1, a, b2)  ·
+ └── merge join  ·                   ·           (a, b1, a, b2)  ·
       │          type                left outer  ·               ·
       │          equality            (a) = (a)   ·               ·
       │          left cols are key   ·           ·               ·
@@ -1205,7 +1205,7 @@ EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
 ----
 ·           distribution        local       ·               ·
 ·           vectorized          true        ·               ·
-merge-join  ·                   ·           (a, b1, a, b2)  ·
+merge join  ·                   ·           (a, b1, a, b2)  ·
  │          type                left outer  ·               ·
  │          equality            (a) = (a)   ·               ·
  │          left cols are key   ·           ·               ·
@@ -1227,7 +1227,7 @@ render           ·                   ·           (a, b1, b2)     ·
  │               render 0            a           ·               ·
  │               render 1            b1          ·               ·
  │               render 2            b2          ·               ·
- └── merge-join  ·                   ·           (a, b2, a, b1)  ·
+ └── merge join  ·                   ·           (a, b2, a, b1)  ·
       │          type                left outer  ·               ·
       │          equality            (a) = (a)   ·               ·
       │          left cols are key   ·           ·               ·
@@ -1250,7 +1250,7 @@ render           ·                   ·           (a, b1, a, b2)  ·
  │               render 1            b1          ·               ·
  │               render 2            a           ·               ·
  │               render 3            b2          ·               ·
- └── merge-join  ·                   ·           (a, b2, a, b1)  ·
+ └── merge join  ·                   ·           (a, b2, a, b1)  ·
       │          type                left outer  ·               ·
       │          equality            (a) = (a)   ·               ·
       │          left cols are key   ·           ·               ·
@@ -1289,7 +1289,7 @@ EXPLAIN SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a, b) = (a, b)
       │          right cols are key  ·
@@ -1331,7 +1331,7 @@ render          ·             ·
  │              render 1      b
  │              render 2      c
  │              render 3      d
- └── hash-join  ·             ·
+ └── hash join  ·             ·
       │         type          inner
       │         equality      (a, c) = (a, c)
       │         pred          (b = b) AND (d = d)
@@ -1358,7 +1358,7 @@ render           ·             ·
  │               render 4      a
  │               render 5      c
  │               render 6      d
- └── cross-join  ·             ·
+ └── cross join  ·             ·
       │          type          inner
       │          pred          b = b
       ├── scan   ·             ·
@@ -1383,7 +1383,7 @@ render          ·             ·
  │              render 3      d
  │              render 4      c
  │              render 5      d
- └── hash-join  ·             ·
+ └── hash join  ·             ·
       │         type          inner
       │         equality      (a) = (a)
       │         pred          b = b
@@ -1408,7 +1408,7 @@ render          ·             ·
  │              render 2      c
  │              render 3      d
  │              render 4      d
- └── hash-join  ·             ·
+ └── hash join  ·             ·
       │         type          inner
       │         equality      (a, c) = (a, c)
       │         pred          b = b
@@ -1427,7 +1427,7 @@ EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.b = bar.b
 ----
 ·           distribution  local
 ·           vectorized    true
-cross-join  ·             ·
+cross join  ·             ·
  │          type          inner
  │          pred          b = b
  ├── scan   ·             ·
@@ -1445,7 +1445,7 @@ EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
 ----
 ·          distribution  local
 ·          vectorized    true
-hash-join  ·             ·
+hash join  ·             ·
  │         type          inner
  │         equality      (a) = (a)
  │         pred          b = b
@@ -1463,7 +1463,7 @@ EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.b = bar.b
 ----
 ·           distribution  local
 ·           vectorized    true
-cross-join  ·             ·
+cross join  ·             ·
  │          type          inner
  │          pred          b = b
  ├── scan   ·             ·
@@ -1481,7 +1481,7 @@ EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
 ----
 ·          distribution  local
 ·          vectorized    true
-hash-join  ·             ·
+hash join  ·             ·
  │         type          inner
  │         equality      (a) = (a)
  │         pred          b = b
@@ -1499,7 +1499,7 @@ EXPLAIN SELECT * FROM foo JOIN bar USING (a,b) WHERE foo.c = bar.c AND foo.d = b
 ·               distribution  local
 ·               vectorized    true
 render          ·             ·
- └── hash-join  ·             ·
+ └── hash join  ·             ·
       │         type          inner
       │         equality      (a, c) = (a, c)
       │         pred          (b = b) AND (d = d)
@@ -1532,7 +1532,7 @@ EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ·                vectorized    true
 filter           ·             ·
  │               filter        c = 6.0
- └── index-join  ·             ·
+ └── index join  ·             ·
       │          table         zigzag@primary
       │          key columns   a
       └── scan   ·             ·
@@ -1549,7 +1549,7 @@ EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----
 ·            distribution  local
 ·            vectorized    true
-zigzag-join  ·             ·
+zigzag join  ·             ·
  │           type          inner
  │           pred          (@2 = 5) AND (@3 = 6.0)
  ├── scan    ·             ·
@@ -1566,13 +1566,13 @@ EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0
 ----
 ·                 distribution           local
 ·                 vectorized             true
-lookup-join       ·                      ·
+lookup join       ·                      ·
  │                table                  zigzag@primary
  │                type                   inner
  │                equality               (a) = (a)
  │                equality cols are key  ·
  │                parallel               ·
- └── zigzag-join  ·                      ·
+ └── zigzag join  ·                      ·
       │           type                   inner
       │           pred                   (@2 = 5) AND (@3 = 6.0)
       ├── scan    ·                      ·
@@ -1588,14 +1588,14 @@ EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0 AND d > 4
 ----
 ·                 distribution           local
 ·                 vectorized             true
-lookup-join       ·                      ·
+lookup join       ·                      ·
  │                table                  zigzag@primary
  │                type                   inner
  │                equality               (a) = (a)
  │                equality cols are key  ·
  │                parallel               ·
  │                pred                   d > 4.0
- └── zigzag-join  ·                      ·
+ └── zigzag join  ·                      ·
       │           type                   inner
       │           pred                   (@2 = 5) AND (@3 = 6.0)
       ├── scan    ·                      ·
@@ -1626,7 +1626,7 @@ EXPLAIN SELECT * FROM zigzag2 WHERE a = 1 AND b = 2 AND c IS NULL
 ·                vectorized    true
 filter           ·             ·
  │               filter        c IS NULL
- └── index-join  ·             ·
+ └── index join  ·             ·
       │          table         zigzag2@primary
       │          key columns   rowid
       └── scan   ·             ·
@@ -1640,7 +1640,7 @@ EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn USING(x)
 ·                    distribution    local
 ·                    vectorized      true
 render               ·               ·
- └── merge-join      ·               ·
+ └── merge join      ·               ·
       │              type            inner
       │              equality        (x) = (x)
       │              mergeJoinOrder  +"(x=x)"
@@ -1662,7 +1662,7 @@ EXPLAIN SELECT * FROM onecolumn NATURAL INNER MERGE JOIN twocolumn
 ·                    distribution    local
 ·                    vectorized      true
 render               ·               ·
- └── merge-join      ·               ·
+ └── merge join      ·               ·
       │              type            inner
       │              equality        (x) = (x)
       │              mergeJoinOrder  +"(x=x)"
@@ -1683,7 +1683,7 @@ EXPLAIN SELECT * FROM onecolumn CROSS MERGE JOIN twocolumn WHERE onecolumn.x = t
 ----
 ·               distribution    local
 ·               vectorized      true
-merge-join      ·               ·
+merge join      ·               ·
  │              type            inner
  │              equality        (x) = (x)
  │              mergeJoinOrder  +"(x=x)"
@@ -1713,7 +1713,7 @@ EXPLAIN SELECT * FROM cards LEFT OUTER HASH JOIN customers ON customers.id = car
 ----
 ·          distribution        local
 ·          vectorized          true
-hash-join  ·                   ·
+hash join  ·                   ·
  │         type                inner
  │         equality            (cust) = (id)
  │         right cols are key  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -41,13 +41,13 @@ EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc
 ----
 ·                 distribution           local        ·                         ·
 ·                 vectorized             true         ·                         ·
-lookup-join       ·                      ·            (a, b, c, d, b, x, c, y)  ·
+lookup join       ·                      ·            (a, b, c, d, b, x, c, y)  ·
  │                table                  cy@primary   ·                         ·
  │                type                   inner        ·                         ·
  │                equality               (c) = (c)    ·                         ·
  │                equality cols are key  ·            ·                         ·
  │                parallel               ·            ·                         ·
- └── lookup-join  ·                      ·            (a, b, c, d, b, x)        ·
+ └── lookup join  ·                      ·            (a, b, c, d, b, x)        ·
       │           table                  bx@primary   ·                         ·
       │           type                   inner        ·                         ·
       │           equality               (b) = (b)    ·                         ·
@@ -65,13 +65,13 @@ EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc
 ----
 ·                 distribution           local        ·                         ·
 ·                 vectorized             true         ·                         ·
-lookup-join       ·                      ·            (a, b, c, d, b, x, c, y)  ·
+lookup join       ·                      ·            (a, b, c, d, b, x, c, y)  ·
  │                table                  cy@primary   ·                         ·
  │                type                   inner        ·                         ·
  │                equality               (c) = (c)    ·                         ·
  │                equality cols are key  ·            ·                         ·
  │                parallel               ·            ·                         ·
- └── lookup-join  ·                      ·            (a, b, c, d, b, x)        ·
+ └── lookup join  ·                      ·            (a, b, c, d, b, x)        ·
       │           table                  bx@primary   ·                         ·
       │           type                   inner        ·                         ·
       │           equality               (b) = (b)    ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -14,7 +14,7 @@ limit                 ·             ·            (k, v, w)  +v
  │                    count         2            ·          ·
  └── filter           ·             ·            (k, v, w)  +v
       │               filter        w > 30       ·          ·
-      └── index-join  ·             ·            (k, v, w)  +v
+      └── index join  ·             ·            (k, v, w)  +v
            │          table         t@primary    ·          ·
            │          key columns   k            ·          ·
            └── scan   ·             ·            (k, v)     +v
@@ -169,7 +169,7 @@ EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 ORDER BY v LIMIT 
 render           ·             ·          (k, w)     ·
  │               render 0      k          ·          ·
  │               render 1      w          ·          ·
- └── index-join  ·             ·          (k, v, w)  +v
+ └── index join  ·             ·          (k, v, w)  +v
       │          table         t@primary  ·          ·
       │          key columns   k          ·          ·
       └── scan   ·             ·          (k, v)     +v

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -34,7 +34,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b
 tree         field         description  columns             ordering
 ·            distribution  full         ·                   ·
 ·            vectorized    true         ·                   ·
-lookup-join  ·             ·            (a, b, c, d, e, f)  ·
+lookup join  ·             ·            (a, b, c, d, e, f)  ·
  │           table         def@primary  ·                   ·
  │           type          inner        ·                   ·
  │           equality      (b) = (f)    ·                   ·
@@ -48,7 +48,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND e = c
 tree         field                  description      columns             ordering
 ·            distribution           full             ·                   ·
 ·            vectorized             true             ·                   ·
-lookup-join  ·                      ·                (a, b, c, d, e, f)  ·
+lookup join  ·                      ·                (a, b, c, d, e, f)  ·
  │           table                  def@primary      ·                   ·
  │           type                   inner            ·                   ·
  │           equality               (b, c) = (f, e)  ·                   ·
@@ -64,7 +64,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a > 1 AND e > 1
 tree         field         description  columns             ordering
 ·            distribution  full         ·                   ·
 ·            vectorized    true         ·                   ·
-lookup-join  ·             ·            (a, b, c, d, e, f)  ·
+lookup join  ·             ·            (a, b, c, d, e, f)  ·
  │           table         def@primary  ·                   ·
  │           type          inner        ·                   ·
  │           equality      (b) = (f)    ·                   ·
@@ -79,7 +79,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = a WHERE f > 1
 tree         field         description  columns             ordering
 ·            distribution  full         ·                   ·
 ·            vectorized    true         ·                   ·
-lookup-join  ·             ·            (a, b, c, d, e, f)  ·
+lookup join  ·             ·            (a, b, c, d, e, f)  ·
  │           table         def@primary  ·                   ·
  │           type          inner        ·                   ·
  │           equality      (a) = (f)    ·                   ·
@@ -94,7 +94,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a >= e
 tree         field         description  columns             ordering
 ·            distribution  full         ·                   ·
 ·            vectorized    true         ·                   ·
-lookup-join  ·             ·            (a, b, c, d, e, f)  ·
+lookup join  ·             ·            (a, b, c, d, e, f)  ·
  │           table         def@primary  ·                   ·
  │           type          inner        ·                   ·
  │           equality      (b) = (f)    ·                   ·
@@ -109,7 +109,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND a >= e
 tree         field         description  columns             ordering
 ·            distribution  full         ·                   ·
 ·            vectorized    true         ·                   ·
-lookup-join  ·             ·            (a, b, c, d, e, f)  ·
+lookup join  ·             ·            (a, b, c, d, e, f)  ·
  │           table         def@primary  ·                   ·
  │           type          inner        ·                   ·
  │           equality      (b) = (f)    ·                   ·
@@ -170,7 +170,7 @@ render               ·                      ·                            (a, b
  │                   render 1               b                            ·                         ·
  │                   render 2               c                            ·                         ·
  │                   render 3               d                            ·                         ·
- └── lookup-join     ·                      ·                            (a, b, c, d, a, b, c, d)  ·
+ └── lookup join     ·                      ·                            (a, b, c, d, a, b, c, d)  ·
       │              table                  data@primary                 ·                         ·
       │              type                   inner                        ·                         ·
       │              equality               (a, b, c, d) = (a, b, c, d)  ·                         ·
@@ -228,7 +228,7 @@ distinct               ·             ·                  (title)               
  │                     order key     title              ·                             ·
  └── render            ·             ·                  (title)                       +title
       │                render 0      title              ·                             ·
-      └── lookup-join  ·             ·                  (title, shelf, title, shelf)  +title
+      └── lookup join  ·             ·                  (title, shelf, title, shelf)  +title
            │           table         books2@primary     ·                             ·
            │           type          inner              ·                             ·
            │           equality      (title) = (title)  ·                             ·
@@ -260,12 +260,12 @@ distinct                  ·             ·                 (name)              
  │                        distinct on   name              ·                                         ·
  └── render               ·             ·                 (name)                                    ·
       │                   render 0      name              ·                                         ·
-      └── lookup-join     ·             ·                 (title, shelf, name, book, title, shelf)  ·
+      └── lookup join     ·             ·                 (title, shelf, name, book, title, shelf)  ·
            │              table         books2@primary    ·                                         ·
            │              type          inner             ·                                         ·
            │              equality      (book) = (title)  ·                                         ·
            │              pred          shelf != shelf    ·                                         ·
-           └── hash-join  ·             ·                 (title, shelf, name, book)                ·
+           └── hash join  ·             ·                 (title, shelf, name, book)                ·
                 │         type          inner             ·                                         ·
                 │         equality      (title) = (book)  ·                                         ·
                 ├── scan  ·             ·                 (title, shelf)                            ·
@@ -295,7 +295,7 @@ tree                 field         description       columns              orderi
 ·                    vectorized    true              ·                    ·
 render               ·             ·                 (name)               +name
  │                   render 0      name              ·                    ·
- └── lookup-join     ·             ·                 (name, book, title)  +name
+ └── lookup join     ·             ·                 (name, book, title)  +name
       │              table         books2@primary    ·                    ·
       │              type          inner             ·                    ·
       │              equality      (book) = (title)  ·                    ·
@@ -319,7 +319,7 @@ render           ·             ·               (title, edition, shelf, title, 
  │               render 3      title           ·                                               ·
  │               render 4      edition         ·                                               ·
  │               render 5      shelf           ·                                               ·
- └── cross-join  ·             ·               (title, edition, shelf, title, edition, shelf)  ·
+ └── cross join  ·             ·               (title, edition, shelf, title, edition, shelf)  ·
       │          type          cross           ·                                               ·
       ├── scan   ·             ·               (title, edition, shelf)                         ·
       │          table         books2@primary  ·                                               ·
@@ -383,7 +383,7 @@ EXPLAIN (VERBOSE) SELECT small.a, large.c FROM small JOIN large ON small.a = lar
 render            ·             ·              (a, c)     ·
  │                render 0      a              ·          ·
  │                render 1      c              ·          ·
- └── lookup-join  ·             ·              (a, b, c)  ·
+ └── lookup join  ·             ·              (a, b, c)  ·
       │           table         large@bc       ·          ·
       │           type          inner          ·          ·
       │           equality      (a) = (b)      ·          ·
@@ -400,13 +400,13 @@ EXPLAIN (VERBOSE) SELECT small.a, large.d FROM small JOIN large ON small.a = lar
 render                 ·                      ·                (a, d)        ·
  │                     render 0               a                ·             ·
  │                     render 1               d                ·             ·
- └── lookup-join       ·                      ·                (a, a, b, d)  ·
+ └── lookup join       ·                      ·                (a, a, b, d)  ·
       │                table                  large@primary    ·             ·
       │                type                   inner            ·             ·
       │                equality               (a, b) = (a, b)  ·             ·
       │                equality cols are key  ·                ·             ·
       │                parallel               ·                ·             ·
-      └── lookup-join  ·                      ·                (a, a, b)     ·
+      └── lookup join  ·                      ·                (a, a, b)     ·
            │           table                  large@bc         ·             ·
            │           type                   inner            ·             ·
            │           equality               (a) = (b)        ·             ·
@@ -424,7 +424,7 @@ EXPLAIN (VERBOSE) SELECT small.b, large.a FROM small LEFT JOIN large ON small.b 
 ----
 ·            distribution  full           ·       ·
 ·            vectorized    true           ·       ·
-lookup-join  ·             ·              (b, a)  ·
+lookup join  ·             ·              (b, a)  ·
  │           table         large@primary  ·       ·
  │           type          left outer     ·       ·
  │           equality      (b) = (a)      ·       ·
@@ -441,7 +441,7 @@ EXPLAIN (VERBOSE) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t
 render            ·             ·              (a, b)     +a
  │                render 0      a              ·          ·
  │                render 1      b              ·          ·
- └── lookup-join  ·             ·              (a, a, b)  +a
+ └── lookup join  ·             ·              (a, a, b)  +a
       │           table         large@primary  ·          ·
       │           type          left outer     ·          ·
       │           equality      (a) = (a)      ·          ·
@@ -464,7 +464,7 @@ EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c 
 render            ·             ·              (c, c)     ·
  │                render 0      c              ·          ·
  │                render 1      c              ·          ·
- └── lookup-join  ·             ·              (c, b, c)  ·
+ └── lookup join  ·             ·              (c, b, c)  ·
       │           table         large@bc       ·          ·
       │           type          left outer     ·          ·
       │           equality      (c) = (b)      ·          ·
@@ -481,13 +481,13 @@ EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c 
 render                 ·                      ·                (c, d)        ·
  │                     render 0               c                ·             ·
  │                     render 1               d                ·             ·
- └── lookup-join       ·                      ·                (c, a, b, d)  ·
+ └── lookup join       ·                      ·                (c, a, b, d)  ·
       │                table                  large@primary    ·             ·
       │                type                   left outer       ·             ·
       │                equality               (a, b) = (a, b)  ·             ·
       │                equality cols are key  ·                ·             ·
       │                parallel               ·                ·             ·
-      └── lookup-join  ·                      ·                (c, a, b)     ·
+      └── lookup join  ·                      ·                (c, a, b)     ·
            │           table                  large@bc         ·             ·
            │           type                   left outer       ·             ·
            │           equality               (c) = (b)        ·             ·
@@ -504,7 +504,7 @@ EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c 
 render            ·             ·              (c, c)     ·
  │                render 0      c              ·          ·
  │                render 1      c              ·          ·
- └── lookup-join  ·             ·              (c, b, c)  ·
+ └── lookup join  ·             ·              (c, b, c)  ·
       │           table         large@bc       ·          ·
       │           type          left outer     ·          ·
       │           equality      (c) = (b)      ·          ·
@@ -524,7 +524,7 @@ EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c 
 render               ·             ·              (c, d)     ·
  │                   render 0      c              ·          ·
  │                   render 1      d              ·          ·
- └── hash-join       ·             ·              (b, d, c)  ·
+ └── hash join       ·             ·              (b, d, c)  ·
       │              type          right outer    ·          ·
       │              equality      (b) = (c)      ·          ·
       ├── filter     ·             ·              (b, d)     ·
@@ -557,7 +557,7 @@ EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e 
 ·                    vectorized    true             ·                ·
 render               ·             ·                (a)              ·
  │                   render 0      a                ·                ·
- └── lookup-join     ·             ·                (a, d, e, a, d)  ·
+ └── lookup join     ·             ·                (a, d, e, a, d)  ·
       │              table         u@idx            ·                ·
       │              type          inner            ·                ·
       │              equality      (d, a) = (d, a)  ·                ·
@@ -581,7 +581,7 @@ EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e 
 ·                    vectorized             true       ·                ·
 render               ·                      ·          (a)              ·
  │                   render 0               a          ·                ·
- └── lookup-join     ·                      ·          (a, d, e, a, d)  ·
+ └── lookup join     ·                      ·          (a, d, e, a, d)  ·
       │              table                  u@idx      ·                ·
       │              type                   inner      ·                ·
       │              equality               (d) = (d)  ·                ·
@@ -608,7 +608,7 @@ EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = 
 ·                    vectorized    true                   ·                      ·
 render               ·             ·                      (a)                    ·
  │                   render 0      a                      ·                      ·
- └── lookup-join     ·             ·                      (a, b, d, e, a, b, d)  ·
+ └── lookup join     ·             ·                      (a, b, d, e, a, b, d)  ·
       │              table         u@idx                  ·                      ·
       │              type          inner                  ·                      ·
       │              equality      (d, a, b) = (d, a, b)  ·                      ·
@@ -632,7 +632,7 @@ EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = 
 ·                    vectorized    true                   ·                      ·
 render               ·             ·                      (a)                    ·
  │                   render 0      a                      ·                      ·
- └── lookup-join     ·             ·                      (a, b, d, e, a, b, d)  ·
+ └── lookup join     ·             ·                      (a, b, d, e, a, b, d)  ·
       │              table         u@idx                  ·                      ·
       │              type          inner                  ·                      ·
       │              equality      (d, b, a) = (d, b, a)  ·                      ·
@@ -656,7 +656,7 @@ EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = 
 ·                    vectorized    true       ·                ·
 render               ·             ·          (a)              ·
  │                   render 0      a          ·                ·
- └── lookup-join     ·             ·          (a, d, e, a, d)  ·
+ └── lookup join     ·             ·          (a, d, e, a, d)  ·
       │              table         u@idx      ·                ·
       │              type          inner      ·                ·
       │              equality      (d) = (d)  ·                ·
@@ -679,7 +679,7 @@ render            ·             ·            (d, e, f, a, b, c)  ·
  │                render 3      a            ·                   ·
  │                render 4      b            ·                   ·
  │                render 5      c            ·                   ·
- └── lookup-join  ·             ·            (a, b, c, d, e, f)  +a
+ └── lookup join  ·             ·            (a, b, c, d, e, f)  +a
       │           table         def@primary  ·                   ·
       │           type          inner        ·                   ·
       │           equality      (a) = (f)    ·                   ·
@@ -693,7 +693,7 @@ EXPLAIN (VERBOSE) SELECT * FROM def INNER MERGE JOIN abc ON a=f ORDER BY a
 ----
 ·           distribution    full         ·                   ·
 ·           vectorized      true         ·                   ·
-merge-join  ·               ·            (d, e, f, a, b, c)  +f
+merge join  ·               ·            (d, e, f, a, b, c)  +f
  │          type            inner        ·                   ·
  │          equality        (f) = (a)    ·                   ·
  │          mergeJoinOrder  +"(f=a)"     ·                   ·
@@ -712,7 +712,7 @@ EXPLAIN (VERBOSE) SELECT * FROM def INNER HASH JOIN abc ON a=f ORDER BY a
 ·               vectorized    true         ·                   ·
 sort            ·             ·            (d, e, f, a, b, c)  +f
  │              order         +f           ·                   ·
- └── hash-join  ·             ·            (d, e, f, a, b, c)  ·
+ └── hash join  ·             ·            (d, e, f, a, b, c)  ·
       │         type          inner        ·                   ·
       │         equality      (f) = (a)    ·                   ·
       ├── scan  ·             ·            (d, e, f)           ·
@@ -728,7 +728,7 @@ EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f)
 ----
 ·            distribution  full         ·          ·
 ·            vectorized    true         ·          ·
-lookup-join  ·             ·            (a, b, c)  ·
+lookup join  ·             ·            (a, b, c)  ·
  │           table         def@primary  ·          ·
  │           type          semi         ·          ·
  │           equality      (a) = (f)    ·          ·
@@ -741,7 +741,7 @@ EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=
 ----
 ·            distribution  full         ·          ·
 ·            vectorized    true         ·          ·
-lookup-join  ·             ·            (a, b, c)  ·
+lookup join  ·             ·            (a, b, c)  ·
  │           table         def@primary  ·          ·
  │           type          anti         ·          ·
  │           equality      (a) = (f)    ·          ·
@@ -754,7 +754,7 @@ EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AN
 ----
 ·            distribution           full             ·          ·
 ·            vectorized             true             ·          ·
-lookup-join  ·                      ·                (a, b, c)  ·
+lookup join  ·                      ·                (a, b, c)  ·
  │           table                  def@primary      ·          ·
  │           type                   semi             ·          ·
  │           equality               (a, c) = (f, e)  ·          ·
@@ -769,7 +769,7 @@ EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=
 ----
 ·            distribution           full             ·          ·
 ·            vectorized             true             ·          ·
-lookup-join  ·                      ·                (a, b, c)  ·
+lookup join  ·                      ·                (a, b, c)  ·
  │           table                  def@primary      ·          ·
  │           type                   anti             ·          ·
  │           equality               (a, c) = (f, e)  ·          ·
@@ -784,7 +784,7 @@ EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AN
 ----
 ·            distribution  full         ·          ·
 ·            vectorized    true         ·          ·
-lookup-join  ·             ·            (a, b, c)  ·
+lookup join  ·             ·            (a, b, c)  ·
  │           table         def@primary  ·          ·
  │           type          semi         ·          ·
  │           equality      (a) = (f)    ·          ·
@@ -798,7 +798,7 @@ EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=
 ----
 ·            distribution  full         ·          ·
 ·            vectorized    true         ·          ·
-lookup-join  ·             ·            (a, b, c)  ·
+lookup join  ·             ·            (a, b, c)  ·
  │           table         def@primary  ·          ·
  │           type          anti         ·          ·
  │           equality      (a) = (f)    ·          ·
@@ -846,7 +846,7 @@ group                  ·             ·
  │                     aggregate 0   count_rows()
  │                     scalar        ·
  └── render            ·             ·
-      └── lookup-join  ·             ·
+      └── lookup join  ·             ·
            │           table         a@primary
            │           type          inner
            │           equality      (a) = (a)
@@ -1440,42 +1440,42 @@ limit                                                                  ·       
            │                                                           aggregate 1            count_rows()
            │                                                           group by               s_name
            └── render                                                  ·                      ·
-                └── lookup-join                                        ·                      ·
+                └── lookup join                                        ·                      ·
                      │                                                 table                  lineitem@primary
                      │                                                 type                   semi
                      │                                                 equality               (l_orderkey) = (l_orderkey)
                      │                                                 pred                   l_suppkey != l_suppkey
-                     └── lookup-join                                   ·                      ·
+                     └── lookup join                                   ·                      ·
                           │                                            table                  orders@primary
                           │                                            type                   inner
                           │                                            equality               (l_orderkey) = (o_orderkey)
                           │                                            equality cols are key  ·
                           │                                            parallel               ·
                           │                                            pred                   o_orderstatus = 'F'
-                          └── lookup-join                              ·                      ·
+                          └── lookup join                              ·                      ·
                                │                                       table                  lineitem@primary
                                │                                       type                   anti
                                │                                       equality               (l_orderkey) = (l_orderkey)
                                │                                       pred                   l_receiptdate > l_commitdate
                                └── render                              ·                      ·
-                                    └── lookup-join                    ·                      ·
+                                    └── lookup join                    ·                      ·
                                          │                             table                  lineitem@primary
                                          │                             type                   inner
                                          │                             equality               (l_orderkey, l_linenumber) = (l_orderkey, l_linenumber)
                                          │                             equality cols are key  ·
                                          │                             parallel               ·
                                          │                             pred                   l_receiptdate > l_commitdate
-                                         └── lookup-join               ·                      ·
+                                         └── lookup join               ·                      ·
                                               │                        table                  lineitem@l_sk
                                               │                        type                   inner
                                               │                        equality               (s_suppkey) = (l_suppkey)
-                                              └── lookup-join          ·                      ·
+                                              └── lookup join          ·                      ·
                                                    │                   table                  supplier@primary
                                                    │                   type                   inner
                                                    │                   equality               (s_suppkey) = (s_suppkey)
                                                    │                   equality cols are key  ·
                                                    │                   parallel               ·
-                                                   └── lookup-join     ·                      ·
+                                                   └── lookup join     ·                      ·
                                                         │              table                  supplier@s_nk
                                                         │              type                   inner
                                                         │              equality               (n_nationkey) = (s_nationkey)
@@ -1500,7 +1500,7 @@ EXPLAIN (VERBOSE)
 ·                          vectorized             true                                          ·                                          ·
 render                     ·                      ·                                             (pk)                                       ·
  │                         render 0               pk                                            ·                                          ·
- └── lookup-join           ·                      ·                                             ("project_const_col_@14", pk, col0, col3)  ·
+ └── lookup join           ·                      ·                                             ("project_const_col_@14", pk, col0, col3)  ·
       │                    table                  tab4@tab4_col3_col4_key                       ·                                          ·
       │                    type                   semi                                          ·                                          ·
       │                    equality               (col0, project_const_col_@14) = (col3, col4)  ·                                          ·
@@ -1511,7 +1511,7 @@ render                     ·                      ·                           
            │               render 1               pk                                            ·                                          ·
            │               render 2               col0                                          ·                                          ·
            │               render 3               col3                                          ·                                          ·
-           └── index-join  ·                      ·                                             (pk, col0, col3)                           ·
+           └── index join  ·                      ·                                             (pk, col0, col3)                           ·
                 │          table                  tab4@primary                                  ·                                          ·
                 │          key columns            pk                                            ·                                          ·
                 └── scan   ·                      ·                                             (pk, col3)                                 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -270,7 +270,7 @@ render                ·                ·
  └── sort             ·                ·
       │               order            +b,+a,+d
       │               already ordered  +b,+a
-      └── index-join  ·                ·
+      └── index join  ·                ·
            │          table            abc@primary
            │          key columns      a, b, c
            └── scan   ·                ·
@@ -574,7 +574,7 @@ EXPLAIN (VERBOSE) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDE
 render                      ·              ·                   (b)     ·
  │                          render 0       b                   ·       ·
  └── run                    ·              ·                   (a, b)  ·
-      └── insert-fast-path  ·              ·                   (a, b)  ·
+      └── insert fast path  ·              ·                   (a, b)  ·
 ·                           into           t(a, b, c)          ·       ·
 ·                           strategy       inserter            ·       ·
 ·                           auto commit    ·                   ·       ·
@@ -869,7 +869,7 @@ render                      ·                      ·                 (k)      
       └── render            ·                      ·                 (k, v)           ·
            │                render 0               k                 ·                ·
            │                render 1               v                 ·                ·
-           └── lookup-join  ·                      ·                 (column1, k, v)  ·
+           └── lookup join  ·                      ·                 (column1, k, v)  ·
                 │           table                  kv@primary        ·                ·
                 │           type                   inner             ·                ·
                 │           equality               (column1) = (k)   ·                ·
@@ -887,7 +887,7 @@ EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ·                vectorized          true               ·             ·
 render           ·                   ·                  (k)           ·
  │               render 0            k                  ·             ·
- └── merge-join  ·                   ·                  (k, v, k, v)  -v,+k
+ └── merge join  ·                   ·                  (k, v, k, v)  -v,+k
       │          type                inner              ·             ·
       │          equality            (v, k) = (v, k)    ·             ·
       │          left cols are key   ·                  ·             ·
@@ -913,7 +913,7 @@ sort                  ·             ·                (x, y, z)      +x
  │                    order         +x               ·              ·
  └── filter           ·             ·                (x, y, z)      ·
       │               filter        x = y            ·              ·
-      └── index-join  ·             ·                (x, y, z)      ·
+      └── index join  ·             ·                (x, y, z)      ·
            │          table         xyz@primary      ·              ·
            │          key columns   rowid            ·              ·
            └── scan   ·             ·                (y, z, rowid)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -57,7 +57,7 @@ EXECUTE change_stats
 ----
 ·           distribution        full
 ·           vectorized          true
-merge-join  ·                   ·
+merge join  ·                   ·
  │          type                inner
  │          equality            (a) = (c)
  │          left cols are key   ·
@@ -81,7 +81,7 @@ EXECUTE change_stats
 ----
 ·            distribution           full
 ·            vectorized             true
-lookup-join  ·                      ·
+lookup join  ·                      ·
  │           table                  cd@primary
  │           type                   inner
  │           equality               (a) = (c)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1320,7 +1320,7 @@ EXPLAIN SELECT price FROM a WHERE item IN ('sock', 'ball')
 ·                distribution  local
 ·                vectorized    true
 render           ·             ·
- └── index-join  ·             ·
+ └── index join  ·             ·
       │          table         a@primary
       │          key columns   a
       └── scan   ·             ·
@@ -1336,7 +1336,7 @@ EXPLAIN SELECT item FROM a WHERE price > 5 AND price < 10 OR price > 20 AND pric
 ·                distribution  local
 ·                vectorized    true
 render           ·             ·
- └── index-join  ·             ·
+ └── index join  ·             ·
       │          table         a@primary
       │          key columns   a
       └── scan   ·             ·
@@ -1501,7 +1501,7 @@ render                         ·             ·
       └── sort                 ·             ·
            │                   order         +z
            └── project set     ·             ·
-                └── hash-join  ·             ·
+                └── hash join  ·             ·
                      │         type          inner
                      │         equality      (y) = (y)
                      ├── scan  ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -528,7 +528,7 @@ EXPLAIN SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE
 ·                    distribution           local
 ·                    vectorized             true
 render               ·                      ·
- └── lookup-join     ·                      ·
+ └── lookup join     ·                      ·
       │              table                  t@primary
       │              type                   inner
       │              equality               (b) = (a)
@@ -546,7 +546,7 @@ EXPLAIN SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE)
 ·                    distribution           local
 ·                    vectorized             true
 render               ·                      ·
- └── lookup-join     ·                      ·
+ └── lookup join     ·                      ·
       │              table                  t@primary
       │              type                   inner
       │              equality               (b) = (a)
@@ -565,7 +565,7 @@ EXPLAIN SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE OF t
 ·                    distribution           local
 ·                    vectorized             true
 render               ·                      ·
- └── lookup-join     ·                      ·
+ └── lookup join     ·                      ·
       │              table                  t@primary
       │              type                   inner
       │              equality               (b) = (a)
@@ -583,7 +583,7 @@ EXPLAIN SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE OF t)
 ·                    distribution           local
 ·                    vectorized             true
 render               ·                      ·
- └── lookup-join     ·                      ·
+ └── lookup join     ·                      ·
       │              table                  t@primary
       │              type                   inner
       │              equality               (b) = (a)
@@ -630,40 +630,40 @@ render     ·             ·
 query TTT
 EXPLAIN SELECT * FROM [SELECT a FROM t FOR UPDATE]
 ----
-·                      distribution      local
-·                      vectorized        false
-root                   ·                 ·
- ├── scan buffer node  ·                 ·
- │                     label             buffer 1
- └── subquery          ·                 ·
-      │                id                @S1
-      │                original sql      SELECT a FROM t FOR UPDATE
-      │                exec mode         all rows
-      └── buffer node  ·                 ·
-           │           label             buffer 1
-           └── scan    ·                 ·
-·                      table             t@primary
-·                      spans             FULL SCAN
-·                      locking strength  for update
+·                    distribution      local
+·                    vectorized        false
+root                 ·                 ·
+ ├── scan buffer     ·                 ·
+ │                   label             buffer 1
+ └── subquery        ·                 ·
+      │              id                @S1
+      │              original sql      SELECT a FROM t FOR UPDATE
+      │              exec mode         all rows
+      └── buffer     ·                 ·
+           │         label             buffer 1
+           └── scan  ·                 ·
+·                    table             t@primary
+·                    spans             FULL SCAN
+·                    locking strength  for update
 
 query TTT
 EXPLAIN WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
 ----
-·                      distribution      local
-·                      vectorized        false
-root                   ·                 ·
- ├── scan buffer node  ·                 ·
- │                     label             buffer 1 (cte)
- └── subquery          ·                 ·
-      │                id                @S1
-      │                original sql      SELECT a FROM t FOR UPDATE
-      │                exec mode         all rows
-      └── buffer node  ·                 ·
-           │           label             buffer 1 (cte)
-           └── scan    ·                 ·
-·                      table             t@primary
-·                      spans             FULL SCAN
-·                      locking strength  for update
+·                    distribution      local
+·                    vectorized        false
+root                 ·                 ·
+ ├── scan buffer     ·                 ·
+ │                   label             buffer 1 (cte)
+ └── subquery        ·                 ·
+      │              id                @S1
+      │              original sql      SELECT a FROM t FOR UPDATE
+      │              exec mode         all rows
+      └── buffer     ·                 ·
+           │         label             buffer 1 (cte)
+           └── scan  ·                 ·
+·                    table             t@primary
+·                    spans             FULL SCAN
+·                    locking strength  for update
 
 # Verify that the unused CTE doesn't get eliminated.
 # TODO(radu): we should at least not buffer the rows in this case.
@@ -671,22 +671,22 @@ query TTT
 EXPLAIN WITH sfu AS (SELECT a FROM t FOR UPDATE)
 SELECT c FROM u
 ----
-·                      distribution      local
-·                      vectorized        true
-root                   ·                 ·
- ├── scan              ·                 ·
- │                     table             u@primary
- │                     spans             FULL SCAN
- └── subquery          ·                 ·
-      │                id                @S1
-      │                original sql      SELECT a FROM t FOR UPDATE
-      │                exec mode         all rows
-      └── buffer node  ·                 ·
-           │           label             buffer 1 (sfu)
-           └── scan    ·                 ·
-·                      table             t@primary
-·                      spans             FULL SCAN
-·                      locking strength  for update
+·                    distribution      local
+·                    vectorized        true
+root                 ·                 ·
+ ├── scan            ·                 ·
+ │                   table             u@primary
+ │                   spans             FULL SCAN
+ └── subquery        ·                 ·
+      │              id                @S1
+      │              original sql      SELECT a FROM t FOR UPDATE
+      │              exec mode         all rows
+      └── buffer     ·                 ·
+           │         label             buffer 1 (sfu)
+           └── scan  ·                 ·
+·                    table             t@primary
+·                    spans             FULL SCAN
+·                    locking strength  for update
 
 # ------------------------------------------------------------------------------
 # Tests with joins.
@@ -698,7 +698,7 @@ EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -719,7 +719,7 @@ EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -739,7 +739,7 @@ EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF u
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -759,7 +759,7 @@ EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t, u
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -780,7 +780,7 @@ EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t FOR SHARE OF u
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -804,7 +804,7 @@ EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2 FOR SHARE 
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -825,7 +825,7 @@ EXPLAIN SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR UPDATE
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -846,7 +846,7 @@ EXPLAIN SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR NO KEY UPDATE OF t
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -867,7 +867,7 @@ EXPLAIN SELECT * FROM t JOIN u USING (a) FOR SHARE FOR NO KEY UPDATE OF t FOR UP
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -892,7 +892,7 @@ EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -922,7 +922,7 @@ EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -942,7 +942,7 @@ EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u2
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -962,7 +962,7 @@ EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2, u2
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -987,7 +987,7 @@ EXPLAIN SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -1017,7 +1017,7 @@ EXPLAIN SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF j
 ·                distribution        local
 ·                vectorized          true
 render           ·                   ·
- └── merge-join  ·                   ·
+ └── merge join  ·                   ·
       │          type                inner
       │          equality            (a) = (a)
       │          left cols are key   ·
@@ -1041,7 +1041,7 @@ EXPLAIN SELECT * FROM t, u FOR UPDATE
 ----
 ·           distribution      local
 ·           vectorized        true
-cross-join  ·                 ·
+cross join  ·                 ·
  │          type              cross
  ├── scan   ·                 ·
  │          table             t@primary
@@ -1057,7 +1057,7 @@ EXPLAIN SELECT * FROM t, u FOR UPDATE OF t
 ----
 ·           distribution      local
 ·           vectorized        true
-cross-join  ·                 ·
+cross join  ·                 ·
  │          type              cross
  ├── scan   ·                 ·
  │          table             t@primary
@@ -1072,7 +1072,7 @@ EXPLAIN SELECT * FROM t, u FOR SHARE OF t FOR UPDATE OF u
 ----
 ·           distribution      local
 ·           vectorized        true
-cross-join  ·                 ·
+cross join  ·                 ·
  │          type              cross
  ├── scan   ·                 ·
  │          table             t@primary
@@ -1088,7 +1088,7 @@ EXPLAIN SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE
 ----
 ·           distribution      local
 ·           vectorized        true
-cross-join  ·                 ·
+cross join  ·                 ·
  │          type              cross
  ├── scan   ·                 ·
  │          table             t@primary
@@ -1107,7 +1107,7 @@ EXPLAIN SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF sub
 ----
 ·           distribution      local
 ·           vectorized        true
-cross-join  ·                 ·
+cross join  ·                 ·
  │          type              cross
  ├── scan   ·                 ·
  │          table             t@primary

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -205,17 +205,17 @@ render                ·               ·                    (b, a, c, d, a, c, 
  │                    render 4        a                    ·                         ·
  │                    render 5        c                    ·                         ·
  │                    render 6        d                    ·                         ·
- └── merge-join       ·               ·                    (a, b, c, d, a, b, c, d)  ·
+ └── merge join       ·               ·                    (a, b, c, d, a, b, c, d)  ·
       │               type            inner                ·                         ·
       │               equality        (b) = (b)            ·                         ·
       │               mergeJoinOrder  +"(b=b)"             ·                         ·
-      ├── index-join  ·               ·                    (a, b, c, d)              ·
+      ├── index join  ·               ·                    (a, b, c, d)              ·
       │    │          table           t@primary            ·                         ·
       │    │          key columns     a, b                 ·                         ·
       │    └── scan   ·               ·                    (a, b, c)                 ·
       │               table           t@bc                 ·                         ·
       │               spans           /"3"-/"3"/PrefixEnd  ·                         ·
-      └── index-join  ·               ·                    (a, b, c, d)              ·
+      └── index join  ·               ·                    (a, b, c, d)              ·
            │          table           t@primary            ·                         ·
            │          key columns     a, b                 ·                         ·
            └── scan   ·               ·                    (a, b, c)                 ·
@@ -736,7 +736,7 @@ EXPLAIN (VERBOSE) SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20
 ----
 ·             distribution  local                    ·           ·
 ·             vectorized    true                     ·           ·
-index-join    ·             ·                        (id, k, v)  -k
+index join    ·             ·                        (id, k, v)  -k
  │            table         test2@primary            ·           ·
  │            key columns   id                       ·           ·
  └── revscan  ·             ·                        (id, k)     -k
@@ -968,7 +968,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM NULL
 ----
 ·           distribution  local         ·           ·
 ·           vectorized    true          ·           ·
-index-join  ·             ·             (x, y)      ·
+index join  ·             ·             (x, y)      ·
  │          table         xy@primary    ·           ·
  │          key columns   rowid         ·           ·
  └── scan   ·             ·             (y, rowid)  ·
@@ -980,7 +980,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM 4
 ----
 ·           distribution  local        ·           ·
 ·           vectorized    true         ·           ·
-index-join  ·             ·            (x, y)      ·
+index join  ·             ·            (x, y)      ·
  │          table         xy@primary   ·           ·
  │          key columns   rowid        ·           ·
  └── scan   ·             ·            (y, rowid)  ·
@@ -994,7 +994,7 @@ EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
 ·                vectorized    true         ·           ·
 render           ·             ·            (x)         ·
  │               render 0      x            ·           ·
- └── index-join  ·             ·            (x, y)      ·
+ └── index join  ·             ·            (x, y)      ·
       │          table         xy@primary   ·           ·
       │          key columns   rowid        ·           ·
       └── scan   ·             ·            (y, rowid)  ·
@@ -1073,7 +1073,7 @@ EXPLAIN SELECT * FROM noncover WHERE b = 2
 ----
 ·           distribution  local
 ·           vectorized    true
-index-join  ·             ·
+index join  ·             ·
  │          table         noncover@primary
  │          key columns   a
  └── scan   ·             ·
@@ -1100,7 +1100,7 @@ EXPLAIN SELECT * FROM noncover WHERE c = 6
 ----
 ·           distribution  local
 ·           vectorized    true
-index-join  ·             ·
+index join  ·             ·
  │          table         noncover@primary
  │          key columns   a
  └── scan   ·             ·
@@ -1178,7 +1178,7 @@ EXPLAIN SELECT * FROM noncover ORDER BY c LIMIT 5
 ----
 ·           distribution  local
 ·           vectorized    true
-index-join  ·             ·
+index join  ·             ·
  │          table         noncover@primary
  │          key columns   a
  └── scan   ·             ·
@@ -1211,7 +1211,7 @@ EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c LIMIT 5 OFFSET 5
 ·                vectorized    true
 limit            ·             ·
  │               offset        5
- └── index-join  ·             ·
+ └── index join  ·             ·
       │          table         noncover@primary
       │          key columns   a
       └── scan   ·             ·
@@ -1282,7 +1282,7 @@ EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0
 ----
 ·               distribution  local
 ·               vectorized    true
-index-join      ·             ·
+index join      ·             ·
  │              table         t2@primary
  │              key columns   a
  └── filter     ·             ·
@@ -1316,7 +1316,7 @@ EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c != b
 ----
 ·           distribution  local
 ·           vectorized    true
-index-join  ·             ·
+index join  ·             ·
  │          table         t2@primary
  │          key columns   a
  └── scan   ·             ·
@@ -1425,7 +1425,7 @@ EXPLAIN (VERBOSE) SELECT a FROM t2 WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s !
 ·                vectorized    true        ·          ·
 render           ·             ·           (a)        ·
  │               render 0      a           ·          ·
- └── index-join  ·             ·           (a, b, s)  ·
+ └── index join  ·             ·           (a, b, s)  ·
       │          table         t2@primary  ·          ·
       │          key columns   a           ·          ·
       └── scan   ·             ·           (a, b)     ·
@@ -1442,7 +1442,7 @@ EXPLAIN (VERBOSE) SELECT w FROM t3 WHERE v > 0 AND v < 10 ORDER BY v
 ·                vectorized    true        ·       ·
 render           ·             ·           (w)     ·
  │               render 0      w           ·       ·
- └── index-join  ·             ·           (v, w)  +v
+ └── index join  ·             ·           (v, w)  +v
       │          table         t3@primary  ·       ·
       │          key columns   k           ·       ·
       └── scan   ·             ·           (k, v)  +v

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -87,7 +87,7 @@ EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ·                vectorized    true
 filter           ·             ·
  │               filter        (a >= 20) AND (a <= 30)
- └── index-join  ·             ·
+ └── index join  ·             ·
       │          table         abcd@primary
       │          key columns   a
       └── scan   ·             ·
@@ -102,7 +102,7 @@ EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} WHERE a >= 20 AND a <= 30
 ·                  vectorized    true
 filter             ·             ·
  │                 filter        (a >= 20) AND (a <= 30)
- └── index-join    ·             ·
+ └── index join    ·             ·
       │            table         abcd@primary
       │            key columns   a
       └── revscan  ·             ·
@@ -115,7 +115,7 @@ EXPLAIN SELECT * FROM abcd@b ORDER BY b DESC LIMIT 5
 ----
 ·             distribution  local
 ·             vectorized    true
-index-join    ·             ·
+index join    ·             ·
  │            table         abcd@primary
  │            key columns   a
  └── revscan  ·             ·
@@ -129,7 +129,7 @@ EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} ORDER BY b DESC LIMIT 5
 ----
 ·             distribution  local
 ·             vectorized    true
-index-join    ·             ·
+index join    ·             ·
  │            table         abcd@primary
  │            key columns   a
  └── revscan  ·             ·
@@ -144,7 +144,7 @@ EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,ASC} ORDER BY b DESC LIMIT 5
 ----
 ·                    distribution  local
 ·                    vectorized    true
-index-join           ·             ·
+index join           ·             ·
  │                   table         abcd@primary
  │                   key columns   a
  └── limit           ·             ·
@@ -163,7 +163,7 @@ EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ·                vectorized    true
 filter           ·             ·
  │               filter        (a >= 20) AND (a <= 30)
- └── index-join  ·             ·
+ └── index join  ·             ·
       │          table         abcd@primary
       │          key columns   a
       └── scan   ·             ·
@@ -204,7 +204,7 @@ EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 render                ·             ·
  └── filter           ·             ·
       │               filter        (c >= 20) AND (c <= 30)
-      └── index-join  ·             ·
+      └── index join  ·             ·
            │          table         abcd@primary
            │          key columns   a
            └── scan   ·             ·
@@ -241,7 +241,7 @@ EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ·                vectorized    true
 filter           ·             ·
  │               filter        (c >= 20) AND (c < 40)
- └── index-join  ·             ·
+ └── index join  ·             ·
       │          table         abcd@primary
       │          key columns   a
       └── scan   ·             ·
@@ -255,7 +255,7 @@ EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ·                vectorized    true
 filter           ·             ·
  │               filter        (a >= 20) AND (a <= 30)
- └── index-join  ·             ·
+ └── index join  ·             ·
       │          table         abcd@primary
       │          key columns   a
       └── scan   ·             ·
@@ -267,7 +267,7 @@ EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
 ·           distribution  local
 ·           vectorized    true
-index-join  ·             ·
+index join  ·             ·
  │          table         abcd@primary
  │          key columns   a
  └── scan   ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -16,13 +16,13 @@ EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x)
 root                                ·             ·
  ├── limit                          ·             ·
  │    │                             count         1
- │    └── scan buffer node          ·             ·
+ │    └── scan buffer               ·             ·
  │                                  label         buffer 1 (a)
  └── subquery                       ·             ·
       │                             id            @S1
       │                             original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
       │                             exec mode     all rows
-      └── buffer node               ·             ·
+      └── buffer                    ·             ·
            │                        label         buffer 1 (a)
            └── spool                ·             ·
                 └── run             ·             ·
@@ -42,13 +42,13 @@ EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
 root                                ·             ·
  ├── limit                          ·             ·
  │    │                             count         1
- │    └── scan buffer node          ·             ·
+ │    └── scan buffer               ·             ·
  │                                  label         buffer 1 (a)
  └── subquery                       ·             ·
       │                             id            @S1
       │                             original sql  DELETE FROM t RETURNING x
       │                             exec mode     all rows
-      └── buffer node               ·             ·
+      └── buffer                    ·             ·
            │                        label         buffer 1 (a)
            └── spool                ·             ·
                 └── run             ·             ·
@@ -69,13 +69,13 @@ EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
 root                                     ·                 ·
  ├── limit                               ·                 ·
  │    │                                  count             1
- │    └── scan buffer node               ·                 ·
+ │    └── scan buffer                    ·                 ·
  │                                       label             buffer 1 (a)
  └── subquery                            ·                 ·
       │                                  id                @S1
       │                                  original sql      UPDATE t SET x = x + 1 RETURNING x
       │                                  exec mode         all rows
-      └── buffer node                    ·                 ·
+      └── buffer                         ·                 ·
            │                             label             buffer 1 (a)
            └── spool                     ·                 ·
                 └── run                  ·                 ·
@@ -98,13 +98,13 @@ EXPLAIN WITH a AS (UPSERT INTO t VALUES (2), (3) RETURNING x)
 root                                  ·             ·
  ├── limit                            ·             ·
  │    │                               count         1
- │    └── scan buffer node            ·             ·
+ │    └── scan buffer                 ·             ·
  │                                    label         buffer 1 (a)
  └── subquery                         ·             ·
       │                               id            @S1
       │                               original sql  UPSERT INTO t VALUES (2), (3) RETURNING x
       │                               exec mode     all rows
-      └── buffer node                 ·             ·
+      └── buffer                      ·             ·
            │                          label         buffer 1 (a)
            └── spool                  ·             ·
                 └── run               ·             ·
@@ -123,13 +123,13 @@ EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x] LIMIT 1
 root                                ·             ·
  ├── limit                          ·             ·
  │    │                             count         1
- │    └── scan buffer node          ·             ·
+ │    └── scan buffer               ·             ·
  │                                  label         buffer 1
  └── subquery                       ·             ·
       │                             id            @S1
       │                             original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
       │                             exec mode     all rows
-      └── buffer node               ·             ·
+      └── buffer                    ·             ·
            │                        label         buffer 1
            └── spool                ·             ·
                 └── run             ·             ·
@@ -148,13 +148,13 @@ EXPLAIN SELECT * FROM [DELETE FROM t RETURNING x] LIMIT 1
 root                                ·             ·
  ├── limit                          ·             ·
  │    │                             count         1
- │    └── scan buffer node          ·             ·
+ │    └── scan buffer               ·             ·
  │                                  label         buffer 1
  └── subquery                       ·             ·
       │                             id            @S1
       │                             original sql  DELETE FROM t RETURNING x
       │                             exec mode     all rows
-      └── buffer node               ·             ·
+      └── buffer                    ·             ·
            │                        label         buffer 1
            └── spool                ·             ·
                 └── run             ·             ·
@@ -173,13 +173,13 @@ EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
 root                                     ·                 ·
  ├── limit                               ·                 ·
  │    │                                  count             1
- │    └── scan buffer node               ·                 ·
+ │    └── scan buffer                    ·                 ·
  │                                       label             buffer 1
  └── subquery                            ·                 ·
       │                                  id                @S1
       │                                  original sql      UPDATE t SET x = x + 1 RETURNING x
       │                                  exec mode         all rows
-      └── buffer node                    ·                 ·
+      └── buffer                         ·                 ·
            │                             label             buffer 1
            └── spool                     ·                 ·
                 └── run                  ·                 ·
@@ -201,13 +201,13 @@ EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2), (3) RETURNING x] LIMIT 1
 root                                  ·             ·
  ├── limit                            ·             ·
  │    │                               count         1
- │    └── scan buffer node            ·             ·
+ │    └── scan buffer                 ·             ·
  │                                    label         buffer 1
  └── subquery                         ·             ·
       │                               id            @S1
       │                               original sql  UPSERT INTO t VALUES (2), (3) RETURNING x
       │                               exec mode     all rows
-      └── buffer node                 ·             ·
+      └── buffer                      ·             ·
            │                          label         buffer 1
            └── spool                  ·             ·
                 └── run               ·             ·
@@ -228,13 +228,13 @@ root                                ·             ·
  │    │                             aggregate 0   count_rows()
  │    │                             scalar        ·
  │    └── render                    ·             ·
- │         └── scan buffer node     ·             ·
+ │         └── scan buffer          ·             ·
  │                                  label         buffer 1
  └── subquery                       ·             ·
       │                             id            @S1
       │                             original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
       │                             exec mode     all rows
-      └── buffer node               ·             ·
+      └── buffer                    ·             ·
            │                        label         buffer 1
            └── spool                ·             ·
                 └── run             ·             ·
@@ -251,9 +251,9 @@ EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x], t
 ·                                   distribution  local
 ·                                   vectorized    false
 root                                ·             ·
- ├── cross-join                     ·             ·
+ ├── cross join                     ·             ·
  │    │                             type          cross
- │    ├── scan buffer node          ·             ·
+ │    ├── scan buffer               ·             ·
  │    │                             label         buffer 1
  │    └── scan                      ·             ·
  │                                  table         t@primary
@@ -262,7 +262,7 @@ root                                ·             ·
       │                             id            @S1
       │                             original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
       │                             exec mode     all rows
-      └── buffer node               ·             ·
+      └── buffer                    ·             ·
            │                        label         buffer 1
            └── spool                ·             ·
                 └── run             ·             ·
@@ -281,41 +281,41 @@ EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x),
              b AS (INSERT INTO t SELECT x+1 FROM a RETURNING x)
         SELECT * FROM b LIMIT 1
 ----
-·                                                    distribution  local
-·                                                    vectorized    false
-root                                                 ·             ·
- ├── limit                                           ·             ·
- │    │                                              count         1
- │    └── scan buffer node                           ·             ·
- │                                                   label         buffer 2 (b)
- ├── subquery                                        ·             ·
- │    │                                              id            @S1
- │    │                                              original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
- │    │                                              exec mode     all rows
- │    └── buffer node                                ·             ·
- │         │                                         label         buffer 1 (a)
- │         └── spool                                 ·             ·
- │              └── run                              ·             ·
- │                   └── insert                      ·             ·
- │                        │                          into          t(x)
- │                        │                          strategy      inserter
- │                        └── scan                   ·             ·
- │                                                   table         t2@primary
- │                                                   spans         FULL SCAN
- └── subquery                                        ·             ·
-      │                                              id            @S2
-      │                                              original sql  INSERT INTO t SELECT x + 1 FROM a RETURNING x
-      │                                              exec mode     all rows
-      └── buffer node                                ·             ·
-           │                                         label         buffer 2 (b)
-           └── spool                                 ·             ·
-                └── run                              ·             ·
-                     └── insert                      ·             ·
-                          │                          into          t(x)
-                          │                          strategy      inserter
-                          └── render                 ·             ·
-                               └── scan buffer node  ·             ·
-·                                                    label         buffer 1 (a)
+·                                               distribution  local
+·                                               vectorized    false
+root                                            ·             ·
+ ├── limit                                      ·             ·
+ │    │                                         count         1
+ │    └── scan buffer                           ·             ·
+ │                                              label         buffer 2 (b)
+ ├── subquery                                   ·             ·
+ │    │                                         id            @S1
+ │    │                                         original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
+ │    │                                         exec mode     all rows
+ │    └── buffer                                ·             ·
+ │         │                                    label         buffer 1 (a)
+ │         └── spool                            ·             ·
+ │              └── run                         ·             ·
+ │                   └── insert                 ·             ·
+ │                        │                     into          t(x)
+ │                        │                     strategy      inserter
+ │                        └── scan              ·             ·
+ │                                              table         t2@primary
+ │                                              spans         FULL SCAN
+ └── subquery                                   ·             ·
+      │                                         id            @S2
+      │                                         original sql  INSERT INTO t SELECT x + 1 FROM a RETURNING x
+      │                                         exec mode     all rows
+      └── buffer                                ·             ·
+           │                                    label         buffer 2 (b)
+           └── spool                            ·             ·
+                └── run                         ·             ·
+                     └── insert                 ·             ·
+                          │                     into          t(x)
+                          │                     strategy      inserter
+                          └── render            ·             ·
+                               └── scan buffer  ·             ·
+·                                               label         buffer 1 (a)
 
 # Check that no spool is inserted if a top-level render is elided.
 query TTT
@@ -324,13 +324,13 @@ EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ·                                   distribution  local
 ·                                   vectorized    false
 root                                ·             ·
- ├── scan buffer node               ·             ·
+ ├── scan buffer                    ·             ·
  │                                  label         buffer 1
  └── subquery                       ·             ·
       │                             id            @S1
       │                             original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
       │                             exec mode     all rows
-      └── buffer node               ·             ·
+      └── buffer                    ·             ·
            │                        label         buffer 1
            └── spool                ·             ·
                 └── run             ·             ·
@@ -346,30 +346,30 @@ root                                ·             ·
 query TTT
 EXPLAIN INSERT INTO t SELECT x+1 FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
-·                                     distribution  local
-·                                     vectorized    false
-root                                  ·             ·
- ├── count                            ·             ·
- │    └── insert                      ·             ·
- │         │                          into          t(x)
- │         │                          strategy      inserter
- │         └── render                 ·             ·
- │              └── scan buffer node  ·             ·
- │                                    label         buffer 1
- └── subquery                         ·             ·
-      │                               id            @S1
-      │                               original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
-      │                               exec mode     all rows
-      └── buffer node                 ·             ·
-           │                          label         buffer 1
-           └── spool                  ·             ·
-                └── run               ·             ·
-                     └── insert       ·             ·
-                          │           into          t(x)
-                          │           strategy      inserter
-                          └── scan    ·             ·
-·                                     table         t2@primary
-·                                     spans         FULL SCAN
+·                                   distribution  local
+·                                   vectorized    false
+root                                ·             ·
+ ├── count                          ·             ·
+ │    └── insert                    ·             ·
+ │         │                        into          t(x)
+ │         │                        strategy      inserter
+ │         └── render               ·             ·
+ │              └── scan buffer     ·             ·
+ │                                  label         buffer 1
+ └── subquery                       ·             ·
+      │                             id            @S1
+      │                             original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
+      │                             exec mode     all rows
+      └── buffer                    ·             ·
+           │                        label         buffer 1
+           └── spool                ·             ·
+                └── run             ·             ·
+                     └── insert     ·             ·
+                          │         into          t(x)
+                          │         strategy      inserter
+                          └── scan  ·             ·
+·                                   table         t2@primary
+·                                   spans         FULL SCAN
 
 # Check that simple computations using RETURNING get their spool pulled up.
 query TTT
@@ -382,13 +382,13 @@ root                                     ·             ·
  │    │                                  count         10
  │    └── filter                         ·             ·
  │         │                             filter        "?column?" < 3
- │         └── scan buffer node          ·             ·
+ │         └── scan buffer               ·             ·
  │                                       label         buffer 1
  └── subquery                            ·             ·
       │                                  id            @S1
       │                                  original sql  INSERT INTO t SELECT * FROM t2 RETURNING x + 10
       │                                  exec mode     all rows
-      └── buffer node                    ·             ·
+      └── buffer                         ·             ·
            │                             label         buffer 1
            └── spool                     ·             ·
                 └── render               ·             ·
@@ -409,13 +409,13 @@ EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10] WHERE @1 <
 root                                     ·             ·
  ├── filter                              ·             ·
  │    │                                  filter        "?column?" < 3
- │    └── scan buffer node               ·             ·
+ │    └── scan buffer                    ·             ·
  │                                       label         buffer 1
  └── subquery                            ·             ·
       │                                  id            @S1
       │                                  original sql  INSERT INTO t SELECT * FROM t2 RETURNING x + 10
       │                                  exec mode     all rows
-      └── buffer node                    ·             ·
+      └── buffer                         ·             ·
            │                             label         buffer 1
            └── spool                     ·             ·
                 └── render               ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
@@ -24,7 +24,7 @@ root                        ·              ·                                  
       │                     id             @S1                                                                                 ·                    ·
       │                     original sql   ALTER TABLE test.public.my_spatial_table ADD COLUMN geom1 GEOMETRY(POINT,4326)      ·                    ·
       │                     exec mode      all rows                                                                            ·                    ·
-      └── buffer node       ·              ·                                                                                   ()                   ·
+      └── buffer            ·              ·                                                                                   ()                   ·
            │                label          buffer 1                                                                            ·                    ·
            └── alter table  ·              ·                                                                                   ()                   ·
 
@@ -182,14 +182,14 @@ root                        ·             ·                                   
  │    │                     id            @S1                                                                 ·                                          ·
  │    │                     original sql  ALTER TABLE my_spatial_table ADD COLUMN geom7 GEOMETRY(POINT,4326)  ·                                          ·
  │    │                     exec mode     all rows                                                            ·                                          ·
- │    └── buffer node       ·             ·                                                                   ()                                         ·
+ │    └── buffer            ·             ·                                                                   ()                                         ·
  │         │                label         buffer 1                                                            ·                                          ·
  │         └── alter table  ·             ·                                                                   ()                                         ·
  └── subquery               ·             ·                                                                   ·                                          ·
       │                     id            @S2                                                                 ·                                          ·
       │                     original sql  ALTER TABLE my_spatial_table ADD COLUMN geom8 GEOMETRY(POINT,4326)  ·                                          ·
       │                     exec mode     all rows                                                            ·                                          ·
-      └── buffer node       ·             ·                                                                   ()                                         ·
+      └── buffer            ·             ·                                                                   ()                                         ·
            │                label         buffer 2                                                            ·                                          ·
            └── alter table  ·             ·                                                                   ()                                         ·
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -15,7 +15,7 @@ EXPLAIN SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
 ·                   distribution  local
 ·                   vectorized    true
-cross-join          ·             ·
+cross join          ·             ·
  │                  type          cross
  ├── project set    ·             ·
  │    └── emptyrow  ·             ·
@@ -60,9 +60,9 @@ EXPLAIN (VERBOSE) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) F
 ----
 ·                   distribution  local                  ·                                         ·
 ·                   vectorized    true                   ·                                         ·
-cross-join          ·             ·                      (a, b, generate_series, generate_series)  ·
+cross join          ·             ·                      (a, b, generate_series, generate_series)  ·
  │                  type          cross                  ·                                         ·
- ├── cross-join     ·             ·                      (a, b)                                    ·
+ ├── cross join     ·             ·                      (a, b)                                    ·
  │    │             type          cross                  ·                                         ·
  │    ├── scan      ·             ·                      (a)                                       ·
  │    │             table         t@primary              ·                                         ·
@@ -119,7 +119,7 @@ render                          ·                   ·                         
            │                    render 3            z                                                      ·                                                ·
            └── project set      ·                   ·                                                      (x, y, x, z, x, n)                               ·
                 │               render 0            information_schema._pg_expandarray(ARRAY[@1, @2, @4])  ·                                                ·
-                └── merge-join  ·                   ·                                                      (x, y, x, z)                                     ·
+                └── merge join  ·                   ·                                                      (x, y, x, z)                                     ·
                      │          type                inner                                                  ·                                                ·
                      │          equality            (x) = (x)                                              ·                                                ·
                      │          left cols are key   ·                                                      ·                                                ·
@@ -142,7 +142,7 @@ render                      ·             ·                        (generate_s
  │                          render 0      generate_series          ·                        ·
  └── project set            ·             ·                        (x, z, generate_series)  ·
       │                     render 0      generate_series(@1, @2)  ·                        ·
-      └── cross-join        ·             ·                        (x, z)                   ·
+      └── cross join        ·             ·                        (x, z)                   ·
            │                type          semi                     ·                        ·
            │                pred          z < generate_series      ·                        ·
            ├── scan         ·             ·                        (x, z)                   ·
@@ -170,7 +170,7 @@ render                ·                   ·                                   
       │               render 0            generate_subscripts(ARRAY[0, @1, 1, 2])  ·                                                           ·
       │               render 1            generate_series(@1, @2)                  ·                                                           ·
       │               render 2            unnest(ARRAY[0, @1, @2, @4])             ·                                                           ·
-      └── merge-join  ·                   ·                                        (x, y, x, z)                                                ·
+      └── merge join  ·                   ·                                        (x, y, x, z)                                                ·
            │          type                left outer                               ·                                                           ·
            │          equality            (x) = (x)                                ·                                                           ·
            │          left cols are key   ·                                        ·                                                           ·
@@ -203,7 +203,7 @@ root                            ·             ·                               
       └── max1row               ·             ·                                     (unnest)              ·
            └── render           ·             ·                                     (unnest)              ·
                 │               render 0      unnest                                ·                     ·
-                └── apply-join  ·             ·                                     (x, y, unnest)        ·
+                └── apply join  ·             ·                                     (x, y, unnest)        ·
                      │          type          inner                                 ·                     ·
                      └── scan   ·             ·                                     (x, y)                ·
 ·                               table         xy@primary                            ·                     ·
@@ -238,7 +238,7 @@ render                              ·                   ·                     
                 │                   render 0            id                        ·                                             ·
                 │                   render 1            data                      ·                                             ·
                 │                   render 2            "?column?"                ·                                             ·
-                └── hash-join       ·                   ·                         (column10, id, data, column11, "?column?")    ·
+                └── hash join       ·                   ·                         (column10, id, data, column11, "?column?")    ·
                      │              type                left outer                ·                                             ·
                      │              equality            (column10) = (column11)   ·                                             ·
                      ├── render     ·                   ·                         (column10, id, data)                          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -85,7 +85,7 @@ EXPLAIN (VERBOSE) SELECT a FROM abc WHERE a IN (SELECT a FROM abc WHERE b < 0)
 ----
 ·               distribution        local        ·       ·
 ·               vectorized          true         ·       ·
-merge-join      ·                   ·            (a)     ·
+merge join      ·                   ·            (a)     ·
  │              type                semi         ·       ·
  │              equality            (a) = (a)    ·       ·
  │              left cols are key   ·            ·       ·
@@ -148,7 +148,7 @@ WHERE
 ·                    vectorized    true             ·                          ·
 render               ·             ·                (col0)                     ·
  │                   render 0      col0             ·                          ·
- └── index-join      ·             ·                (col0, col3, col4, rowid)  ·
+ └── index join      ·             ·                (col0, col3, col4, rowid)  ·
       │              table         tab4@primary     ·                          ·
       │              key columns   rowid            ·                          ·
       └── filter     ·             ·                (col0, col4, rowid)        ·
@@ -169,7 +169,7 @@ EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE a.x=b.x)
 ----
 ·           distribution        local      ·       ·
 ·           vectorized          true       ·       ·
-merge-join  ·                   ·          (x, y)  ·
+merge join  ·                   ·          (x, y)  ·
  │          type                semi       ·       ·
  │          equality            (x) = (x)  ·       ·
  │          left cols are key   ·          ·       ·
@@ -187,7 +187,7 @@ EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE b.x-1 = a.x
 ----
 ·               distribution       local            ·          ·
 ·               vectorized         true             ·          ·
-hash-join       ·                  ·                (x, y)     ·
+hash join       ·                  ·                (x, y)     ·
  │              type               semi             ·          ·
  │              equality           (x) = (column7)  ·          ·
  │              left cols are key  ·                ·          ·
@@ -205,7 +205,7 @@ EXPLAIN (VERBOSE) SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE b.x = a
 ----
 ·           distribution        local      ·       ·
 ·           vectorized          true       ·       ·
-merge-join  ·                   ·          (x, y)  ·
+merge join  ·                   ·          (x, y)  ·
  │          type                anti       ·       ·
  │          equality            (x) = (x)  ·       ·
  │          left cols are key   ·          ·       ·
@@ -223,7 +223,7 @@ EXPLAIN (VERBOSE) SELECT * FROM b WHERE NOT EXISTS(SELECT * FROM a WHERE x-1 = b
 ----
 ·               distribution       local            ·          ·
 ·               vectorized         true             ·          ·
-hash-join       ·                  ·                (x, z)     ·
+hash join       ·                  ·                (x, z)     ·
  │              type               anti             ·          ·
  │              equality           (x) = (column7)  ·          ·
  │              left cols are key  ·                ·          ·
@@ -259,7 +259,7 @@ EXPLAIN(verbose) SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) 
 ----
 ·           distribution  local        ·          ·
 ·           vectorized    false        ·          ·
-apply-join  ·             ·            (a, b, c)  ·
+apply join  ·             ·            (a, b, c)  ·
  │          type          semi         ·          ·
  │          pred          column1 = a  ·          ·
  └── scan   ·             ·            (a, b, c)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -91,7 +91,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3) AND (a,b,c) < (8
 ·                vectorized    true                                                  ·              ·
 filter           ·             ·                                                     (a, b, c)      ·
  │               filter        ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))  ·              ·
- └── index-join  ·             ·                                                     (a, b, c)      ·
+ └── index join  ·             ·                                                     (a, b, c)      ·
       │          table         abc@primary                                           ·              ·
       │          key columns   rowid                                                 ·              ·
       └── scan   ·             ·                                                     (a, b, rowid)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -344,13 +344,13 @@ EXPLAIN (VERBOSE) SELECT * FROM [ UPDATE abc SET a=c RETURNING a ] ORDER BY a
 root                                          ·                 ·                                 (a)                  +a
  ├── sort                                     ·                 ·                                 (a)                  +a
  │    │                                       order             +a                                ·                    ·
- │    └── scan buffer node                    ·                 ·                                 (a)                  ·
+ │    └── scan buffer                         ·                 ·                                 (a)                  ·
  │                                            label             buffer 1                          ·                    ·
  └── subquery                                 ·                 ·                                 ·                    ·
       │                                       id                @S1                               ·                    ·
       │                                       original sql      UPDATE abc SET a = c RETURNING a  ·                    ·
       │                                       exec mode         all rows                          ·                    ·
-      └── buffer node                         ·                 ·                                 (a)                  ·
+      └── buffer                              ·                 ·                                 (a)                  ·
            │                                  label             buffer 1                          ·                    ·
            └── spool                          ·                 ·                                 (a)                  ·
                 └── render                    ·                 ·                                 (a)                  ·
@@ -417,7 +417,7 @@ count                           ·             ·               ()              
            │                    render 3      2               ·                 ·
            └── filter           ·             ·               (a, b, c)         ·
                 │               filter        a = 1           ·                 ·
-                └── index-join  ·             ·               (a, b, c)         ·
+                └── index join  ·             ·               (a, b, c)         ·
                      │          table         t38799@primary  ·                 ·
                      │          key columns   a               ·                 ·
                      └── scan   ·             ·               (a, b)            ·
@@ -502,7 +502,7 @@ count                      ·                 ·
       │                    strategy          updater
       │                    auto commit       ·
       └── render           ·                 ·
-           └── index-join  ·                 ·
+           └── index join  ·                 ·
                 │          table             kv3@primary
                 │          key columns       k
                 └── scan   ·                 ·
@@ -522,7 +522,7 @@ count                      ·                 ·
       │                    strategy          updater
       │                    auto commit       ·
       └── render           ·                 ·
-           └── index-join  ·                 ·
+           └── index join  ·                 ·
                 │          table             kv3@primary
                 │          key columns       k
                 └── scan   ·                 ·
@@ -632,7 +632,7 @@ count                      ·             ·
       │                    strategy      updater
       │                    auto commit   ·
       └── render           ·             ·
-           └── index-join  ·             ·
+           └── index join  ·             ·
                 │          table         kv3@primary
                 │          key columns   k
                 └── scan   ·             ·
@@ -651,7 +651,7 @@ count                      ·             ·
       │                    strategy      updater
       │                    auto commit   ·
       └── render           ·             ·
-           └── index-join  ·             ·
+           └── index join  ·             ·
                 │          table         kv3@primary
                 │          key columns   k
                 └── scan   ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -16,7 +16,7 @@ count                      ·                   ·
       │                    strategy            updater
       │                    auto commit         ·
       └── render           ·                   ·
-           └── merge-join  ·                   ·
+           └── merge join  ·                   ·
                 │          type                inner
                 │          equality            (a) = (a)
                 │          left cols are key   ·
@@ -47,7 +47,7 @@ count                          ·                  ·
       └── render               ·                  ·
            └── distinct        ·                  ·
                 │              distinct on        a
-                └── hash-join  ·                  ·
+                └── hash join  ·                  ·
                      │         type               inner
                      │         equality           (a) = (a)
                      │         left cols are key  ·
@@ -80,7 +80,7 @@ render                          ·                   ·
            │                    strategy            updater
            │                    auto commit         ·
            └── render           ·                   ·
-                └── merge-join  ·                   ·
+                └── merge join  ·                   ·
                      │          type                inner
                      │          equality            (a) = (a)
                      │          left cols are key   ·
@@ -114,7 +114,7 @@ run                        ·                   ·            (a, b, c, a, b, c)
            │               render 5            a            ·                                 ·
            │               render 6            b            ·                                 ·
            │               render 7            c            ·                                 ·
-           └── merge-join  ·                   ·            (a, b, c, a, b, c)                ·
+           └── merge join  ·                   ·            (a, b, c, a, b, c)                ·
                 │          type                inner        ·                                 ·
                 │          equality            (a) = (a)    ·                                 ·
                 │          left cols are key   ·            ·                                 ·
@@ -142,7 +142,7 @@ count                            ·                      ·
       └── render                 ·                      ·
            └── distinct          ·                      ·
                 │                distinct on            a
-                └── lookup-join  ·                      ·
+                └── lookup join  ·                      ·
                      │           table                  abc@primary
                      │           type                   inner
                      │           equality               (column1) = (a)
@@ -172,13 +172,13 @@ count                               ·                  ·
       └── render                    ·                  ·
            └── distinct             ·                  ·
                 │                   distinct on        a
-                └── hash-join       ·                  ·
+                └── hash join       ·                  ·
                      │              type               inner
                      │              equality           (a) = (a)
                      ├── scan       ·                  ·
                      │              table              ab@primary
                      │              spans              FULL SCAN
-                     └── hash-join  ·                  ·
+                     └── hash join  ·                  ·
                           │         type               inner
                           │         equality           (a) = (a)
                           │         left cols are key  ·
@@ -213,13 +213,13 @@ run                                 ·                  ·
       └── render                    ·                  ·
            └── distinct             ·                  ·
                 │                   distinct on        a
-                └── hash-join       ·                  ·
+                └── hash join       ·                  ·
                      │              type               inner
                      │              equality           (a) = (a)
                      ├── scan       ·                  ·
                      │              table              ab@primary
                      │              spans              FULL SCAN
-                     └── hash-join  ·                  ·
+                     └── hash join  ·                  ·
                           │         type               inner
                           │         equality           (a) = (a)
                           │         left cols are key  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -98,7 +98,7 @@ count                                         ·                      ·
            │                                  render 0               k
            │                                  render 1               column7
            │                                  render 2               k
-           └── lookup-join                    ·                      ·
+           └── lookup join                    ·                      ·
                 │                             table                  kv@primary
                 │                             type                   inner
                 │                             equality               (k) = (k)
@@ -169,7 +169,7 @@ count                            ·              ·
                 │                render 6       b
                 │                render 7       c
                 │                render 8       d
-                └── cross-join   ·              ·
+                └── cross join   ·              ·
                      │           type           left outer
                      ├── values  ·              ·
                      │           size           4 columns, 1 row
@@ -354,13 +354,13 @@ EXPLAIN (VERBOSE) SELECT * FROM [UPSERT INTO xyz SELECT a, b, c FROM abc RETURNI
 root                                               ·             ·                                                    (z)                           +z
  ├── sort                                          ·             ·                                                    (z)                           +z
  │    │                                            order         +z                                                   ·                             ·
- │    └── scan buffer node                         ·             ·                                                    (z)                           ·
+ │    └── scan buffer                              ·             ·                                                    (z)                           ·
  │                                                 label         buffer 1                                             ·                             ·
  └── subquery                                      ·             ·                                                    ·                             ·
       │                                            id            @S1                                                  ·                             ·
       │                                            original sql  UPSERT INTO xyz SELECT a, b, c FROM abc RETURNING z  ·                             ·
       │                                            exec mode     all rows                                             ·                             ·
-      └── buffer node                              ·             ·                                                    (z)                           ·
+      └── buffer                                   ·             ·                                                    (z)                           ·
            │                                       label         buffer 1                                             ·                             ·
            └── spool                               ·             ·                                                    (z)                           ·
                 └── render                         ·             ·                                                    (z)                           ·
@@ -446,7 +446,7 @@ count                       ·                      ·                   ()     
            │                render 4               c                   ·                      ·
            │                render 5               b                   ·                      ·
            │                render 6               a                   ·                      ·
-           └── lookup-join  ·                      ·                   (a, b, a, b, c)        ·
+           └── lookup join  ·                      ·                   (a, b, a, b, c)        ·
                 │           table                  table38627@primary  ·                      ·
                 │           type                   inner               ·                      ·
                 │           equality               (a) = (a)           ·                      ·
@@ -496,7 +496,7 @@ count                                 ·                      ·                
                 │                     render 4               x                                            ·                                                  ·
                 │                     render 5               y                                            ·                                                  ·
                 │                     render 6               z                                            ·                                                  ·
-                └── lookup-join       ·                      ·                                            (column1, column2, column3, x, y, z)               ·
+                └── lookup join       ·                      ·                                            (column1, column2, column3, x, y, z)               ·
                      │                table                  tdup@tdup_y_z_key                            ·                                                  ·
                      │                type                   left outer                                   ·                                                  ·
                      │                equality               (column2, column3) = (y, z)                  ·                                                  ·
@@ -552,7 +552,7 @@ count                                    ·                   ·                
                 │                        render 4            a                                      ·                                ·
                 │                        render 5            b                                      ·                                ·
                 │                        render 6            c                                      ·                                ·
-                └── merge-join           ·                   ·                                      (a, b, c, x, y, z)               ·
+                └── merge join           ·                   ·                                      (a, b, c, x, y, z)               ·
                      │                   type                right outer                            ·                                ·
                      │                   equality            (b, c) = (y, z)                        ·                                ·
                      │                   mergeJoinOrder      +"(b=y)",+"(c=z)"                      ·                                ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -67,7 +67,7 @@ EXPLAIN SELECT * FROM pg_constraint INNER LOOKUP JOIN pg_class on conrelid=pg_cl
 ----
 ·                          distribution  local
 ·                          vectorized    false
-virtual-table-lookup-join  ·             ·
+virtual table lookup join  ·             ·
  │                         table         pg_class@pg_class_oid_idx
  │                         type          inner
  │                         equality      (conrelid) = (oid)
@@ -79,7 +79,7 @@ EXPLAIN SELECT * FROM pg_constraint LEFT LOOKUP JOIN pg_class on conrelid=pg_cla
 ----
 ·                          distribution  local
 ·                          vectorized    false
-virtual-table-lookup-join  ·             ·
+virtual table lookup join  ·             ·
  │                         table         pg_class@pg_class_oid_idx
  │                         type          left outer
  │                         equality      (conrelid) = (oid)
@@ -122,7 +122,7 @@ render                                                                     ·   
  └── sort                                                                  ·             ·
       │                                                                    order         +conname
       └── render                                                           ·             ·
-           └── hash-join                                                   ·             ·
+           └── hash join                                                   ·             ·
                 │                                                          type          inner
                 │                                                          equality      (oid) = (connamespace)
                 ├── filter                                                 ·             ·
@@ -130,24 +130,24 @@ render                                                                     ·   
                 │    └── render                                            ·             ·
                 │         └── virtual table                                ·             ·
                 │                                                          source        pg_namespace@primary
-                └── virtual-table-lookup-join                              ·             ·
+                └── virtual table lookup join                              ·             ·
                      │                                                     table         pg_attribute@pg_attribute_attrelid_idx
                      │                                                     type          inner
                      │                                                     equality      (oid) = (attrelid)
                      │                                                     pred          column135 = attnum
                      └── render                                            ·             ·
-                          └── virtual-table-lookup-join                    ·             ·
+                          └── virtual table lookup join                    ·             ·
                                │                                           table         pg_attribute@pg_attribute_attrelid_idx
                                │                                           type          inner
                                │                                           equality      (oid) = (attrelid)
                                │                                           pred          (column110 = attnum) AND (attrelid = 'b'::REGCLASS)
                                └── render                                  ·             ·
-                                    └── virtual-table-lookup-join          ·             ·
+                                    └── virtual table lookup join          ·             ·
                                          │                                 table         pg_class@pg_class_oid_idx
                                          │                                 type          inner
                                          │                                 equality      (conrelid) = (oid)
                                          │                                 pred          oid = 'b'::REGCLASS
-                                         └── virtual-table-lookup-join     ·             ·
+                                         └── virtual table lookup join     ·             ·
                                               │                            table         pg_class@pg_class_oid_idx
                                               │                            type          inner
                                               │                            equality      (confrelid) = (oid)

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -10,24 +10,24 @@ query TTTTT
 EXPLAIN (VERBOSE)
   WITH t AS (SELECT a FROM y) SELECT * FROM t JOIN t AS q ON true
 ----
-·                           distribution  local            ·       ·
-·                           vectorized    false            ·       ·
-root                        ·             ·                (a, a)  ·
- ├── cross-join             ·             ·                (a, a)  ·
- │    │                     type          cross            ·       ·
- │    ├── scan buffer node  ·             ·                (a)     ·
- │    │                     label         buffer 1 (t)     ·       ·
- │    └── scan buffer node  ·             ·                (a)     ·
- │                          label         buffer 1 (t)     ·       ·
- └── subquery               ·             ·                ·       ·
-      │                     id            @S1              ·       ·
-      │                     original sql  SELECT a FROM y  ·       ·
-      │                     exec mode     all rows         ·       ·
-      └── buffer node       ·             ·                (a)     ·
-           │                label         buffer 1 (t)     ·       ·
-           └── scan         ·             ·                (a)     ·
-·                           table         y@primary        ·       ·
-·                           spans         FULL SCAN        ·       ·
+·                      distribution  local            ·       ·
+·                      vectorized    false            ·       ·
+root                   ·             ·                (a, a)  ·
+ ├── cross join        ·             ·                (a, a)  ·
+ │    │                type          cross            ·       ·
+ │    ├── scan buffer  ·             ·                (a)     ·
+ │    │                label         buffer 1 (t)     ·       ·
+ │    └── scan buffer  ·             ·                (a)     ·
+ │                     label         buffer 1 (t)     ·       ·
+ └── subquery          ·             ·                ·       ·
+      │                id            @S1              ·       ·
+      │                original sql  SELECT a FROM y  ·       ·
+      │                exec mode     all rows         ·       ·
+      └── buffer       ·             ·                (a)     ·
+           │           label         buffer 1 (t)     ·       ·
+           └── scan    ·             ·                (a)     ·
+·                      table         y@primary        ·       ·
+·                      spans         FULL SCAN        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -48,13 +48,13 @@ EXPLAIN (VERBOSE)
 ·                                          distribution   local                                 ·                   ·
 ·                                          vectorized     false                                 ·                   ·
 root                                       ·              ·                                     (a)                 ·
- ├── scan buffer node                      ·              ·                                     (a)                 ·
+ ├── scan buffer                           ·              ·                                     (a)                 ·
  │                                         label          buffer 1 (t)                          ·                   ·
  └── subquery                              ·              ·                                     ·                   ·
       │                                    id             @S1                                   ·                   ·
       │                                    original sql   INSERT INTO x VALUES (1) RETURNING a  ·                   ·
       │                                    exec mode      all rows                              ·                   ·
-      └── buffer node                      ·              ·                                     (a)                 ·
+      └── buffer                           ·              ·                                     (a)                 ·
            │                               label          buffer 1 (t)                          ·                   ·
            └── spool                       ·              ·                                     (a)                 ·
                 └── render                 ·              ·                                     (a)                 ·
@@ -84,7 +84,7 @@ EXPLAIN (VERBOSE)
 ----
 ·           distribution  local               ·      ·
 ·           vectorized    true                ·      ·
-cross-join  ·             ·                   (col)  ·
+cross join  ·             ·                   (col)  ·
  │          type          cross               ·      ·
  ├── scan   ·             ·                   ()     ·
  │          table         table39010@primary  ·      ·
@@ -102,15 +102,15 @@ EXPLAIN (VERBOSE)
   )
   SELECT sum(n) FROM t
 ----
-·                             distribution   local               ·          ·
-·                             vectorized     false               ·          ·
-group                         ·              ·                   (sum)      ·
- │                            aggregate 0    sum(n)              ·          ·
- │                            scalar         ·                   ·          ·
- └── render                   ·              ·                   (n)        ·
-      │                       render 0       column1             ·          ·
-      └── recursive cte node  ·              ·                   (column1)  ·
-           │                  label          working buffer (t)  ·          ·
-           └── values         ·              ·                   (column1)  ·
-·                             size           1 column, 1 row     ·          ·
-·                             row 0, expr 0  1                   ·          ·
+·                        distribution   local               ·          ·
+·                        vectorized     false               ·          ·
+group                    ·              ·                   (sum)      ·
+ │                       aggregate 0    sum(n)              ·          ·
+ │                       scalar         ·                   ·          ·
+ └── render              ·              ·                   (n)        ·
+      │                  render 0       column1             ·          ·
+      └── recursive cte  ·              ·                   (column1)  ·
+           │             label          working buffer (t)  ·          ·
+           └── values    ·              ·                   (column1)  ·
+·                        size           1 column, 1 row     ·          ·
+·                        row 0, expr 0  1                   ·          ·

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -155,7 +155,7 @@ render                                                    (cid int, date date, v
  │                   render 0            (@1)[int]
  │                   render 1            (@3)[date]
  │                   render 2            (@2)[decimal]
- └── hash-join                                            (cid int, value decimal, date date, date date)
+ └── hash join                                            (cid int, value decimal, date date, date date)
       │              type                inner
       │              equality            (date) = (date)
       │              right cols are key
@@ -180,7 +180,7 @@ attrs:
 - key: render
   value: value
 children:
-- name: hash-join
+- name: hash join
   attrs:
   - key: type
     value: inner

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -871,12 +871,12 @@ func nodeName(plan planNode) string {
 
 	case *joinNode:
 		if len(n.mergeJoinOrdering) > 0 {
-			return "merge-join"
+			return "merge join"
 		}
 		if len(n.pred.leftEqualityIndices) == 0 {
-			return "cross-join"
+			return "cross join"
 		}
-		return "hash-join"
+		return "hash join"
 	}
 
 	name, ok := planNodeNames[reflect.TypeOf(plan)]
@@ -914,8 +914,8 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&alterTableNode{}):        "alter table",
 	reflect.TypeOf(&alterTypeNode{}):         "alter type",
 	reflect.TypeOf(&alterRoleNode{}):         "alter role",
-	reflect.TypeOf(&applyJoinNode{}):         "apply-join",
-	reflect.TypeOf(&bufferNode{}):            "buffer node",
+	reflect.TypeOf(&applyJoinNode{}):         "apply join",
+	reflect.TypeOf(&bufferNode{}):            "buffer",
 	reflect.TypeOf(&cancelQueriesNode{}):     "cancel queries",
 	reflect.TypeOf(&cancelSessionsNode{}):    "cancel sessions",
 	reflect.TypeOf(&changePrivilegesNode{}):  "change privileges",
@@ -954,19 +954,19 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&GrantRoleNode{}):         "grant role",
 	reflect.TypeOf(&groupNode{}):             "group",
 	reflect.TypeOf(&hookFnNode{}):            "plugin",
-	reflect.TypeOf(&indexJoinNode{}):         "index-join",
+	reflect.TypeOf(&indexJoinNode{}):         "index join",
 	reflect.TypeOf(&insertNode{}):            "insert",
-	reflect.TypeOf(&insertFastPathNode{}):    "insert-fast-path",
-	reflect.TypeOf(&interleavedJoinNode{}):   "interleaved-join",
-	reflect.TypeOf(&invertedFilterNode{}):    "inverted-filter",
-	reflect.TypeOf(&invertedJoinNode{}):      "inverted-join",
+	reflect.TypeOf(&insertFastPathNode{}):    "insert fast path",
+	reflect.TypeOf(&interleavedJoinNode{}):   "interleaved join",
+	reflect.TypeOf(&invertedFilterNode{}):    "inverted filter",
+	reflect.TypeOf(&invertedJoinNode{}):      "inverted join",
 	reflect.TypeOf(&joinNode{}):              "join",
 	reflect.TypeOf(&limitNode{}):             "limit",
-	reflect.TypeOf(&lookupJoinNode{}):        "lookup-join",
+	reflect.TypeOf(&lookupJoinNode{}):        "lookup join",
 	reflect.TypeOf(&max1RowNode{}):           "max1row",
 	reflect.TypeOf(&ordinalityNode{}):        "ordinality",
 	reflect.TypeOf(&projectSetNode{}):        "project set",
-	reflect.TypeOf(&recursiveCTENode{}):      "recursive cte node",
+	reflect.TypeOf(&recursiveCTENode{}):      "recursive cte",
 	reflect.TypeOf(&relocateNode{}):          "relocate",
 	reflect.TypeOf(&renameColumnNode{}):      "rename column",
 	reflect.TypeOf(&renameDatabaseNode{}):    "rename database",
@@ -977,7 +977,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&rowCountNode{}):          "count",
 	reflect.TypeOf(&rowSourceToPlanNode{}):   "row source to plan node",
 	reflect.TypeOf(&saveTableNode{}):         "save table",
-	reflect.TypeOf(&scanBufferNode{}):        "scan buffer node",
+	reflect.TypeOf(&scanBufferNode{}):        "scan buffer",
 	reflect.TypeOf(&scanNode{}):              "scan",
 	reflect.TypeOf(&scatterNode{}):           "scatter",
 	reflect.TypeOf(&scrubNode{}):             "scrub",
@@ -986,7 +986,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&setClusterSettingNode{}): "set cluster setting",
 	reflect.TypeOf(&setVarNode{}):            "set",
 	reflect.TypeOf(&setZoneConfigNode{}):     "configure zone",
-	reflect.TypeOf(&showFingerprintsNode{}):  "showFingerprints",
+	reflect.TypeOf(&showFingerprintsNode{}):  "show fingerprints",
 	reflect.TypeOf(&showTraceNode{}):         "show trace for",
 	reflect.TypeOf(&showTraceReplicaNode{}):  "replica trace",
 	reflect.TypeOf(&sortNode{}):              "sort",
@@ -1001,8 +1001,8 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&upsertNode{}):            "upsert",
 	reflect.TypeOf(&valuesNode{}):            "values",
 	reflect.TypeOf(&virtualTableNode{}):      "virtual table values",
-	reflect.TypeOf(&vTableLookupJoinNode{}):  "virtual-table-lookup-join",
+	reflect.TypeOf(&vTableLookupJoinNode{}):  "virtual table lookup join",
 	reflect.TypeOf(&windowNode{}):            "window",
 	reflect.TypeOf(&zeroNode{}):              "norows",
-	reflect.TypeOf(&zigzagJoinNode{}):        "zigzag-join",
+	reflect.TypeOf(&zigzagJoinNode{}):        "zigzag join",
 }


### PR DESCRIPTION
Node naming had several inconsistencies. This change cleans them up:
 - use spaces everywhere instead of dashes or camel casing
 - remove unnecessary "node" from the name

Release note (sql change): cosmetic improvements to EXPLAIN node
naming.