### PR TITLE
opt: modify JoinOrderBuilder lookup tables to handle special cases

### DIFF
--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -2644,7 +2644,7 @@ func (c *CustomFuncs) ShouldReorderJoins(root memo.RelExpr) bool {
 // first expression of the memo group is used for construction of the join
 // graph. For more information, see the comment in join_order_builder.go.
 func (c *CustomFuncs) ReorderJoins(grp memo.RelExpr) memo.RelExpr {
-	c.e.o.JoinOrderBuilder().Init(c.e.f)
+	c.e.o.JoinOrderBuilder().Init(c.e.f, c.e.evalCtx)
 	c.e.o.JoinOrderBuilder().Reorder(grp.FirstExpr())
 	return grp
 }

--- a/pkg/sql/opt/xform/join_order_builder_test.go
+++ b/pkg/sql/opt/xform/join_order_builder_test.go
@@ -28,6 +28,10 @@ type testEdge struct {
 	left  string
 	right string
 
+	// notNull is a string of the form "AB" which represents the set of base
+	// relations on which nulls are rejected by the edge's predicate.
+	notNull string
+
 	// ses is a string of the form "AB" which represents the set of base relations
 	// referenced by the edge's predicate.
 	ses string
@@ -272,6 +276,111 @@ func TestJoinOrderBuilder_CalcTES(t *testing.T) {
 			expectedTES:   "ABCD",
 			expectedRules: "",
 		},
+		{ // 15
+			// SELECT * FROM
+			// (
+			//   SELECT * FROM A
+			//   FULL JOIN B
+			//   ON (A.x = B.x OR A.x IS NULL OR B.x IS NULL)
+			// )
+			// FULL JOIN
+			// (
+			//   SELECT * FROM C
+			//   FULL JOIN D
+			//   ON (C.x = D.x OR C.x IS NULL OR D.x IS NULL)
+			// )
+			// ON (A.y = D.y OR A.y IS NULL OR D.y IS NULL)
+			rootEdge: testEdge{joinOp: opt.FullJoinOp, left: "AB", right: "CD", ses: "AD"},
+			leftChildEdges: []testEdge{
+				{joinOp: opt.FullJoinOp, left: "A", right: "B", ses: "AB"},
+			},
+			rightChildEdges: []testEdge{
+				{joinOp: opt.FullJoinOp, left: "C", right: "D", ses: "CD"},
+			},
+			expectedTES:   "ABCD",
+			expectedRules: "",
+		},
+		{ // 16
+			// SELECT * FROM
+			// (
+			//   SELECT * FROM A
+			//   FULL JOIN B ON A.x = B.x
+			// )
+			// FULL JOIN
+			// (
+			//   SELECT * FROM C
+			//   FULL JOIN D ON C.x = D.x
+			// )
+			// ON A.y = C.y
+			rootEdge: testEdge{joinOp: opt.FullJoinOp, left: "AB", right: "CD", ses: "AD", notNull: "AD"},
+			leftChildEdges: []testEdge{
+				{joinOp: opt.FullJoinOp, left: "A", right: "B", ses: "AB", notNull: "AB"},
+			},
+			rightChildEdges: []testEdge{
+				{joinOp: opt.FullJoinOp, left: "C", right: "D", ses: "CD", notNull: "CD"},
+			},
+			expectedTES:   "AD",
+			expectedRules: "",
+		},
+		{ // 17
+			// SELECT * FROM
+			// (
+			//   SELECT * FROM A
+			//   LEFT JOIN B ON A.x = B.x
+			// )
+			// LEFT JOIN
+			// (
+			//   SELECT * FROM C
+			//   LEFT JOIN D ON C.x = D.x
+			// )
+			// ON A.y = C.y
+			rootEdge: testEdge{joinOp: opt.LeftJoinOp, left: "AB", right: "CD", ses: "AD", notNull: "AD"},
+			leftChildEdges: []testEdge{
+				{joinOp: opt.LeftJoinOp, left: "A", right: "B", ses: "AB", notNull: "AB"},
+			},
+			rightChildEdges: []testEdge{
+				{joinOp: opt.LeftJoinOp, left: "C", right: "D", ses: "CD", notNull: "CD"},
+			},
+			expectedTES:   "ACD",
+			expectedRules: "",
+		},
+		{ // 18
+			// SELECT * FROM
+			// (
+			//   SELECT * FROM A
+			//   LEFT JOIN B ON A.x = B.x
+			// )
+			// LEFT JOIN
+			// (
+			//   SELECT * FROM C
+			//   LEFT JOIN D ON C.x = D.x
+			// )
+			// ON B.y = C.y
+			rootEdge: testEdge{joinOp: opt.LeftJoinOp, left: "AB", right: "CD", ses: "BD", notNull: "BD"},
+			leftChildEdges: []testEdge{
+				{joinOp: opt.LeftJoinOp, left: "A", right: "B", ses: "AB", notNull: "AB"},
+			},
+			rightChildEdges: []testEdge{
+				{joinOp: opt.LeftJoinOp, left: "C", right: "D", ses: "CD", notNull: "CD"},
+			},
+			expectedTES:   "BCD",
+			expectedRules: "",
+		},
+		{ // 19
+			// SELECT * FROM
+			// (
+			//   SELECT * FROM A
+			//   FULL JOIN B ON A.x = B.x
+			// )
+			// FULL JOIN C ON B.y = C.y OR B IS NULL
+			rootEdge: testEdge{joinOp: opt.FullJoinOp, left: "AB", right: "C", ses: "BC", notNull: "C"},
+			leftChildEdges: []testEdge{
+				{joinOp: opt.FullJoinOp, left: "A", right: "B", ses: "AB", notNull: "AB"},
+			},
+			rightChildEdges: []testEdge{},
+			expectedTES:     "ABC",
+			expectedRules:   "",
+		},
 	}
 
 	for i, tc := range testCases {
@@ -316,8 +425,9 @@ func makeEdge(e testEdge) *edge {
 		rightVertexes: parseVertexSet(e.right),
 	}
 	return &edge{
-		op:  operator,
-		ses: parseVertexSet(e.ses),
+		op:               operator,
+		nullRejectedRels: parseVertexSet(e.notNull),
+		ses:              parseVertexSet(e.ses),
 	}
 }
 

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -2142,34 +2142,36 @@ project
  │    │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  │    │    │    │    │    ├── key: (1,5,6,9-11)
  │    │    │    │    │    ├── fd: (1)-->(2,3), (5,6)-->(7), (9-11)-->(12), (14)-->(15-17), (1,5,6,9-11)-->(14-17)
- │    │    │    │    │    ├── left-join (hash)
+ │    │    │    │    │    ├── left-join (merge)
  │    │    │    │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:5 orders1_.ordernumber:6 orderdate:7 lineitems2_.customerid:9 lineitems2_.ordernumber:10 lineitems2_.productid:11 lineitems2_.quantity:12
+ │    │    │    │    │    │    ├── left ordering: +1
+ │    │    │    │    │    │    ├── right ordering: +5
  │    │    │    │    │    │    ├── key: (1,5,6,9-11)
  │    │    │    │    │    │    ├── fd: (1)-->(2,3), (5,6)-->(7), (9-11)-->(12)
+ │    │    │    │    │    │    ├── scan customer0_
+ │    │    │    │    │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null
+ │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    │    ├── fd: (1)-->(2,3)
+ │    │    │    │    │    │    │    └── ordering: +1
  │    │    │    │    │    │    ├── left-join (merge)
- │    │    │    │    │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:5 orders1_.ordernumber:6 orderdate:7
- │    │    │    │    │    │    │    ├── left ordering: +1
- │    │    │    │    │    │    │    ├── right ordering: +5
- │    │    │    │    │    │    │    ├── key: (1,5,6)
- │    │    │    │    │    │    │    ├── fd: (1)-->(2,3), (5,6)-->(7)
- │    │    │    │    │    │    │    ├── scan customer0_
- │    │    │    │    │    │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null
- │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3)
- │    │    │    │    │    │    │    │    └── ordering: +1
+ │    │    │    │    │    │    │    ├── columns: orders1_.customerid:5!null orders1_.ordernumber:6!null orderdate:7!null lineitems2_.customerid:9 lineitems2_.ordernumber:10 lineitems2_.productid:11 lineitems2_.quantity:12
+ │    │    │    │    │    │    │    ├── left ordering: +5,+6
+ │    │    │    │    │    │    │    ├── right ordering: +9,+10
+ │    │    │    │    │    │    │    ├── key: (5,6,9-11)
+ │    │    │    │    │    │    │    ├── fd: (5,6)-->(7), (9-11)-->(12)
+ │    │    │    │    │    │    │    ├── ordering: +5
  │    │    │    │    │    │    │    ├── scan orders1_
  │    │    │    │    │    │    │    │    ├── columns: orders1_.customerid:5!null orders1_.ordernumber:6!null orderdate:7!null
  │    │    │    │    │    │    │    │    ├── key: (5,6)
  │    │    │    │    │    │    │    │    ├── fd: (5,6)-->(7)
