### PR TITLE
cli: make fewer assumptions about the origin of `stderr` in tests

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -51,6 +51,7 @@ type cliTest struct {
 	*server.TestServer
 	certsDir    string
 	cleanupFunc func() error
+	prevStderr  *os.File
 
 	// t is the testing.T instance used for this test.
 	// Example_xxx tests may have this set to nil.
@@ -157,6 +158,7 @@ func newCLITest(params cliTestParams) cliTest {
 	// Ensure that CLI error messages and anything meant for the
 	// original stderr is redirected to stdout, where it can be
 	// captured.
+	c.prevStderr = stderr
 	stderr = os.Stdout
 
 	return c
@@ -218,7 +220,7 @@ func (c *cliTest) cleanup() {
 	}()
 
 	// Restore stderr.
-	stderr = log.OrigStderr
+	stderr = c.prevStderr
 
 	log.Info(context.Background(), "stopping server and cleaning up CLI test")
 

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -230,8 +230,8 @@ func TestUnavailableZip(t *testing.T) {
 		t:          t,
 		TestServer: tc.Server(0).(*server.TestServer),
 	}
+	defer func(prevStderr *os.File) { stderr = prevStderr }(stderr)
 	stderr = os.Stdout
-	defer func() { stderr = log.OrigStderr }()
 
 	// Keep the timeout short so that the test doesn't take forever.
 	out, err := c.RunWithCapture("debug zip --cpu-profile-duration=0 " + os.DevNull + " --timeout=.5s")
@@ -304,8 +304,8 @@ func TestPartialZip(t *testing.T) {
 		t:          t,
 		TestServer: tc.Server(0).(*server.TestServer),
 	}
+	defer func(prevStderr *os.File) { stderr = prevStderr }(stderr)
 	stderr = os.Stdout
-	defer func() { stderr = log.OrigStderr }()
 
 	// NB: we spend a second profiling here to make sure it actually tries the
 	// down nodes (and fails only there, succeeding on the available node).


### PR DESCRIPTION
This further removes a dependency on the knowledge that the `log`
package knows anything about stderr, in CLI tests.

Found this while working on #52200.

Release note: None