### PR TITLE
release-19.2: storage: don't corrupt unsafe value buffer in replayTransactionalWrite

### DIFF
--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1226,6 +1226,7 @@ func replayTransactionalWrite(
 ) error {
 	var found bool
 	var writtenValue []byte
+	var writtenValueSafety valueSafety
 	var err error
 	metaKey := MakeMVCCMetadataKey(key)
 	if txn.Sequence == meta.Txn.Sequence {
@@ -1236,7 +1237,7 @@ func replayTransactionalWrite(
 		defer getBuf.release()
 		getBuf.meta = buf.meta
 		var exVal *roachpb.Value
-		if exVal, _, _, err = mvccGetInternal(
+		if exVal, _, writtenValueSafety, err = mvccGetInternal(
 			ctx, iter, metaKey, timestamp, true /* consistent */, unsafeValue, txn, getBuf); err != nil {
 			return err
 		}
@@ -1245,6 +1246,7 @@ func replayTransactionalWrite(
 	} else {
 		// Get the value from the intent history.
 		writtenValue, found = meta.GetIntentValue(txn.Sequence)
+		writtenValueSafety = safeValue
 	}
 	if !found {
 		return errors.Errorf("transaction %s with sequence %d missing an intent with lower sequence %d",
@@ -1264,6 +1266,13 @@ func replayTransactionalWrite(
 				return err
 			}
 		} else {
+			// We're going to be using the iterator again, so make sure the
+			// existing writtenValue bytes are safe and won't be corrupted.
+			if writtenValueSafety == unsafeValue {
+				writtenValue = append([]byte(nil), writtenValue...)
+				writtenValueSafety = safeValue
+			}
+
 			// If the previous value at the key wasn't written by this transaction,
 			// we must apply the value function to the last committed value on the key.
 			getBuf := newGetBuffer()


### PR DESCRIPTION
Backport 1/1 commits from #52234.

/cc @cockroachdb/release

---

Fixes #49482.
Fixes #50386.
Fixes #50683.

This commit fixes a bug in replayTransactionalWrite that resulted in
incorrect "transaction %s with sequence %d has a different value %+v
after recomputing from what was written" errors being thrown when write
requests were reissued, often due to transaction refreshes after
partially successful batches. The bug was caused by an unsafe byte
buffer acquired through `Iterator.UnsafeValue` being used after its
iterator had been moved. Moving an iterator invalidates and potentially
corrupts unsafe memory. This caused a sanity check later in the function
to occasionally fail.

I had a hard time reproducing this in a unit test. Even with very large
keys, very large values, interspersed compactions, and a durable Pebble
instance, I couldn't create a situation where moving the iterator
actually caused corruption in value previously retrieved using
`iter.UnsafeValue`. Maybe I'm missing a trick there. Regardless, this
certainly seems to fix the failures observed in #50683, as I can no
longer reproduce it under stress.

This will need to be backported to release-20.1, release-19.2, and
release-19.1, as all three release branches are susceptible to the
spurious errors that this bug can result in.

Release note (bug fix): Large write requests no longer have a chance
of erroneously throwing a "transaction with sequence has a different
value" error.
