### PR TITLE
sql: add PartialIndexMutator for generating random partial indexes

### DIFF
--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -64,16 +65,18 @@ func randTables(r *rand.Rand) string {
 		SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
 		SET CLUSTER SETTING sql.stats.histogram_collection.enabled = false;
 		SET experimental_enable_enums = true;
+		SET experimental_partial_indexes = true;
 	`)
 
 	// Create the random tables.
 	stmts := sqlbase.RandCreateTables(r, "table", r.Intn(5)+1,
 		mutations.ForeignKeyMutator,
 		mutations.StatisticsMutator,
+		mutations.PartialIndexMutator,
 	)
 
 	for _, stmt := range stmts {
-		sb.WriteString(stmt.String())
+		sb.WriteString(tree.SerializeForDisplay(stmt))
 		sb.WriteString(";\n")
 	}
 

--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -40,6 +40,10 @@ var (
 	// indexes in CREATE TABLE.
 	IndexStoringMutator MultiStatementMutation = sqlbase.IndexStoringMutator
 
+	// PartialIndexMutator adds random partial index predicate expressions to
+	// indexes.
+	PartialIndexMutator MultiStatementMutation = sqlbase.PartialIndexMutator
+
 	// PostgresMutator modifies strings such that they execute identically
 	// in both Postgres and Cockroach (however this mutator does not remove
 	// features not supported by Postgres; use PostgresCreateTableMutator
@@ -292,8 +296,12 @@ func statisticsMutator(
 				// Should not happen.
 				panic(err)
 			}
+			j, err := tree.ParseDJSON(string(b))
+			if err != nil {
+				panic(err)
+			}
 			alter.Cmds = append(alter.Cmds, &tree.AlterTableInjectStats{
-				Stats: tree.NewDString(string(b)),
+				Stats: j,
 			})
 			stmts = append(stmts, alter)
 			changed = true


### PR DESCRIPTION
This commit adds `PartialIndexMutator` for generating random partial
indexes for randomized tests. The mutator is enabled for sqlsmith in
this commit. Once the temporary `experimential_partial_indexes` session
setting is removed, the mutation should be run for every invocation of
`RandCreateTable`, similar to `IndexStoringMutator`.

Fixes #52030

Release note: None