### PR TITLE
storage: don't corrupt unsafe value buffer in replayTransactionalWrite

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -64,10 +64,10 @@ type SimpleIterator interface {
 	// for a key.
 	NextKey()
 	// UnsafeKey returns the same value as Key, but the memory is invalidated on
-	// the next call to {Next,Prev,Seek,SeekReverse,Close}.
+	// the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
 	UnsafeKey() MVCCKey
 	// UnsafeValue returns the same value as Value, but the memory is
-	// invalidated on the next call to {Next,Prev,Seek,SeekReverse,Close}.
+	// invalidated on the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
 	UnsafeValue() []byte
 }
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1322,6 +1322,7 @@ func replayTransactionalWrite(
 ) error {
 	var found bool
 	var writtenValue []byte
+	var writtenValueSafety valueSafety
 	var err error
 	metaKey := MakeMVCCMetadataKey(key)
 	if txn.Sequence == meta.Txn.Sequence {
@@ -1332,7 +1333,7 @@ func replayTransactionalWrite(
 		defer getBuf.release()
 		getBuf.meta = buf.meta
 		var exVal *roachpb.Value
-		if exVal, _, _, err = mvccGetInternal(
+		if exVal, _, writtenValueSafety, err = mvccGetInternal(
 			ctx, iter, metaKey, timestamp, true /* consistent */, unsafeValue, txn, getBuf); err != nil {
 			return err
 		}
@@ -1341,6 +1342,7 @@ func replayTransactionalWrite(
 	} else {
 		// Get the value from the intent history.
 		writtenValue, found = meta.GetIntentValue(txn.Sequence)
+		writtenValueSafety = safeValue
 	}
 	if !found {
 		return errors.Errorf("transaction %s with sequence %d missing an intent with lower sequence %d",
@@ -1360,8 +1362,14 @@ func replayTransactionalWrite(
 			prevVal := prevIntent.Value
 
 			exVal = &roachpb.Value{RawBytes: prevVal}
-		}
-		if exVal == nil {
+		} else {
+			// We're going to be using the iterator again, so make sure the
+			// existing writtenValue bytes are safe and won't be corrupted.
+			if writtenValueSafety == unsafeValue {
+				writtenValue = append([]byte(nil), writtenValue...)
+				writtenValueSafety = safeValue
+			}
+
 			// If the previous value at the key wasn't written by this
 			// transaction, or it was hidden by a rolled back seqnum, we
 			// look at last committed value on the key.

--- a/pkg/storage/testdata/mvcc_histories/idempotent_transactions
+++ b/pkg/storage/testdata/mvcc_histories/idempotent_transactions
@@ -54,7 +54,7 @@ error: (*withstack.withStack:) transaction 00000000-0000-0000-0000-000000000001 
 
 run ok
 with t=a k=i
-  # On a separate key, start an increment.
+  # On a separate nonexistent key, start an increment.
   txn_step n=3
   increment
   # As long as the sequence is unchanged, replaying the increment doesn't increase the value.
@@ -75,8 +75,11 @@ data: "i"/0.000000011,0 -> /INT/1
 
 run ok
 with t=a k=i
-  # Increment again.
+  # Increment previously nonexistent key again.
   txn_step
+  increment
+  # As long as the sequence is unchanged, replaying the increment doesn't increase the value.
+  increment
   increment
   txn_step n=-1
   # Replaying an older increment doesn't increase the value.
@@ -84,6 +87,8 @@ with t=a k=i
   increment
   increment
 ----
+inc: current value = 2
+inc: current value = 2
 inc: current value = 2
 inc: current value = 1
 inc: current value = 1
@@ -94,3 +99,69 @@ meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 
 data: "a"/0.000000011,0 -> /BYTES/second
 meta: "i"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=3} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{2 /INT/1}}
 data: "i"/0.000000011,0 -> /INT/2
+
+# Write a key outside of the transaction.
+run ok
+increment k=i2 ts=10
+----
+inc: current value = 1
+>> at end:
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=1} ts=0.000000011,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
+data: "a"/0.000000011,0 -> /BYTES/second
+meta: "i"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=3} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{2 /INT/1}}
+data: "i"/0.000000011,0 -> /INT/2
+data: "i2"/0.000000010,0 -> /INT/1
+
+run ok
+with t=a k=i2
+  # On a separate existent key, start an increment.
+  txn_step n=2
+  increment
+  # As long as the sequence is unchanged, replaying the increment doesn't increase the value.
+  increment
+  increment
+  increment
+----
+inc: current value = 2
+inc: current value = 2
+inc: current value = 2
+inc: current value = 2
+>> at end:
+txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=4} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=1} ts=0.000000011,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
+data: "a"/0.000000011,0 -> /BYTES/second
+meta: "i"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=3} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{2 /INT/1}}
+data: "i"/0.000000011,0 -> /INT/2
+meta: "i2"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=4} ts=0.000000011,0 del=false klen=12 vlen=6
+data: "i2"/0.000000011,0 -> /INT/2
+data: "i2"/0.000000010,0 -> /INT/1
+
+run ok
+with t=a k=i2
+  # Increment previously existent key again.
+  txn_step
+  increment
+  # As long as the sequence is unchanged, replaying the increment doesn't increase the value.
+  increment
+  increment
+  txn_step n=-1
+  # Replaying an older increment doesn't increase the value.
+  increment
+  increment
+  increment
+----
+inc: current value = 3
+inc: current value = 3
+inc: current value = 3
+inc: current value = 2
+inc: current value = 2
+inc: current value = 2
+>> at end:
+txn: "a" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=4} lock=true stat=PENDING rts=0.000000011,0 wto=false max=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=1} ts=0.000000011,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}}
+data: "a"/0.000000011,0 -> /BYTES/second
+meta: "i"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=3} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{2 /INT/1}}
+data: "i"/0.000000011,0 -> /INT/2
+meta: "i2"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=0.000000011,0 min=0,0 seq=5} ts=0.000000011,0 del=false klen=12 vlen=6 ih={{4 /INT/2}}
+data: "i2"/0.000000011,0 -> /INT/3
+data: "i2"/0.000000010,0 -> /INT/1


### PR DESCRIPTION
Fixes #49482.
Fixes #50386.
Fixes #50683.

This commit fixes a bug in replayTransactionalWrite that resulted in
incorrect "transaction %s with sequence %d has a different value %+v
after recomputing from what was written" errors being thrown when write
requests were reissued, often due to transaction refreshes after
partially successful batches. The bug was caused by an unsafe byte
buffer acquired through `Iterator.UnsafeValue` being used after its
iterator had been moved. Moving an iterator invalidates and potentially
corrupts unsafe memory. This caused a sanity check later in the function
to occasionally fail.

I had a hard time reproducing this in a unit test. Even with very large
keys, very large values, interspersed compactions, and a durable Pebble
instance, I couldn't create a situation where moving the iterator
actually caused corruption in value previously retrieved using
`iter.UnsafeValue`. Maybe I'm missing a trick there. Regardless, this
certainly seems to fix the failures observed in #50683, as I can no
longer reproduce it under stress.

This will need to be backported to release-20.1, release-19.2, and
release-19.1, as all three release branches are susceptible to the
spurious errors that this bug can result in.

Release note (bug fix): Large write requests no longer have a chance
of erroneously throwing a "transaction with sequence has a different
value" error.