### PR TITLE
builtins: fix str to geometry conversion case

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -3891,3 +3891,11 @@ FROM ( VALUES
 false  true   0   true   true
 false  false  7   true   false
 false  false  97  false  false
+
+# Test for 2+ string arguments for Geometry where one side of the arguments
+# raises an error.
+statement error Unknown type: 'ABC'
+SELECT ST_Intersects('abc'::string, 'POINT(1 0)'::string)
+
+statement error Unknown type: 'ABC'
+SELECT ST_Intersects('POINT(1 0)'::string, 'abc'::string)

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3990,19 +3990,13 @@ func appendStrArgOverloadForGeometryArgOverloads(def builtinDefinition) builtinD
 		// Wrap the overloads to cast to Geometry.
 		newOverload.Types = newArgTypes
 		newOverload.Fn = func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-			var err error
-			argsToCast.ForEach(func(i int) {
+			for i, ok := argsToCast.Next(0); ok; i, ok = argsToCast.Next(i + 1) {
 				arg := string(tree.MustBeDString(args[i]))
-				var g *geo.Geometry
-				g, err = geo.ParseGeometry(arg)
+				g, err := geo.ParseGeometry(arg)
 				if err != nil {
-					// This will be caught by the check outside the closure.
-					return
+					return nil, err
 				}
 				args[i] = tree.NewDGeometry(g)
-			})
-			if err != nil {
-				return nil, err
 			}
 			return ov.Fn(ctx, args)
 		}


### PR DESCRIPTION
Fixed a bug where if an error with regards to parsing a string to EWKT
was found in a string overload, the error would be overriden by the next
argument resolution.

Refs: #51718

Release note: None