- │    │    │    │    │    │    │    │    └── ordering: +5
+ │    │    │    │    │    │    │    │    └── ordering: +5,+6
+ │    │    │    │    │    │    │    ├── scan lineitems2_
+ │    │    │    │    │    │    │    │    ├── columns: lineitems2_.customerid:9!null lineitems2_.ordernumber:10!null lineitems2_.productid:11!null lineitems2_.quantity:12
+ │    │    │    │    │    │    │    │    ├── key: (9-11)
+ │    │    │    │    │    │    │    │    ├── fd: (9-11)-->(12)
+ │    │    │    │    │    │    │    │    └── ordering: +9,+10
  │    │    │    │    │    │    │    └── filters (true)
- │    │    │    │    │    │    ├── scan lineitems2_
- │    │    │    │    │    │    │    ├── columns: lineitems2_.customerid:9!null lineitems2_.ordernumber:10!null lineitems2_.productid:11!null lineitems2_.quantity:12
- │    │    │    │    │    │    │    ├── key: (9-11)
- │    │    │    │    │    │    │    └── fd: (9-11)-->(12)
- │    │    │    │    │    │    └── filters
- │    │    │    │    │    │         ├── orders1_.customerid:5 = lineitems2_.customerid:9 [outer=(5,9), constraints=(/5: (/NULL - ]; /9: (/NULL - ]), fd=(5)==(9), (9)==(5)]
- │    │    │    │    │    │         └── orders1_.ordernumber:6 = lineitems2_.ordernumber:10 [outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
+ │    │    │    │    │    │    └── filters (true)
  │    │    │    │    │    ├── scan product3_
  │    │    │    │    │    │    ├── columns: product3_.productid:14!null product3_.description:15!null product3_.cost:16 product3_.numberavailable:17
  │    │    │    │    │    │    ├── key: (14)

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -183,13 +183,14 @@ project
  │    │    │         ├── key columns: [127] = [130]
  │    │    │         ├── lookup columns are key
  │    │    │         ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (73)~~>(74), (74)~~>(73), (78)-->(79), (98)-->(99), (126)-->(127,128), (130)-->(131), (131)-->(130)
- │    │    │         ├── right-join (hash)
+ │    │    │         ├── left-join (lookup pg_namespace)
  │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 i.inhrelid:41 i.inhparent:42 c2.oid:45 c2.relname:46 c2.relnamespace:47 n2.oid:73 n2.nspname:74 indexrelid:78 indrelid:79 indisclustered:85 ci.oid:98 ci.relname:99 ftrelid:126 ftserver:127 ftoptions:128
+ │    │    │         │    ├── key columns: [47] = [73]
+ │    │    │         │    ├── lookup columns are key
  │    │    │         │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (73)~~>(74), (74)~~>(73), (78)-->(79), (98)-->(99), (126)-->(127,128)
- │    │    │         │    ├── left-join (hash)
- │    │    │         │    │    ├── columns: i.inhrelid:41!null i.inhparent:42!null c2.oid:45!null c2.relname:46!null c2.relnamespace:47!null n2.oid:73 n2.nspname:74
- │    │    │         │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
- │    │    │         │    │    ├── fd: (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (73)-->(74), (74)-->(73)
+ │    │    │         │    ├── right-join (hash)
+ │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 i.inhrelid:41 i.inhparent:42 c2.oid:45 c2.relname:46 c2.relnamespace:47 indexrelid:78 indrelid:79 indisclustered:85 ci.oid:98 ci.relname:99 ftrelid:126 ftserver:127 ftoptions:128
+ │    │    │         │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (78)-->(79), (1,78)-->(85,98,99), (98)-->(99), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
  │    │    │         │    │    ├── inner-join (hash)
  │    │    │         │    │    │    ├── columns: i.inhrelid:41!null i.inhparent:42!null c2.oid:45!null c2.relname:46!null c2.relnamespace:47!null
  │    │    │         │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -202,74 +203,69 @@ project
  │    │    │         │    │    │    │    └── fd: (45)-->(46,47), (46,47)-->(45)
  │    │    │         │    │    │    └── filters
  │    │    │         │    │    │         └── i.inhparent:42 = c2.oid:45 [outer=(42,45), constraints=(/42: (/NULL - ]; /45: (/NULL - ]), fd=(42)==(45), (45)==(42)]
- │    │    │         │    │    ├── scan n2@pg_namespace_nspname_index
- │    │    │         │    │    │    ├── columns: n2.oid:73!null n2.nspname:74!null
- │    │    │         │    │    │    ├── key: (73)
- │    │    │         │    │    │    └── fd: (73)-->(74), (74)-->(73)
- │    │    │         │    │    └── filters
- │    │    │         │    │         └── n2.oid:73 = c2.relnamespace:47 [outer=(47,73), constraints=(/47: (/NULL - ]; /73: (/NULL - ]), fd=(47)==(73), (73)==(47)]
- │    │    │         │    ├── left-join (lookup pg_class)
- │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 indexrelid:78 indrelid:79 indisclustered:85 ci.oid:98 ci.relname:99 ftrelid:126 ftserver:127 ftoptions:128
- │    │    │         │    │    ├── key columns: [78] = [98]
- │    │    │         │    │    ├── lookup columns are key
- │    │    │         │    │    ├── key: (1,78)
- │    │    │         │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (78)-->(79), (1,78)-->(34,35,85,98,99), (98)-->(99), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
- │    │    │         │    │    ├── right-join (hash)
- │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 indexrelid:78 indrelid:79 indisclustered:85 ftrelid:126 ftserver:127 ftoptions:128
+ │    │    │         │    │    ├── left-join (lookup pg_class)
+ │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 indexrelid:78 indrelid:79 indisclustered:85 ci.oid:98 ci.relname:99 ftrelid:126 ftserver:127 ftoptions:128
+ │    │    │         │    │    │    ├── key columns: [78] = [98]
+ │    │    │         │    │    │    ├── lookup columns are key
  │    │    │         │    │    │    ├── key: (1,78)
- │    │    │         │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (78)-->(79), (1,78)-->(34,35,85), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
- │    │    │         │    │    │    ├── select
- │    │    │         │    │    │    │    ├── columns: indexrelid:78!null indrelid:79!null indisclustered:85!null
- │    │    │         │    │    │    │    ├── key: (78)
- │    │    │         │    │    │    │    ├── fd: ()-->(85), (78)-->(79)
- │    │    │         │    │    │    │    ├── scan ind
+ │    │    │         │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (78)-->(79), (1,78)-->(34,35,85,98,99), (98)-->(99), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+ │    │    │         │    │    │    ├── right-join (hash)
+ │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 indexrelid:78 indrelid:79 indisclustered:85 ftrelid:126 ftserver:127 ftoptions:128
+ │    │    │         │    │    │    │    ├── key: (1,78)
+ │    │    │         │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (78)-->(79), (1,78)-->(34,35,85), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+ │    │    │         │    │    │    │    ├── select
  │    │    │         │    │    │    │    │    ├── columns: indexrelid:78!null indrelid:79!null indisclustered:85!null
  │    │    │         │    │    │    │    │    ├── key: (78)
- │    │    │         │    │    │    │    │    └── fd: (78)-->(79,85)
- │    │    │         │    │    │    │    └── filters
- │    │    │         │    │    │    │         └── indisclustered:85 = true [outer=(85), constraints=(/85: [/true - /true]; tight), fd=()-->(85)]
- │    │    │         │    │    │    ├── left-join (lookup pg_tablespace)
- │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 ftrelid:126 ftserver:127 ftoptions:128
- │    │    │         │    │    │    │    ├── key columns: [8] = [34]
- │    │    │         │    │    │    │    ├── lookup columns are key
- │    │    │         │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
- │    │    │         │    │    │    │    ├── left-join (lookup pg_foreign_table)
- │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null ftrelid:126 ftserver:127 ftoptions:128
- │    │    │         │    │    │    │    │    ├── key columns: [1] = [126]
+ │    │    │         │    │    │    │    │    ├── fd: ()-->(85), (78)-->(79)
+ │    │    │         │    │    │    │    │    ├── scan ind
+ │    │    │         │    │    │    │    │    │    ├── columns: indexrelid:78!null indrelid:79!null indisclustered:85!null
+ │    │    │         │    │    │    │    │    │    ├── key: (78)
+ │    │    │         │    │    │    │    │    │    └── fd: (78)-->(79,85)
+ │    │    │         │    │    │    │    │    └── filters
+ │    │    │         │    │    │    │    │         └── indisclustered:85 = true [outer=(85), constraints=(/85: [/true - /true]; tight), fd=()-->(85)]
+ │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace)
+ │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 ftrelid:126 ftserver:127 ftoptions:128
+ │    │    │         │    │    │    │    │    ├── key columns: [8] = [34]
  │    │    │         │    │    │    │    │    ├── lookup columns are key
  │    │    │         │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (3)==(29), (29)==(3)
- │    │    │         │    │    │    │    │    ├── inner-join (hash)
- │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null
- │    │    │         │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    │         │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+ │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_table)
+ │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null ftrelid:126 ftserver:127 ftoptions:128
+ │    │    │         │    │    │    │    │    │    ├── key columns: [1] = [126]
+ │    │    │         │    │    │    │    │    │    ├── lookup columns are key
  │    │    │         │    │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3)
