### PR TITLE
release-19.1: roachtest: skip flaky scaledata/job-coordinator test

### DIFF
--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -45,10 +45,17 @@ func registerScaleData(r *registry) {
 		app, flags := app, flags // copy loop iterator vars
 		const duration = 10 * time.Minute
 		for _, n := range []int{3, 6} {
+			var skip, skipDetail string
+			if app == "job-coordinator" {
+				skip = "skipping flaky scaledata/job-coordinator test"
+				skipDetail = "work underway to deflake https://github.com/cockroachdb/cockroach/issues/51765"
+			}
 			r.Add(testSpec{
 				Name:    fmt.Sprintf("scaledata/%s/nodes=%d", app, n),
 				Timeout: 2 * duration,
 				Cluster: makeClusterSpec(n + 1),
+				Skip: skip,
+				SkipDetails: skipDetail,
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runSqlapp(ctx, t, c, app, flags, duration)
 				},


### PR DESCRIPTION
Backport 1/1 commits from #52208.

/cc @cockroachdb/release

---

The test is flaky and has been failing for more than a week.
We will skip until we find out what causes it to flake.
Fixign the test is tracked in
https://github.com/cockroachdb/cockroach/issues/51765

Release note: None
