### PR TITLE
opt: generate constrained partial index scans

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -32,12 +32,12 @@ CREATE TABLE u (
 query T kvtrace
 SELECT a FROM t WHERE a > b AND c = 'foo'
 ----
-Scan /Table/53/{4-5}
+Scan /Table/53/4/"foo"{-/PrefixEnd}
 
 query T kvtrace
 SELECT a FROM t@c_partial WHERE a > b AND c = 'foo'
 ----
-Scan /Table/53/{4-5}
+Scan /Table/53/4/"foo"{-/PrefixEnd}
 
 statement error index "c_partial" is a partial index that does not contain all the rows needed to execute this query
 SELECT a FROM t@c_partial WHERE a > b AND c = 'bar'

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -125,7 +125,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		s.ApplySelectivity(sb.selectivityFromMultiColDistinctCounts(cols, sel, s))
 
 		// Update null counts.
-		sb.updateNullCountsFromNotNullCols(sel, relProps.NotNullCols, s)
+		sb.updateNullCountsFromNotNullCols(relProps.NotNullCols, s)
 
 		// Check if the statistics match the expected value.
 		testStats(t, s, expectedStats)

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -59,6 +59,74 @@ scan a
  ├── prune: (3)
  └── interesting orderings: (+1) (-3)
 
+# Test partial index scan not null columns.
+exec-ddl
+CREATE INDEX i ON a (y) WHERE y > 0 AND y < 5
+----
+
+opt
+SELECT s, y FROM a WHERE y > 0 AND y < 5
+----
+index-join a
+ ├── columns: s:3(string) y:2(int!null)
+ ├── prune: (3)
+ ├── interesting orderings: (-3) (+2)
+ └── scan a@i,partial
+      ├── columns: x:1(int!null) y:2(int!null)
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── prune: (1,2)
+      └── interesting orderings: (+1) (+2,+1)
+
+exec-ddl
+DROP INDEX i
+----
+
+# Test partial index scan cardinality.
+exec-ddl
+CREATE INDEX i ON a (y) WHERE x > 0 AND x < 5
+----
+
+# Disable GenerateConstrainedScans to verify that the partial index scan in its
+# own group has a cardinality of [0 - 4].
+opt disable=GenerateConstrainedScans
+SELECT s FROM a WHERE x > 0 AND x < 5 AND y = 1
+----
+project
+ ├── columns: s:3(string)
+ ├── cardinality: [0 - 4]
+ ├── prune: (3)
+ ├── interesting orderings: (-3)
+ └── index-join a
+      ├── columns: x:1(int!null) y:2(int!null) s:3(string)
+      ├── cardinality: [0 - 4]
+      ├── key: (1)
+      ├── fd: ()-->(2), (1)-->(3)
+      ├── prune: (3)
+      ├── interesting orderings: (+1) (-3) (+2,+1)
+      └── select
+           ├── columns: x:1(int!null) y:2(int!null)
+           ├── cardinality: [0 - 4]
+           ├── key: (1)
+           ├── fd: ()-->(2)
+           ├── prune: (1)
+           ├── interesting orderings: (+1) (+2,+1)
+           ├── scan a@i,partial
+           │    ├── columns: x:1(int!null) y:2(int)
+           │    ├── cardinality: [0 - 4]
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2)
+           │    ├── prune: (1,2)
+           │    └── interesting orderings: (+1) (+2,+1)
+           └── filters
+                └── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+                     ├── variable: y:2 [type=int]
+                     └── const: 1 [type=int]
+
+exec-ddl
+DROP INDEX i
+----
+
 # Test limited scan.
 opt
 SELECT s, x FROM a WHERE x > 1 LIMIT 2

--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -1,7 +1,5 @@
 # ------------------------
 # Tests without Histograms
-# TODO(mgartner): Add more interesting tests for constrained partial index
-# scans, with and without histograms.
 # ------------------------
 
 exec-ddl
@@ -116,7 +114,7 @@ index-join a
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  └── scan a@idx,partial
-      ├── columns: k:1(int!null) i:2(int)
+      ├── columns: k:1(int!null) i:2(int!null)
       ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0, distinct(2)=500, null(2)=0]
       ├── key: (1)
       └── fd: (1)-->(2)
