### PR TITLE
rowexec: add missing disk stats to join reader

### DIFF
--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -466,7 +466,10 @@ func TestJoinReader(t *testing.T) {
 
 					var res sqlbase.EncDatumRows
 					for {
-						row := out.NextNoMeta(t)
+						row, meta := out.Next()
+						if meta != nil && meta.Metrics == nil {
+							t.Fatalf("unexpected metadata %+v", meta)
+						}
 						if row == nil {
 							break
 						}
@@ -593,7 +596,10 @@ CREATE TABLE test.t (a INT, s STRING, INDEX (a, s))`); err != nil {
 
 	count := 0
 	for {
-		row := out.NextNoMeta(t)
+		row, meta := out.Next()
+		if meta != nil && meta.Metrics == nil {
+			t.Fatalf("unexpected metadata %+v", meta)
+		}
 		if row == nil {
 			break
 		}
@@ -1072,7 +1078,8 @@ func BenchmarkJoinReader(b *testing.B) {
 									spilled = true
 								}
 								meta := output.DrainMeta(ctx)
-								if meta != nil {
+								if len(meta) != 1 || meta[0].Metrics == nil {
+									// Expect a single metadata payload with Metrics set.
 									b.Fatalf("unexpected metadata: %v", meta)
 								}
 								if output.NumRowsDisposed() != expectedNumOutputRows {

--- a/pkg/sql/rowexec/utils_test.go
+++ b/pkg/sql/rowexec/utils_test.go
@@ -69,7 +69,11 @@ func runProcessorTest(
 	}
 	var res sqlbase.EncDatumRows
 	for {
-		row := out.NextNoMeta(t).Copy()
+		row, meta := out.Next()
+		if meta != nil && meta.Metrics == nil {
+			t.Fatalf("unexpected metadata %+v", meta)
+		}
+		row = row.Copy()
 		if row == nil {
 			break
 		}


### PR DESCRIPTION
Previously, only TableReaders contributed to the top-level disk
statistics. JoinReaders are the other big missing piece - add them.

Release note (sql change): query statistics now include the disk bytes
and rows read from lookup and index joins, in addition to ordinary table
scans.