### PR TITLE
sql: use a string builder in decodeCopy

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"io"
 	"strconv"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -418,7 +419,7 @@ func (c *copyMachine) addRow(ctx context.Context, line []byte) error {
 //
 // See: https://www.postgresql.org/docs/9.5/static/sql-copy.html#AEN74432
 func decodeCopy(in string) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	start := 0
 	for i, n := 0, len(in); i < n; i++ {
 		if in[i] != '\\' {


### PR DESCRIPTION
For returning strings, a string builder is better than a bytes buffer.

```
name                  old time/op    new time/op    delta
DecodeCopySimple-12     10.8ns ± 1%    10.6ns ± 1%   -2.03%  (p=0.024 n=5+5)
DecodeCopyEscaped-12     249ns ± 1%     178ns ± 2%  -28.71%  (p=0.008 n=5+5)

name                  old alloc/op   new alloc/op   delta
DecodeCopySimple-12      0.00B          0.00B          ~     (all equal)
DecodeCopyEscaped-12     96.0B ± 0%     40.0B ± 0%  -58.33%  (p=0.008 n=5+5)

name                  old allocs/op  new allocs/op  delta
DecodeCopySimple-12       0.00           0.00          ~     (all equal)
DecodeCopyEscaped-12      2.00 ± 0%      2.00 ± 0%     ~     (all equal)
```

Release note: None