- │    │    │         │    │    │    │    │    │    ├── select
- │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+ │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (3)==(29), (29)==(3)
+ │    │    │         │    │    │    │    │    │    ├── inner-join (hash)
+ │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null
+ │    │    │         │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
  │    │    │         │    │    │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │    │    │         │    │    │    │    │    │    │    ├── scan c
+ │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3)
+ │    │    │         │    │    │    │    │    │    │    ├── select
  │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
  │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │         │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │         │    │    │    │    │    │    │    │    ├── scan c
+ │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+ │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │         │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │         │    │    │    │    │    │    │    │    └── filters
+ │    │    │         │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
+ │    │    │         │    │    │    │    │    │    │    ├── scan n@pg_namespace_nspname_index
+ │    │    │         │    │    │    │    │    │    │    │    ├── columns: n.oid:29!null n.nspname:30!null
+ │    │    │         │    │    │    │    │    │    │    │    ├── constraint: /30: [/'public' - /'public']
+ │    │    │         │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │         │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │         │    │    │    │    │    │    │    │    └── fd: ()-->(29,30)
  │    │    │         │    │    │    │    │    │    │    └── filters
- │    │    │         │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
- │    │    │         │    │    │    │    │    │    ├── scan n@pg_namespace_nspname_index
- │    │    │         │    │    │    │    │    │    │    ├── columns: n.oid:29!null n.nspname:30!null
- │    │    │         │    │    │    │    │    │    │    ├── constraint: /30: [/'public' - /'public']
- │    │    │         │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │         │    │    │    │    │    │    │    ├── key: ()
- │    │    │         │    │    │    │    │    │    │    └── fd: ()-->(29,30)
- │    │    │         │    │    │    │    │    │    └── filters
- │    │    │         │    │    │    │    │    │         └── n.oid:29 = c.relnamespace:3 [outer=(3,29), constraints=(/3: (/NULL - ]; /29: (/NULL - ]), fd=(3)==(29), (29)==(3)]
+ │    │    │         │    │    │    │    │    │    │         └── n.oid:29 = c.relnamespace:3 [outer=(3,29), constraints=(/3: (/NULL - ]; /29: (/NULL - ]), fd=(3)==(29), (29)==(3)]
+ │    │    │         │    │    │    │    │    │    └── filters (true)
  │    │    │         │    │    │    │    │    └── filters (true)
