### PR TITLE
cli: improve interactive sql shell timings

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -217,6 +217,9 @@ var sqlCtx = struct {
 	// "intelligent behavior" in the SQL shell as possible and become
 	// more verbose (sets echo).
 	debugMode bool
+
+	// Determines whether to display server execution timings in the CLI.
+	enableServerExecutionTimings bool
 }{cliContext: &cliCtx}
 
 // setSQLContextDefaults set the default values in sqlCtx.  This
@@ -230,6 +233,7 @@ func setSQLContextDefaults() {
 	sqlCtx.showTimes = false
 	sqlCtx.debugMode = false
 	sqlCtx.echo = false
+	sqlCtx.enableServerExecutionTimings = false
 }
 
 // zipCtx captures the command-line parameters of the `zip` command.

--- a/pkg/cli/interactive_tests/test_timing.tcl
+++ b/pkg/cli/interactive_tests/test_timing.tcl
@@ -1,0 +1,30 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+# This test ensures timing displayed in the CLI works as expected.
+
+spawn $argv demo movr
+eexpect root@
+
+start_test "Test that server execution time and network latency are printed by default."
+send "SELECT * FROM vehicles LIMIT 1;\r"
+eexpect "1 row"
+eexpect "Server Execution Time:"
+eexpect "Network Latency:"
+
+# Ditto with multiple statements on one line
+send "SELECT * FROM vehicles LIMIT 1; CREATE TABLE t(a int);\r"
+eexpect "1 row"
+eexpect "Note: timings for multiple statements on a single line are not supported"
+end_test
+
+start_test "Test show_server_execution_times works correctly"
+send "\\set show_server_times=false\r"
+send "SELECT * FROM vehicles LIMIT 1;\r"
+eexpect "\nTime:"
+send "\\set show_server_times=true\r"
+send "SELECT * FROM vehicles LIMIT 1;\r"
+eexpect "Server Execution Time:"
+eexpect "Network Latency:"
+end_test

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -229,11 +229,31 @@ func Parse(sql string) (Statements, error) {
 // single statement, and returns that Statement. ParseOne will always
 // interpret the INT and SERIAL types as 64-bit types, since this is
 // used in various internal-execution paths where we might receive
-// bits of SQL from other nodes. In general, we expect that all
+// bits of SQL from other nodes. In general,earwe expect that all
 // user-generated SQL has been run through the ParseWithInt() function.
 func ParseOne(sql string) (Statement, error) {
 	var p Parser
 	return p.parseOneWithDepth(1, sql)
+}
+
+// HasMultipleStatements returns true if the sql string contains more than one
+// statements.
+func HasMultipleStatements(sql string) bool {
+	var p Parser
+	p.scanner.init(sql)
+	defer p.scanner.cleanup()
+	count := 0
+	for {
+		_, _, done := p.scanOneStmt()
+		if done {
+			break
+		}
+		count++
+		if count > 1 {
+			return true
+		}
+	}
+	return false
 }
 
 // ParseQualifiedTableName parses a SQL string of the form


### PR DESCRIPTION
Previously, the CLI displayed timings by timing a query on the client.
This would include both the client-server latency and the query
execution time, without bucketing which is what. This patch changes
this by switching the way we calculate timings in the CLI. Instead of
timing on the client, we now send a `SHOW LAST QUERY STATISTICS` query
after a statement is executed. This allows us to display both the
network latency and the network latency as separate values.

Additionally, this patch no longer displays timings for queries that
include multiple statements on one line. This is to mitigate #48180,
where timings for executing all the statements are incorrectly
attributed to the first statement. Actually fixing the issue is beyond
the scope of this PR.

Fixes #49450

Release note (cli change): The CLI no longer prints a blanket `Time`
for queries. Instead, if `show_times` is turned on and the server
version is >=20.2, the CLI prints two separate times -- the server
execution time and the network latency.

Release justification: low risk, high benefit change to existing
functionality.