@@ -139,18 +137,50 @@ index-join a
  ├── stats: [rows=140, distinct(2)=14, null(2)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
+ └── scan a@idx,partial
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── constraint: /2/1: [/16 - /29]
+      ├── stats: [rows=140, distinct(2)=14, null(2)=0]
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+opt disable=GenerateConstrainedScans
+SELECT * FROM a WHERE i > 15 AND i < 30
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string) t:4(string)
+ ├── stats: [rows=140, distinct(2)=14, null(2)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
  └── select
       ├── columns: k:1(int!null) i:2(int!null)
       ├── stats: [rows=140, distinct(2)=14, null(2)=0]
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── scan a@idx,partial
-      │    ├── columns: k:1(int!null) i:2(int)
+      │    ├── columns: k:1(int!null) i:2(int!null)
       │    ├── stats: [rows=490, distinct(1)=490, null(1)=0, distinct(2)=49, null(2)=0]
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
       └── filters
            └── (i:2 > 15) AND (i:2 < 30) [type=bool, outer=(2), constraints=(/2: [/16 - /29]; tight)]
+
+opt
+SELECT * FROM a WHERE (i > 0 AND i < 10) OR (i > 40 AND i < 50)
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string) t:4(string)
+ ├── stats: [rows=180, distinct(2)=18, null(2)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan a@idx,partial
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── constraint: /2/1
+      │    ├── [/1 - /9]
+      │    └── [/41 - /49]
+      ├── stats: [rows=180, distinct(2)=18, null(2)=0]
+      ├── key: (1)
+      └── fd: (1)-->(2)
 
 exec-ddl
 DROP INDEX idx
@@ -174,12 +204,12 @@ index-join a
       ├── columns: k:1(int!null) s:3(string!null) t:4(string!null)
       ├── stats: [rows=1.0395, distinct(3)=1.0395, null(3)=0, distinct(4)=1.0395, null(4)=0]
       ├── key: (1)
-      ├── fd: (1)-->(3,4)
+      ├── fd: (1)-->(3,4), (3)==(4), (4)==(3)
       ├── scan a@idx,partial
-      │    ├── columns: k:1(int!null) s:3(string) t:4(string)
+      │    ├── columns: k:1(int!null) s:3(string!null) t:4(string!null)
       │    ├── stats: [rows=9.3555, distinct(1)=9.3555, null(1)=0, distinct(3)=9.3555, null(3)=0, distinct(4)=9.3555, null(4)=0]
       │    ├── key: (1)
-      │    └── fd: (1)-->(3,4)
+      │    └── fd: (1)-->(3,4), (3)==(4), (4)==(3)
       └── filters
            ├── s:3 LIKE '%foo%' [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
            └── t:4 LIKE '%bar%' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
@@ -212,6 +242,178 @@ exec-ddl
 DROP INDEX idx
 ----
 
+# Test for a partial index with a predicate that references an un-indexed
+# column.
+
+exec-ddl
+CREATE INDEX idx ON a (i) WHERE s IN ('foo', 'bar', 'baz')
+----
+
+opt
+SELECT * FROM a WHERE i > 10 AND i < 20 AND s IN ('foo', 'bar', 'baz')
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
+ ├── stats: [rows=24.8207143, distinct(2)=9, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=24.8207143, null(2,3)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan a@idx,partial
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── constraint: /2/1: [/11 - /19]
+      ├── stats: [rows=24.8207143, distinct(2)=9, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=24.8207143, null(2,3)=0]
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+opt
+SELECT * FROM a WHERE i > 10 AND i < 20 AND s = 'baz'
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
+ ├── stats: [rows=8.27357143, distinct(2)=8.27357143, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=8.27357143, null(2,3)=0]
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,4)
+ ├── index-join a
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string) t:4(string)
+ │    ├── stats: [rows=24.8207143]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── scan a@idx,partial
+ │         ├── columns: k:1(int!null) i:2(int!null)
+ │         ├── constraint: /2/1: [/11 - /19]
+ │         ├── stats: [rows=24.8207143, distinct(2)=9, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=24.8207143, null(2,3)=0]
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2)
+ └── filters
+      └── s:3 = 'baz' [type=bool, outer=(3), constraints=(/3: [/'baz' - /'baz']; tight), fd=()-->(3)]
+
+opt
+SELECT * FROM a WHERE (i = 100 AND s = 'foo') OR (i = 200 AND s = 'bar')
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
+ ├── stats: [rows=1.22571429, distinct(2)=1.22571429, null(2)=0, distinct(3)=1.22571429, null(3)=0, distinct(2,3)=1.22571429, null(2,3)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── index-join a
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string) t:4(string)
+ │    ├── stats: [rows=5.51571429]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    └── scan a@idx,partial
+ │         ├── columns: k:1(int!null) i:2(int!null)
+ │         ├── constraint: /2/1
+ │         │    ├── [/100 - /100]
+ │         │    └── [/200 - /200]
+ │         ├── stats: [rows=5.51571429, distinct(2)=2, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=5.51571429, null(2,3)=0]
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2)
+ └── filters
+      └── ((i:2 = 100) AND (s:3 = 'foo')) OR ((i:2 = 200) AND (s:3 = 'bar')) [type=bool, outer=(2,3), constraints=(/2: [/100 - /100] [/200 - /200]; /3: [/'bar' - /'bar'] [/'foo' - /'foo'])]
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Test for a partial index with a predicate that references indexed and
+# un-indexed columns.
+
+exec-ddl
+CREATE INDEX idx ON a (i) WHERE i > 0 AND i < 50 AND s = 'foo'
+----
+
+opt
+SELECT * FROM a WHERE i > 10 AND i < 20 AND s = 'foo'
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
+ ├── stats: [rows=8.27357143, distinct(2)=8.27357143, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=8.27357143, null(2,3)=0]
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,4)
+ └── scan a@idx,partial
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── constraint: /2/1: [/11 - /19]
+      ├── stats: [rows=8.27357143, distinct(2)=8.27357143, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=8.27357143, null(2,3)=0]
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Test for a multi-column partial index with a predicate the references one
+# indexed column.
+
+exec-ddl
+CREATE INDEX idx ON a (i, s) WHERE s IN ('foo', 'bar', 'baz')
+----
+
+opt
+SELECT * FROM a WHERE i > 10 AND i < 20 AND s IN ('foo', 'bar', 'baz')
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
+ ├── stats: [rows=24.8207143, distinct(2)=9, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=24.8207143, null(2,3)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan a@idx,partial
+      ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+      ├── constraint: /2/3/1: [/11 - /19]
+      ├── stats: [rows=24.8207143, distinct(2)=9, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=24.8207143, null(2,3)=0]
+      ├── key: (1)
+      └── fd: (1)-->(2,3)
+
+opt
+SELECT * FROM a WHERE i > 10 AND i < 50 AND s = 'baz'
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
+ ├── stats: [rows=35.8521429, distinct(2)=35.8521429, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=35.8521429, null(2,3)=0]
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,4)
+ └── select
+      ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+      ├── stats: [rows=35.8521429, distinct(3)=1, null(3)=0]
+      ├── key: (1)
+      ├── fd: ()-->(3), (1)-->(2)
+      ├── scan a@idx,partial
+      │    ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+      │    ├── constraint: /2/3/1: [/11/'baz' - /49/'baz']
+      │    ├── stats: [rows=107.556429, distinct(1)=107.556429, null(1)=0, distinct(2)=39, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=107.556429, null(2,3)=0]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           └── s:3 = 'baz' [type=bool, outer=(3), constraints=(/3: [/'baz' - /'baz']; tight), fd=()-->(3)]
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Test for a multi-column partial index with a predicate that references all
+# indexed columns.
+
+exec-ddl
+CREATE INDEX idx ON a (i, s) WHERE i > 0 AND i < 50 AND s = 'foo'
+----
+
+opt
+SELECT * FROM a WHERE i > 10 AND i < 20 AND s = 'foo'
+----
+index-join a
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null) t:4(string)
+ ├── stats: [rows=8.27357143, distinct(2)=8.27357143, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=8.27357143, null(2,3)=0]
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,4)
+ └── scan a@idx,partial
+      ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+      ├── constraint: /2/3/1: [/11 - /19]
+      ├── stats: [rows=8.27357143, distinct(2)=8.27357143, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=8.27357143, null(2,3)=0]
+      ├── key: (1)
+      └── fd: ()-->(3), (1)-->(2)
+
+exec-ddl
+DROP INDEX idx
+----
+
 # ---------------------
 # Tests with Histograms
 # ---------------------