- │    │    │         │    │    │    │    └── filters (true)
- │    │    │         │    │    │    └── filters
- │    │    │         │    │    │         └── indrelid:79 = c.oid:1 [outer=(1,79), constraints=(/1: (/NULL - ]; /79: (/NULL - ]), fd=(1)==(79), (79)==(1)]
- │    │    │         │    │    └── filters (true)
- │    │    │         │    └── filters
- │    │    │         │         └── i.inhrelid:41 = c.oid:1 [outer=(1,41), constraints=(/1: (/NULL - ]; /41: (/NULL - ]), fd=(1)==(41), (41)==(1)]
+ │    │    │         │    │    │    │    └── filters
+ │    │    │         │    │    │    │         └── indrelid:79 = c.oid:1 [outer=(1,79), constraints=(/1: (/NULL - ]; /79: (/NULL - ]), fd=(1)==(79), (79)==(1)]
+ │    │    │         │    │    │    └── filters (true)
+ │    │    │         │    │    └── filters
+ │    │    │         │    │         └── i.inhrelid:41 = c.oid:1 [outer=(1,41), constraints=(/1: (/NULL - ]; /41: (/NULL - ]), fd=(1)==(41), (41)==(1)]
+ │    │    │         │    └── filters (true)
  │    │    │         └── filters (true)
  │    │    └── filters
  │    │         └── pg_inherits.inhparent:140 = c.oid:1 [outer=(1,140), constraints=(/1: (/NULL - ]; /140: (/NULL - ]), fd=(1)==(140), (140)==(1)]

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -187,13 +187,14 @@ sort
       │    │    │         ├── key columns: [127] = [130]
       │    │    │         ├── lookup columns are key
       │    │    │         ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (73)~~>(74), (74)~~>(73), (78)-->(79), (98)-->(99), (126)-->(127,128), (130)-->(131), (131)-->(130)
-      │    │    │         ├── right-join (hash)
+      │    │    │         ├── left-join (lookup pg_namespace)
       │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 i.inhrelid:41 i.inhparent:42 c2.oid:45 c2.relname:46 c2.relnamespace:47 n2.oid:73 n2.nspname:74 indexrelid:78 indrelid:79 indisclustered:85 ci.oid:98 ci.relname:99 ftrelid:126 ftserver:127 ftoptions:128
+      │    │    │         │    ├── key columns: [47] = [73]
+      │    │    │         │    ├── lookup columns are key
       │    │    │         │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (73)~~>(74), (74)~~>(73), (78)-->(79), (98)-->(99), (126)-->(127,128)
