### PR TITLE
sql: improve SHOW TABLES to show row count

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -74,6 +74,7 @@ table_name NOT IN (
 	'index_columns',
 	'table_columns',
 	'table_indexes',
+	'table_row_statistics',
 	'ranges',
 	'ranges_no_leases',
 	'predefined_comments',

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -328,7 +328,7 @@ func (s *adminServer) DatabaseDetails(
 	// Marshal table names.
 	{
 		scanner := makeResultScanner(cols)
-		if a, e := len(cols), 3; a != e {
+		if a, e := len(cols), 4; a != e {
 			return nil, s.serverErrorf("show tables columns mismatch: %d != expected %d", a, e)
 		}
 		for _, row := range rows {

--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -77,6 +77,7 @@ const (
 	CrdbInternalTableColumnsTableID
 	CrdbInternalTableIndexesTableID
 	CrdbInternalTablesTableID
+	CrdbInternalTablesTableLastStatsID
 	CrdbInternalTxnStatsTableID
 	CrdbInternalZonesTableID
 	InformationSchemaID

--- a/pkg/sql/delegate/show_tables.go
+++ b/pkg/sql/delegate/show_tables.go
@@ -43,53 +43,34 @@ func (d *delegator) delegateShowTables(n *tree.ShowTables) (tree.Statement, erro
 		schemaClause = "AND ns.nspname NOT IN ('information_schema', 'pg_catalog', 'crdb_internal', 'pg_extension')"
 	}
 
-	var query string
+	const getTablesQuery = `
+SELECT ns.nspname AS schema_name,
+       pc.relname AS table_name,
+       CASE
+       WHEN pc.relkind = 'v' THEN 'view'
+       WHEN pc.relkind = 'S' THEN 'sequence'
+       ELSE 'table'
+       END AS type,
+       s.estimated_row_count AS estimated_row_count
+       %[3]s
+  FROM %[1]s.pg_catalog.pg_class AS pc
+  JOIN %[1]s.pg_catalog.pg_namespace AS ns ON (ns.oid = pc.relnamespace)
+  LEFT
+  JOIN %[1]s.pg_catalog.pg_description AS pd ON (pc.oid = pd.objoid AND pd.objsubid = 0)
+  LEFT
+  JOIN crdb_internal.table_row_statistics AS s on (s.table_id = pc.oid::INT8)
+ WHERE pc.relkind IN ('r', 'v', 'S') %[2]s
+ ORDER BY schema_name, table_name
+`
+	var comment string
 	if n.WithComment {
-		const getTablesQuery = `
-SELECT
-	ns.nspname AS schema_name,
-	pc.relname AS table_name,
-	(CASE
-		WHEN pc.relkind = 'v' THEN 'view'
-		WHEN pc.relkind = 'S' THEN 'sequence'
-		ELSE 'table'
-	END) AS "type",
-  COALESCE(pd.description, '') AS comment
- FROM %[1]s.pg_catalog.pg_class       AS pc
- JOIN %[1]s.pg_catalog.pg_namespace   AS ns ON (ns.oid = pc.relnamespace)
- LEFT JOIN %[1]s.pg_catalog.pg_description AS pd ON (pc.oid = pd.objoid AND pd.objsubid = 0)
-WHERE pc.relkind IN ('r', 'v', 'S') %[2]s
-ORDER BY schema_name, table_name
-`
-
-		query = fmt.Sprintf(
-			getTablesQuery,
-			&name.CatalogName,
-			schemaClause,
-		)
-
-	} else {
-		const getTablesQuery = `
-SELECT
-	ns.nspname AS schema_name,
-	pc.relname AS table_name,
-	(CASE
-		WHEN pc.relkind = 'v' THEN 'view'
-		WHEN pc.relkind = 'S' THEN 'sequence'
-		ELSE 'table'
-	END) AS "type"
- FROM %[1]s.pg_catalog.pg_class       AS pc
- JOIN %[1]s.pg_catalog.pg_namespace   AS ns ON (ns.oid = pc.relnamespace)
-WHERE pc.relkind IN ('r', 'v', 'S') %[2]s
-ORDER BY schema_name, table_name
-`
-
-		query = fmt.Sprintf(
-			getTablesQuery,
-			&name.CatalogName,
-			schemaClause,
-		)
+		comment = `, COALESCE(pd.description, '')       AS comment`
 	}
-
+	query := fmt.Sprintf(
+		getTablesQuery,
+		&name.CatalogName,
+		schemaClause,
+		comment,
+	)
 	return parse(query)
 }

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
@@ -36,10 +36,10 @@ DROP TABLE t
 statement error schema change cannot be initiated in this version until the version upgrade is finalized
 TRUNCATE TABLE t
 
-query TTT
+query TTTI
 SHOW TABLES
 ----
-public  t  table
+public  t  table  0
 
 subtest columns
 
@@ -143,10 +143,10 @@ CREATE TABLE db.t (a INT)
 statement error schema change cannot be initiated in this version until the version upgrade is finalized
 DROP DATABASE db
 
-query TTT
+query TTTI
 SHOW TABLES FROM db
 ----
-public  t  table
+public  t  table  NULL
 
 subtest non_backfill_schema_changes
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -8,48 +8,49 @@ CREATE TABLE crdb_internal.t (x INT)
 query error database "crdb_internal" does not exist
 DROP DATABASE crdb_internal
 
-query TTT
+query TTTI
 SHOW TABLES FROM crdb_internal
 ----
-crdb_internal  backward_dependencies      table
-crdb_internal  builtin_functions          table
-crdb_internal  cluster_queries            table
-crdb_internal  cluster_sessions           table
-crdb_internal  cluster_settings           table
-crdb_internal  cluster_transactions       table
-crdb_internal  create_statements          table
-crdb_internal  create_type_statements     table
-crdb_internal  databases                  table
-crdb_internal  feature_usage              table
-crdb_internal  forward_dependencies       table
-crdb_internal  gossip_alerts              table
-crdb_internal  gossip_liveness            table
-crdb_internal  gossip_network             table
-crdb_internal  gossip_nodes               table
-crdb_internal  index_columns              table
-crdb_internal  jobs                       table
-crdb_internal  kv_node_status             table
-crdb_internal  kv_store_status            table
-crdb_internal  leases                     table
-crdb_internal  node_build_info            table
-crdb_internal  node_metrics               table
-crdb_internal  node_queries               table
-crdb_internal  node_runtime_info          table
-crdb_internal  node_sessions              table
-crdb_internal  node_statement_statistics  table
-crdb_internal  node_transactions          table
-crdb_internal  node_txn_stats             table
-crdb_internal  partitions                 table
-crdb_internal  predefined_comments        table
-crdb_internal  ranges                     view
-crdb_internal  ranges_no_leases           table
-crdb_internal  schema_changes             table
-crdb_internal  session_trace              table
-crdb_internal  session_variables          table
-crdb_internal  table_columns              table
-crdb_internal  table_indexes              table
-crdb_internal  tables                     table
-crdb_internal  zones                      table
+crdb_internal  backward_dependencies      table  NULL
+crdb_internal  builtin_functions          table  NULL
+crdb_internal  cluster_queries            table  NULL
+crdb_internal  cluster_sessions           table  NULL
+crdb_internal  cluster_settings           table  NULL
+crdb_internal  cluster_transactions       table  NULL
+crdb_internal  create_statements          table  NULL
+crdb_internal  create_type_statements     table  NULL
+crdb_internal  databases                  table  NULL
+crdb_internal  feature_usage              table  NULL
+crdb_internal  forward_dependencies       table  NULL
+crdb_internal  gossip_alerts              table  NULL
+crdb_internal  gossip_liveness            table  NULL
+crdb_internal  gossip_network             table  NULL
+crdb_internal  gossip_nodes               table  NULL
+crdb_internal  index_columns              table  NULL
+crdb_internal  jobs                       table  NULL
+crdb_internal  kv_node_status             table  NULL
+crdb_internal  kv_store_status            table  NULL
+crdb_internal  leases                     table  NULL
+crdb_internal  node_build_info            table  NULL
+crdb_internal  node_metrics               table  NULL
+crdb_internal  node_queries               table  NULL
+crdb_internal  node_runtime_info          table  NULL
+crdb_internal  node_sessions              table  NULL
+crdb_internal  node_statement_statistics  table  NULL
+crdb_internal  node_transactions          table  NULL
+crdb_internal  node_txn_stats             table  NULL
+crdb_internal  partitions                 table  NULL
+crdb_internal  predefined_comments        table  NULL
+crdb_internal  ranges                     view   NULL
+crdb_internal  ranges_no_leases           table  NULL
+crdb_internal  schema_changes             table  NULL
+crdb_internal  session_trace              table  NULL
+crdb_internal  session_variables          table  NULL
+crdb_internal  table_columns              table  NULL
+crdb_internal  table_indexes              table  NULL
+crdb_internal  table_row_statistics       table  NULL
+crdb_internal  tables                     table  NULL
+crdb_internal  zones                      table  NULL
 
 statement ok
 CREATE DATABASE testdb; CREATE TABLE testdb.foo(x INT)

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -170,12 +170,12 @@ users       foo         true        2             id           ASC        false 
 statement ok
 CREATE VIEW v2 AS SELECT name FROM v
 
-query TTT
+query TTTI
 SHOW TABLES
 ----
-public  users  table
-public  v      view
-public  v2     view
+public  users  table  0
+public  v      view   0
+public  v2     view   0 
 
 statement ok
 GRANT ALL ON users to testuser
@@ -199,10 +199,10 @@ SHOW INDEXES FROM users
 table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
 users       primary     false       1             id           ASC        false    false
 
-query TTT
+query TTTI
 SHOW TABLES
 ----
-public  users  table
+public  users  table  0
 
 # Test the syntax without a '@'
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -6,11 +6,11 @@ CREATE TABLE a (id INT PRIMARY KEY)
 statement ok
 CREATE TABLE b (id INT PRIMARY KEY)
 
-query TTT
+query TTTI
 SHOW TABLES FROM test
 ----
-public  a  table
-public  b  table
+public  a  table  0
+public  b  table  0
 
 statement ok
 INSERT INTO a VALUES (3),(7),(2)
@@ -35,10 +35,10 @@ SELECT job_type, status FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE GC' OR 
 SCHEMA CHANGE     succeeded
 SCHEMA CHANGE GC  running
 
-query TTT
+query TTTI
 SHOW TABLES FROM test
 ----
-public  b  table
+public  b  table  0
 
 statement error pgcode 42P01 relation "a" does not exist
 SELECT * FROM a

--- a/pkg/sql/logictest/testdata/logic_test/drop_view
+++ b/pkg/sql/logictest/testdata/logic_test/drop_view
@@ -12,12 +12,12 @@ CREATE VIEW b AS SELECT k,v from a
 statement ok
 CREATE VIEW c AS SELECT k,v from b
 
-query TTT
+query TTTI
 SHOW TABLES FROM test
 ----
-public  a  table
-public  b  view
-public  c  view
+public  a  table  0
+public  b  view   0
+public  c  view   0
 
 statement error cannot drop relation "a" because view "b" depends on it
 DROP TABLE a
@@ -40,14 +40,14 @@ DROP VIEW d
 statement ok
 GRANT ALL ON d TO testuser
 
-query TTT
+query TTTI
 SHOW TABLES FROM test
 ----
-public  a        table
-public  b        view
-public  c        view
-public  d        view
-public  diamond  view
+public  a        table  0
+public  b        view   0
+public  c        view   0
+public  d        view   0
+public  diamond  view   0 
 
 user testuser
 
@@ -77,24 +77,24 @@ GRANT ALL ON testuser2 to testuser
 statement ok
 GRANT ALL ON testuser3 to testuser
 
-query TTT
+query TTTI
 SHOW TABLES FROM test
 ----
-public  a          table
-public  b          view
-public  c          view
-public  d          view
-public  diamond    view
-public  testuser1  view
-public  testuser2  view
-public  testuser3  view
+public  a          table  0
+public  b          view   0
+public  c          view   0
+public  d          view   0
+public  diamond    view   0
+public  testuser1  view   0
+public  testuser2  view   0
+public  testuser3  view   0
 
 user testuser
 
 statement ok
 DROP VIEW testuser3
 
-query TTT
+query TTTI
 SHOW TABLES FROM test
 ----
 
@@ -107,7 +107,7 @@ DROP VIEW testuser1 RESTRICT
 statement ok
 DROP VIEW testuser1 CASCADE
 
-query TTT
+query TTTI
 SHOW TABLES FROM test
 ----
 
@@ -138,7 +138,7 @@ user root
 statement ok
 DROP TABLE a CASCADE
 
-query TTT
+query TTTI
 SHOW TABLES FROM test
 ----
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1030,26 +1030,26 @@ statement ok
 DROP INDEX refers@another_idx
 
 # refers is not visible because it is in the ADD state.
-query TTT
+query TTTI
 SHOW TABLES FROM test
 ----
-public  bar                   table
-public  child                 table
-public  customers             table
-public  delivery              table
-public  domain_modules        table
-public  domains               table
-public  foo                   table
-public  grandchild            table
-public  modules               table
-public  pairs                 table
-public  referee               table
-public  refpairs              table
-public  refpairs_c_between    table
-public  refpairs_wrong_order  table
-public  tx                    table
-public  tx_leg                table
-public  unindexed             table
+public  bar                   table  0
+public  child                 table  0
+public  customers             table  0
+public  delivery              table  0
+public  domain_modules        table  0
+public  domains               table  0
+public  foo                   table  0
+public  grandchild            table  0
+public  modules               table  0
+public  pairs                 table  0
+public  referee               table  0
+public  refpairs              table  0
+public  refpairs_c_between    table  0
+public  refpairs_wrong_order  table  0
+public  tx                    table  0
+public  tx_leg                table  0
+public  unindexed             table  0
 
 statement ok
 COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -73,6 +73,7 @@ test           crdb_internal       session_trace                      public   S
 test           crdb_internal       session_variables                  public   SELECT
 test           crdb_internal       table_columns                      public   SELECT
 test           crdb_internal       table_indexes                      public   SELECT
+test           crdb_internal       table_row_statistics               public   SELECT
 test           crdb_internal       tables                             public   SELECT
 test           crdb_internal       zones                              public   SELECT
 test           information_schema  NULL                               admin    ALL

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -11,30 +11,30 @@ CREATE TABLE information_schema.t (x INT)
 query error database "information_schema" does not exist
 DROP DATABASE information_schema
 
-query TTT
+query TTTI
 SHOW TABLES FROM information_schema
 ----
-information_schema  administrable_role_authorizations  table
-information_schema  applicable_roles                   table
-information_schema  check_constraints                  table
-information_schema  column_privileges                  table
-information_schema  columns                            table
-information_schema  constraint_column_usage            table
-information_schema  enabled_roles                      table
-information_schema  key_column_usage                   table
-information_schema  parameters                         table
-information_schema  referential_constraints            table
-information_schema  role_table_grants                  table
-information_schema  routines                           table
-information_schema  schema_privileges                  table
-information_schema  schemata                           table
-information_schema  sequences                          table
-information_schema  statistics                         table
-information_schema  table_constraints                  table
-information_schema  table_privileges                   table
-information_schema  tables                             table
-information_schema  user_privileges                    table
-information_schema  views                              table
+information_schema  administrable_role_authorizations  table  NULL
+information_schema  applicable_roles                   table  NULL
+information_schema  check_constraints                  table  NULL
+information_schema  column_privileges                  table  NULL
+information_schema  columns                            table  NULL
+information_schema  constraint_column_usage            table  NULL
+information_schema  enabled_roles                      table  NULL
+information_schema  key_column_usage                   table  NULL
+information_schema  parameters                         table  NULL
+information_schema  referential_constraints            table  NULL
+information_schema  role_table_grants                  table  NULL
+information_schema  routines                           table  NULL
+information_schema  schema_privileges                  table  NULL
+information_schema  schemata                           table  NULL
+information_schema  sequences                          table  NULL
+information_schema  statistics                         table  NULL
+information_schema  table_constraints                  table  NULL
+information_schema  table_privileges                   table  NULL
+information_schema  tables                             table  NULL
+information_schema  user_privileges                    table  NULL
+information_schema  views                              table  NULL
 
 # Verify that the name is not special for databases.
 
@@ -118,30 +118,30 @@ postgres
 system
 test
 
-query TTT
+query TTTI
 SHOW TABLES FROM test.information_schema
 ----
-information_schema  administrable_role_authorizations  table
-information_schema  applicable_roles                   table
-information_schema  check_constraints                  table
-information_schema  column_privileges                  table
-information_schema  columns                            table
-information_schema  constraint_column_usage            table
-information_schema  enabled_roles                      table
-information_schema  key_column_usage                   table
-information_schema  parameters                         table
-information_schema  referential_constraints            table
-information_schema  role_table_grants                  table
-information_schema  routines                           table
-information_schema  schema_privileges                  table
-information_schema  schemata                           table
-information_schema  sequences                          table
-information_schema  statistics                         table
-information_schema  table_constraints                  table
-information_schema  table_privileges                   table
-information_schema  tables                             table
-information_schema  user_privileges                    table
-information_schema  views                              table
+information_schema  administrable_role_authorizations  table  NULL
+information_schema  applicable_roles                   table  NULL
+information_schema  check_constraints                  table  NULL
+information_schema  column_privileges                  table  NULL
+information_schema  columns                            table  NULL
+information_schema  constraint_column_usage            table  NULL
+information_schema  enabled_roles                      table  NULL
+information_schema  key_column_usage                   table  NULL
+information_schema  parameters                         table  NULL
+information_schema  referential_constraints            table  NULL
+information_schema  role_table_grants                  table  NULL
+information_schema  routines                           table  NULL
+information_schema  schema_privileges                  table  NULL
+information_schema  schemata                           table  NULL
+information_schema  sequences                          table  NULL
+information_schema  statistics                         table  NULL
+information_schema  table_constraints                  table  NULL
+information_schema  table_privileges                   table  NULL
+information_schema  tables                             table  NULL
+information_schema  user_privileges                    table  NULL
+information_schema  views                              table  NULL
 
 query TT colnames
 SHOW CREATE TABLE information_schema.tables
@@ -253,6 +253,7 @@ crdb_internal       session_trace
 crdb_internal       session_variables
 crdb_internal       table_columns
 crdb_internal       table_indexes
+crdb_internal       table_row_statistics
 crdb_internal       tables
 crdb_internal       zones
 information_schema  administrable_role_authorizations
@@ -402,6 +403,7 @@ session_trace
 session_variables
 table_columns
 table_indexes
+table_row_statistics
 tables
 zones
 administrable_role_authorizations
@@ -511,6 +513,7 @@ views
 user_privileges
 tables
 tables
+table_row_statistics
 table_privileges
 table_indexes
 table_constraints
@@ -558,6 +561,7 @@ system         crdb_internal       session_trace                      SYSTEM VIE
 system         crdb_internal       session_variables                  SYSTEM VIEW  NO                  1
 system         crdb_internal       table_columns                      SYSTEM VIEW  NO                  1
 system         crdb_internal       table_indexes                      SYSTEM VIEW  NO                  1
+system         crdb_internal       table_row_statistics               SYSTEM VIEW  NO                  1
 system         crdb_internal       tables                             SYSTEM VIEW  NO                  1
 system         crdb_internal       zones                              SYSTEM VIEW  NO                  1
 system         information_schema  administrable_role_authorizations  SYSTEM VIEW  NO                  1
@@ -1654,6 +1658,7 @@ NULL     public   system         crdb_internal       session_trace              
 NULL     public   system         crdb_internal       session_variables                  SELECT          NULL          YES
 NULL     public   system         crdb_internal       table_columns                      SELECT          NULL          YES
 NULL     public   system         crdb_internal       table_indexes                      SELECT          NULL          YES
+NULL     public   system         crdb_internal       table_row_statistics               SELECT          NULL          YES
 NULL     public   system         crdb_internal       tables                             SELECT          NULL          YES
 NULL     public   system         crdb_internal       zones                              SELECT          NULL          YES
 NULL     public   system         information_schema  administrable_role_authorizations  SELECT          NULL          YES
@@ -2018,6 +2023,7 @@ NULL     public   system         crdb_internal       session_trace              
 NULL     public   system         crdb_internal       session_variables                  SELECT          NULL          YES
 NULL     public   system         crdb_internal       table_columns                      SELECT          NULL          YES
 NULL     public   system         crdb_internal       table_indexes                      SELECT          NULL          YES
+NULL     public   system         crdb_internal       table_row_statistics               SELECT          NULL          YES
 NULL     public   system         crdb_internal       tables                             SELECT          NULL          YES
 NULL     public   system         crdb_internal       zones                              SELECT          NULL          YES
 NULL     public   system         information_schema  administrable_role_authorizations  SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/namespace
+++ b/pkg/sql/logictest/testdata/logic_test/namespace
@@ -6,27 +6,27 @@ statement ok
 CREATE DATABASE public; CREATE TABLE public.public.t(a INT)
 
 # "public" with the current database designates the public schema
-query TTT
+query TTTI
 SHOW TABLES FROM public
 ----
-public  a  table
+public  a  table  0
 
 # To access all tables in database "public", one must specify
 # its public schema explicitly.
-query TTT
+query TTTI
 SHOW TABLES FROM public.public
 ----
-public  t  table
+public  t  table  NULL
 
 # Of course one can also list the tables in "public" by making it the
 # current database.
 statement ok
 SET database = public
 
-query TTT
+query TTTI
 SHOW TABLES
 ----
-public  t  table
+public  t  table  0
 
 statement ok
 SET database = test; DROP DATABASE public

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -14,60 +14,60 @@ CREATE TABLE pg_catalog.t (x INT)
 query error database "pg_catalog" does not exist
 DROP DATABASE pg_catalog
 
-query TTT
+query TTTI
 SHOW TABLES FROM pg_catalog
 ----
-pg_catalog  pg_aggregate             table
-pg_catalog  pg_am                    table
-pg_catalog  pg_attrdef               table
-pg_catalog  pg_attribute             table
-pg_catalog  pg_auth_members          table
-pg_catalog  pg_authid                table
-pg_catalog  pg_available_extensions  table
-pg_catalog  pg_cast                  table
-pg_catalog  pg_class                 table
-pg_catalog  pg_collation             table
-pg_catalog  pg_constraint            table
-pg_catalog  pg_conversion            table
-pg_catalog  pg_database              table
-pg_catalog  pg_default_acl           table
-pg_catalog  pg_depend                table
-pg_catalog  pg_description           table
-pg_catalog  pg_enum                  table
-pg_catalog  pg_event_trigger         table
-pg_catalog  pg_extension             table
-pg_catalog  pg_foreign_data_wrapper  table
-pg_catalog  pg_foreign_server        table
-pg_catalog  pg_foreign_table         table
-pg_catalog  pg_index                 table
-pg_catalog  pg_indexes               table
-pg_catalog  pg_inherits              table
-pg_catalog  pg_language              table
-pg_catalog  pg_locks                 table
-pg_catalog  pg_matviews              table
-pg_catalog  pg_namespace             table
-pg_catalog  pg_operator              table
-pg_catalog  pg_prepared_statements   table
-pg_catalog  pg_prepared_xacts        table
-pg_catalog  pg_proc                  table
-pg_catalog  pg_range                 table
-pg_catalog  pg_rewrite               table
-pg_catalog  pg_roles                 table
-pg_catalog  pg_seclabel              table
-pg_catalog  pg_seclabels             table
-pg_catalog  pg_sequence              table
-pg_catalog  pg_settings              table
-pg_catalog  pg_shdepend              table
-pg_catalog  pg_shdescription         table
-pg_catalog  pg_shseclabel            table
-pg_catalog  pg_stat_activity         table
-pg_catalog  pg_tables                table
-pg_catalog  pg_tablespace            table
-pg_catalog  pg_trigger               table
-pg_catalog  pg_type                  table
-pg_catalog  pg_user                  table
-pg_catalog  pg_user_mapping          table
-pg_catalog  pg_views                 table
+pg_catalog  pg_aggregate             table  NULL
+pg_catalog  pg_am                    table  NULL
+pg_catalog  pg_attrdef               table  NULL
+pg_catalog  pg_attribute             table  NULL
+pg_catalog  pg_auth_members          table  NULL
+pg_catalog  pg_authid                table  NULL
+pg_catalog  pg_available_extensions  table  NULL
+pg_catalog  pg_cast                  table  NULL
+pg_catalog  pg_class                 table  NULL
+pg_catalog  pg_collation             table  NULL
+pg_catalog  pg_constraint            table  NULL
+pg_catalog  pg_conversion            table  NULL
+pg_catalog  pg_database              table  NULL
+pg_catalog  pg_default_acl           table  NULL
+pg_catalog  pg_depend                table  NULL
+pg_catalog  pg_description           table  NULL
+pg_catalog  pg_enum                  table  NULL
+pg_catalog  pg_event_trigger         table  NULL
+pg_catalog  pg_extension             table  NULL
+pg_catalog  pg_foreign_data_wrapper  table  NULL
+pg_catalog  pg_foreign_server        table  NULL
+pg_catalog  pg_foreign_table         table  NULL
+pg_catalog  pg_index                 table  NULL
+pg_catalog  pg_indexes               table  NULL
+pg_catalog  pg_inherits              table  NULL
+pg_catalog  pg_language              table  NULL
+pg_catalog  pg_locks                 table  NULL
+pg_catalog  pg_matviews              table  NULL
+pg_catalog  pg_namespace             table  NULL
+pg_catalog  pg_operator              table  NULL
+pg_catalog  pg_prepared_statements   table  NULL
+pg_catalog  pg_prepared_xacts        table  NULL
+pg_catalog  pg_proc                  table  NULL
+pg_catalog  pg_range                 table  NULL
+pg_catalog  pg_rewrite               table  NULL
+pg_catalog  pg_roles                 table  NULL
+pg_catalog  pg_seclabel              table  NULL
+pg_catalog  pg_seclabels             table  NULL
+pg_catalog  pg_sequence              table  NULL
+pg_catalog  pg_settings              table  NULL
+pg_catalog  pg_shdepend              table  NULL
+pg_catalog  pg_shdescription         table  NULL
+pg_catalog  pg_shseclabel            table  NULL
+pg_catalog  pg_stat_activity         table  NULL
+pg_catalog  pg_tables                table  NULL
+pg_catalog  pg_tablespace            table  NULL
+pg_catalog  pg_trigger               table  NULL
+pg_catalog  pg_type                  table  NULL
+pg_catalog  pg_user                  table  NULL
+pg_catalog  pg_user_mapping          table  NULL
+pg_catalog  pg_views                 table  NULL
 
 # Verify "pg_catalog" is a regular db name
 
@@ -91,60 +91,60 @@ SELECT * FROM pg_catalog.pg_class c WHERE nonexistent_function()
 
 # Verify pg_catalog handles reflection correctly.
 
-query TTT
+query TTTI
 SHOW TABLES FROM test.pg_catalog
 ----
-pg_catalog  pg_aggregate             table
-pg_catalog  pg_am                    table
-pg_catalog  pg_attrdef               table
-pg_catalog  pg_attribute             table
-pg_catalog  pg_auth_members          table
-pg_catalog  pg_authid                table
-pg_catalog  pg_available_extensions  table
-pg_catalog  pg_cast                  table
-pg_catalog  pg_class                 table
-pg_catalog  pg_collation             table
-pg_catalog  pg_constraint            table
-pg_catalog  pg_conversion            table
-pg_catalog  pg_database              table
-pg_catalog  pg_default_acl           table
-pg_catalog  pg_depend                table
-pg_catalog  pg_description           table
-pg_catalog  pg_enum                  table
-pg_catalog  pg_event_trigger         table
-pg_catalog  pg_extension             table
-pg_catalog  pg_foreign_data_wrapper  table
-pg_catalog  pg_foreign_server        table
-pg_catalog  pg_foreign_table         table
-pg_catalog  pg_index                 table
-pg_catalog  pg_indexes               table
-pg_catalog  pg_inherits              table
-pg_catalog  pg_language              table
-pg_catalog  pg_locks                 table
-pg_catalog  pg_matviews              table
-pg_catalog  pg_namespace             table
-pg_catalog  pg_operator              table
-pg_catalog  pg_prepared_statements   table
-pg_catalog  pg_prepared_xacts        table
-pg_catalog  pg_proc                  table
-pg_catalog  pg_range                 table
-pg_catalog  pg_rewrite               table
-pg_catalog  pg_roles                 table
-pg_catalog  pg_seclabel              table
-pg_catalog  pg_seclabels             table
-pg_catalog  pg_sequence              table
-pg_catalog  pg_settings              table
-pg_catalog  pg_shdepend              table
-pg_catalog  pg_shdescription         table
-pg_catalog  pg_shseclabel            table
-pg_catalog  pg_stat_activity         table
-pg_catalog  pg_tables                table
-pg_catalog  pg_tablespace            table
-pg_catalog  pg_trigger               table
-pg_catalog  pg_type                  table
-pg_catalog  pg_user                  table
-pg_catalog  pg_user_mapping          table
-pg_catalog  pg_views                 table
+pg_catalog  pg_aggregate             table  NULL
+pg_catalog  pg_am                    table  NULL
+pg_catalog  pg_attrdef               table  NULL
+pg_catalog  pg_attribute             table  NULL
+pg_catalog  pg_auth_members          table  NULL
+pg_catalog  pg_authid                table  NULL
+pg_catalog  pg_available_extensions  table  NULL
+pg_catalog  pg_cast                  table  NULL
+pg_catalog  pg_class                 table  NULL
+pg_catalog  pg_collation             table  NULL
+pg_catalog  pg_constraint            table  NULL
+pg_catalog  pg_conversion            table  NULL
+pg_catalog  pg_database              table  NULL
+pg_catalog  pg_default_acl           table  NULL
+pg_catalog  pg_depend                table  NULL
+pg_catalog  pg_description           table  NULL
+pg_catalog  pg_enum                  table  NULL
+pg_catalog  pg_event_trigger         table  NULL
+pg_catalog  pg_extension             table  NULL
+pg_catalog  pg_foreign_data_wrapper  table  NULL
+pg_catalog  pg_foreign_server        table  NULL
+pg_catalog  pg_foreign_table         table  NULL
+pg_catalog  pg_index                 table  NULL
+pg_catalog  pg_indexes               table  NULL
+pg_catalog  pg_inherits              table  NULL
+pg_catalog  pg_language              table  NULL
+pg_catalog  pg_locks                 table  NULL
+pg_catalog  pg_matviews              table  NULL
+pg_catalog  pg_namespace             table  NULL
+pg_catalog  pg_operator              table  NULL
+pg_catalog  pg_prepared_statements   table  NULL
+pg_catalog  pg_prepared_xacts        table  NULL
+pg_catalog  pg_proc                  table  NULL
+pg_catalog  pg_range                 table  NULL
+pg_catalog  pg_rewrite               table  NULL
+pg_catalog  pg_roles                 table  NULL
+pg_catalog  pg_seclabel              table  NULL
+pg_catalog  pg_seclabels             table  NULL
+pg_catalog  pg_sequence              table  NULL
+pg_catalog  pg_settings              table  NULL
+pg_catalog  pg_shdepend              table  NULL
+pg_catalog  pg_shdescription         table  NULL
+pg_catalog  pg_shseclabel            table  NULL
+pg_catalog  pg_stat_activity         table  NULL
+pg_catalog  pg_tables                table  NULL
+pg_catalog  pg_tablespace            table  NULL
+pg_catalog  pg_trigger               table  NULL
+pg_catalog  pg_type                  table  NULL
+pg_catalog  pg_user                  table  NULL
+pg_catalog  pg_user_mapping          table  NULL
+pg_catalog  pg_views                 table  NULL
 
 query TT colnames
 SHOW CREATE TABLE pg_catalog.pg_namespace
@@ -902,8 +902,8 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967222  2143281868  0         4294967224  450499961  0            n
-4294967222  4089604113  0         4294967224  450499960  0            n
+4294967221  2143281868  0         4294967223  450499961  0            n
+4294967221  4089604113  0         4294967223  450499960  0            n
 
 # All entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table.
@@ -915,7 +915,7 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967222  4294967224  pg_constraint  pg_class
+4294967221  4294967223  pg_constraint  pg_class
 
 # All entries in pg_depend are foreign key constraints that reference an index
 # in pg_class.
@@ -1576,119 +1576,120 @@ SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS d
   FROM pg_catalog.pg_description
 ----
 objoid      classoid    objsubid  description
-4294967294  4294967224  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967292  4294967224  0         built-in functions (RAM/static)
-4294967291  4294967224  0         running queries visible by current user (cluster RPC; expensive!)
-4294967289  4294967224  0         running sessions visible to current user (cluster RPC; expensive!)
-4294967288  4294967224  0         cluster settings (RAM)
-4294967290  4294967224  0         running user transactions visible by the current user (cluster RPC; expensive!)
-4294967287  4294967224  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967286  4294967224  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
-4294967285  4294967224  0         databases accessible by the current user (KV scan)
-4294967284  4294967224  0         telemetry counters (RAM; local node only)
-4294967283  4294967224  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967281  4294967224  0         locally known gossiped health alerts (RAM; local node only)
-4294967280  4294967224  0         locally known gossiped node liveness (RAM; local node only)
-4294967279  4294967224  0         locally known edges in the gossip network (RAM; local node only)
-4294967282  4294967224  0         locally known gossiped node details (RAM; local node only)
-4294967278  4294967224  0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967277  4294967224  0         decoded job metadata from system.jobs (KV scan)
-4294967276  4294967224  0         node details across the entire cluster (cluster RPC; expensive!)
-4294967275  4294967224  0         store details and status (cluster RPC; expensive!)
-4294967274  4294967224  0         acquired table leases (RAM; local node only)
-4294967293  4294967224  0         detailed identification strings (RAM, local node only)
-4294967270  4294967224  0         current values for metrics (RAM; local node only)
-4294967273  4294967224  0         running queries visible by current user (RAM; local node only)
-4294967265  4294967224  0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967271  4294967224  0         running sessions visible by current user (RAM; local node only)
-4294967261  4294967224  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967272  4294967224  0         running user transactions visible by the current user (RAM; local node only)
-4294967257  4294967224  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967269  4294967224  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967268  4294967224  0         comments for predefined virtual tables (RAM/static)
-4294967267  4294967224  0         range metadata without leaseholder details (KV join; expensive!)
-4294967264  4294967224  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967263  4294967224  0         session trace accumulated so far (RAM)
-4294967262  4294967224  0         session variables (RAM)
-4294967260  4294967224  0         details for all columns accessible by current user in current database (KV scan)
-4294967259  4294967224  0         indexes accessible by current user in current database (KV scan)
-4294967258  4294967224  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967256  4294967224  0         decoded zone configurations from system.zones (KV scan)
-4294967254  4294967224  0         roles for which the current user has admin option
-4294967253  4294967224  0         roles available to the current user
-4294967252  4294967224  0         check constraints
-4294967251  4294967224  0         column privilege grants (incomplete)
-4294967250  4294967224  0         table and view columns (incomplete)
-4294967249  4294967224  0         columns usage by constraints
-4294967248  4294967224  0         roles for the current user
-4294967247  4294967224  0         column usage by indexes and key constraints
-4294967246  4294967224  0         built-in function parameters (empty - introspection not yet supported)
-4294967245  4294967224  0         foreign key constraints
-4294967244  4294967224  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967243  4294967224  0         built-in functions (empty - introspection not yet supported)
-4294967241  4294967224  0         schema privileges (incomplete; may contain excess users or roles)
-4294967242  4294967224  0         database schemas (may contain schemata without permission)
-4294967240  4294967224  0         sequences
-4294967239  4294967224  0         index metadata and statistics (incomplete)
-4294967238  4294967224  0         table constraints
-4294967237  4294967224  0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967236  4294967224  0         tables and views
-4294967234  4294967224  0         grantable privileges (incomplete)
-4294967235  4294967224  0         views (incomplete)
-4294967232  4294967224  0         aggregated built-in functions (incomplete)
-4294967231  4294967224  0         index access methods (incomplete)
-4294967230  4294967224  0         column default values
-4294967229  4294967224  0         table columns (incomplete - see also information_schema.columns)
-4294967227  4294967224  0         role membership
-4294967228  4294967224  0         authorization identifiers - differs from postgres as we do not display passwords,
-4294967226  4294967224  0         available extensions
-4294967225  4294967224  0         casts (empty - needs filling out)
-4294967224  4294967224  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967223  4294967224  0         available collations (incomplete)
-4294967222  4294967224  0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967221  4294967224  0         encoding conversions (empty - unimplemented)
-4294967220  4294967224  0         available databases (incomplete)
-4294967219  4294967224  0         default ACLs (empty - unimplemented)
-4294967218  4294967224  0         dependency relationships (incomplete)
-4294967217  4294967224  0         object comments
-4294967215  4294967224  0         enum types and labels (empty - feature does not exist)
-4294967214  4294967224  0         event triggers (empty - feature does not exist)
-4294967213  4294967224  0         installed extensions (empty - feature does not exist)
-4294967212  4294967224  0         foreign data wrappers (empty - feature does not exist)
-4294967211  4294967224  0         foreign servers (empty - feature does not exist)
-4294967210  4294967224  0         foreign tables (empty  - feature does not exist)
-4294967209  4294967224  0         indexes (incomplete)
-4294967208  4294967224  0         index creation statements
-4294967207  4294967224  0         table inheritance hierarchy (empty - feature does not exist)
-4294967206  4294967224  0         available languages (empty - feature does not exist)
-4294967205  4294967224  0         locks held by active processes (empty - feature does not exist)
-4294967204  4294967224  0         available materialized views (empty - feature does not exist)
-4294967203  4294967224  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967202  4294967224  0         operators (incomplete)
-4294967201  4294967224  0         prepared statements
-4294967200  4294967224  0         prepared transactions (empty - feature does not exist)
-4294967199  4294967224  0         built-in functions (incomplete)
-4294967198  4294967224  0         range types (empty - feature does not exist)
-4294967197  4294967224  0         rewrite rules (empty - feature does not exist)
-4294967196  4294967224  0         database roles
-4294967183  4294967224  0         security labels (empty - feature does not exist)
-4294967195  4294967224  0         security labels (empty)
-4294967194  4294967224  0         sequences (see also information_schema.sequences)
-4294967193  4294967224  0         session variables (incomplete)
-4294967192  4294967224  0         shared dependencies (empty - not implemented)
-4294967216  4294967224  0         shared object comments
-4294967182  4294967224  0         shared security labels (empty - feature not supported)
-4294967184  4294967224  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967189  4294967224  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967188  4294967224  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967187  4294967224  0         triggers (empty - feature does not exist)
-4294967186  4294967224  0         scalar types (incomplete)
-4294967191  4294967224  0         database users
-4294967190  4294967224  0         local to remote user mapping (empty - feature does not exist)
-4294967185  4294967224  0         view definitions (incomplete - see also information_schema.views)
-4294967180  4294967224  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967179  4294967224  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967178  4294967224  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967294  4294967223  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  4294967223  0         built-in functions (RAM/static)
+4294967291  4294967223  0         running queries visible by current user (cluster RPC; expensive!)
+4294967289  4294967223  0         running sessions visible to current user (cluster RPC; expensive!)
+4294967288  4294967223  0         cluster settings (RAM)
+4294967290  4294967223  0         running user transactions visible by the current user (cluster RPC; expensive!)
+4294967287  4294967223  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967286  4294967223  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
+4294967285  4294967223  0         databases accessible by the current user (KV scan)
+4294967284  4294967223  0         telemetry counters (RAM; local node only)
+4294967283  4294967223  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967281  4294967223  0         locally known gossiped health alerts (RAM; local node only)
+4294967280  4294967223  0         locally known gossiped node liveness (RAM; local node only)
+4294967279  4294967223  0         locally known edges in the gossip network (RAM; local node only)
+4294967282  4294967223  0         locally known gossiped node details (RAM; local node only)
+4294967278  4294967223  0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967277  4294967223  0         decoded job metadata from system.jobs (KV scan)
+4294967276  4294967223  0         node details across the entire cluster (cluster RPC; expensive!)
+4294967275  4294967223  0         store details and status (cluster RPC; expensive!)
+4294967274  4294967223  0         acquired table leases (RAM; local node only)
+4294967293  4294967223  0         detailed identification strings (RAM, local node only)
+4294967270  4294967223  0         current values for metrics (RAM; local node only)
+4294967273  4294967223  0         running queries visible by current user (RAM; local node only)
+4294967265  4294967223  0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967271  4294967223  0         running sessions visible by current user (RAM; local node only)
+4294967261  4294967223  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967272  4294967223  0         running user transactions visible by the current user (RAM; local node only)
+4294967256  4294967223  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967269  4294967223  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967268  4294967223  0         comments for predefined virtual tables (RAM/static)
+4294967267  4294967223  0         range metadata without leaseholder details (KV join; expensive!)
+4294967264  4294967223  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967263  4294967223  0         session trace accumulated so far (RAM)
+4294967262  4294967223  0         session variables (RAM)
+4294967260  4294967223  0         details for all columns accessible by current user in current database (KV scan)
+4294967259  4294967223  0         indexes accessible by current user in current database (KV scan)
+4294967257  4294967223  0         the latest stats for all tables accessible by current user in current database (KV scan)
+4294967258  4294967223  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967255  4294967223  0         decoded zone configurations from system.zones (KV scan)
+4294967253  4294967223  0         roles for which the current user has admin option
+4294967252  4294967223  0         roles available to the current user
+4294967251  4294967223  0         check constraints
+4294967250  4294967223  0         column privilege grants (incomplete)
+4294967249  4294967223  0         table and view columns (incomplete)
+4294967248  4294967223  0         columns usage by constraints
+4294967247  4294967223  0         roles for the current user
+4294967246  4294967223  0         column usage by indexes and key constraints
+4294967245  4294967223  0         built-in function parameters (empty - introspection not yet supported)
+4294967244  4294967223  0         foreign key constraints
+4294967243  4294967223  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967242  4294967223  0         built-in functions (empty - introspection not yet supported)
+4294967240  4294967223  0         schema privileges (incomplete; may contain excess users or roles)
+4294967241  4294967223  0         database schemas (may contain schemata without permission)
+4294967239  4294967223  0         sequences
+4294967238  4294967223  0         index metadata and statistics (incomplete)
+4294967237  4294967223  0         table constraints
+4294967236  4294967223  0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967235  4294967223  0         tables and views
+4294967233  4294967223  0         grantable privileges (incomplete)
+4294967234  4294967223  0         views (incomplete)
+4294967231  4294967223  0         aggregated built-in functions (incomplete)
+4294967230  4294967223  0         index access methods (incomplete)
+4294967229  4294967223  0         column default values
+4294967228  4294967223  0         table columns (incomplete - see also information_schema.columns)
+4294967226  4294967223  0         role membership
+4294967227  4294967223  0         authorization identifiers - differs from postgres as we do not display passwords,
+4294967225  4294967223  0         available extensions
+4294967224  4294967223  0         casts (empty - needs filling out)
+4294967223  4294967223  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967222  4294967223  0         available collations (incomplete)
+4294967221  4294967223  0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967220  4294967223  0         encoding conversions (empty - unimplemented)
+4294967219  4294967223  0         available databases (incomplete)
+4294967218  4294967223  0         default ACLs (empty - unimplemented)
+4294967217  4294967223  0         dependency relationships (incomplete)
+4294967216  4294967223  0         object comments
+4294967214  4294967223  0         enum types and labels (empty - feature does not exist)
+4294967213  4294967223  0         event triggers (empty - feature does not exist)
+4294967212  4294967223  0         installed extensions (empty - feature does not exist)
+4294967211  4294967223  0         foreign data wrappers (empty - feature does not exist)
+4294967210  4294967223  0         foreign servers (empty - feature does not exist)
+4294967209  4294967223  0         foreign tables (empty  - feature does not exist)
+4294967208  4294967223  0         indexes (incomplete)
+4294967207  4294967223  0         index creation statements
+4294967206  4294967223  0         table inheritance hierarchy (empty - feature does not exist)
+4294967205  4294967223  0         available languages (empty - feature does not exist)
+4294967204  4294967223  0         locks held by active processes (empty - feature does not exist)
+4294967203  4294967223  0         available materialized views (empty - feature does not exist)
+4294967202  4294967223  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967201  4294967223  0         operators (incomplete)
+4294967200  4294967223  0         prepared statements
+4294967199  4294967223  0         prepared transactions (empty - feature does not exist)
+4294967198  4294967223  0         built-in functions (incomplete)
+4294967197  4294967223  0         range types (empty - feature does not exist)
+4294967196  4294967223  0         rewrite rules (empty - feature does not exist)
+4294967195  4294967223  0         database roles
+4294967182  4294967223  0         security labels (empty - feature does not exist)
+4294967194  4294967223  0         security labels (empty)
+4294967193  4294967223  0         sequences (see also information_schema.sequences)
+4294967192  4294967223  0         session variables (incomplete)
+4294967191  4294967223  0         shared dependencies (empty - not implemented)
+4294967215  4294967223  0         shared object comments
+4294967181  4294967223  0         shared security labels (empty - feature not supported)
+4294967183  4294967223  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967188  4294967223  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967187  4294967223  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967186  4294967223  0         triggers (empty - feature does not exist)
+4294967185  4294967223  0         scalar types (incomplete)
+4294967190  4294967223  0         database users
+4294967189  4294967223  0         local to remote user mapping (empty - feature does not exist)
+4294967184  4294967223  0         view definitions (incomplete - see also information_schema.views)
+4294967179  4294967223  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967178  4294967223  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967177  4294967223  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -124,10 +124,10 @@ user root
 statement ok
 CREATE VIEW t.v AS SELECT k,v FROM u.kv
 
-query TTT
+query TTTI
 SHOW TABLES FROM u
 ----
-public  kv  table
+public  kv  table  0
 
 statement error cannot rename database because relation "t.public.v" depends on relation "u.public.kv"
 ALTER DATABASE u RENAME TO v

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -20,10 +20,10 @@ SELECT * FROM kv
 1 2
 3 4
 
-query TTT
+query TTTI
 SHOW TABLES
 ----
-public  kv  table
+public  kv  table  0
 
 statement ok
 ALTER TABLE kv RENAME TO new_kv
@@ -37,10 +37,10 @@ SELECT * FROM new_kv
 1 2
 3 4
 
-query TTT
+query TTTI
 SHOW TABLES
 ----
-public  new_kv  table
+public  new_kv  table  0
 
 # check the name in the descriptor, which is used by SHOW GRANTS, is also changed
 query TTTTT
@@ -96,11 +96,11 @@ GRANT CREATE ON DATABASE test TO testuser
 statement ok
 ALTER TABLE test.t RENAME TO t2
 
-query TTT
+query TTTI
 SHOW TABLES
 ----
-public  new_kv  table
-public  t2      table
+public  new_kv  table  0
+public  t2      table  0
 
 user testuser
 
@@ -123,15 +123,15 @@ ALTER TABLE test.new_kv RENAME TO test2.t
 statement ok
 ALTER TABLE test.t2 RENAME TO test2.t2
 
-query TTT
+query TTTI
 SHOW TABLES
 ----
 
-query TTT
+query TTTI
 SHOW TABLES FROM test2
 ----
-public  t   table
-public  t2  table
+public  t   table  NULL
+public  t2  table  NULL
 
 user root
 
@@ -264,10 +264,10 @@ INSERT INTO d.kv2 (k,v) VALUES ('c', 'd')
 statement ok
 USE d
 
-query TTT
+query TTTI
 SHOW TABLES
 ----
-public  kv  table
+public  kv  table  0
 
 query TTT
 EXPLAIN ALTER TABLE kv RENAME TO kv2
@@ -277,7 +277,7 @@ EXPLAIN ALTER TABLE kv RENAME TO kv2
 rename table  ·             ·
 
 # Verify that the EXPLAIN above does not actually rename the table (#30543)
-query TTT
+query TTTI
 SHOW TABLES
 ----
-public  kv  table
+public  kv  table  0

--- a/pkg/sql/logictest/testdata/logic_test/rename_view
+++ b/pkg/sql/logictest/testdata/logic_test/rename_view
@@ -22,11 +22,11 @@ SELECT * FROM v
 1 2
 3 4
 
-query TTT
+query TTTI
 SHOW TABLES
 ----
-public  kv  table
-public  v   view
+public  kv  table  0
+public  v   view   0
 
 statement error pgcode 42809 "kv" is not a view
 ALTER VIEW kv RENAME TO new_kv
@@ -44,11 +44,11 @@ SELECT * FROM new_v
 1 2
 3 4
 
-query TTT
+query TTTI
 SHOW TABLES
 ----
-public  kv     table
-public  new_v  view
+public  kv     table  0
+public  new_v  view   0
 
 # check the name in the descriptor, which is used by SHOW GRANTS, is also changed
 query TTTTT
@@ -107,13 +107,13 @@ GRANT CREATE ON DATABASE test TO testuser
 statement ok
 ALTER VIEW test.v RENAME TO v2
 
-query TTT
+query TTTI
 SHOW TABLES FROM test
 ----
-public  kv     table
-public  new_v  view
-public  t      table
-public  v2     view
+public  kv     table  0
+public  new_v  view   0
+public  t      table  0
+public  v2     view   0
 
 user testuser
 
@@ -136,15 +136,15 @@ ALTER VIEW test.new_v RENAME TO test2.v
 statement ok
 ALTER VIEW test.v2 RENAME TO test2.v2
 
-query TTT
+query TTTI
 SHOW TABLES FROM test
 ----
 
-query TTT
+query TTTI
 SHOW TABLES FROM test2
 ----
-public  v   view
-public  v2  view
+public  v   view  NULL
+public  v2  view  NULL
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1156,12 +1156,12 @@ SHOW DATABASES
 ----
 publicdb
 
-query TTT
+query TTTI
 SHOW TABLES FROM publicdb
 ----
-public  publictable  table
+public  publictable  table  NULL
 
-query TTT
+query TTTI
 SHOW TABLES FROM privatedb
 ----
 
@@ -1204,6 +1204,6 @@ SELECT * FROM publicdb.publictable
 statement error user testuser does not have INSERT privilege on relation publictable
 INSERT INTO publicdb.publictable VALUES (1)
 
-query TTT
+query TTTI
 SHOW TABLES FROM publicdb
 ----

--- a/pkg/sql/logictest/testdata/logic_test/save_table
+++ b/pkg/sql/logictest/testdata/logic_test/save_table
@@ -77,20 +77,20 @@ key  val
 9    nine
 10   one-zero
 
-query TTT rowsort
+query TTTI rowsort
 SHOW TABLES
 ----
-public  save_table_test_scan_1  table
-public  st_lookup_join_2        table
-public  st_project_1            table
-public  st_scan_4               table
-public  st_select_3             table
-public  st_test_merge_join_2    table
-public  st_test_project_1       table
-public  st_test_scan_3          table
-public  st_test_scan_4          table
-public  t                       table
-public  u                       table
+public  save_table_test_scan_1  table  0
+public  st_lookup_join_2        table  0
+public  st_project_1            table  0
+public  st_scan_4               table  0
+public  st_select_3             table  0
+public  st_test_merge_join_2    table  0
+public  st_test_project_1       table  0
+public  st_test_scan_3          table  0
+public  st_test_scan_4          table  0
+public  t                       table  0
+public  u                       table  0
 
 # Only root may use the saveTableNode.
 

--- a/pkg/sql/logictest/testdata/logic_test/select_search_path
+++ b/pkg/sql/logictest/testdata/logic_test/select_search_path
@@ -1,7 +1,7 @@
 # Test that pg_catalog tables are accessible without qualifying table/view
 # names.
 
-query TTT
+query TTTT
 SHOW TABLES
 ----
 

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -25,10 +25,10 @@ statement ok
 CREATE TABLE bar (k INT PRIMARY KEY)
 
 # Verify that the table is indeed in "foo".
-query TTT
+query TTTI
 SHOW TABLES FROM foo
 ----
-public  bar  table
+public  bar  table  0
 
 # Verify set to empty string.
 statement ok
@@ -44,10 +44,10 @@ statement error no database specified
 SHOW TABLES
 
 # Verify SHOW TABLES FROM works when there is no current database.
-query TTT
+query TTTI
 SHOW TABLES FROM foo
 ----
-public  bar  table
+public  bar  table  0
 
 # SET statement succeeds, CREATE TABLE fails.
 statement error pgcode 42P07 relation \"bar\" already exists
@@ -60,10 +60,10 @@ database
 foo
 
 # SET succeeds
-query TTT
+query TTTI
 SHOW TABLES from foo
 ----
-public  bar  table
+public  bar  table  0
 
 statement error invalid variable name: ""
 SET ROW (1, TRUE, NULL)

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -186,71 +186,71 @@ SELECT * FROM [SHOW SEQUENCES FROM system]
 ----
 sequence_name
 
-query TTT colnames,rowsort
+query TTTT colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system]
 ----
-schema_name  table_name                       type
-public       namespace                        table
-public       descriptor                       table
-public       users                            table
-public       zones                            table
-public       settings                         table
-public       tenants                          table
-public       lease                            table
-public       eventlog                         table
-public       rangelog                         table
-public       ui                               table
-public       jobs                             table
-public       web_sessions                     table
-public       table_statistics                 table
-public       locations                        table
-public       role_members                     table
-public       comments                         table
-public       replication_constraint_stats     table
-public       replication_critical_localities  table
-public       replication_stats                table
-public       reports_meta                     table
-public       namespace2                       table
-public       protected_ts_meta                table
-public       protected_ts_records             table
-public       role_options                     table
-public       statement_bundle_chunks          table
-public       statement_diagnostics_requests   table
-public       statement_diagnostics            table
-public       scheduled_jobs                   table
+schema_name  table_name                       type   estimated_row_count
+public       namespace                        table  NULL
+public       descriptor                       table  NULL
+public       users                            table  NULL
+public       zones                            table  NULL
+public       settings                         table  NULL
+public       tenants                          table  NULL
+public       lease                            table  NULL
+public       eventlog                         table  NULL
+public       rangelog                         table  NULL
+public       ui                               table  NULL
+public       jobs                             table  NULL
+public       web_sessions                     table  NULL
+public       table_statistics                 table  NULL
+public       locations                        table  NULL
+public       role_members                     table  NULL
+public       comments                         table  NULL
+public       replication_constraint_stats     table  NULL
+public       replication_critical_localities  table  NULL
+public       replication_stats                table  NULL
+public       reports_meta                     table  NULL
+public       namespace2                       table  NULL
+public       protected_ts_meta                table  NULL
+public       protected_ts_records             table  NULL
+public       role_options                     table  NULL
+public       statement_bundle_chunks          table  NULL
+public       statement_diagnostics_requests   table  NULL
+public       statement_diagnostics            table  NULL
+public       scheduled_jobs                   table  NULL
 
-query TTTT colnames,rowsort
+query TTTTT colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system WITH COMMENT]
 ----
-schema_name  table_name                       type   comment
-public       namespace                        table  ·
-public       descriptor                       table  ·
-public       users                            table  ·
-public       zones                            table  ·
-public       settings                         table  ·
-public       tenants                          table  ·
-public       lease                            table  ·
-public       eventlog                         table  ·
-public       rangelog                         table  ·
-public       ui                               table  ·
-public       jobs                             table  ·
-public       web_sessions                     table  ·
-public       table_statistics                 table  ·
-public       locations                        table  ·
-public       role_members                     table  ·
-public       comments                         table  ·
-public       replication_constraint_stats     table  ·
-public       replication_critical_localities  table  ·
-public       replication_stats                table  ·
-public       reports_meta                     table  ·
-public       namespace2                       table  ·
-public       protected_ts_meta                table  ·
-public       protected_ts_records             table  ·
-public       role_options                     table  ·
-public       statement_bundle_chunks          table  ·
-public       statement_diagnostics_requests   table  ·
-public       statement_diagnostics            table  ·
-public       scheduled_jobs                   table  ·
+schema_name  table_name                       type   estimated_row_count  comment
+public       namespace                        table  NULL                 ·
+public       descriptor                       table  NULL                 ·
+public       users                            table  NULL                 ·
+public       zones                            table  NULL                 ·
+public       settings                         table  NULL                 ·
+public       tenants                          table  NULL                 ·
+public       lease                            table  NULL                 ·
+public       eventlog                         table  NULL                 ·
+public       rangelog                         table  NULL                 ·
+public       ui                               table  NULL                 ·
+public       jobs                             table  NULL                 ·
+public       web_sessions                     table  NULL                 ·
+public       table_statistics                 table  NULL                 ·
+public       locations                        table  NULL                 ·
+public       role_members                     table  NULL                 ·
+public       comments                         table  NULL                 ·
+public       replication_constraint_stats     table  NULL                 ·
+public       replication_critical_localities  table  NULL                 ·
+public       replication_stats                table  NULL                 ·
+public       reports_meta                     table  NULL                 ·
+public       namespace2                       table  NULL                 ·
+public       protected_ts_meta                table  NULL                 ·
+public       protected_ts_records             table  NULL                 ·
+public       role_options                     table  NULL                 ·
+public       statement_bundle_chunks          table  NULL                 ·
+public       statement_diagnostics_requests   table  NULL                 ·
+public       statement_diagnostics            table  NULL                 ·
+public       scheduled_jobs                   table  NULL                 ·
 
 query ITTT colnames
 SELECT node_id, user_name, application_name, active_queries
@@ -277,11 +277,11 @@ pg_catalog
 pg_extension
 public
 
-query TTT colnames
+query TTTI colnames
 CREATE TABLE foo(x INT); SELECT * FROM [SHOW TABLES]
 ----
-schema_name  table_name  type
-public       foo         table
+schema_name  table_name  type   estimated_row_count
+public       foo         table  0
 
 
 query T colnames

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -7,37 +7,37 @@ postgres
 system
 test
 
-query TTT
+query TTTT
 SHOW TABLES FROM system
 ----
-public  comments                         table
-public  descriptor                       table
-public  eventlog                         table
-public  jobs                             table
-public  lease                            table
-public  locations                        table
-public  namespace                        table
-public  namespace2                       table
-public  protected_ts_meta                table
-public  protected_ts_records             table
-public  rangelog                         table
-public  replication_constraint_stats     table
-public  replication_critical_localities  table
-public  replication_stats                table
-public  reports_meta                     table
-public  role_members                     table
-public  role_options                     table
-public  scheduled_jobs                   table
-public  settings                         table
-public  statement_bundle_chunks          table
-public  statement_diagnostics            table
-public  statement_diagnostics_requests   table
-public  table_statistics                 table
-public  tenants                          table
-public  ui                               table
-public  users                            table
-public  web_sessions                     table
-public  zones                            table
+public  comments                         table  NULL
+public  descriptor                       table  NULL
+public  eventlog                         table  NULL
+public  jobs                             table  NULL
+public  lease                            table  NULL
+public  locations                        table  NULL
+public  namespace                        table  NULL
+public  namespace2                       table  NULL
+public  protected_ts_meta                table  NULL
+public  protected_ts_records             table  NULL
+public  rangelog                         table  NULL
+public  replication_constraint_stats     table  NULL
+public  replication_critical_localities  table  NULL
+public  replication_stats                table  NULL
+public  reports_meta                     table  NULL
+public  role_members                     table  NULL
+public  role_options                     table  NULL
+public  scheduled_jobs                   table  NULL
+public  settings                         table  NULL
+public  statement_bundle_chunks          table  NULL
+public  statement_diagnostics            table  NULL
+public  statement_diagnostics_requests   table  NULL
+public  table_statistics                 table  NULL
+public  tenants                          table  NULL
+public  ui                               table  NULL
+public  users                            table  NULL
+public  web_sessions                     table  NULL
+public  zones                            table  NULL
 
 query I rowsort
 SELECT id FROM system.descriptor

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -1,3 +1,5 @@
+# LogicTest: !3node-tenant(50049)
+
 statement ok
 SET DATABASE = ""
 
@@ -40,11 +42,11 @@ CREATE TABLE IF NOT EXISTS a (id INT PRIMARY KEY)
 statement ok
 COMMENT ON TABLE a IS 'a_comment'
 
-query TTT colnames
+query TTTI colnames
 SHOW TABLES FROM test
 ----
-schema_name  table_name  type
-public       a           table
+schema_name  table_name  type   estimated_row_count
+public       a           table  0
 
 statement ok
 CREATE TABLE b (id INT PRIMARY KEY)
@@ -133,15 +135,15 @@ a            INT8       false        NULL            ·                      {pr
 b            INT8       false        NULL            ·                      {primary}  false
 c            INT8       false        NULL            ·                      {primary}  false
 
-query TTTT
+query TTTIT
 SHOW TABLES FROM test WITH COMMENT
 ----
-public  a  table  a_comment
-public  b  table  ·
-public  c  table  ·
-public  d  table  ·
-public  e  table  ·
-public  f  table  ·
+public  a  table  0  a_comment
+public  b  table  0  ·
+public  c  table  0  ·
+public  d  table  0  ·
+public  e  table  0  ·
+public  f  table  0  ·
 
 statement ok
 SET DATABASE = ""
@@ -497,3 +499,175 @@ query I
 SELECT a.public.c.d FROM a.public.c
 ----
 1
+
+statement ok
+CREATE TABLE t0 (a INT)
+
+statement ok
+GRANT ALL ON t0 to testuser
+
+statement ok
+CREATE DATABASE rowtest
+
+statement ok
+GRANT ALL ON DATABASE rowtest TO testuser
+
+user testuser
+
+statement ok
+SET DATABASE = rowtest
+
+statement ok
+CREATE TABLE t1 (a INT)
+
+statement ok
+INSERT INTO t1 SELECT a FROM generate_series(1, 1024) AS a(a)
+
+# only tables from current database
+query TTTI
+SHOW TABLES
+----
+public  t1  table  0
+
+# see only virtual tables (estimated_row_count is NULL)
+# and tables testuser has access to (estimated_row_count >= 0)
+query TI rowsort
+select table_name, estimated_row_count from crdb_internal.table_row_statistics;
+----
+backward_dependencies              NULL
+builtin_functions                  NULL
+cluster_queries                    NULL
+cluster_sessions                   NULL
+cluster_settings                   NULL
+cluster_transactions               NULL
+create_statements                  NULL
+create_type_statements             NULL
+databases                          NULL
+feature_usage                      NULL
+forward_dependencies               NULL
+gossip_alerts                      NULL
+gossip_liveness                    NULL
+gossip_network                     NULL
+gossip_nodes                       NULL
+index_columns                      NULL
+jobs                               NULL
+kv_node_status                     NULL
+kv_store_status                    NULL
+leases                             NULL
+node_build_info                    NULL
+node_metrics                       NULL
+node_queries                       NULL
+node_runtime_info                  NULL
+node_sessions                      NULL
+node_statement_statistics          NULL
+node_transactions                  NULL
+node_txn_stats                     NULL
+partitions                         NULL
+predefined_comments                NULL
+ranges                             NULL
+ranges_no_leases                   NULL
+schema_changes                     NULL
+session_trace                      NULL
+session_variables                  NULL
+table_columns                      NULL
+table_indexes                      NULL
+table_row_statistics               NULL
+tables                             NULL
+zones                              NULL
+administrable_role_authorizations  NULL
+applicable_roles                   NULL
+check_constraints                  NULL
+column_privileges                  NULL
+columns                            NULL
+constraint_column_usage            NULL
+enabled_roles                      NULL
+key_column_usage                   NULL
+parameters                         NULL
+referential_constraints            NULL
+role_table_grants                  NULL
+routines                           NULL
+schema_privileges                  NULL
+schemata                           NULL
+sequences                          NULL
+statistics                         NULL
+table_constraints                  NULL
+table_privileges                   NULL
+tables                             NULL
+user_privileges                    NULL
+views                              NULL
+pg_aggregate                       NULL
+pg_am                              NULL
+pg_attrdef                         NULL
+pg_attribute                       NULL
+pg_auth_members                    NULL
+pg_authid                          NULL
+pg_available_extensions            NULL
+pg_cast                            NULL
+pg_class                           NULL
+pg_collation                       NULL
+pg_constraint                      NULL
+pg_conversion                      NULL
+pg_database                        NULL
+pg_default_acl                     NULL
+pg_depend                          NULL
+pg_description                     NULL
+pg_enum                            NULL
+pg_event_trigger                   NULL
+pg_extension                       NULL
+pg_foreign_data_wrapper            NULL
+pg_foreign_server                  NULL
+pg_foreign_table                   NULL
+pg_index                           NULL
+pg_indexes                         NULL
+pg_inherits                        NULL
+pg_language                        NULL
+pg_locks                           NULL
+pg_matviews                        NULL
+pg_namespace                       NULL
+pg_operator                        NULL
+pg_prepared_statements             NULL
+pg_prepared_xacts                  NULL
+pg_proc                            NULL
+pg_range                           NULL
+pg_rewrite                         NULL
+pg_roles                           NULL
+pg_seclabel                        NULL
+pg_seclabels                       NULL
+pg_sequence                        NULL
+pg_settings                        NULL
+pg_shdepend                        NULL
+pg_shdescription                   NULL
+pg_shseclabel                      NULL
+pg_stat_activity                   NULL
+pg_tables                          NULL
+pg_tablespace                      NULL
+pg_trigger                         NULL
+pg_type                            NULL
+pg_user                            NULL
+pg_user_mapping                    NULL
+pg_views                           NULL
+geography_columns                  NULL
+geometry_columns                   NULL
+spatial_ref_sys                    NULL
+t1                                 0
+
+statement ok
+ANALYZE t1
+
+query I
+SELECT estimated_row_count FROM [SHOW TABLES] where table_name = 't1'
+----
+1024
+
+statement ok
+DELETE FROM rowtest.t1 WHERE a > 1000;
+
+statement ok
+ANALYZE rowtest.t1
+
+query I
+SELECT estimated_row_count FROM [SHOW TABLES from rowtest] where table_name = 't1'
+----
+1000
+
+user root

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -180,57 +180,81 @@ sort                     ·             ·
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES] WHERE field != 'size'
 ----
-·                                            distribution  local
-·                                            vectorized    false
-render                                       ·             ·
- └── sort                                    ·             ·
-      │                                      order         +nspname,+relname
-      └── render                             ·             ·
-           └── hash join                     ·             ·
-                │                            type          inner
-                │                            equality      (oid) = (relnamespace)
-                ├── filter                   ·             ·
-                │    │                       filter        nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
-                │    └── render              ·             ·
-                │         └── virtual table  ·             ·
-                │                            source        pg_namespace@primary
-                └── filter                   ·             ·
-                     │                       filter        relkind IN ('S', 'r', 'v')
-                     └── render              ·             ·
-                          └── virtual table  ·             ·
-·                                            source        pg_class@primary
+·                                                           distribution       local
+·                                                           vectorized         false
+render                                                      ·                  ·
+ └── sort                                                   ·                  ·
+      │                                                     order              +nspname,+relname
+      └── render                                            ·                  ·
+           └── hash join                                    ·                  ·
+                │                                           type               right outer
+                │                                           equality           (table_id) = (column44)
+                ├── render                                  ·                  ·
+                │    └── virtual table                      ·                  ·
+                │                                           source             table_row_statistics@primary
+                └── render                                  ·                  ·
+                     └── hash join                          ·                  ·
+                          │                                 type               inner
+                          │                                 equality           (oid) = (relnamespace)
+                          ├── filter                        ·                  ·
+                          │    │                            filter             nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
+                          │    └── render                   ·                  ·
+                          │         └── virtual table       ·                  ·
+                          │                                 source             pg_namespace@primary
+                          └── hash join                     ·                  ·
+                               │                            type               left outer
+                               │                            equality           (oid) = (objoid)
+                               │                            left cols are key  ·
+                               ├── filter                   ·                  ·
+                               │    │                       filter             relkind IN ('S', 'r', 'v')
+                               │    └── render              ·                  ·
+                               │         └── virtual table  ·                  ·
+                               │                            source             pg_class@primary
+                               └── filter                   ·                  ·
+                                    │                       filter             objsubid = 0
+                                    └── render              ·                  ·
+                                         └── virtual table  ·                  ·
+·                                                           source             pg_description@primary
+
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE field != 'size'
 ----
-·                                                 distribution       local
-·                                                 vectorized         false
-render                                            ·                  ·
- └── sort                                         ·                  ·
-      │                                           order              +nspname,+relname
-      └── render                                  ·                  ·
-           └── hash join                          ·                  ·
-                │                                 type               inner
-                │                                 equality           (oid) = (relnamespace)
-                ├── filter                        ·                  ·
-                │    │                            filter             nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
-                │    └── render                   ·                  ·
-                │         └── virtual table       ·                  ·
-                │                                 source             pg_namespace@primary
-                └── hash join                     ·                  ·
-                     │                            type               left outer
-                     │                            equality           (oid) = (objoid)
-                     │                            left cols are key  ·
-                     ├── filter                   ·                  ·
-                     │    │                       filter             relkind IN ('S', 'r', 'v')
-                     │    └── render              ·                  ·
-                     │         └── virtual table  ·                  ·
-                     │                            source             pg_class@primary
-                     └── filter                   ·                  ·
-                          │                       filter             objsubid = 0
-                          └── render              ·                  ·
-                               └── virtual table  ·                  ·
-·                                                 source             pg_description@primary
+·                                                           distribution       local
+·                                                           vectorized         false
+render                                                      ·                  ·
+ └── sort                                                   ·                  ·
+      │                                                     order              +nspname,+relname
+      └── render                                            ·                  ·
+           └── hash join                                    ·                  ·
+                │                                           type               right outer
+                │                                           equality           (table_id) = (column44)
+                ├── render                                  ·                  ·
+                │    └── virtual table                      ·                  ·
+                │                                           source             table_row_statistics@primary
+                └── render                                  ·                  ·
+                     └── hash join                          ·                  ·
+                          │                                 type               inner
+                          │                                 equality           (oid) = (relnamespace)
+                          ├── filter                        ·                  ·
+                          │    │                            filter             nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
+                          │    └── render                   ·                  ·
+                          │         └── virtual table       ·                  ·
+                          │                                 source             pg_namespace@primary
+                          └── hash join                     ·                  ·
+                               │                            type               left outer
+                               │                            equality           (oid) = (objoid)
+                               │                            left cols are key  ·
+                               ├── filter                   ·                  ·
+                               │    │                       filter             relkind IN ('S', 'r', 'v')
+                               │    └── render              ·                  ·
+                               │         └── virtual table  ·                  ·
+                               │                            source             pg_class@primary
+                               └── filter                   ·                  ·
+                                    │                       filter             objsubid = 0
+                                    └── render              ·                  ·
+                                         └── virtual table  ·                  ·
+·                                                           source             pg_description@primary
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE field != 'size'

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -553,7 +553,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.Results("users", "primary", false, 1, "username", "ASC", false, false),
 		}},
 		{"SHOW TABLES FROM system", []preparedQueryTest{
-			baseTest.Results("public", "comments", "table").Others(27),
+			baseTest.Results("public", "comments", "table", gosql.NullString{}).Others(27),
 		}},
 		{"SHOW SCHEMAS FROM system", []preparedQueryTest{
 			baseTest.Results("crdb_internal").Others(4),


### PR DESCRIPTION
Fixes #48755

This change adds column `estimated_row_count` into result of the "SHOW TABLES"
to show estimated (not real) number of rows.

Besides that the body of the `delegator.delegateShowTables` was a bit
simplified (we do not need two almost similar versions of the query) and
new virtual table `crdb_internal.table_row_statistics` was added (to
show stats for non-root users).

Release note (sql change): This change modifies `SHOW TABLES` to return
estimates number of rows. New column's name is `estimated_row_count`.
Number of rows is taken from `system.table_statistics` table (via
`crdb_internal.table_row_statistics` which shows only tables accessible
for current user).