### PR TITLE
sql: backfill partial indexes

### DIFF
--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -140,7 +140,7 @@ func (p *planner) addColumnImpl(
 	}
 
 	if d.IsComputed() {
-		computedColValidator := schemaexpr.NewComputedColumnValidator(
+		computedColValidator := schemaexpr.MakeComputedColumnValidator(
 			params.ctx,
 			n.tableDesc,
 			&params.p.semaCtx,

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -214,7 +214,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						err = infoErr
 						return
 					}
-					ckBuilder := schemaexpr.NewCheckConstraintBuilder(params.ctx, *tn, n.tableDesc, &params.p.semaCtx)
+					ckBuilder := schemaexpr.MakeCheckConstraintBuilder(params.ctx, *tn, n.tableDesc, &params.p.semaCtx)
 					for k := range info {
 						ckBuilder.MarkNameInUse(k)
 					}
@@ -374,7 +374,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 
 			// We cannot remove this column if there are computed columns that use it.
-			computedColValidator := schemaexpr.NewComputedColumnValidator(
+			computedColValidator := schemaexpr.MakeComputedColumnValidator(
 				params.ctx,
 				n.tableDesc,
 				&params.p.semaCtx,

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1390,7 +1390,7 @@ func runSchemaChangesInTxn(
 				doneColumnBackfill = true
 
 			case *descpb.DescriptorMutation_Index:
-				if err := indexBackfillInTxn(ctx, planner.Txn(), planner.EvalContext(), immutDesc, traceKV); err != nil {
+				if err := indexBackfillInTxn(ctx, planner.Txn(), planner.EvalContext(), planner.SemaCtx(), immutDesc, traceKV); err != nil {
 					return err
 				}
 
@@ -1720,11 +1720,12 @@ func indexBackfillInTxn(
 	ctx context.Context,
 	txn *kv.Txn,
 	evalCtx *tree.EvalContext,
+	semaCtx *tree.SemaContext,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	traceKV bool,
 ) error {
 	var backfiller backfill.IndexBackfiller
-	if err := backfiller.Init(evalCtx, tableDesc); err != nil {
+	if err := backfiller.InitForLocalUse(ctx, evalCtx, semaCtx, tableDesc); err != nil {
 		return err
 	}
 	sp := tableDesc.PrimaryIndexSpan(evalCtx.Codec)

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -94,7 +94,7 @@ func (p *planner) setupFamilyAndConstraintForShard(
 		inuseNames[k] = struct{}{}
 	}
 
-	ckBuilder := schemaexpr.NewCheckConstraintBuilder(ctx, p.tableName, tableDesc, &p.semaCtx)
+	ckBuilder := schemaexpr.MakeCheckConstraintBuilder(ctx, p.tableName, tableDesc, &p.semaCtx)
 	ckName, err := ckBuilder.DefaultName(ckDef.Expr)
 	if err != nil {
 		return err
@@ -212,7 +212,7 @@ func MakeIndexDescriptor(
 				"session variable experimental_partial_indexes is set to false, cannot create a partial index")
 		}
 
-		idxValidator := schemaexpr.NewIndexPredicateValidator(params.ctx, n.Table, tableDesc, &params.p.semaCtx)
+		idxValidator := schemaexpr.MakeIndexPredicateValidator(params.ctx, n.Table, tableDesc, &params.p.semaCtx)
 		expr, err := idxValidator.Validate(n.Predicate)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1428,7 +1428,7 @@ func MakeTableDesc(
 		}
 		return nil
 	}
-	idxValidator := schemaexpr.NewIndexPredicateValidator(ctx, n.Table, &desc, semaCtx)
+	idxValidator := schemaexpr.MakeIndexPredicateValidator(ctx, n.Table, &desc, semaCtx)
 	for _, def := range n.Defs {
 		switch d := def.(type) {
 		case *tree.ColumnTableDef, *tree.LikeTableDef:
@@ -1694,7 +1694,7 @@ func MakeTableDesc(
 		newTableName:   &n.Table,
 	}
 
-	ckBuilder := schemaexpr.NewCheckConstraintBuilder(ctx, n.Table, &desc, semaCtx)
+	ckBuilder := schemaexpr.MakeCheckConstraintBuilder(ctx, n.Table, &desc, semaCtx)
 	for _, def := range n.Defs {
 		switch d := def.(type) {
 		case *tree.ColumnTableDef:
@@ -1724,7 +1724,7 @@ func MakeTableDesc(
 
 	// Now that we have all the other columns set up, we can validate
 	// any computed columns.
-	computedColValidator := schemaexpr.NewComputedColumnValidator(
+	computedColValidator := schemaexpr.MakeComputedColumnValidator(
 		ctx,
 		&desc,
 		semaCtx,

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -700,6 +700,17 @@ SELECT * FROM x ORDER BY a
 3 6 7
 6 12 10
 
+# Multiple ADD COLUMNs can only reference columns that are defined previously.
+statement error pq: column "t" does not exist, referenced in "lower\(t\)"
+ALTER TABLE x
+    ADD COLUMN s STRING AS (lower(t)) STORED,
+    ADD COLUMN t STRING
+
+statement ok
+ALTER TABLE x
+    ADD COLUMN s STRING,
+    ADD COLUMN t STRING AS (lower(s)) STORED
+
 # Verify a bad statement fails.
 statement error pq: could not parse "a" as type int
 ALTER TABLE x ADD COLUMN d INT AS (a + 'a') STORED

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -2,9 +2,8 @@
 
 # TODO(mgartner): remove this once partial indexes are fully supported.
 statement ok
-SET experimental_partial_indexes=on
-
-#### Validate partial index predicates.
+SET experimental_partial_indexes=on;
+SET experimental_enable_enums = true;
 
 statement ok
 CREATE TABLE t1 (a INT, INDEX (a) WHERE a = 0)
@@ -74,16 +73,15 @@ CREATE TABLE error (a INT, INDEX (a) WHERE unknown.a > 0)
 statement error no data source matches prefix: unknown.error
 CREATE TABLE error (a INT, INDEX (a) WHERE unknown.error.a > 9)
 
-#### Validate CREATE TABLE ... UNIQUE INDEX predicate.
+# Validate CREATE TABLE ... UNIQUE INDEX predicate.
 
 statement ok
 CREATE TABLE t4 (a INT, UNIQUE INDEX (a) WHERE a = 0)
 
-# Don't allow invalid predicates.
 statement error expected index predicate expression to have type bool, but '1' has type int
 CREATE TABLE error (a INT, UNIQUE INDEX (a) WHERE 1)
 
-#### Validate CREATE INDEX predicate.
+# Validate CREATE INDEX predicate.
 
 statement ok
 CREATE TABLE t5 (a INT)
@@ -99,7 +97,7 @@ CREATE INDEX error ON t5 (a) WHERE 1
 statement error no data source matches prefix: t4
 CREATE INDEX error ON t5 (a) WHERE t4.a = 1
 
-#### Dequalify table references.
+# Dequalify table references.
 
 statement ok
 CREATE TABLE t6 (
@@ -134,7 +132,7 @@ t6  CREATE TABLE public.t6 (
     FAMILY "primary" (a, rowid)
 )
 
-#### Renaming a column updates the index predicates.
+# Renaming a column updates the index predicates.
 
 statement ok
 ALTER TABLE t6 RENAME COLUMN a TO b
@@ -156,7 +154,7 @@ t6  CREATE TABLE public.t6 (
     FAMILY "primary" (b, rowid)
 )
 
-#### Renaming a table keeps the index predicates intact.
+# Renaming a table keeps the index predicates intact.
 
 statement ok
 ALTER TABLE t6 RENAME TO t7
@@ -178,7 +176,7 @@ t7  CREATE TABLE public.t7 (
     FAMILY "primary" (b, rowid)
 )
 
-#### Dropping a column referenced in the predicate drops the index.
+# Dropping a column referenced in the predicate drops the index.
 
 statement ok
 CREATE TABLE t8 (
@@ -203,8 +201,8 @@ t8  CREATE TABLE public.t8 (
     FAMILY fam_0_a_b_c_rowid (a, b, rowid)
 )
 
-#### CREATE TABLE LIKE ... INCLUDING INDEXES copies partial index predicate
-#### expressions to the new table.
+# CREATE TABLE LIKE ... INCLUDING INDEXES copies partial index predicate
+# expressions to the new table.
 
 statement ok
 CREATE TABLE t9 (a INT, b INT, INDEX (a) WHERE b > 1)
@@ -222,7 +220,7 @@ t10  CREATE TABLE public.t10 (
      FAMILY "primary" (a, b, rowid)
 )
 
-#### Update a non-indexed column referenced by the predicate.
+# Update a non-indexed column referenced by the predicate.
 
 statement ok
 CREATE TABLE a (
@@ -236,42 +234,42 @@ CREATE TABLE a (
 )
 
 statement ok
-INSERT INTO a VALUES (1, 1, 1);
+INSERT INTO a VALUES (1, 1, 1)
 
 statement ok
 UPDATE a SET b = b + 1 WHERE a = 1
 
-query III
+query III rowsort
 SELECT * FROM a@idx_c_b_gt_1 WHERE b > 1
 ----
 1  2  1
 
-#### Return error if evaluating the predicate errs and do not insert or update
-#### the row.
+# Return error if evaluating the predicate errs and do not insert or update the
+# row.
 
 statement ok
-CREATE TABLE b (a INT, b INT, INDEX (a) WHERE 1 / b = 1);
+CREATE TABLE b (a INT, b INT, INDEX (a) WHERE 1 / b = 1)
 
 statement error division by zero
 INSERT INTO b VALUES (1, 0)
 
-query I
+query I rowsort
 SELECT count(1) FROM b
 ----
 0
 
 statement ok
-INSERT INTO b VALUES (1, 1);
+INSERT INTO b VALUES (1, 1)
 
 statement error division by zero
 UPDATE b SET b = 0 WHERE a = 1
 
-query II
+query II rowsort
 SELECT * FROM b
 ----
 1  1
 
-#### Update two rows where one is in a partial index and one is not.
+# Update two rows where one is in a partial index and one is not.
 
 statement ok
 CREATE TABLE c (
@@ -281,8 +279,7 @@ CREATE TABLE c (
 )
 
 statement ok
-INSERT INTO c VALUES (3, 30);
-INSERT INTO c VALUES (300, 3000)
+INSERT INTO c VALUES (3, 30), (300, 3000)
 
 statement ok
 UPDATE c SET i = i + 1
@@ -292,7 +289,7 @@ SELECT * FROM c@i_0_100_idx WHERE i > 0 AND i < 100
 ----
 3  31
 
-#### Partial index entries are kept consistent throughout multiple mutations.
+# Partial index entries are kept consistent throughout multiple mutations.
 
 statement ok
 CREATE TABLE d (
@@ -308,12 +305,13 @@ CREATE TABLE d (
 # Inserting values populates partial indexes.
 
 statement ok
-INSERT INTO d VALUES (1, 1, 1.0, 'foo', true);
-INSERT INTO d VALUES (2, 2, 2.0, 'foo', false);
-INSERT INTO d VALUES (3, 3, 3.0, 'bar', true);
-INSERT INTO d VALUES (100, 100, 100.0, 'foo', true);
-INSERT INTO d VALUES (200, 200, 200.0, 'foo', false);
-INSERT INTO d VALUES (300, 300, 300.0, 'bar', true);
+INSERT INTO d VALUES
+    (1, 1, 1.0, 'foo', true),
+    (2, 2, 2.0, 'foo', false),
+    (3, 3, 3.0, 'bar', true),
+    (100, 100, 100.0, 'foo', true),
+    (200, 200, 200.0, 'foo', false),
+    (300, 300, 300.0, 'bar', true)
 
 query IIRTB rowsort
 SELECT * FROM d@i_0_100_idx WHERE i > 0 AND i < 100
@@ -358,7 +356,7 @@ SELECT * FROM d@f_b_s_foo_idx WHERE b AND s = 'foo'
 # Upsert a conflicting row, taking it out of the second partial index.
 
 statement ok
-UPSERT INTO d VALUES (300, 320, 300.0, 'bar', true);
+UPSERT INTO d VALUES (300, 320, 300.0, 'bar', true)
 
 query IIRTB rowsort
 SELECT * FROM d@f_b_s_foo_idx WHERE b AND s = 'foo'
@@ -370,7 +368,7 @@ SELECT * FROM d@f_b_s_foo_idx WHERE b AND s = 'foo'
 # Upsert a conflicting row, adding it into the second partial index.
 
 statement ok
-UPSERT INTO d VALUES (300, 330, 300.0, 'foo', true);
+UPSERT INTO d VALUES (300, 330, 300.0, 'foo', true)
 
 query IIRTB rowsort
 SELECT * FROM d@f_b_s_foo_idx WHERE b AND s = 'foo'
@@ -383,7 +381,7 @@ SELECT * FROM d@f_b_s_foo_idx WHERE b AND s = 'foo'
 # Upsert a non-conflicting row.
 
 statement ok
-UPSERT INTO d VALUES (400, 400, 400.0, 'foo', true);
+UPSERT INTO d VALUES (400, 400, 400.0, 'foo', true)
 
 query IIRTB rowsort
 SELECT * FROM d@i_0_100_idx WHERE i > 0 AND i < 100
@@ -456,6 +454,141 @@ SELECT * FROM d@f_b_s_foo_idx WHERE b AND s = 'foo'
 300  330  300  foo  true
 400  400  400  foo  true
 
+# Backfill a partial index.
+
+statement ok
+CREATE TABLE e (a INT, b INT)
+
+statement ok
+INSERT INTO e VALUES
+    (1, 10),
+    (2, 20),
+    (3, 30),
+    (4, 40),
+    (5, 50),
+    (6, 60)
+
+statement ok
+CREATE INDEX a_b_gt_30_idx ON e (a) WHERE b > 30
+
+# Note: This is guaranteed to be a full scan over the partial index because b
+# is not an indexed column. Therefore, this is a valid way to retrieve all rows
+# that have entries in the partial index.
+query II rowsort
+SELECT * FROM e@a_b_gt_30_idx WHERE b > 30
+----
+4  40
+5  50
+6  60
+
+# Backfill a partial index when a new table is created in the same transaction.
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE f (a INT, b INT)
+
+statement ok
+INSERT INTO f VALUES (1, 10), (6, 60)
+
+statement ok
+CREATE INDEX a_b_gt_30_idx ON f (a) WHERE b > 30
+
+statement ok
+COMMIT
+
+query II rowsort
+SELECT * FROM f@a_b_gt_30_idx WHERE b > 30
+----
+6  60
+
+# Backfill a partial index with a reference to a new column in the predicate.
+
+statement ok
+CREATE TABLE g (a INT)
+
+statement ok
+INSERT INTO g VALUES (1)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE g ADD COLUMN b INT
+
+statement ok
+CREATE INDEX a_b_null_idx ON g (a) WHERE b IS NULL
+
+statement ok
+COMMIT
+
+query II rowsort
+SELECT * FROM g@a_b_null_idx WHERE b IS NULL
+----
+1  NULL
+
+# Backfill a partial index with a user defined type.
+
+statement ok
+CREATE TYPE enum AS ENUM ('foo', 'bar', 'baz')
+
+statement ok
+CREATE TABLE h (a INT, b enum)
+
+statement ok
+INSERT INTO h VALUES (1, 'foo'), (2, 'bar')
+
+statement ok
+CREATE INDEX a_b_foo_idx ON h (a) WHERE b = 'foo'
+
+query IT rowsort
+SELECT * FROM h@a_b_foo_idx WHERE b = 'foo'
+----
+1  foo
+
+# Backfill a partial index with a user defined type when a new table is created
+# in the same transaction.
+# TODO(mgartner): Uncomment this test. This test is fails sporadically with
+# "cannot publish new versions for descriptors ... old versions still in use".
+# This appears unrelated to partial indexes. See issue #52539.
+#
+# statement ok
+# BEGIN
+#
+# statement ok
+# CREATE TABLE i (a INT, b enum)
+#
+# statement ok
+# INSERT INTO i VALUES (1, 'foo'), (2, 'bar')
+#
+# statement ok
+# CREATE INDEX a_b_foo_idx ON i (a) WHERE b = 'foo'
+#
+# statement ok
+# COMMIT
+#
+# query IT rowsort
+# SELECT * FROM i@a_b_foo_idx WHERE b = 'foo'
+# ----
+# 1  foo
+
+# Add a primary key to a table with a partial index.
+
+statement ok
+CREATE TABLE j (k INT NOT NULL, a INT, INDEX a_gt_5_idx (a) WHERE a > 5)
+
+statement ok
+INSERT INTO j VALUES (1, 1), (6, 6)
+
+statement ok
+ALTER TABLE j ADD PRIMARY KEY (k)
+
+query II rowsort
+SELECT * FROM j@a_gt_5_idx WHERE a > 5
+----
+6  6
+
 # Regression tests for #52318. Mutations on partial indexes in the
 # DELETE_AND_WRITE_ONLY state should update the indexes correctly.
 
@@ -472,7 +605,7 @@ BEGIN; CREATE INDEX i ON t52318 (a) WHERE b > 5
 statement ok
 INSERT INTO t52318 (a, b) VALUES (1, 1), (6, 6)
 
-query II
+query II rowsort
 SELECT * FROM t52318 WHERE b > 5
 ----
 6  6
@@ -480,7 +613,7 @@ SELECT * FROM t52318 WHERE b > 5
 statement ok
 UPDATE t52318 SET b = b + 1
 
-query II
+query II rowsort
 SELECT * FROM t52318 WHERE b > 5
 ----
 6  7

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -217,7 +217,7 @@ func NewProcessor(
 		}
 		switch core.Backfiller.Type {
 		case execinfrapb.BackfillerSpec_Index:
-			return newIndexBackfiller(flowCtx, processorID, *core.Backfiller, post, outputs[0])
+			return newIndexBackfiller(ctx, flowCtx, processorID, *core.Backfiller, post, outputs[0])
 		case execinfrapb.BackfillerSpec_Column:
 			return newColumnBackfiller(ctx, flowCtx, processorID, *core.Backfiller, post, outputs[0])
 		}

--- a/pkg/sql/schemaexpr/check_constraint.go
+++ b/pkg/sql/schemaexpr/check_constraint.go
@@ -36,10 +36,10 @@ type CheckConstraintBuilder struct {
 	inUseNames map[string]struct{}
 }
 
-// NewCheckConstraintBuilder returns a CheckConstraintBuilder struct that can
+// MakeCheckConstraintBuilder returns a CheckConstraintBuilder struct that can
 // be used to build descpb.TableDescriptor_CheckConstraints. See Build for more
 // details.
-func NewCheckConstraintBuilder(
+func MakeCheckConstraintBuilder(
 	ctx context.Context,
 	tableName tree.TableName,
 	desc *sqlbase.MutableTableDescriptor,

--- a/pkg/sql/schemaexpr/check_constraint_test.go
+++ b/pkg/sql/schemaexpr/check_constraint_test.go
@@ -37,7 +37,7 @@ func TestCheckConstraintBuilder_Build(t *testing.T) {
 		[]testCol{{"c", types.String}},
 	)
 
-	builder := NewCheckConstraintBuilder(ctx, tn, &desc, &semaCtx)
+	builder := MakeCheckConstraintBuilder(ctx, tn, &desc, &semaCtx)
 	builder.MarkNameInUse("check_a3")
 
 	testData := []struct {
@@ -156,7 +156,7 @@ func TestCheckConstraintBuilder_DefaultName(t *testing.T) {
 		[]testCol{{"c", types.String}, {"d", types.String}, {"e", types.String}},
 	)
 
-	builder := NewCheckConstraintBuilder(ctx, tn, &desc, &semaCtx)
+	builder := MakeCheckConstraintBuilder(ctx, tn, &desc, &semaCtx)
 
 	testData := []struct {
 		expr     string

--- a/pkg/sql/schemaexpr/column.go
+++ b/pkg/sql/schemaexpr/column.go
@@ -253,3 +253,13 @@ func replaceColumnVars(
 
 	return newExpr, colIDs, err
 }
+
+// columnDescriptorsToPtrs returns a list of references to the input
+// ColumnDescriptors.
+func columnDescriptorsToPtrs(cols []descpb.ColumnDescriptor) []*descpb.ColumnDescriptor {
+	ptrs := make([]*descpb.ColumnDescriptor, len(cols))
+	for i := range cols {
+		ptrs[i] = &cols[i]
+	}
+	return ptrs
+}

--- a/pkg/sql/schemaexpr/expr.go
+++ b/pkg/sql/schemaexpr/expr.go
@@ -13,6 +13,7 @@ package schemaexpr
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -46,10 +47,14 @@ func DeserializeTableDescExpr(
 	return typed, nil
 }
 
-// DequalifyAndValidateExpr takes an expr de-qualifies the column names and
-// validates that expression is valid, has the correct type and
-// has no impure functions if allowImpure is false.
-// Returns the type-checked and constant-folded expression.
+// DequalifyAndValidateExpr validates that an expression has the given type
+// and contains no functions with a volatility greater than maxVolatility. The
+// type-checked and constant-folded expression and the set of column IDs within
+// the expression are returned, if valid.
+// TODO(mgartner): Ideally this should return a serialized expression string on
+// success. Returning a tree.TypedExpr is dangerous because variables have been
+// replaced with dummyColumns which are not useful outside the context of
+// type-checking the expression.
 func DequalifyAndValidateExpr(
 	ctx context.Context,
 	desc sqlbase.TableDescriptor,
@@ -127,4 +132,80 @@ func ExtractColumnIDs(
 	})
 
 	return colIDs, err
+}
+
+// nameResolver is used to replace unresolved names in expressions with
+// IndexedVars.
+type nameResolver struct {
+	evalCtx    *tree.EvalContext
+	tableID    descpb.ID
+	source     *sqlbase.DataSourceInfo
+	nrc        *nameResolverIVarContainer
+	ivarHelper *tree.IndexedVarHelper
+}
+
+// newNameResolver creates and returns a nameResolver.
+func newNameResolver(
+	evalCtx *tree.EvalContext, tableID descpb.ID, tn *tree.TableName, cols []*descpb.ColumnDescriptor,
+) *nameResolver {
+	source := sqlbase.NewSourceInfoForSingleTable(
+		*tn,
+		sqlbase.ResultColumnsFromColDescPtrs(tableID, cols),
+	)
+	nrc := &nameResolverIVarContainer{cols}
+	ivarHelper := tree.MakeIndexedVarHelper(nrc, len(cols))
+
+	return &nameResolver{
+		evalCtx:    evalCtx,
+		tableID:    tableID,
+		source:     source,
+		nrc:        nrc,
+		ivarHelper: &ivarHelper,
+	}
+}
+
+// resolveNames returns an expression equivalent to the input expression with
+// unresolved names replaced with IndexedVars.
+func (nr *nameResolver) resolveNames(expr tree.Expr) (tree.Expr, error) {
+	return sqlbase.ResolveNames(expr, nr.source, *nr.ivarHelper, nr.evalCtx.SessionData.SearchPath)
+}
+
+// addColumn adds a new column to the nameResolver so that it can be resolved in
+// future calls to resolveNames.
+func (nr *nameResolver) addColumn(col *descpb.ColumnDescriptor) {
+	nr.ivarHelper.AppendSlot()
+	nr.nrc.cols = append(nr.nrc.cols, col)
+	newCols := sqlbase.ResultColumnsFromColDescs(nr.tableID, []descpb.ColumnDescriptor{*col})
+	nr.source.SourceColumns = append(nr.source.SourceColumns, newCols...)
+}
+
+// addIVarContainerToSemaCtx assigns semaCtx's IVarContainer as the
+// nameResolver's internal indexed var container.
+func (nr *nameResolver) addIVarContainerToSemaCtx(semaCtx *tree.SemaContext) {
+	semaCtx.IVarContainer = nr.nrc
+}
+
+// nameResolverIVarContainer is a help type that implements
+// tree.IndexedVarContainer. It is used to resolve and type check columns in
+// expressions. It does not support evaluation.
+type nameResolverIVarContainer struct {
+	cols []*descpb.ColumnDescriptor
+}
+
+// IndexedVarEval implements the tree.IndexedVarContainer interface.
+// Evaluation is not support, so this function panics.
+func (nrc *nameResolverIVarContainer) IndexedVarEval(
+	idx int, ctx *tree.EvalContext,
+) (tree.Datum, error) {
+	panic("unsupported")
+}
+
+// IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
+func (nrc *nameResolverIVarContainer) IndexedVarResolvedType(idx int) *types.T {
+	return nrc.cols[idx].Type
+}
+
+// IndexVarNodeFormatter implements the tree.IndexedVarContainer interface.
+func (nrc *nameResolverIVarContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
+	return nil
 }

--- a/pkg/sql/schemaexpr/partial_index_test.go
+++ b/pkg/sql/schemaexpr/partial_index_test.go
@@ -37,7 +37,7 @@ func TestIndexPredicateValidator_Validate(t *testing.T) {
 		[]testCol{{"c", types.String}},
 	)
 
-	validator := NewIndexPredicateValidator(ctx, tn, &desc, &semaCtx)
+	validator := MakeIndexPredicateValidator(ctx, tn, &desc, &semaCtx)
 
 	testData := []struct {
 		expr          string

--- a/pkg/sql/sqlbase/default_exprs.go
+++ b/pkg/sql/sqlbase/default_exprs.go
@@ -25,6 +25,7 @@ import (
 // The length of the result slice matches the length of the input column descriptors.
 // For every column that has no default expression, a NULL expression is reported
 // as default.
+// TODO(mgartner): Move this to the schemaexpr package.
 func MakeDefaultExprs(
 	ctx context.Context,
 	cols []descpb.ColumnDescriptor,

--- a/pkg/sql/sqlbase/table_col_set.go
+++ b/pkg/sql/sqlbase/table_col_set.go
@@ -46,8 +46,11 @@ func (s TableColSet) ForEach(f func(col descpb.ColumnID)) {
 	s.set.ForEach(func(i int) { f(descpb.ColumnID(i)) })
 }
 
-// Ordered returns a slice with all the descpb.ColumnIDs in the set, in increasing
-// order.
+// UnionWith adds all the columns from rhs to this set.
+func (s *TableColSet) UnionWith(rhs TableColSet) { s.set.UnionWith(rhs.set) }
+
+// Ordered returns a slice with all the descpb.ColumnIDs in the set, in
+// increasing order.
 func (s TableColSet) Ordered() []descpb.ColumnID {
 	if s.Empty() {
 		return nil

--- a/pkg/sql/sqlbase/table_col_set_test.go
+++ b/pkg/sql/sqlbase/table_col_set_test.go
@@ -29,7 +29,7 @@ func BenchmarkColSet(b *testing.B) {
 			}
 		}
 	})
-	b.Run("colset", func(b *testing.B) {
+	b.Run("tablecolset", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var c TableColSet
 			for j := 0; j < n; j++ {


### PR DESCRIPTION
#### sql: backfill partial indexes

This commit adds support for backfilling partial indexes. Adding partial
indexes to tables that already have rows will now correctly backfill the
partial index such that it only indexes rows that satisfy the partial
index.

In order to backfill partial indexes, the backfiller first generates a
typed expression from the partial index predicate string. Then, for each
row in the table, the typed predicate expression is evaluated. If the
result is true, index entries are generated for the partial index.

Fixes #51852 

Release note: None

#### sql: add tests for computed columns that reference other new columns

This commit adds tests for adding computed columns that reference other
new columns added in the same `ALTER TABLE` statement. These cases were
previously untested.

Release note: None