@@ -220,8 +422,7 @@ exec-ddl
 CREATE TABLE hist (
   k INT PRIMARY KEY,
   i INT,
-  s STRING,
-  INDEX idx_i (s) WHERE i > 100 AND i <= 200
+  s STRING
 )
 ----
 
@@ -241,6 +442,20 @@ ALTER TABLE hist INJECT STATISTICS '[
       {"num_eq": 20, "num_range": 270, "distinct_range": 9, "upper_bound": "300"},
       {"num_eq": 30, "num_range": 360, "distinct_range": 9, "upper_bound": "400"}
     ]
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 40,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "apple"},
+      {"num_eq": 100, "num_range": 100, "distinct_range": 9, "upper_bound": "banana"},
+      {"num_eq": 100, "num_range": 100, "distinct_range": 9, "upper_bound": "cherry"},
+      {"num_eq": 200, "num_range": 100, "distinct_range": 9, "upper_bound": "mango"},
+      {"num_eq": 200, "num_range": 100, "distinct_range": 9, "upper_bound": "pineapple"}
+    ]
   }
 ]'
 ----
@@ -249,6 +464,11 @@ ALTER TABLE hist INJECT STATISTICS '[
 # not 11. It is currently one more than it should be because
 # updateDistinctCountFromHistogram increments the distinct count before the null
 # count has been set to zero.
+
+exec-ddl
+CREATE INDEX idx ON hist (s) WHERE i > 100 AND i <= 200
+----
+
 opt
 SELECT * FROM hist WHERE i > 125 AND i < 150
 ----
@@ -264,7 +484,7 @@ select
  │    ├── stats: [rows=190]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
- │    └── scan hist@idx_i,partial
+ │    └── scan hist@idx,partial
  │         ├── columns: k:1(int!null) s:3(string)
  │         ├── stats: [rows=190, distinct(2)=11, null(2)=0]
  │         │   histogram(2)=  0   0   180  10
