### PR TITLE
roachtest: bump PredecessorVersion(20.2) to 20.1.4

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1155,7 +1155,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	// (see runVersionUpgrade). The same is true for adding a new key to this
 	// map.
 	verMap := map[string]string{
-		"20.2": "20.1.3",
+		"20.2": "20.1.4",
 		"20.1": "19.2.9",
 		"19.2": "19.1.11",
 		"19.1": "2.1.9",


### PR DESCRIPTION
Release note: None