### PR TITLE
opt: panic when optbuilder encounters non-immutable partial index predicates

### DIFF
--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -781,9 +782,20 @@ func (mb *mutationBuilder) projectPartialIndexCols(colIDs opt.ColList, predScope
 			texpr := predScope.resolveAndRequireType(expr, types.Bool)
 			scopeCol := mb.b.addColumn(projectionScope, "", texpr)
 
-			mb.b.buildScalar(texpr, predScope, projectionScope, scopeCol, nil)
-			colIDs[ord] = scopeCol.id
+			var scalar opt.ScalarExpr
+			mb.b.factory.FoldingControl().TemporarilyDisallowStableFolds(func() {
+				scalar = mb.b.buildScalar(texpr, predScope, projectionScope, scopeCol, nil)
+			})
 
+			// Expressions with non-immutable operators are not supported as
+			// partial index predicates.
+			var sharedProps props.Shared
+			memo.BuildSharedProps(scalar, &sharedProps)
+			if sharedProps.VolatilitySet.HasStable() || sharedProps.VolatilitySet.HasVolatile() {
+				panic(errors.AssertionFailedf("partial index predicate is not immutable"))
+			}
+
+			colIDs[ord] = scopeCol.id
 			ord++
 		}
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -718,14 +718,9 @@ func (b *Builder) addPartialIndexPredicatesForTable(tabMeta *opt.TableMeta) {
 		filter := b.factory.ConstructFiltersItem(scalar)
 
 		// Expressions with non-immutable operators are not supported as partial
-		// index predicates, so add a replacement expression of False. A partial
-		// index with a False predicate will never be used to satisfy a query.
-		// It is safer to use a False predicate than no predicate so that the
-		// optimizer won't incorrectly assume that the index is a full index.
+		// index predicates.
 		if filter.ScalarProps().VolatilitySet.HasStable() || filter.ScalarProps().VolatilitySet.HasVolatile() {
-			fals := memo.FiltersExpr{b.factory.ConstructFiltersItem(memo.FalseSingleton)}
-			tabMeta.AddPartialIndexPredicate(indexOrd, &fals)
-			return
+			panic(errors.AssertionFailedf("partial index predicate is not immutable"))
 		}
 
 		// Wrap the predicate filter expression in a FiltersExpr and normalize


### PR DESCRIPTION
This commit adds a panic when optbuilder encounters a non-immutable
partial index predicate expression while building select and mutation
opt trees. Partials index predicates must be immutable, which is
validated when they are created by `schemaexpr.IndexPredicateValidator`.
If optbuilder encounters a predicate with non-immutable operators, a
panic is preferred to producing incorrect query results.

Release note: None