@@ -273,3 +493,285 @@ select
  │         └── fd: (1)-->(3)
  └── filters
       └── (i:2 > 125) AND (i:2 < 150) [type=bool, outer=(2), constraints=(/2: [/126 - /149]; tight)]
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Test for an indexed column that is also constrained by partial index predicate.
+
+exec-ddl
+CREATE INDEX idx ON hist (i) WHERE i > 100 AND i <= 200
+----
+
+opt
+SELECT * FROM hist WHERE i > 125 AND i < 150
+----
+index-join hist
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string)
+ ├── stats: [rows=43.6363636, distinct(2)=4.09090909, null(2)=0]
+ │   histogram(2)=  0   0   41.818 1.8182
+ │                <--- 125 -------- 149 -
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ └── scan hist@idx,partial
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── constraint: /2/1: [/126 - /149]
+      ├── stats: [rows=43.6363636, distinct(2)=4.09090909, null(2)=0]
+      │   histogram(2)=  0   0   41.818 1.8182
+      │                <--- 125 -------- 149 -
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+opt disable=GenerateConstrainedScans
+SELECT * FROM hist WHERE i > 125 AND i < 150
+----
+index-join hist
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string)
+ ├── stats: [rows=43.6363636, distinct(2)=4.09090909, null(2)=0]
+ │   histogram(2)=  0   0   41.818 1.8182
+ │                <--- 125 -------- 149 -
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ └── select
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── stats: [rows=43.6363636, distinct(2)=3.09090909, null(2)=0]
+      │   histogram(2)=  0   0   41.818 1.8182
+      │                <--- 125 -------- 149 -
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan hist@idx,partial
+      │    ├── columns: k:1(int!null) i:2(int!null)
+      │    ├── stats: [rows=190, distinct(1)=190, null(1)=0, distinct(2)=11, null(2)=0]
+      │    │   histogram(2)=  0   0   180  10
+      │    │                <--- 100 ----- 200
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── (i:2 > 125) AND (i:2 < 150) [type=bool, outer=(2), constraints=(/2: [/126 - /149]; tight)]
+
+opt
+SELECT * FROM hist WHERE (i > 100 AND i < 125) OR (i > 150 AND i < 175)
+----
+index-join hist
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string)
+ ├── stats: [rows=87.2727273, distinct(2)=7.18181818, null(2)=0]
+ │   histogram(2)=  0   0   41.818 1.8182 0   0   41.818 1.8182
+ │                <--- 100 -------- 124 ---- 150 -------- 174 -
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ └── scan hist@idx,partial
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── constraint: /2/1
+      │    ├── [/101 - /124]
+      │    └── [/151 - /174]
+      ├── stats: [rows=87.2727273, distinct(2)=7.18181818, null(2)=0]
+      │   histogram(2)=  0   0   41.818 1.8182 0   0   41.818 1.8182
+      │                <--- 100 -------- 124 ---- 150 -------- 174 -
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Test for a partial index with a predicate that references an un-indexed
+# column.
+
+exec-ddl
+CREATE INDEX idx ON hist (i) WHERE s IN ('banana', 'cherry', 'mango')
+----
+
+opt
+SELECT * FROM hist WHERE i > 125 AND i < 130 AND s IN ('banana', 'cherry', 'mango')
+----
+index-join hist
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+ ├── stats: [rows=4.60955951, distinct(2)=2.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=4.60955951, null(2,3)=0]
+ │   histogram(2)=  0   0   3.4572 1.1524
+ │                <--- 125 -------- 129 -
+ │   histogram(3)=  0   1.1524   0   1.1524   0  2.3048
+ │                <--- 'banana' --- 'cherry' --- 'mango'
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ └── scan hist@idx,partial
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── constraint: /2/1: [/126 - /129]
+      ├── stats: [rows=4.60955951, distinct(2)=2.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=4.60955951, null(2,3)=0]
+      │   histogram(2)=  0   0   3.4572 1.1524
+      │                <--- 125 -------- 129 -
+      │   histogram(3)=  0   1.1524   0   1.1524   0  2.3048
+      │                <--- 'banana' --- 'cherry' --- 'mango'
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+opt
+SELECT * FROM hist WHERE i > 125 AND i < 130 AND s = 'mango'
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+ ├── stats: [rows=2.30477976, distinct(2)=2.27272727, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=2.27272727, null(2,3)=0]
+ │   histogram(2)=  0   0   1.7286 0.57619
+ │                <--- 125 --------- 129 -
+ │   histogram(3)=  0  2.3048
+ │                <--- 'mango'
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
+ ├── index-join hist
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=4.60955951]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan hist@idx,partial
+ │         ├── columns: k:1(int!null) i:2(int!null)
+ │         ├── constraint: /2/1: [/126 - /129]
+ │         ├── stats: [rows=4.60955951, distinct(2)=2.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=4.60955951, null(2,3)=0]
+ │         │   histogram(2)=  0   0   3.4572 1.1524
+ │         │                <--- 125 -------- 129 -
+ │         │   histogram(3)=  0   1.1524   0   1.1524   0  2.3048
+ │         │                <--- 'banana' --- 'cherry' --- 'mango'
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2)
+ └── filters
+      └── s:3 = 'mango' [type=bool, outer=(3), constraints=(/3: [/'mango' - /'mango']; tight), fd=()-->(3)]
+
+opt
+SELECT * FROM hist WHERE (i = 100 AND s = 'banana') OR (i = 200 AND s = 'cherry')
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+ ├── stats: [rows=1.28083333, distinct(2)=1.28083333, null(2)=0, distinct(3)=1.28083333, null(3)=0, distinct(2,3)=1.28083333, null(2,3)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join hist
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=12.6762887]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan hist@idx,partial
+ │         ├── columns: k:1(int!null) i:2(int!null)
+ │         ├── constraint: /2/1
+ │         │    ├── [/100 - /100]
+ │         │    └── [/200 - /200]
+ │         ├── stats: [rows=12.6762887, distinct(2)=3, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=9, null(2,3)=0]
+ │         │   histogram(2)=  0 6.3381 0 6.3381
+ │         │                <--- 100 ---- 200 -
+ │         │   histogram(3)=  0   3.1691   0   3.1691   0  6.3381
+ │         │                <--- 'banana' --- 'cherry' --- 'mango'
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2)
+ └── filters
+      └── ((i:2 = 100) AND (s:3 = 'banana')) OR ((i:2 = 200) AND (s:3 = 'cherry')) [type=bool, outer=(2,3), constraints=(/2: [/100 - /100] [/200 - /200]; /3: [/'banana' - /'banana'] [/'cherry' - /'cherry'])]
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Test for a partial index with a predicate that references indexed and
+# un-indexed columns.
+
+exec-ddl
+CREATE INDEX idx ON hist (i) WHERE i > 100 AND i <= 200 AND s = 'banana'
+----
+
+opt
+SELECT * FROM hist WHERE i > 125 AND i < 150 AND s = 'banana'
+----
+index-join hist
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+ ├── stats: [rows=6.91433927, distinct(2)=4.09090909, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=4.09090909, null(2,3)=0]
+ │   histogram(2)=  0   0   6.6262 0.2881
+ │                <--- 125 -------- 149 -
+ │   histogram(3)=  0   6.9143
+ │                <--- 'banana'
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
+ └── scan hist@idx,partial
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── constraint: /2/1: [/126 - /149]
+      ├── stats: [rows=6.91433927, distinct(2)=4.09090909, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=4.09090909, null(2,3)=0]
+      │   histogram(2)=  0   0   6.6262 0.2881
+      │                <--- 125 -------- 149 -
+      │   histogram(3)=  0   6.9143
+      │                <--- 'banana'
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Test for a multi-column partial index with a predicate the references one
+# indexed column.
+
+exec-ddl
+CREATE INDEX idx ON hist (i, s) WHERE s IN ('banana', 'cherry', 'mango')
+----
+
+opt
+SELECT * FROM hist WHERE i > 125 AND i < 130 AND s IN ('banana', 'cherry', 'mango')
+----
+scan hist@idx,partial
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+ ├── constraint: /2/3/1: [/126 - /129]
+ ├── stats: [rows=4.60955951, distinct(2)=2.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=4.60955951, null(2,3)=0]
+ │   histogram(2)=  0   0   3.4572 1.1524
+ │                <--- 125 -------- 129 -
+ │   histogram(3)=  0   1.1524   0   1.1524   0  2.3048
+ │                <--- 'banana' --- 'cherry' --- 'mango'
+ ├── key: (1)
+ └── fd: (1)-->(2,3)
+
+opt
+SELECT * FROM hist WHERE i > 125 AND i < 130 AND s = 'mango'
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+ ├── stats: [rows=2.30477976, distinct(2)=2.27272727, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=2.27272727, null(2,3)=0]
+ │   histogram(2)=  0   0   1.7286 0.57619
+ │                <--- 125 --------- 129 -
+ │   histogram(3)=  0  2.3048
+ │                <--- 'mango'
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
+ ├── scan hist@idx,partial
+ │    ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+ │    ├── constraint: /2/3/1: [/126/'mango' - /129/'mango']
+ │    ├── stats: [rows=4.60955951, distinct(2)=2.27272727, null(2)=0, distinct(3)=3, null(3)=0, distinct(2,3)=4.60955951, null(2,3)=0]
+ │    │   histogram(2)=  0   0   3.4572 1.1524
+ │    │                <--- 125 -------- 129 -
+ │    │   histogram(3)=  0   1.1524   0   1.1524   0  2.3048
+ │    │                <--- 'banana' --- 'cherry' --- 'mango'
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── s:3 = 'mango' [type=bool, outer=(3), constraints=(/3: [/'mango' - /'mango']; tight), fd=()-->(3)]
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Test for a multi-column partial index with a predicate that references all
+# indexed columns.
+
+exec-ddl
+CREATE INDEX idx ON hist (i, s) WHERE i > 100 AND i <= 200 AND s = 'banana'
+----
+
+opt
+SELECT * FROM hist WHERE i > 125 AND i < 130 AND s = 'banana'
+----
+scan hist@idx,partial
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+ ├── constraint: /2/3/1: [/126 - /129]
+ ├── stats: [rows=1.15238988, distinct(2)=1.15238988, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=1.15238988, null(2,3)=0]
+ │   histogram(2)=  0   0   0.86429 0.2881
+ │                <--- 125 --------- 129 -
+ │   histogram(3)=  0   1.1524
+ │                <--- 'banana'
+ ├── key: (1)
+ └── fd: ()-->(3), (1)-->(2)
+
+exec-ddl
+DROP INDEX idx
+----