-      │    │    │         │    ├── left-join (hash)
-      │    │    │         │    │    ├── columns: i.inhrelid:41!null i.inhparent:42!null c2.oid:45!null c2.relname:46!null c2.relnamespace:47!null n2.oid:73 n2.nspname:74
-      │    │    │         │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
-      │    │    │         │    │    ├── fd: (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (73)-->(74), (74)-->(73)
+      │    │    │         │    ├── right-join (hash)
+      │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 i.inhrelid:41 i.inhparent:42 c2.oid:45 c2.relname:46 c2.relnamespace:47 indexrelid:78 indrelid:79 indisclustered:85 ci.oid:98 ci.relname:99 ftrelid:126 ftserver:127 ftoptions:128
+      │    │    │         │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (78)-->(79), (1,78)-->(85,98,99), (98)-->(99), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
       │    │    │         │    │    ├── inner-join (hash)
       │    │    │         │    │    │    ├── columns: i.inhrelid:41!null i.inhparent:42!null c2.oid:45!null c2.relname:46!null c2.relnamespace:47!null
       │    │    │         │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -206,74 +207,69 @@ sort
       │    │    │         │    │    │    │    └── fd: (45)-->(46,47), (46,47)-->(45)
       │    │    │         │    │    │    └── filters
       │    │    │         │    │    │         └── i.inhparent:42 = c2.oid:45 [outer=(42,45), constraints=(/42: (/NULL - ]; /45: (/NULL - ]), fd=(42)==(45), (45)==(42)]
-      │    │    │         │    │    ├── scan n2@pg_namespace_nspname_index
-      │    │    │         │    │    │    ├── columns: n2.oid:73!null n2.nspname:74!null
-      │    │    │         │    │    │    ├── key: (73)
-      │    │    │         │    │    │    └── fd: (73)-->(74), (74)-->(73)
-      │    │    │         │    │    └── filters
-      │    │    │         │    │         └── n2.oid:73 = c2.relnamespace:47 [outer=(47,73), constraints=(/47: (/NULL - ]; /73: (/NULL - ]), fd=(47)==(73), (73)==(47)]
-      │    │    │         │    ├── left-join (lookup pg_class)
-      │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 indexrelid:78 indrelid:79 indisclustered:85 ci.oid:98 ci.relname:99 ftrelid:126 ftserver:127 ftoptions:128
-      │    │    │         │    │    ├── key columns: [78] = [98]
-      │    │    │         │    │    ├── lookup columns are key
-      │    │    │         │    │    ├── key: (1,78)
-      │    │    │         │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (78)-->(79), (1,78)-->(34,35,85,98,99), (98)-->(99), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
-      │    │    │         │    │    ├── right-join (hash)
-      │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 indexrelid:78 indrelid:79 indisclustered:85 ftrelid:126 ftserver:127 ftoptions:128
+      │    │    │         │    │    ├── left-join (lookup pg_class)
+      │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 indexrelid:78 indrelid:79 indisclustered:85 ci.oid:98 ci.relname:99 ftrelid:126 ftserver:127 ftoptions:128
+      │    │    │         │    │    │    ├── key columns: [78] = [98]
+      │    │    │         │    │    │    ├── lookup columns are key
       │    │    │         │    │    │    ├── key: (1,78)
-      │    │    │         │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (78)-->(79), (1,78)-->(34,35,85), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
-      │    │    │         │    │    │    ├── select
-      │    │    │         │    │    │    │    ├── columns: indexrelid:78!null indrelid:79!null indisclustered:85!null
-      │    │    │         │    │    │    │    ├── key: (78)
-      │    │    │         │    │    │    │    ├── fd: ()-->(85), (78)-->(79)
-      │    │    │         │    │    │    │    ├── scan ind
+      │    │    │         │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (78)-->(79), (1,78)-->(34,35,85,98,99), (98)-->(99), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+      │    │    │         │    │    │    ├── right-join (hash)
+      │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 indexrelid:78 indrelid:79 indisclustered:85 ftrelid:126 ftserver:127 ftoptions:128
+      │    │    │         │    │    │    │    ├── key: (1,78)
+      │    │    │         │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (78)-->(79), (1,78)-->(34,35,85), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+      │    │    │         │    │    │    │    ├── select
       │    │    │         │    │    │    │    │    ├── columns: indexrelid:78!null indrelid:79!null indisclustered:85!null
       │    │    │         │    │    │    │    │    ├── key: (78)
-      │    │    │         │    │    │    │    │    └── fd: (78)-->(79,85)
-      │    │    │         │    │    │    │    └── filters
-      │    │    │         │    │    │    │         └── indisclustered:85 = true [outer=(85), constraints=(/85: [/true - /true]; tight), fd=()-->(85)]
-      │    │    │         │    │    │    ├── left-join (lookup pg_tablespace)
-      │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 ftrelid:126 ftserver:127 ftoptions:128
-      │    │    │         │    │    │    │    ├── key columns: [8] = [34]
-      │    │    │         │    │    │    │    ├── lookup columns are key
-      │    │    │         │    │    │    │    ├── key: (1)
-      │    │    │         │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
-      │    │    │         │    │    │    │    ├── left-join (lookup pg_foreign_table)
-      │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null ftrelid:126 ftserver:127 ftoptions:128
-      │    │    │         │    │    │    │    │    ├── key columns: [1] = [126]
+      │    │    │         │    │    │    │    │    ├── fd: ()-->(85), (78)-->(79)
+      │    │    │         │    │    │    │    │    ├── scan ind
+      │    │    │         │    │    │    │    │    │    ├── columns: indexrelid:78!null indrelid:79!null indisclustered:85!null
+      │    │    │         │    │    │    │    │    │    ├── key: (78)
+      │    │    │         │    │    │    │    │    │    └── fd: (78)-->(79,85)
+      │    │    │         │    │    │    │    │    └── filters
+      │    │    │         │    │    │    │    │         └── indisclustered:85 = true [outer=(85), constraints=(/85: [/true - /true]; tight), fd=()-->(85)]
+      │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace)
+      │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 ftrelid:126 ftserver:127 ftoptions:128
+      │    │    │         │    │    │    │    │    ├── key columns: [8] = [34]
       │    │    │         │    │    │    │    │    ├── lookup columns are key
       │    │    │         │    │    │    │    │    ├── key: (1)
-      │    │    │         │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (3)==(29), (29)==(3)
-      │    │    │         │    │    │    │    │    ├── inner-join (hash)
-      │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null
-      │    │    │         │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    │         │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+      │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_table)
+      │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null ftrelid:126 ftserver:127 ftoptions:128
+      │    │    │         │    │    │    │    │    │    ├── key columns: [1] = [126]
+      │    │    │         │    │    │    │    │    │    ├── lookup columns are key
       │    │    │         │    │    │    │    │    │    ├── key: (1)
-      │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3)
-      │    │    │         │    │    │    │    │    │    ├── select
-      │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+      │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (3)==(29), (29)==(3)
+      │    │    │         │    │    │    │    │    │    ├── inner-join (hash)
+      │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null
+      │    │    │         │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       │    │    │         │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
-      │    │    │         │    │    │    │    │    │    │    ├── scan c
+      │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3)
+      │    │    │         │    │    │    │    │    │    │    ├── select
       │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
       │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+      │    │    │         │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+      │    │    │         │    │    │    │    │    │    │    │    ├── scan c
+      │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+      │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │         │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+      │    │    │         │    │    │    │    │    │    │    │    └── filters
+      │    │    │         │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
+      │    │    │         │    │    │    │    │    │    │    ├── scan n@pg_namespace_nspname_index
+      │    │    │         │    │    │    │    │    │    │    │    ├── columns: n.oid:29!null n.nspname:30!null
+      │    │    │         │    │    │    │    │    │    │    │    ├── constraint: /30: [/'public' - /'public']
+      │    │    │         │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │         │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │         │    │    │    │    │    │    │    │    └── fd: ()-->(29,30)
       │    │    │         │    │    │    │    │    │    │    └── filters
-      │    │    │         │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
-      │    │    │         │    │    │    │    │    │    ├── scan n@pg_namespace_nspname_index
-      │    │    │         │    │    │    │    │    │    │    ├── columns: n.oid:29!null n.nspname:30!null
-      │    │    │         │    │    │    │    │    │    │    ├── constraint: /30: [/'public' - /'public']
-      │    │    │         │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │         │    │    │    │    │    │    │    ├── key: ()
-      │    │    │         │    │    │    │    │    │    │    └── fd: ()-->(29,30)
-      │    │    │         │    │    │    │    │    │    └── filters
-      │    │    │         │    │    │    │    │    │         └── n.oid:29 = c.relnamespace:3 [outer=(3,29), constraints=(/3: (/NULL - ]; /29: (/NULL - ]), fd=(3)==(29), (29)==(3)]
+      │    │    │         │    │    │    │    │    │    │         └── n.oid:29 = c.relnamespace:3 [outer=(3,29), constraints=(/3: (/NULL - ]; /29: (/NULL - ]), fd=(3)==(29), (29)==(3)]
+      │    │    │         │    │    │    │    │    │    └── filters (true)
       │    │    │         │    │    │    │    │    └── filters (true)
