### PR TITLE
workload: don't retry endlessly the prepation phase of TPCC

### DIFF
--- a/pkg/ccl/workloadccl/roachmartccl/roachmart.go
+++ b/pkg/ccl/workloadccl/roachmartccl/roachmart.go
@@ -200,7 +200,9 @@ func (m *roachmart) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (m *roachmart) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (m *roachmart) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(m, m.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -661,7 +661,7 @@ func (c *transientCluster) runWorkload(
 
 	// Dummy registry to prove to the Opser.
 	reg := histogram.NewRegistry(time.Duration(100) * time.Millisecond)
-	ops, err := opser.Ops(sqlUrls, reg)
+	ops, err := opser.Ops(ctx, sqlUrls, reg)
 	if err != nil {
 		return errors.Wrap(err, "unable to create workload")
 	}

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -788,7 +788,10 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 	}
 	defer func() { _ = os.RemoveAll(resultsDir) }()
 	s := search.NewLineSearcher(1, b.LoadWarehouses, b.EstimatedMax, initStepSize, precision)
+	iteration := 0
 	if res, err := s.Search(func(warehouses int) (bool, error) {
+		iteration++
+		t.l.Printf("initializing cluster for %d warehouses (search attempt: %d)", warehouses, iteration)
 		m := newMonitor(ctx, c, roachNodes)
 		// Restart the cluster before each iteration to help eliminate
 		// inter-trial interactions.

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -177,7 +177,9 @@ func (b *bank) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (b *bank) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (b *bank) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(b, b.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/bulkingest/bulkingest.go
+++ b/pkg/workload/bulkingest/bulkingest.go
@@ -175,7 +175,9 @@ func (w *bulkingest) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *bulkingest) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (w *bulkingest) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/indexes/indexes.go
+++ b/pkg/workload/indexes/indexes.go
@@ -141,8 +141,9 @@ func (w *indexes) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *indexes) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
-	ctx := context.Background()
+func (w *indexes) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
+++ b/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
@@ -430,7 +430,7 @@ func (w *interleavedPartitioned) Tables() []workload.Table {
 
 // Ops implements the Opser interface.
 func (w *interleavedPartitioned) Ops(
-	urls []string, reg *histogram.Registry,
+	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, ``, urls)
 	if err != nil {

--- a/pkg/workload/jsonload/json.go
+++ b/pkg/workload/jsonload/json.go
@@ -126,7 +126,9 @@ func (w *jsonLoad) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *jsonLoad) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (w *jsonLoad) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -205,7 +205,9 @@ func (w *kv) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *kv) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (w *kv) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	writeSeq := 0
 	if w.writeSeq != "" {
 		first := w.writeSeq[0]
@@ -227,7 +229,6 @@ func (w *kv) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, er
 		}
 	}
 
-	ctx := context.Background()
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/ledger/ledger.go
+++ b/pkg/workload/ledger/ledger.go
@@ -11,6 +11,7 @@
 package ledger
 
 import (
+	"context"
 	gosql "database/sql"
 	"hash/fnv"
 	"math/rand"
@@ -179,7 +180,9 @@ func (w *ledger) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *ledger) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (w *ledger) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/movr/workload.go
+++ b/pkg/workload/movr/workload.go
@@ -296,7 +296,9 @@ func (m *movrWorker) generateWorkSimulation() func(context.Context) error {
 }
 
 // Ops implements the Opser interface
-func (m *movr) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (m *movr) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	// Initialize the faker in case it hasn't been setup already.
 	m.fakerOnce.Do(func() {
 		m.faker = faker.NewFaker()

--- a/pkg/workload/querybench/query_bench.go
+++ b/pkg/workload/querybench/query_bench.go
@@ -106,7 +106,9 @@ func (*queryBench) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (g *queryBench) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (g *queryBench) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/querylog/querylog.go
+++ b/pkg/workload/querylog/querylog.go
@@ -171,9 +171,9 @@ func (w *querylog) Hooks() workload.Hooks {
 }
 
 // Ops implements the Opser interface.
-func (w *querylog) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
-	ctx := context.Background()
-
+func (w *querylog) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/queue/queue.go
+++ b/pkg/workload/queue/queue.go
@@ -69,7 +69,9 @@ func (w *queue) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *queue) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (w *queue) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -111,7 +111,9 @@ type col struct {
 }
 
 // Ops implements the Opser interface.
-func (w *random) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (w *random) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -170,7 +170,9 @@ func (s *schemaChange) Tables() []workload.Table {
 }
 
 // Tables implements the workload.Opser interface.
-func (s *schemaChange) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (s *schemaChange) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(s, s.dbOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/sqlsmith/sqlsmith.go
+++ b/pkg/workload/sqlsmith/sqlsmith.go
@@ -115,7 +115,9 @@ func (g *sqlSmith) validateErrorSetting() error {
 }
 
 // Ops implements the Opser interface.
-func (g *sqlSmith) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (g *sqlSmith) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	if err := g.validateErrorSetting(); err != nil {
 		return workload.QueryLoad{}, err
 	}

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -559,7 +559,9 @@ func (w *tpcc) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *tpcc) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (w *tpcc) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	// It would be nice to remove the need for this and to require that
 	// partitioning and scattering occurs only when the PostLoad hook is
 	// run, but to maintain backward compatibility, it's easiest to allow
@@ -675,7 +677,7 @@ func (w *tpcc) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, 
 		idx := len(ql.WorkerFns) - 1
 		sem <- struct{}{}
 		group.Go(func() error {
-			worker, err := newWorker(context.TODO(), w, db, reg.GetHandle(), warehouse)
+			worker, err := newWorker(ctx, w, db, reg.GetHandle(), warehouse)
 			if err == nil {
 				ql.WorkerFns[idx] = worker.run
 			}

--- a/pkg/workload/tpccchecks/checks_generator.go
+++ b/pkg/workload/tpccchecks/checks_generator.go
@@ -93,7 +93,9 @@ func (*tpccChecks) Meta() workload.Meta {
 }
 
 // Ops implements the Opser interface.
-func (w *tpccChecks) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (w *tpccChecks) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.flags.Lookup("db").Value.String(), urls)
 	if err != nil {
 		return workload.QueryLoad{}, fmt.Errorf("%v", err)

--- a/pkg/workload/tpcds/tpcds.go
+++ b/pkg/workload/tpcds/tpcds.go
@@ -258,7 +258,9 @@ func (w *tpcds) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *tpcds) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (w *tpcds) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -299,7 +299,9 @@ func (w *tpch) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *tpch) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (w *tpch) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -74,7 +74,7 @@ type Flagser interface {
 // to have been created and initialized before running these.
 type Opser interface {
 	Generator
-	Ops(urls []string, reg *histogram.Registry) (QueryLoad, error)
+	Ops(ctx context.Context, urls []string, reg *histogram.Registry) (QueryLoad, error)
 }
 
 // Hookser returns any hooks associated with the generator.

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -361,7 +361,9 @@ func (g *ycsb) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (g *ycsb) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+func (g *ycsb) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err


### PR DESCRIPTION
Stop retrying the load-generator-creation phase of workload after 10m,
even when --tolerate-errors is passed. Before this patch, this step
could retry endlessly (up to the parent roachtest's timeout (default
10h)). This step is not under the control of --duration (I think for
good reason) and so I've hardcoded a 10m cutoff.

We've seen in #51785 that, under chaos, this step can retry endlessly.
With this patch, the test will fail quicker.

Touches #51785

Release note: None