--- a/pkg/sql/opt/testutils/testcat/drop_index.go
+++ b/pkg/sql/opt/testutils/testcat/drop_index.go
@@ -46,9 +46,10 @@ func (tc *Catalog) DropIndex(stmt *tree.DropIndex) {
 		}
 
 		// Delete the index from the table.
-		idxLen := len(foundTab.Indexes)
-		foundTab.Indexes[idxOrd] = foundTab.Indexes[idxLen-1]
-		foundTab.Indexes = foundTab.Indexes[:idxLen-1]
+		numIndexes := len(foundTab.Indexes)
+		foundTab.Indexes[idxOrd] = foundTab.Indexes[numIndexes-1]
+		foundTab.Indexes[idxOrd].ordinal = idxOrd
+		foundTab.Indexes = foundTab.Indexes[:numIndexes-1]
 	}
 }
 

--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -23,7 +23,15 @@ TABLE kv
       └── k int not null
 
 exec-ddl
+CREATE INDEX idx2 ON kv (v)
+----
+
+exec-ddl
 DROP INDEX idx
+----
+
+exec-ddl
+DROP INDEX idx2
 ----
 
 exec-ddl

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -340,10 +340,22 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 	// Iterate over all non-inverted indexes.
 	md := c.e.mem.Metadata()
 	tabMeta := md.TableMeta(scanPrivate.Table)
-	iter := makeScanIndexIter(c.e.mem, scanPrivate, rejectInvertedIndexes|rejectPartialIndexes)
+	iter := makeScanIndexIter(c.e.mem, scanPrivate, rejectInvertedIndexes)
 	for iter.Next() {
-		// TODO(mgartner): Generate constrained scans for partial indexes if
-		// they are implied by the filter.
+		// If the index is a partial index, check whether or not the filter
+		// implies the predicate.
+		_, isPartialIndex := md.Table(scanPrivate.Table).Index(iter.IndexOrdinal()).Predicate()
+		var pred memo.FiltersExpr
+		if isPartialIndex {
+			pred = memo.PartialIndexPredicate(tabMeta, iter.IndexOrdinal())
+			remainingFilters, ok := c.im.FiltersImplyPredicate(explicitFilters, pred)
+			if !ok {
+				// The filters do not imply the predicate, so the partial index
+				// cannot be used.
+				continue
+			}
+			explicitFilters = remainingFilters
+		}
 
 		// We only consider the partition values when a particular index can otherwise
 		// not be constrained. For indexes that are constrained, the partitioned values

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3784,13 +3784,13 @@ memo (optimized, ~14KB, required=[presentation: a:1])
  ├── G7: (index-join G10 t5,cols=(1,2))
  │    └── []
  │         ├── best: (index-join G10 t5,cols=(1,2))
- │         └── cost: 565.58
+ │         └── cost: 559.92
  ├── G8: (contains G11 G12)
  ├── G9: (filters)
  ├── G10: (scan t5@b_idx,cols=(1),constrained)
  │    └── []
  │         ├── best: (scan t5@b_idx,cols=(1),constrained)
- │         └── cost: 114.45
+ │         └── cost: 113.31
  ├── G11: (variable b)
  └── G12: (const '{"a": 1, "c": 2}')
 

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -87,19 +87,7 @@ CREATE TABLE p (
     i INT,
     f FLOAT,
     s STRING,
-    b BOOL,
-    INDEX if_s (i) STORING (f, s) WHERE s = 'foo'
-)
-----
-
-exec-ddl
-CREATE TABLE q (
-    i INT,
-    s STRING,
-    b BOOL,
-    INDEX i (i),
-    INDEX i_gt_0 (i) WHERE i > 0,
-    INDEX s_eq_foo (s) WHERE s = 'foo'
+    b BOOL
 )
 ----
 
@@ -118,6 +106,11 @@ CREATE TABLE no_explicit_primary_key
 # GeneratePartialIndexScans
 # --------------------------------------------------
 
+
+exec-ddl
+CREATE INDEX idx ON p (i) STORING (f, s) WHERE s = 'foo'
+----
+
 # Generate a lone partial index scan when the index is covering and there are no
 # remaining filters.
 opt expect=GeneratePartialIndexScans
@@ -125,7 +118,7 @@ SELECT i FROM p WHERE s = 'foo'
 ----
 project
  ├── columns: i:1
- └── scan p@if_s,partial
+ └── scan p@idx,partial
       ├── columns: i:1 s:3!null
       └── fd: ()-->(3)
 
@@ -139,8 +132,9 @@ project
  └── select
       ├── columns: i:1 f:2 s:3!null
       ├── fd: ()-->(3)
-      ├── scan p@if_s,partial
-      │    └── columns: i:1 f:2 s:3
+      ├── scan p@idx,partial
+      │    ├── columns: i:1 f:2 s:3!null
+      │    └── fd: ()-->(3)
       └── filters
            └── (i:1 = 1) OR (f:2 = 2.0) [outer=(1,2)]
 
@@ -154,10 +148,10 @@ project
  └── index-join p
       ├── columns: s:3!null b:4
       ├── fd: ()-->(3)
-      └── scan p@if_s,partial
-           ├── columns: s:3 rowid:5!null
+      └── scan p@idx,partial
+           ├── columns: s:3!null rowid:5!null
            ├── key: (5)
-           └── fd: (5)-->(3)
+           └── fd: ()-->(3)
 
 # Generate a partial index scan inside a select inside an index-join when the
 # index is not covering and there are remaining filters that are covered by the
@@ -171,13 +165,13 @@ project
       ├── columns: i:1 f:2 s:3!null b:4
       ├── fd: ()-->(3)
       └── select
-           ├── columns: i:1 f:2 s:3 rowid:5!null
+           ├── columns: i:1 f:2 s:3!null rowid:5!null
            ├── key: (5)
-           ├── fd: (5)-->(1-3)
-           ├── scan p@if_s,partial
-           │    ├── columns: i:1 f:2 s:3 rowid:5!null
+           ├── fd: ()-->(3), (5)-->(1,2)
+           ├── scan p@idx,partial
+           │    ├── columns: i:1 f:2 s:3!null rowid:5!null
            │    ├── key: (5)
-           │    └── fd: (5)-->(1-3)
+           │    └── fd: ()-->(3), (5)-->(1,2)
            └── filters
                 └── (i:1 = 1) OR (f:2 = 2.0) [outer=(1,2)]
 
@@ -194,94 +188,96 @@ project
       ├── fd: ()-->(3,4)
       ├── index-join p
       │    ├── columns: s:3 b:4
-      │    └── scan p@if_s,partial
-      │         ├── columns: s:3 rowid:5!null
+      │    ├── fd: ()-->(3)
+      │    └── scan p@idx,partial
+      │         ├── columns: s:3!null rowid:5!null
       │         ├── key: (5)
-      │         └── fd: (5)-->(3)
+      │         └── fd: ()-->(3)
       └── filters
            └── b:4 [outer=(4), constraints=(/4: [/true - /true]; tight), fd=()-->(4)]
 
 # Generate a partial index scan inside a Select/IndexJoin/Select when the index
 # is not covering and the remaining filters are partially covered by the index.
 opt expect=GeneratePartialIndexScans
-SELECT b FROM p WHERE s = 'foo' AND i = 1 AND b
+SELECT b FROM p WHERE s = 'foo' AND f = 1 AND b
 ----
 project
  ├── columns: b:4!null
  ├── fd: ()-->(4)
  └── select
-      ├── columns: i:1!null s:3!null b:4!null
-      ├── fd: ()-->(1,3,4)
+      ├── columns: f:2!null s:3!null b:4!null
+      ├── fd: ()-->(2-4)
       ├── index-join p
-      │    ├── columns: i:1 s:3 b:4
-      │    ├── fd: ()-->(1)
+      │    ├── columns: f:2 s:3 b:4
+      │    ├── fd: ()-->(2,3)
       │    └── select
-      │         ├── columns: i:1!null s:3 rowid:5!null
+      │         ├── columns: f:2!null s:3!null rowid:5!null
       │         ├── key: (5)
-      │         ├── fd: ()-->(1), (5)-->(3)
-      │         ├── scan p@if_s,partial
-      │         │    ├── columns: i:1 s:3 rowid:5!null
+      │         ├── fd: ()-->(2,3)
+      │         ├── scan p@idx,partial
+      │         │    ├── columns: f:2 s:3!null rowid:5!null
       │         │    ├── key: (5)
-      │         │    └── fd: (5)-->(1,3)
+      │         │    └── fd: ()-->(3), (5)-->(2)
       │         └── filters
-      │              └── i:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+      │              └── f:2 = 1.0 [outer=(2), constraints=(/2: [/1.0 - /1.0]; tight), fd=()-->(2)]
       └── filters
            └── b:4 [outer=(4), constraints=(/4: [/true - /true]; tight), fd=()-->(4)]
 
 # Generate multiple partial index scans when there are multiple partial indexes
 # that have predicates implied by the filters.
-memo expect=GeneratePartialIndexScans
-SELECT * FROM q WHERE i > 0 AND s = 'foo'
+
+exec-ddl
+CREATE INDEX idx2 ON p (s) WHERE i > 0
 ----
-memo (optimized, ~11KB, required=[presentation: i:1,s:2,b:3])
- ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G5)
- │    └── [presentation: i:1,s:2,b:3]
- │         ├── best: (select G6 G7)
- │         └── cost: 51.34
- ├── G2: (scan q,cols=(1-3))
+
+memo expect=GeneratePartialIndexScans
+SELECT * FROM p WHERE i > 0 AND s = 'foo'
+----
+memo (optimized, ~10KB, required=[presentation: i:1,f:2,s:3,b:4])
+ ├── G1: (select G2 G3) (index-join G4 p,cols=(1-4)) (index-join G5 p,cols=(1-4)) (index-join G6 p,cols=(1-4))
+ │    └── [presentation: i:1,f:2,s:3,b:4]
+ │         ├── best: (index-join G4 p,cols=(1-4))
+ │         └── cost: 26.05
+ ├── G2: (scan p,cols=(1-4))
  │    └── []
