### PR TITLE
sql: add another exception for vectorize=experimental_always

### DIFF
--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -202,8 +202,16 @@ func (p *planNodeToRowSource) ConsumerClosed() {
 
 // IsException implements the VectorizeAlwaysException interface.
 func (p *planNodeToRowSource) IsException() bool {
-	_, ok := p.node.(*setVarNode)
-	return ok
+	if _, ok := p.node.(*setVarNode); ok {
+		// We need to make an exception for changing a session variable.
+		return true
+	}
+	if d, ok := p.node.(*delayedNode); ok {
+		// We want to make an exception for retrieving the current database
+		// name (which is done via a scan of 'session_variables' virtual table.
+		return d.name == "session_variables@primary"
+	}
+	return false
 }
 
 // forwardMetadata will be called by any upstream rowSourceToPlanNode processors


### PR DESCRIPTION
`vectorize=experimental_always` forces the execution of all queries to
be run via the vectorized engine, if that for some reason fails, an
error is returned. The only exception to that rule so far has been `SET`
statements because we need to be able to change the session variable.
This commit adds another exception for retrieving the database name
which allows us to remove cryptic "warning: error retrieving the database
name: pq: unable to vectorize execution plan: core.LocalPlanNode is not
supported" message that is displayed after the query in question has
been executed in the CLI.

Release note: None