-      │    │    │         │    │    │    │    └── filters (true)
-      │    │    │         │    │    │    └── filters
-      │    │    │         │    │    │         └── indrelid:79 = c.oid:1 [outer=(1,79), constraints=(/1: (/NULL - ]; /79: (/NULL - ]), fd=(1)==(79), (79)==(1)]
-      │    │    │         │    │    └── filters (true)
-      │    │    │         │    └── filters
-      │    │    │         │         └── i.inhrelid:41 = c.oid:1 [outer=(1,41), constraints=(/1: (/NULL - ]; /41: (/NULL - ]), fd=(1)==(41), (41)==(1)]
+      │    │    │         │    │    │    │    └── filters
+      │    │    │         │    │    │    │         └── indrelid:79 = c.oid:1 [outer=(1,79), constraints=(/1: (/NULL - ]; /79: (/NULL - ]), fd=(1)==(79), (79)==(1)]
+      │    │    │         │    │    │    └── filters (true)
+      │    │    │         │    │    └── filters
+      │    │    │         │    │         └── i.inhrelid:41 = c.oid:1 [outer=(1,41), constraints=(/1: (/NULL - ]; /41: (/NULL - ]), fd=(1)==(41), (41)==(1)]
+      │    │    │         │    └── filters (true)
       │    │    │         └── filters (true)
       │    │    └── filters
       │    │         └── pg_inherits.inhparent:140 = c.oid:1 [outer=(1,140), constraints=(/1: (/NULL - ]; /140: (/NULL - ]), fd=(1)==(140), (140)==(1)]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -642,7 +642,7 @@ left-join (merge)
 
 # Don't add a join between xyz and stu to the memo (because doing so would
 # create a cross join).
-memo
+exploretrace rule=ReorderJoins format=hide-all
 SELECT *
 FROM stu
 INNER JOIN abc
@@ -650,58 +650,32 @@ ON s = a
 INNER JOIN xyz
 ON b = y
 ----
-memo (optimized, ~27KB, required=[presentation: s:1,t:2,u:3,a:5,b:6,c:7,x:10,y:11,z:12])
- ├── G1: (inner-join G2 G3 G4) (inner-join G5 G6 G7) (inner-join G3 G2 G4) (merge-join G2 G3 G8 inner-join,+6,+11) (lookup-join G2 G8 xyz@yz,keyCols=[6],outCols=(1-3,5-7,10-12)) (inner-join G6 G5 G7) (merge-join G5 G6 G8 inner-join,+1,+5) (merge-join G3 G2 G8 inner-join,+11,+6) (merge-join G6 G5 G8 inner-join,+5,+1) (lookup-join G6 G8 stu,keyCols=[5],outCols=(1-3,5-7,10-12))
- │    └── [presentation: s:1,t:2,u:3,a:5,b:6,c:7,x:10,y:11,z:12]
- │         ├── best: (inner-join G2 G3 G4)
- │         └── cost: 14072.69
- ├── G2: (inner-join G5 G9 G7) (inner-join G9 G5 G7) (merge-join G5 G9 G8 inner-join,+1,+5) (lookup-join G5 G8 abc@ab,keyCols=[1],outCols=(1-3,5-7)) (merge-join G9 G5 G8 inner-join,+5,+1) (lookup-join G9 G8 stu,keyCols=[5],outCols=(1-3,5-7))
- │    ├── [ordering: +6]
- │    │    ├── best: (sort G2)
- │    │    └── cost: 14737.60
- │    └── []
- │         ├── best: (merge-join G5="[ordering: +1]" G9="[ordering: +5]" G8 inner-join,+1,+5)
- │         └── cost: 11880.05
- ├── G3: (scan xyz,cols=(10-12)) (scan xyz@xy,cols=(10-12)) (scan xyz@yz,cols=(10-12))
- │    ├── [ordering: +11]
- │    │    ├── best: (scan xyz@yz,cols=(10-12))
- │    │    └── cost: 1070.02
- │    └── []
- │         ├── best: (scan xyz,cols=(10-12))
- │         └── cost: 1070.02
- ├── G4: (filters G10)
- ├── G5: (scan stu,cols=(1-3)) (scan stu@uts,cols=(1-3))
- │    ├── [ordering: +1]
- │    │    ├── best: (scan stu,cols=(1-3))
- │    │    └── cost: 10600.02
- │    └── []
- │         ├── best: (scan stu,cols=(1-3))
- │         └── cost: 10600.02
- ├── G6: (inner-join G9 G3 G4) (inner-join G3 G9 G4) (merge-join G9 G3 G8 inner-join,+6,+11) (lookup-join G9 G8 xyz@yz,keyCols=[6],outCols=(5-7,10-12)) (merge-join G3 G9 G8 inner-join,+11,+6) (lookup-join G3 G8 abc@bc,keyCols=[11],outCols=(5-7,10-12))
- │    ├── [ordering: +5]
- │    │    ├── best: (sort G6)
- │    │    └── cost: 5053.06
- │    └── []
- │         ├── best: (merge-join G9="[ordering: +6]" G3="[ordering: +11]" G8 inner-join,+6,+11)
- │         └── cost: 2258.06
- ├── G7: (filters G11)
- ├── G8: (filters)
- ├── G9: (scan abc,cols=(5-7)) (scan abc@ab,cols=(5-7)) (scan abc@bc,cols=(5-7))
- │    ├── [ordering: +5]
- │    │    ├── best: (scan abc@ab,cols=(5-7))
- │    │    └── cost: 1070.02
- │    ├── [ordering: +6]
- │    │    ├── best: (scan abc@bc,cols=(5-7))
- │    │    └── cost: 1070.02
- │    └── []
- │         ├── best: (scan abc,cols=(5-7))
- │         └── cost: 1070.02
- ├── G10: (eq G12 G13)
- ├── G11: (eq G14 G15)
- ├── G12: (variable b)
- ├── G13: (variable y)
- ├── G14: (variable s)
- └── G15: (variable a)
+----
+================================================================================
+ReorderJoins
+================================================================================
+Source expression:
+  inner-join (hash)
+   ├── inner-join (merge)
+   │    ├── scan stu
+   │    ├── scan abc@ab
+   │    └── filters (true)
+   ├── scan xyz
+   └── filters
+        └── b = y
+
+New expression 1 of 1:
+  inner-join (hash)
+   ├── scan stu
+   ├── inner-join (hash)
+   │    ├── scan abc
+   │    ├── scan xyz
+   │    └── filters
+   │         └── b = y
+   └── filters
+        └── s = a
+----
+----
 
 # Left join under an inner join. Push the inner join into the left input of the
 # left join.
@@ -838,7 +812,7 @@ project
 
 # Inner join in the right input of a left join; no reordering is valid apart
 # from commutation.
-memo expect=ReorderJoins
+exploretrace rule=ReorderJoins format=hide-all
 SELECT *
 FROM small
 LEFT JOIN