- │         ├── best: (scan q,cols=(1-3))
- │         └── cost: 1070.02
- ├── G3: (filters G9 G10)
- ├── G4: (index-join G11 q,cols=(1-3))
+ │         ├── best: (scan p,cols=(1-4))
+ │         └── cost: 1090.02
+ ├── G3: (filters G7 G8)
+ ├── G4: (select G9 G10)
  │    └── []
- │         ├── best: (index-join G11 q,cols=(1-3))
- │         └── cost: 1706.69
- ├── G5: (filters G10)
- ├── G6: (index-join G12 q,cols=(1-3))
+ │         ├── best: (select G9 G10)
+ │         └── cost: 10.93
+ ├── G5: (select G11 G12)
  │    └── []
- │         ├── best: (index-join G12 q,cols=(1-3))
- │         └── cost: 51.22
- ├── G7: (filters G9)
- ├── G8: (index-join G13 q,cols=(1-3))
+ │         ├── best: (select G11 G12)
+ │         └── cost: 350.03
+ ├── G6: (scan p@idx,partial,cols=(1-3,5),constrained)
  │    └── []
- │         ├── best: (index-join G13 q,cols=(1-3))
- │         └── cost: 1706.69
- ├── G9: (gt G14 G15)
- ├── G10: (eq G16 G17)
- ├── G11: (scan q@i_gt_0,partial,cols=(1,4))
+ │         ├── best: (scan p@idx,partial,cols=(1-3,5),constrained)
+ │         └── cost: 10.09
+ ├── G7: (gt G13 G14)
+ ├── G8: (eq G15 G16)
+ ├── G9: (scan p@idx,partial,cols=(1-3,5))
  │    └── []
- │         ├── best: (scan q@i_gt_0,partial,cols=(1,4))
+ │         ├── best: (scan p@idx,partial,cols=(1-3,5))
+ │         └── cost: 10.81
+ ├── G10: (filters G7)
+ ├── G11: (scan p@idx2,partial,cols=(3,5))
+ │    └── []
+ │         ├── best: (scan p@idx2,partial,cols=(3,5))
  │         └── cost: 346.68
