### PR TITLE
geosegmentize: prevent OOMs

### DIFF
--- a/pkg/geo/geogfn/segmentize_test.go
+++ b/pkg/geo/geogfn/segmentize_test.go
@@ -114,6 +114,12 @@ func TestSegmentize(t *testing.T) {
 		_, err = Segmentize(geog, 0)
 		require.EqualError(t, err, "maximum segment length must be positive")
 	})
+
+	t.Run("many coordinates to segmentize", func(t *testing.T) {
+		g := geo.MustParseGeography("LINESTRING(0 0, 100 80)")
+		_, err := Segmentize(g, 0.001)
+		require.EqualError(t, err, "attempting to segmentize into too many coordinates; need 34359738370 points between [0 0] and [100 80], max 16336")
+	})
 }
 
 func TestSegmentizeCoords(t *testing.T) {
@@ -169,7 +175,8 @@ func TestSegmentizeCoords(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			convertedPoints := segmentizeCoords(test.a, test.b, test.segmentMaxLength)
+			convertedPoints, err := segmentizeCoords(test.a, test.b, test.segmentMaxLength)
+			require.NoError(t, err)
 			require.Equal(t, test.resultantCoordinates, convertedPoints)
 		})
 	}

--- a/pkg/geo/geomfn/segmentize_test.go
+++ b/pkg/geo/geomfn/segmentize_test.go
@@ -179,8 +179,15 @@ func TestSegmentizeCoords(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			convertedPoints := segmentizeCoords(test.a, test.b, test.segmentMaxLength)
+			convertedPoints, err := segmentizeCoords(test.a, test.b, test.segmentMaxLength)
+			require.NoError(t, err)
 			require.Equal(t, test.resultantCoordinates, convertedPoints)
 		})
 	}
+
+	t.Run("many coordinates to segmentize", func(t *testing.T) {
+		g := geo.MustParseGeometry("LINESTRING(0 0, 100 100)")
+		_, err := Segmentize(g, 0.001)
+		require.EqualError(t, err, "attempting to segmentize into too many coordinates; need 282846 points between [0 0] and [100 100], max 16336")
+	})
 }

--- a/pkg/geo/geosegmentize/geosegmentize.go
+++ b/pkg/geo/geosegmentize/geosegmentize.go
@@ -15,6 +15,9 @@ import (
 	"github.com/twpayne/go-geom"
 )
 
+// MaxPoints is the maximum number of points segmentize is allowed to generate.
+const MaxPoints = 16336
+
 // SegmentizeGeom returns a modified geom.T having no segment longer
 // than the given maximum segment length.
 // segmentMaxAngleOrLength represents two different things depending
@@ -28,7 +31,7 @@ import (
 func SegmentizeGeom(
 	geometry geom.T,
 	segmentMaxAngleOrLength float64,
-	segmentizeCoords func(geom.Coord, geom.Coord, float64) []float64,
+	segmentizeCoords func(geom.Coord, geom.Coord, float64) ([]float64, error),
 ) (geom.T, error) {
 	if geometry.Empty() {
 		return geometry, nil
@@ -39,9 +42,13 @@ func SegmentizeGeom(
 	case *geom.LineString:
 		var allFlatCoordinates []float64
 		for pointIdx := 1; pointIdx < geometry.NumCoords(); pointIdx++ {
+			coords, err := segmentizeCoords(geometry.Coord(pointIdx-1), geometry.Coord(pointIdx), segmentMaxAngleOrLength)
+			if err != nil {
+				return nil, err
+			}
 			allFlatCoordinates = append(
 				allFlatCoordinates,
-				segmentizeCoords(geometry.Coord(pointIdx-1), geometry.Coord(pointIdx), segmentMaxAngleOrLength)...,
+				coords...,
 			)
 		}
 		// Appending end point as it wasn't included in the iteration of coordinates.
@@ -63,9 +70,13 @@ func SegmentizeGeom(
 	case *geom.LinearRing:
 		var allFlatCoordinates []float64
 		for pointIdx := 1; pointIdx < geometry.NumCoords(); pointIdx++ {
+			coords, err := segmentizeCoords(geometry.Coord(pointIdx-1), geometry.Coord(pointIdx), segmentMaxAngleOrLength)
+			if err != nil {
+				return nil, err
+			}
 			allFlatCoordinates = append(
 				allFlatCoordinates,
-				segmentizeCoords(geometry.Coord(pointIdx-1), geometry.Coord(pointIdx), segmentMaxAngleOrLength)...,
+				coords...,
 			)
 		}
 		// Appending end point as it wasn't included in the iteration of coordinates.


### PR DESCRIPTION
geosegmentize can be given inputs that break a line down into too many
coordinates. Guard against this by ensuring a maximum amount of
coordinates allowed between points.

PostgreSQL errors the allocate here too.

Resolves #52218.
Resolves #52217.

Release note: None