@@ -850,42 +824,27 @@ LEFT JOIN
 ) large
 ON small.m = large.m
 ----
-memo (optimized, ~16KB, required=[presentation: m:1,n:2,m:5])
- ├── G1: (project G2 G3 m n m)
- │    └── [presentation: m:1,n:2,m:5]
- │         ├── best: (project G2 G3 m n m)
- │         └── cost: 106250127813.24
- ├── G2: (left-join G4 G5 G6) (right-join G5 G4 G6)
- │    └── []
- │         ├── best: (right-join G5 G4 G6)
- │         └── cost: 106250127813.13
- ├── G3: (projections)
- ├── G4: (scan small,cols=(1,2))
- │    └── []
- │         ├── best: (scan small,cols=(1,2))
- │         └── cost: 10.52
- ├── G5: (inner-join G7 G8 G9) (inner-join G8 G7 G9)
- │    └── []
- │         ├── best: (inner-join G7 G8 G9)
- │         └── cost: 106250115551.06
- ├── G6: (filters G10)
- ├── G7: (scan large,cols=(5,6))
- │    └── []
- │         ├── best: (scan large,cols=(5,6))
- │         └── cost: 105000000000.02
- ├── G8: (scan medium,cols=(10))
- │    └── []
- │         ├── best: (scan medium,cols=(10))
- │         └── cost: 104000.02
- ├── G9: (filters G11)
- ├── G10: (eq G12 G13)
- ├── G11: (eq G14 G15)
- ├── G12: (variable small.m)
- ├── G13: (variable large.m)
- ├── G14: (variable large.n)
- └── G15: (variable medium.n)
+----
+================================================================================
+ReorderJoins
+================================================================================
+Source expression:
+  project
+   └── left-join (hash)
+        ├── scan small
+        ├── inner-join (hash)
+        │    ├── scan large
+        │    ├── scan medium
+        │    └── filters
+        │         └── large.n = medium.n
+        └── filters
+             └── small.m = large.m
 