- ├── G12: (scan q@s_eq_foo,partial,cols=(2,4))
- │    └── []
- │         ├── best: (scan q@s_eq_foo,partial,cols=(2,4))
- │         └── cost: 10.41
- ├── G13: (scan q@i,cols=(1,4),constrained)
- │    └── []
- │         ├── best: (scan q@i,cols=(1,4),constrained)
- │         └── cost: 346.68
- ├── G14: (variable i)
- ├── G15: (const 0)
- ├── G16: (variable s)
- └── G17: (const 'foo')
+ ├── G12: (filters G8)
+ ├── G13: (variable i)
+ ├── G14: (const 0)
+ ├── G15: (variable s)
+ └── G16: (const 'foo')
 
 # Do not generate a partial index scan when the predicate is not implied by the
 # filter.
-memo
+memo expect-not=GeneratePartialIndexScans
 SELECT i FROM p WHERE s = 'bar'
 ----
-memo (optimized, ~5KB, required=[presentation: i:1])
+memo (optimized, ~6KB, required=[presentation: i:1])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:1]
  │         ├── best: (project G2 G3 i)
@@ -299,6 +295,14 @@ memo (optimized, ~5KB, required=[presentation: i:1])
  ├── G6: (eq G7 G8)
  ├── G7: (variable s)
  └── G8: (const 'bar')
+
+exec-ddl
+DROP INDEX idx
+----
+
+exec-ddl
+DROP INDEX idx2
+----
 
 # --------------------------------------------------
 # GenerateConstrainedScans
@@ -958,6 +962,240 @@ select
  └── filters
       └── (k:1 + u:2) = 1 [outer=(1,2), immutable]
 
+# Constrained partial index scan.
+
+exec-ddl
+CREATE INDEX idx ON p (i) STORING (f, s) WHERE s = 'foo'
+----
+
+opt
+SELECT i FROM p WHERE s = 'foo' AND i > 5 AND i < 10
+----
+project
+ ├── columns: i:1!null
+ └── scan p@idx,partial
+      ├── columns: i:1!null s:3!null
+      ├── constraint: /1/5: [/6 - /9]
+      └── fd: ()-->(3)
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Constrained partial index scan with indexed column in predicate.
+
+exec-ddl
+CREATE INDEX idx ON p (i) WHERE i > 0
+----
+
+opt
+SELECT i FROM p WHERE i > 10 AND i < 20
+----
+scan p@idx,partial
+ ├── columns: i:1!null
+ └── constraint: /1/5: [/11 - /19]
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Constrained partial index scan with index-join.
+
+exec-ddl
+CREATE INDEX idx ON p (i) WHERE s = 'foo'
+----
+
+opt
+SELECT * FROM p WHERE s = 'foo' AND i > 5 AND i < 10
+----
+index-join p
+ ├── columns: i:1!null f:2 s:3!null b:4
+ ├── fd: ()-->(3)
+ └── scan p@idx,partial
+      ├── columns: i:1!null rowid:5!null
+      ├── constraint: /1/5: [/6 - /9]
+      ├── key: (5)
+      └── fd: (5)-->(1)
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Constrained partial index scan with additional filter.
+
+exec-ddl
+CREATE INDEX idx ON p (i) WHERE i > 0
+----
+
+opt
+SELECT i FROM p WHERE i > 10 AND i < 20 AND b
+----
+project
+ ├── columns: i:1!null
+ └── select
+      ├── columns: i:1!null b:4!null
+      ├── fd: ()-->(4)
+      ├── index-join p
+      │    ├── columns: i:1 b:4
+      │    └── scan p@idx,partial
+      │         ├── columns: i:1!null rowid:5!null
+      │         ├── constraint: /1/5: [/11 - /19]
+      │         ├── key: (5)
+      │         └── fd: (5)-->(1)
+      └── filters
+           └── b:4 [outer=(4), constraints=(/4: [/true - /true]; tight), fd=()-->(4)]
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Constrained partial index scan with additional filters before and after an
+# index-join.
+
+exec-ddl
+CREATE INDEX idx ON p (i) STORING (s) where i > 0
+----
+
+opt
+SELECT * FROM p WHERE i > 10 AND i < 20 AND s = 'bar' AND b
+----
+select
+ ├── columns: i:1!null f:2 s:3!null b:4!null
+ ├── fd: ()-->(3,4)
+ ├── index-join p
+ │    ├── columns: i:1 f:2 s:3 b:4
+ │    ├── fd: ()-->(3)
+ │    └── select
+ │         ├── columns: i:1!null s:3!null rowid:5!null
+ │         ├── key: (5)
+ │         ├── fd: ()-->(3), (5)-->(1)
+ │         ├── scan p@idx,partial
+ │         │    ├── columns: i:1!null s:3 rowid:5!null
+ │         │    ├── constraint: /1/5: [/11 - /19]
+ │         │    ├── key: (5)
+ │         │    └── fd: (5)-->(1,3)
+ │         └── filters
+ │              └── s:3 = 'bar' [outer=(3), constraints=(/3: [/'bar' - /'bar']; tight), fd=()-->(3)]
+ └── filters
+      └── b:4 [outer=(4), constraints=(/4: [/true - /true]; tight), fd=()-->(4)]
+
+exec-ddl
+DROP INDEX idx
+----
+
+# Generate multiple partial index scans in the memo when the filter implies
+# multiple partial index predicates.
+
+exec-ddl
+CREATE INDEX idx ON p (s) WHERE i > 0
+----
+
+exec-ddl
+CREATE INDEX idx2 ON p (i) WHERE s = 'foo'
+----
+
+memo
+SELECT i FROM p WHERE i = 3 AND s = 'foo'
+----
+memo (optimized, ~15KB, required=[presentation: i:1])
+ ├── G1: (project G2 G3 i)
+ │    └── [presentation: i:1]
+ │         ├── best: (project G2 G3 i)
+ │         └── cost: 15.28
+ ├── G2: (select G4 G5) (select G6 G7) (index-join G8 p,cols=(1,3)) (select G9 G7) (index-join G10 p,cols=(1,3))
+ │    └── []
+ │         ├── best: (index-join G8 p,cols=(1,3))
+ │         └── cost: 15.26
+ ├── G3: (projections)
+ ├── G4: (scan p,cols=(1,3))
+ │    └── []
+ │         ├── best: (scan p,cols=(1,3))
+ │         └── cost: 1070.02
+ ├── G5: (filters G11 G12)
+ ├── G6: (index-join G13 p,cols=(1,3))
+ │    └── []
+ │         ├── best: (index-join G13 p,cols=(1,3))
+ │         └── cost: 363.88
+ ├── G7: (filters G11)
+ ├── G8: (select G14 G7)
+ │    └── []
+ │         ├── best: (select G14 G7)
+ │         └── cost: 10.53
+ ├── G9: (index-join G15 p,cols=(1,3))
+ │    └── []
+ │         ├── best: (index-join G15 p,cols=(1,3))
+ │         └── cost: 47.81
+ ├── G10: (scan p@idx2,partial,cols=(1,5),constrained)
+ │    └── []
+ │         ├── best: (scan p@idx2,partial,cols=(1,5),constrained)
+ │         └── cost: 10.31
+ ├── G11: (eq G16 G17)
+ ├── G12: (eq G18 G19)
+ ├── G13: (select G20 G21)
+ │    └── []
+ │         ├── best: (select G20 G21)
+ │         └── cost: 350.03
+ ├── G14: (scan p@idx2,partial,cols=(1,5))
+ │    └── []
+ │         ├── best: (scan p@idx2,partial,cols=(1,5))
+ │         └── cost: 10.41
+ ├── G15: (scan p@idx,partial,cols=(3,5),constrained)
+ │    └── []
+ │         ├── best: (scan p@idx,partial,cols=(3,5),constrained)
+ │         └── cost: 9.72
+ ├── G16: (variable i)
+ ├── G17: (const 3)
+ ├── G18: (variable s)
+ ├── G19: (const 'foo')
+ ├── G20: (scan p@idx,partial,cols=(3,5))
+ │    └── []
+ │         ├── best: (scan p@idx,partial,cols=(3,5))
+ │         └── cost: 346.68
+ └── G21: (filters G12)
+
+exec-ddl
+DROP INDEX idx
+----
+
+exec-ddl
+DROP INDEX idx2
+----
+
+# Do not use partial indexes when the predicate is not implied by the filter.
+
+exec-ddl
+CREATE INDEX idx ON p (i) WHERE s = 'foo'
+----
+
+memo expect-not=GenerateConstrainedScans
+SELECT i FROM p WHERE s = 'bar' AND i = 5
+----
+memo (optimized, ~6KB, required=[presentation: i:1])
+ ├── G1: (project G2 G3 i)
+ │    └── [presentation: i:1]
+ │         ├── best: (project G2 G3 i)
+ │         └── cost: 1080.07
+ ├── G2: (select G4 G5)
+ │    └── []
+ │         ├── best: (select G4 G5)
+ │         └── cost: 1080.05
+ ├── G3: (projections)
+ ├── G4: (scan p,cols=(1,3))
+ │    └── []
+ │         ├── best: (scan p,cols=(1,3))
+ │         └── cost: 1070.02
+ ├── G5: (filters G6 G7)
+ ├── G6: (eq G8 G9)
+ ├── G7: (eq G10 G11)
+ ├── G8: (variable s)
+ ├── G9: (const 'bar')
+ ├── G10: (variable i)
+ └── G11: (const 5)
+
+exec-ddl
+DROP INDEX idx
+----
+
 # --------------------------------------------------
 # GenerateInvertedIndexScans
 # --------------------------------------------------
