### PR TITLE
kvserver: return more range information after a split

### DIFF
--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -170,6 +170,56 @@ func returnRangeInfoIfClientStale(
 			Lease: lease,
 		},
 	}
+
+	// We're going to sometimes return info on the ranges coming right before or
+	// right after r, if it looks like r came from a range that has recently split
+	// and the client doesn't know about it. After a split, the client benefits
+	// from learning about both resulting ranges.
+
+	if cinfo.DescriptorGeneration >= desc.Generation {
+		return
+	}
+
+	maybeAddRange := func(rr KeyRange) {
+		if rr.Desc().Generation != desc.Generation {
+			// The next range does not look like it came from a split that produced
+			// both r and this next range. Of course, this has false negatives (e.g.
+			// if either the LHS or the RHS split multiple times since the client's
+			// version). For best fidelity, the client could send the range's start
+			// and end keys and the server could use that to return all overlapping
+			// descriptors (like we do for RangeKeyMismatchErrors), but sending those
+			// keys on every RPC seems too expensive.
+			return
+		}
+
+		var rangeInfo roachpb.RangeInfo
+		if rep, ok := rr.(*Replica); ok {
+			// Note that we return the lease even if it's expired. The kvclient can
+			// use it as it sees fit.
+			rangeInfo.Desc, rangeInfo.Lease = rep.GetDescAndLease(ctx)
+		} else {
+			rangeInfo.Desc = *rr.Desc()
+		}
+		br.RangeInfos = append(br.RangeInfos, rangeInfo)
+	}
+
+	r.store.VisitReplicasByKey(ctx, roachpb.RKeyMin, desc.StartKey, DescendingKeyOrder, func(ctx context.Context, prevR KeyRange) bool {
+		if !prevR.Desc().EndKey.Equal(desc.StartKey) {
+			// The next range does not correspond to the range immediately preceding r.
+			return false
+		}
+		maybeAddRange(prevR)
+		return false
+	})
+
+	r.store.VisitReplicasByKey(ctx, desc.EndKey, roachpb.RKeyMax, AscendingKeyOrder, func(ctx context.Context, nextR KeyRange) bool {
+		if !nextR.Desc().StartKey.Equal(desc.EndKey) {
+			// The next range does not correspond to the range immediately after r.
+			return false
+		}
+		maybeAddRange(nextR)
+		return false
+	})
 }
 
 // batchExecutionFn is a method on Replica that is able to execute a

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -848,37 +848,46 @@ func TestStoreVisitReplicasByKey(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Query for all ranges.
-	visited := make([]roachpb.RSpan, 0)
-	s.VisitReplicasByKey(ctx, roachpb.RKeyMin, roachpb.RKeyMax, func(_ context.Context, r KeyRange) bool {
-		visited = append(visited, r.Desc().RSpan())
-		return true
-	})
-	require.Equal(t, ranges, visited)
-
-	// Query for some of the ranges.
-	visited = visited[:0]
-	s.VisitReplicasByKey(ctx, ranges[3].Key, ranges[6].EndKey, func(_ context.Context, r KeyRange) bool {
-		visited = append(visited, r.Desc().RSpan())
-		return true
-	})
-	require.Equal(t, ranges[3:7], visited)
-
-	// Like above, but don't use exact boundaries.
-	visited = visited[:0]
-	s.VisitReplicasByKey(ctx, ranges[3].Key.Next(), ranges[6].Key.Next(), func(_ context.Context, r KeyRange) bool {
-		visited = append(visited, r.Desc().RSpan())
-		return true
-	})
-	require.Equal(t, ranges[3:7], visited)
-
-	// Query within a single range.
-	visited = visited[:0]
-	s.VisitReplicasByKey(ctx, ranges[6].Key.Next(), ranges[6].Key.Next(), func(_ context.Context, r KeyRange) bool {
-		visited = append(visited, r.Desc().RSpan())
-		return true
-	})
-	require.Equal(t, ranges[6:7], visited)
+	tests := []struct {
+		name       string
+		start, end roachpb.RKey
+		exp        []roachpb.RSpan
+	}{
+		{
+			name:  "all ranges",
+			start: roachpb.RKeyMin,
+			end:   roachpb.RKeyMax,
+			exp:   ranges,
+		},
+		{
+			name:  "some ranges",
+			start: ranges[3].Key,
+			end:   ranges[6].EndKey,
+			exp:   ranges[3:7],
+		},
+		{
+			name:  "some ranges, inexact boundaries",
+			start: ranges[3].Key.Next(),
+			end:   ranges[6].Key.Next(),
+			exp:   ranges[3:7],
+		},
+		{
+			name:  "within range",
+			start: ranges[6].Key.Next(),
+			end:   ranges[6].Key.Next().Next(),
+			exp:   ranges[6:7],
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var visited []roachpb.RSpan
+			s.VisitReplicasByKey(ctx, tc.start, tc.end, func(_ context.Context, r KeyRange) bool {
+				visited = append(visited, r.Desc().RSpan())
+				return true
+			})
+			require.Equal(t, tc.exp, visited)
+		})
+	}
 }
 
 func TestHasOverlappingReplica(t *testing.T) {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1227,6 +1227,20 @@ func (ts *TestServer) ForceTableGC(
 	return pErr.GoError()
 }
 
+// ScratchRange splits off a range suitable to be used as KV scratch space. (it
+// doesn't overlap system spans or SQL tables).
+//
+// Calling this multiple times is undefined (but see TestCluster.ScratchRange()
+// which is idempotent).
+func (ts *TestServer) ScratchRange() (roachpb.Key, error) {
+	scratchKey := keys.TableDataMax
+	_, _, err := ts.SplitRange(scratchKey)
+	if err != nil {
+		return nil, err
+	}
+	return scratchKey, nil
+}
+
 type testServerFactoryImpl struct{}
 
 // TestServerFactory can be passed to serverutils.InitTestServerFactory

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -207,6 +207,13 @@ type TestServerInterface interface {
 
 	// StartTenant spawns off tenant process connecting to this TestServer.
 	StartTenant(params base.TestTenantArgs) (pgAddr string, _ error)
+
+	// ScratchRange splits off a range suitable to be used as KV scratch space.
+	// (it doesn't overlap system spans or SQL tables).
+	//
+	// Calling this multiple times is undefined (but see
+	// TestCluster.ScratchRange() which is idempotent).
+	ScratchRange() (roachpb.Key, error)
 }
 
 // TestServerFactory encompasses the actual implementation of the shim

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -46,7 +46,7 @@ type TestCluster struct {
 	Conns           []*gosql.DB
 	stopper         *stop.Stopper
 	replicationMode base.TestClusterReplicationMode
-	scratchRangeID  roachpb.RangeID
+	scratchRangeKey roachpb.Key
 	mu              struct {
 		syncutil.Mutex
 		serverStoppers []*stop.Stopper
@@ -685,15 +685,14 @@ func (tc *TestCluster) FindRangeLeaseHolder(
 // kv scratch space (it doesn't overlap system spans or SQL tables). The range
 // is lazily split off on the first call to ScratchRange.
 func (tc *TestCluster) ScratchRange(t testing.TB) roachpb.Key {
-	scratchKey := keys.TableDataMax
-	if tc.scratchRangeID > 0 {
-		return scratchKey
+	if tc.scratchRangeKey != nil {
+		return tc.scratchRangeKey
 	}
-	_, right, err := tc.SplitRange(scratchKey)
+	scratchKey, err := tc.Servers[0].ScratchRange()
 	if err != nil {
 		t.Fatal(err)
 	}
-	tc.scratchRangeID = right.RangeID
+	tc.scratchRangeKey = scratchKey
 	return scratchKey
 }
 


### PR DESCRIPTION
This patches makes responses to clients with stale information contain
information about both sides of a split if it looks like there's been a
recent split and the client has pre-split info.
Before this patch, a replica would only return information about its own
descriptor and lease to a stale client. If a client had pre-split info
and it addressed the LHS of the post-split, it would thus get back the
LHS desc. It'd proceed to remove the pre-split desc from its cache
and add the LHS. If it then tries to access the RHS, it'd have to do a
range lookup. This patch makes it so that the post-split LHS returns
both LHS and RHS info if the LHS and RHS are of the same generation
(which is an indication that they resulted from a split). The RHS, if
addressed, similarly returns both LHS and RHS info, although this
currently probably doesn't matter as much since a client with pre-split
info would never address the RHS (it'd address the LHS and get back a
RangeKeyMismatchError).

This patch reduces the number of range lookups done while splits are
happening, as detected by the kv50/rangelookups/split test. That test
started failing after the recent changes to return range info when a
server detects a stale client. Before those changes, there were fewer
range lookups than currently because, in the scenario presented above,
the pre-split descriptor would persist in the client's cache even after
addressing the post-split LHS. When trying to address the RHS, the
client would get a RangeKeyMismatchError (which the test doesn't count).
After those changes, these mismatch errors were turned into range
lookups (which the test does count). Probably a wash, but the test
doesn't see it that way. With this patch, both the mismatches and
lookups and their sum looks better than ever.

Fixes #51096

Release note: None