### PR TITLE
opt: clean up zig-zag join execution operator

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -656,14 +656,15 @@ func (e *distSQLSpecExecFactory) ConstructInvertedJoin(
 func (e *distSQLSpecExecFactory) ConstructZigzagJoin(
 	leftTable cat.Table,
 	leftIndex cat.Index,
+	leftCols exec.TableColumnOrdinalSet,
+	leftFixedVals []tree.TypedExpr,
+	leftEqCols []exec.TableColumnOrdinal,
 	rightTable cat.Table,
 	rightIndex cat.Index,
-	leftEqCols []exec.NodeColumnOrdinal,
-	rightEqCols []exec.NodeColumnOrdinal,
-	leftCols exec.NodeColumnOrdinalSet,
-	rightCols exec.NodeColumnOrdinalSet,
+	rightCols exec.TableColumnOrdinalSet,
+	rightFixedVals []tree.TypedExpr,
+	rightEqCols []exec.TableColumnOrdinal,
 	onCond tree.TypedExpr,
-	fixedVals []exec.Node,
 	reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: zigzag join")

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -252,22 +252,44 @@ define InvertedJoin {
 
 # ZigzagJoin performs a zigzag join.
 #
-# Each side of the join has two kinds of columns that form a prefix
-# of the specified index: fixed columns (with values specified in
-# fixedVals), and equal columns (with column ordinals specified in
-# {left,right}EqCols). The lengths of leftEqCols and rightEqCols
-# must match.
+# Each side of the join has two kinds of columns: fixed columns and equal
+# columns. The fixed columns correspond 1-to-1 to a prefix of the index columns.
+# The fixed columns and the equal columns together also form a prefix of the
+# index columns.
 define ZigzagJoin {
+    # Left table and index.
     LeftTable cat.Table
     LeftIndex cat.Index
+
+    # LeftCols are the columns that are scanned from the left index.
+    LeftCols exec.TableColumnOrdinalSet
+
+    # LeftFixedVals contains values for the fixed columns (a prefix of the
+    # index columns).
+    LeftFixedVals []tree.TypedExpr
+
+    # LeftEqCols are the left table columns that have equality constraints,
+    # corresponding 1-1 to RightEqCols.
+    LeftEqCols []exec.TableColumnOrdinal
+
+    # Right table and index.
     RightTable cat.Table
     RightIndex cat.Index
-    LeftEqCols []exec.NodeColumnOrdinal
-    RightEqCols []exec.NodeColumnOrdinal
-    LeftCols exec.NodeColumnOrdinalSet
-    RightCols exec.NodeColumnOrdinalSet
+
+    # RightCols are the columns that are scanned from the right index.
+    RightCols exec.TableColumnOrdinalSet
+
+    # RightFixedVals contains values for the fixed columns (a prefix of the
+    # index columns).
+    RightFixedVals []tree.TypedExpr
+
+    # RightEqCols are the right table columns that have equality constraints,
+    # corresponding 1-1 to LeftEqCols.
+    RightEqCols []exec.TableColumnOrdinal
+
+    # OnCond is an extra filter that is evaluated on the results.
+    # TODO(radu): remove this (it can be a separate Select).
     OnCond tree.TypedExpr
-    FixedVals []exec.Node
     ReqOrdering exec.OutputOrdering
 }
 


### PR DESCRIPTION
This change cleans up the zig-zag join execution primitive. We no
longer pass the fixed values as a collection of Values nodes (which
was strange and unnecessary). Instead, we pass them as simple lists of
expressions. The arguments are reorganized and corrected to refer to
TableColumnOrdinals instead of NodeColumnOrdinals.

Release note: None