@@ -987,11 +1225,11 @@ memo (optimized, ~6KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
- │         └── cost: 567.81
+ │         └── cost: 562.14
  ├── G2: (select G4 G5) (index-join G6 b,cols=(1,4))
  │    └── []
  │         ├── best: (index-join G6 b,cols=(1,4))
- │         └── cost: 566.69
+ │         └── cost: 561.02
  ├── G3: (projections)
  ├── G4: (scan b,cols=(1,4))
  │    └── []
@@ -1001,7 +1239,7 @@ memo (optimized, ~6KB, required=[presentation: k:1])
  ├── G6: (scan b@inv_idx,cols=(1),constrained)
  │    └── []
  │         ├── best: (scan b@inv_idx,cols=(1),constrained)
- │         └── cost: 114.45
+ │         └── cost: 113.31
  ├── G7: (contains G8 G9)
  ├── G8: (variable j)
  └── G9: (const '{"a": "b"}')
@@ -2922,30 +3160,20 @@ project
       │    │    ├── columns: k:1!null a:2!null b:3
       │    │    ├── key: (1)
       │    │    ├── fd: ()-->(2), (1)-->(3)
-      │    │    └── select
+      │    │    └── scan t52207@idx_a,partial
       │    │         ├── columns: k:1!null a:2!null
+      │    │         ├── constraint: /2/1: [/1 - /1]
       │    │         ├── key: (1)
-      │    │         ├── fd: ()-->(2)
-      │    │         ├── scan t52207@idx_a,partial
-      │    │         │    ├── columns: k:1!null a:2
-      │    │         │    ├── key: (1)
-      │    │         │    └── fd: (1)-->(2)
-      │    │         └── filters
-      │    │              └── a:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      │    │         └── fd: ()-->(2)
       │    └── index-join t52207
       │         ├── columns: k:5!null a:6 b:7!null
       │         ├── key: (5)
       │         ├── fd: ()-->(7), (5)-->(6)
-      │         └── select
+      │         └── scan t52207@idx_b,partial
       │              ├── columns: k:5!null b:7!null
+      │              ├── constraint: /7/5: [/1 - /1]
       │              ├── key: (5)
-      │              ├── fd: ()-->(7)
-      │              ├── scan t52207@idx_b,partial
-      │              │    ├── columns: k:5!null b:7
-      │              │    ├── key: (5)
-      │              │    └── fd: (5)-->(7)
-      │              └── filters
-      │                   └── b:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      │              └── fd: ()-->(7)
       └── aggregations
            ├── const-agg [as=a:2, outer=(2)]
            │    └── a:2


### PR DESCRIPTION
This commit updates the GenerateConstrainedScans exploration rule so
that constrained partial index scans are now generated. For example,
consider the following index and query:

    CREATE INDEX ON t (a) WHERE b = 'foo'
    SELECT a FROM t WHERE b = 'foo' and a > 0 AND a < 10

GenerateConstrainedScans will generate the following query plan:

    project
     └── index-join t
          └── scan t@t_a_idx,partial
               └── constraint: /1/3: [/1 - /9]

The statistics builder and logical props builder were also updated to
correctly to correctly account for constrained partial index scans.

Fixes #50231 

Release note: None