-memo expect=ReorderJoins
+No new expressions.
+----
+----
+
+exploretrace rule=ReorderJoins format=hide-all
 SELECT *
 FROM
 (
@@ -897,65 +856,205 @@ INNER JOIN small
 ON result.a = small.n AND (small.m = result.b OR result.b IS NULL)
 INNER JOIN xyz ON True
 ----
-memo (optimized, ~29KB, required=[presentation: a:2,b:6,m:9,n:10,x:13,y:14,z:15])
- ├── G1: (project G2 G3 n n m n x y z)
- │    └── [presentation: a:2,b:6,m:9,n:10,x:13,y:14,z:15]
- │         ├── best: (project G2 G3 n n m n x y z)
- │         └── cost: 106250763119.61
- ├── G2: (inner-join G4 G5 G6) (inner-join G5 G4 G6)
- │    └── []
- │         ├── best: (inner-join G4 G5 G6)
- │         └── cost: 106250436419.60
- ├── G3: (projections)
- ├── G4: (inner-join G7 G8 G9) (select G10 G11) (inner-join G8 G7 G9)
- │    └── []
- │         ├── best: (select G10 G11)
- │         └── cost: 106250108223.69
- ├── G5: (scan xyz,cols=(13-15)) (scan xyz@xy,cols=(13-15)) (scan xyz@yz,cols=(13-15))
- │    └── []
- │         ├── best: (scan xyz,cols=(13-15))
- │         └── cost: 1070.02
- ├── G6: (filters)
- ├── G7: (left-join G12 G13 G14) (right-join G13 G12 G14)
- │    └── []
- │         ├── best: (right-join G13 G12 G14)
- │         └── cost: 106251106750.06
- ├── G8: (scan small,cols=(9,10))
- │    └── []
- │         ├── best: (scan small,cols=(9,10))
- │         └── cost: 10.52
- ├── G9: (filters G15 G16)
- ├── G10: (left-join G17 G13 G14) (right-join G13 G17 G14)
- │    └── []
- │         ├── best: (right-join G13 G17 G14)
- │         └── cost: 106250107243.57
- ├── G11: (filters G16)
- ├── G12: (scan medium,cols=(1,2))
- │    └── []
- │         ├── best: (scan medium,cols=(1,2))
- │         └── cost: 105000.02
- ├── G13: (scan large,cols=(5,6))
- │    └── []
- │         ├── best: (scan large,cols=(5,6))
- │         └── cost: 105000000000.02
- ├── G14: (filters G18)
- ├── G15: (eq G19 G20)
- ├── G16: (or G21 G22)
- ├── G17: (inner-join G12 G8 G23) (inner-join G8 G12 G23)
- │    └── []
- │         ├── best: (inner-join G12 G8 G23)
- │         └── cost: 106261.72
- ├── G18: (eq G24 G25)
- ├── G19: (variable medium.n)
- ├── G20: (variable small.n)
- ├── G21: (eq G26 G27)
- ├── G22: (is G27 G28)
- ├── G23: (filters G15)
- ├── G24: (variable large.m)
- ├── G25: (variable medium.m)
- ├── G26: (variable small.m)
- ├── G27: (variable large.n)
- └── G28: (null)
+----
+================================================================================
+ReorderJoins
+================================================================================
+Source expression:
+  project
+   └── inner-join (cross)
+        ├── inner-join (hash)
+        │    ├── right-join (hash)
+        │    │    ├── scan large
+        │    │    ├── scan medium
+        │    │    └── filters
+        │    │         └── large.m = medium.m
+        │    ├── scan small
+        │    └── filters
+        │         ├── medium.n = small.n
+        │         └── (small.m = large.n) OR (large.n IS NULL)
+        ├── scan xyz
+        └── filters (true)
+
+New expression 1 of 1:
+  project
+   └── inner-join (cross)
+        ├── select
+        │    ├── left-join (hash)
+        │    │    ├── inner-join (hash)
+        │    │    │    ├── scan medium
+        │    │    │    ├── scan small
+        │    │    │    └── filters
+        │    │    │         └── medium.n = small.n
+        │    │    ├── scan large
+        │    │    └── filters
+        │    │         └── large.m = medium.m
+        │    └── filters
+        │         └── (small.m = large.n) OR (large.n IS NULL)
+        ├── scan xyz
+        └── filters (true)
+
+================================================================================
+ReorderJoins
+================================================================================
+Source expression:
+  project
+   └── inner-join (cross)
+        ├── select
+        │    ├── right-join (hash)
+        │    │    ├── scan large
+        │    │    ├── inner-join (hash)
+        │    │    │    ├── scan medium
+        │    │    │    ├── scan small
+        │    │    │    └── filters
+        │    │    │         └── medium.n = small.n
+        │    │    └── filters
+        │    │         └── large.m = medium.m
+        │    └── filters
+        │         └── (small.m = large.n) OR (large.n IS NULL)
+        ├── scan xyz
+        └── filters (true)
+
+No new expressions.
+----
+----
+
+# Full join on top of a full join.
+exploretrace rule=ReorderJoins format=hide-all
+SELECT * FROM abc
+FULL JOIN stu ON s = a
+FULL JOIN xyz ON b = y
+----
+----
+================================================================================
+ReorderJoins
+================================================================================
+Source expression:
+  full-join (hash)
+   ├── full-join (merge)
+   │    ├── scan abc@ab
+   │    ├── scan stu
+   │    └── filters (true)
+   ├── scan xyz
+   └── filters
+        └── b = y
+
+New expression 1 of 1:
+  full-join (hash)
+   ├── full-join (hash)
+   │    ├── scan abc
+   │    ├── scan xyz
+   │    └── filters
+   │         └── b = y
+   ├── scan stu
+   └── filters
+        └── s = a
+----
+----
+
+# Full join on top of a full join. Lower join is in right input of upper join.
+exploretrace rule=ReorderJoins format=hide-all
+SELECT * FROM abc
+FULL JOIN
+(
+  SELECT * FROM stu
+  FULL JOIN xyz ON t = y
+) f(s, t, u, x, y, z)
+ON a = x
+----
+----
+================================================================================
+ReorderJoins
+================================================================================
+Source expression:
+  full-join (hash)
+   ├── scan abc
+   ├── full-join (hash)
+   │    ├── scan stu
+   │    ├── scan xyz
+   │    └── filters
+   │         └── t = y
+   └── filters
+        └── a = x
+
+New expression 1 of 1:
+  full-join (hash)
+   ├── scan stu
+   ├── full-join (hash)
+   │    ├── scan abc
+   │    ├── scan xyz
+   │    └── filters
+   │         └── a = x
+   └── filters
+        └── t = y
+----
+----
+
+# Left join on top of a left join.
+exploretrace rule=ReorderJoins format=hide-all
+SELECT * FROM abc
+LEFT JOIN stu ON s = a
+LEFT JOIN xyz ON b = y
+----
+----
+================================================================================
+ReorderJoins
+================================================================================
+Source expression:
+  left-join (hash)
+   ├── left-join (merge)
+   │    ├── scan abc@ab
+   │    ├── scan stu
+   │    └── filters (true)
+   ├── scan xyz
+   └── filters
+        └── b = y
+
+New expression 1 of 1:
+  left-join (hash)
+   ├── left-join (hash)
+   │    ├── scan abc
+   │    ├── scan xyz
+   │    └── filters
+   │         └── b = y
+   ├── scan stu
+   └── filters
+        └── s = a
+----
+----
+
+# Left join on top of a full join.
+exploretrace rule=ReorderJoins format=hide-all
+SELECT * FROM abc
+FULL JOIN stu ON s = a
+LEFT JOIN xyz ON b = y
+----
+----
+================================================================================
+ReorderJoins
+================================================================================
+Source expression:
+  left-join (hash)
+   ├── full-join (merge)
+   │    ├── scan abc@ab
+   │    ├── scan stu
+   │    └── filters (true)
+   ├── scan xyz
+   └── filters
+        └── b = y
+
+New expression 1 of 1:
+  full-join (hash)
+   ├── left-join (hash)
+   │    ├── scan abc
+   │    ├── scan xyz
+   │    └── filters
+   │         └── b = y
+   ├── scan stu
+   └── filters
+        └── s = a
+----
+----
 
 # --------------------------------------------------
 # CommuteJoin

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -1326,7 +1326,9 @@ left-join (hash)
 ----
 
 # Left-asscom property does not apply when the upper left join references the
-# right side of the lower.
+# right side of the lower. However, associative property does apply when the
+# predicate of the upper join rejects nulls on the right input of the lower
+# join.
 reorderjoins format=hide-all
 SELECT *
 FROM bx
@@ -1362,10 +1364,13 @@ y = z [left]
 
 ----Joining AB----
 A B    refs [AB] [left]
+----Joining BC----
+B C    refs [BC] [left]
 ----Joining ABC----
+A BC    refs [AB] [left]
 AB C    refs [BC] [left]
 
-Joins Considered: 2
+Joins Considered: 4
 --------------------------------------------------------------------------------
 ----Final Plan----
 left-join (hash)
@@ -1633,6 +1638,62 @@ inner-join (cross)
  │    └── filters (true)
  ├── scan dz
  └── filters (true)
+--------------------------------------------------------------------------------
+----
+----
+
+reorderjoins format=hide-all
+SELECT *
+FROM bx
+FULL JOIN cy ON b = c
+FULL JOIN dz ON y = z
+----
+----
+--------------------------------------------------------------------------------
+----Join Tree #1----
+full-join (hash)
+ ├── full-join (hash)
+ │    ├── scan bx
+ │    ├── scan cy
+ │    └── filters
+ │         └── b = c
+ ├── scan dz
+ └── filters
+      └── y = z
+
+----Vertexes----
+A:
+scan bx
+
+B:
+scan cy
+
+C:
+scan dz
+
+----Edges----
+b = c [full]
+y = z [full]
+
+----Joining AB----
+A B    refs [AB] [full]
+----Joining BC----
+B C    refs [BC] [full]
+----Joining ABC----
+A BC    refs [AB] [full]
+AB C    refs [BC] [full]
+
+Joins Considered: 4
+--------------------------------------------------------------------------------
+----Final Plan----
+full-join (hash)
+ ├── full-join (merge)
+ │    ├── scan bx
+ │    ├── scan cy
+ │    └── filters (true)
+ ├── scan dz
+ └── filters
+      └── y = z
 --------------------------------------------------------------------------------
 ----
 ----


### PR DESCRIPTION
Some join transformations are only conditionally valid, depending
upon the null-rejecting properties of the join predicates. For
example, this transformation is only valid because both join
predicates reject nulls on relation xy:
```
SELECT * FROM
(
  SELECT * FROM xy
  FULL JOIN ab ON x = a
)
FULL JOIN cd ON c = x
=>
SELECT * FROM
(
  SELECT * FROM xy
  FULL JOIN cd ON c = x
)
FULL JOIN ab ON x = a
```
This patch extends the join property lookup tables of
join_order_builder.go to allow reordering in these cases.

Release note: None