### PR TITLE
util/log: prevent ReportPanic() from swallowing panics in some cases

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -90,7 +90,7 @@ system "($argv sql --insecure -e \"select crdb_internal.force_panic('helloworld'
 # Check the panic is reported on the server's stderr
 eexpect "a SQL panic has occurred"
 eexpect "panic: helloworld"
-eexpect "goroutine"
+eexpect "stack trace"
 eexpect ":/# "
 # Check the panic is reported on the server log file
 send "cat logs/db/logs/cockroach.log\r"


### PR DESCRIPTION
Accompanies #52200 (but is an independent change)

Prior to this patch, if `ReportPanic()` was called and the panic
object ultimately discarded (ie. caught) during tests that were not otherwise using
`TestLogScope`, the panic object would be lost. I believe this was directly noticed by @andreimatei prior.

I also believe this was causing panic objects to disappear quite a lot in fact,
because the test runner *also* catches panics and fails to report
them adequately in some cases (e.g. when the panic occurs during a
`stress` run).

To alleviate the situation, this patch removes some logic previously
present in the code that was attempting (and failing) to remove
duplicate panic prints. That logic was misdesigned to start with anyway
(by me), because it was working under the assumption that
`ReportPanic()` was *only* called for uncaught panics, and another
function `RecoverAndReportNonfatalPanic()` just before that was
blatantly violating that assumption.

Removing the logic causes reportable panics to always be reported in
logs and on stderr, regardless of whether it's caught or not. This
provides more guarantees that the panic object will be seen, at the
expense of having a duplicate print in some edge cases.

Release note: None