### PR TITLE
roachtest: correctly start crdb in acceptance/rapid_restart

### DIFF
--- a/pkg/cmd/roachtest/rapid_restart.go
+++ b/pkg/cmd/roachtest/rapid_restart.go
@@ -47,7 +47,7 @@ func runRapidRestart(ctx context.Context, t *test, c *cluster) {
 			exitCh := make(chan error, 1)
 			go func() {
 				err := c.RunE(ctx, nodes,
-					`mkdir -p {log-dir} && ./cockroach start --insecure --store={store-dir} `+
+					`mkdir -p {log-dir} && ./cockroach start-single-node --insecure --store={store-dir} `+
 						`--log-dir={log-dir} --cache=10% --max-sql-memory=10% `+
 						`--listen-addr=:{pgport:1} --http-port=$[{pgport:1}+1] `+
 						`> {log-dir}/cockroach.stdout 2> {log-dir}/cockroach.stderr`)


### PR DESCRIPTION
--start-single-node was needed. Without it, I think the test's killing
of a node raced with that node dieing by itself, and sometimes the race
resulted in `cockroach stop` first seeing the process but then
`/bin/bash: line 8: kill: (16016) - No such proces`

Fixes #52060

Release note: None