### PR TITLE
backupccl: refactor makeCloudStorage usage

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -74,11 +74,10 @@ func (r BackupFileDescriptors) Less(i, j int) bool {
 func ReadBackupManifestFromURI(
 	ctx context.Context,
 	uri string,
-	user string,
-	makeExternalStorageFromURI cloud.ExternalStorageFromURIFactory,
+	makeExternalStorageFromURI cloud.ScopedExternalStorageFromURIFactory,
 	encryption *jobspb.BackupEncryptionOptions,
 ) (BackupManifest, error) {
-	exportStore, err := makeExternalStorageFromURI(ctx, uri, user)
+	exportStore, err := makeExternalStorageFromURI(ctx, uri)
 
 	if err != nil {
 		return BackupManifest{}, err
@@ -352,14 +351,13 @@ func writeTableStatistics(
 func loadBackupManifests(
 	ctx context.Context,
 	uris []string,
-	user string,
-	makeExternalStorageFromURI cloud.ExternalStorageFromURIFactory,
+	makeExternalStorageFromURI cloud.ScopedExternalStorageFromURIFactory,
 	encryption *jobspb.BackupEncryptionOptions,
 ) ([]BackupManifest, error) {
 	backupManifests := make([]BackupManifest, len(uris))
 
 	for i, uri := range uris {
-		desc, err := ReadBackupManifestFromURI(ctx, uri, user, makeExternalStorageFromURI, encryption)
+		desc, err := ReadBackupManifestFromURI(ctx, uri, makeExternalStorageFromURI, encryption)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read backup descriptor")
 		}

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -60,17 +60,15 @@ func runLoadShow(cmd *cobra.Command, args []string) error {
 		basepath = cloudimpl.MakeLocalStorageURI(basepath)
 	}
 
-	externalStorageFromURI := func(ctx context.Context, uri string,
-		user string) (cloud.ExternalStorage, error) {
+	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
 		return cloudimpl.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{},
-			cluster.NoSettings, blobs.TestEmptyBlobClientFactory, user, nil, nil)
+			cluster.NoSettings, blobs.TestEmptyBlobClientFactory, security.RootUser, nil, nil)
 	}
 	// This reads the raw backup descriptor (with table descriptors possibly not
 	// upgraded from the old FK representation, or even older formats). If more
 	// fields are added to the output, the table descriptors may need to be
 	// upgraded.
-	desc, err := backupccl.ReadBackupManifestFromURI(ctx, basepath, security.RootUser,
-		externalStorageFromURI, nil)
+	desc, err := backupccl.ReadBackupManifestFromURI(ctx, basepath, externalStorageFromURI, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -72,3 +72,6 @@ type ExternalStorageFactory func(ctx context.Context, dest roachpb.ExternalStora
 // ExternalStorageFromURIFactory describes a factory function for ExternalStorage given a URI.
 type ExternalStorageFromURIFactory func(ctx context.Context, uri string,
 	user string) (ExternalStorage, error)
+
+// ScopedExternalStorageFromURIFactory describes a factory function for ExternalStorage given a URI.
+type ScopedExternalStorageFromURIFactory func(ctx context.Context, uri string) (ExternalStorage, error)


### PR DESCRIPTION
This commit cleans up some usages of the
cloud.ExternalStorageFromURIFactory method. It moves the creation of the
creation of ExternalStorage objects to be more localized and audits the
usages to ensure that the store's are properly closed. It also prevents the user
from being passed everywhere we need to create an external storage.

Release note: None

Reviewer notes: I'm not a huge fan of the name `ScopedExternalStorageFromURIFactory`. I'm planning on changing it and am open to any suggestions. I mainly wanted to get any early feedback to see if others thought that a refactor like this would be valuable.