### PR TITLE
backupccl: create type schema change jobs for restored types

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
@@ -1643,6 +1644,75 @@ INSERT INTO d.t VALUES ('hello'), ('howdy');
 			sqlDB.ExpectErr(t, `pq: type "d3.farewell" does not exist`, `CREATE TABLE d3.t (x d3.farewell)`)
 		}
 	})
+}
+
+func TestBackupRestoreDuringUserDefinedTypeChange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Protects typeChangeStarted.
+	var mu syncutil.Mutex
+	typeChangeStarted := make(chan struct{})
+	waitForBackup := make(chan struct{})
+	typeChangeFinished := make(chan struct{})
+	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, 0, InitNone, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
+					RunBeforeEnumMemberPromotion: func() {
+						mu.Lock()
+						defer mu.Unlock()
+						if typeChangeStarted != nil {
+							close(typeChangeStarted)
+							<-waitForBackup
+							typeChangeStarted = nil
+						}
+					},
+				},
+			},
+		},
+	})
+	defer cleanupFn()
+
+	// Create a database with a type.
+	sqlDB.Exec(t, `
+SET experimental_enable_enums = true;
+CREATE DATABASE d;
+CREATE TYPE d.greeting AS ENUM ('hello', 'howdy', 'hi');
+`)
+
+	// Start an ALTER TYPE statement that will block.
+	go func() {
+		// Note we don't use sqlDB.Exec here because we can't Fatal from within a goroutine.
+		if _, err := sqlDB.DB.ExecContext(context.Background(), `ALTER TYPE d.greeting ADD VALUE 'cheers'`); err != nil {
+			t.Error(err)
+		}
+		close(typeChangeFinished)
+	}()
+
+	// Wait on the type change to start.
+	<-typeChangeStarted
+
+	// Now create a backup while the type change job is blocked so that greeting
+	// is backed up with 'cheers' in the READ_ONLY state.
+	sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/test/'`)
+
+	// Let the type change finish.
+	close(waitForBackup)
+	<-typeChangeFinished
+
+	// Now drop the database and restore.
+	sqlDB.Exec(t, `DROP DATABASE d`)
+	sqlDB.Exec(t, `RESTORE DATABASE d FROM 'nodelocal://0/test/'`)
+
+	// The type change job should be scheduled and succeed. Note that we can't use
+	// sqlDB.CheckQueryResultsRetry as it Fatal's upon an error. The case below
+	// will error until the job completes.
+	testutils.SucceedsSoon(t, func() error {
+		_, err := sqlDB.DB.ExecContext(context.Background(), `SELECT 'cheers'::d.greeting`)
+		return err
+	})
+	sqlDB.CheckQueryResults(t, `SELECT 'cheers'::d.greeting`, [][]string{{"cheers"}})
 }
 
 func TestBackupRestoreInterleaved(t *testing.T) {

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -610,6 +610,11 @@ func restore(
 	// `restoreCtx` is used for orchestration logging. All operations that carry
 	// out work get their individual contexts.
 
+	// If there weren't any spans requested, then return early.
+	if len(spans) == 0 {
+		return RowCount{}, nil
+	}
+
 	mu := struct {
 		syncutil.Mutex
 		res               RowCount
@@ -839,10 +844,14 @@ func loadBackupSQLDescs(
 }
 
 type restoreResumer struct {
-	job                *jobs.Job
-	settings           *cluster.Settings
-	databases          []*sqlbase.ImmutableDatabaseDescriptor
-	tables             []sqlbase.TableDescriptorInterface
+	job       *jobs.Job
+	settings  *cluster.Settings
+	databases []*sqlbase.ImmutableDatabaseDescriptor
+	tables    []sqlbase.TableDescriptorInterface
+	// writtenTypes is the set of types that are restored from the backup into
+	// the database. Note that this is not always the set of types within the
+	// backup, as some types might be remapped to existing types in the database.
+	writtenTypes       []sqlbase.TypeDescriptorInterface
 	descriptorCoverage tree.DescriptorCoverage
 	latestStats        []*stats.TableStatisticProto
 	execCfg            *sql.ExecutorConfig
@@ -952,18 +961,16 @@ func isDatabaseEmpty(
 func createImportingDescriptors(
 	ctx context.Context, p sql.PlanHookState, sqlDescs []sqlbase.Descriptor, r *restoreResumer,
 ) (
-	[]*sqlbase.ImmutableDatabaseDescriptor,
-	[]sqlbase.TableDescriptorInterface,
-	[]sqlbase.ID,
-	[]roachpb.Span,
-	error,
+	databases []*sqlbase.ImmutableDatabaseDescriptor,
+	tables []sqlbase.TableDescriptorInterface,
+	oldTableIDs []sqlbase.ID,
+	writtenTypes []sqlbase.TypeDescriptorInterface,
+	spans []roachpb.Span,
+	err error,
 ) {
 	details := r.job.Details().(jobspb.RestoreDetails)
 
-	var databases []*sqlbase.ImmutableDatabaseDescriptor
-	var tables []sqlbase.TableDescriptorInterface
 	var types []sqlbase.TypeDescriptorInterface
-	var oldTableIDs []sqlbase.ID
 	for _, desc := range sqlDescs {
 		if tableDesc := desc.Table(hlc.Timestamp{}); tableDesc != nil {
 			table := sqlbase.NewMutableCreatedTableDescriptor(*tableDesc)
@@ -994,7 +1001,7 @@ func createImportingDescriptors(
 
 	// We get the spans of the restoring tables _as they appear in the backup_,
 	// that is, in the 'old' keyspace, before we reassign the table IDs.
-	spans := spansForAllTableIndexes(p.ExecCfg().Codec, tables, nil)
+	spans = spansForAllTableIndexes(p.ExecCfg().Codec, tables, nil)
 
 	log.Eventf(ctx, "starting restore for %d tables", len(tables))
 
@@ -1005,14 +1012,13 @@ func createImportingDescriptors(
 		tableDescs[i] = table.TableDesc()
 	}
 	if err := RewriteTableDescs(tableDescs, details.DescriptorRewrites, details.OverrideDB); err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 
-	// We might be remapping some types to existing types in the cluster. In that
-	// case, we don't want to create namespace and descriptor entries for those
-	// types. So collect only the types that we need to write here.
+	// For each type, we might be writing the type in the backup, or we could be
+	// remapping to an existing type descriptor. Split up the descriptors into
+	// these two groups.
 	var typesToWrite []sqlbase.TypeDescriptorInterface
-	// We need to know what existing types we are remapping to, so collect them.
 	existingTypeIDs := make(map[sqlbase.ID]struct{})
 	for i := range types {
 		typ := types[i]
@@ -1030,7 +1036,7 @@ func createImportingDescriptors(
 		typDescs[i] = typ.TypeDesc()
 	}
 	if err := rewriteTypeDescs(typDescs, details.DescriptorRewrites); err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 
 	for _, desc := range tableDescs {
@@ -1112,18 +1118,18 @@ func createImportingDescriptors(
 			return err
 		})
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, err
 		}
 
 		// Wait for one version on any existing changed types.
 		for existing := range existingTypeIDs {
 			if err := sql.WaitToUpdateLeases(ctx, p.ExecCfg().LeaseManager, existing); err != nil {
-				return nil, nil, nil, nil, err
+				return nil, nil, nil, nil, nil, err
 			}
 		}
 	}
 
-	return databases, tables, oldTableIDs, spans, nil
+	return databases, tables, oldTableIDs, typesToWrite, spans, nil
 }
 
 // Resume is part of the jobs.Resumer interface.
@@ -1152,11 +1158,12 @@ func (r *restoreResumer) Resume(
 		return err
 	}
 
-	databases, tables, oldTableIDs, spans, err := createImportingDescriptors(ctx, p, sqlDescs, r)
+	databases, tables, oldTableIDs, writtenTypes, spans, err := createImportingDescriptors(ctx, p, sqlDescs, r)
 	if err != nil {
 		return err
 	}
 	r.tables = tables
+	r.writtenTypes = writtenTypes
 	r.descriptorCoverage = details.DescriptorCoverage
 	r.databases = databases
 	r.execCfg = p.ExecCfg()
@@ -1166,7 +1173,7 @@ func (r *restoreResumer) Resume(
 	}
 	r.latestStats = remapRelevantStatistics(backupStats, details.DescriptorRewrites)
 
-	if len(r.tables) == 0 && len(details.Tenants) == 0 {
+	if len(r.tables) == 0 && len(details.Tenants) == 0 && len(r.writtenTypes) == 0 {
 		// We have no tables to restore (we are restoring an empty DB).
 		// Since we have already created any new databases that we needed,
 		// we can return without importing any data.
@@ -1207,7 +1214,7 @@ func (r *restoreResumer) Resume(
 		return errors.Wrap(err, "inserting table statistics")
 	}
 
-	if err := r.publishTables(ctx); err != nil {
+	if err := r.publishDescriptors(ctx); err != nil {
 		return err
 	}
 
@@ -1275,15 +1282,15 @@ func (r *restoreResumer) insertStats(ctx context.Context) error {
 	return nil
 }
 
-// publishTables updates the RESTORED tables status from OFFLINE to PUBLIC.
-func (r *restoreResumer) publishTables(ctx context.Context) error {
+// publishDescriptors updates the RESTORED tables status from OFFLINE to PUBLIC.
+func (r *restoreResumer) publishDescriptors(ctx context.Context) error {
 	details := r.job.Details().(jobspb.RestoreDetails)
 	if details.TablesPublished {
 		return nil
 	}
 	log.Event(ctx, "making tables live")
 
-	newSchemaChangeJobs := make([]*jobs.StartableJob, 0)
+	newDescriptorChangeJobs := make([]*jobs.StartableJob, 0)
 	err := r.execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		// Write the new TableDescriptors and flip state over to public so they can be
 		// accessed.
@@ -1300,7 +1307,7 @@ func (r *restoreResumer) publishTables(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			newSchemaChangeJobs = append(newSchemaChangeJobs, newJobs...)
+			newDescriptorChangeJobs = append(newDescriptorChangeJobs, newJobs...)
 			existingDescVal, err := sqlbase.ConditionalGetTableDescFromTxn(ctx, txn, r.execCfg.Codec, tbl.TableDesc())
 			if err != nil {
 				return errors.Wrap(err, "validating table descriptor has not changed")
@@ -1317,6 +1324,18 @@ func (r *restoreResumer) publishTables(ctx context.Context) error {
 			return errors.Wrap(err, "publishing tables")
 		}
 
+		// For all of the newly created types, make type schema change jobs for any
+		// type descriptors that were backed up in the middle of a type schema change.
+		for _, typ := range r.writtenTypes {
+			if typ.HasPendingSchemaChanges() {
+				typJob, err := createTypeChangeJobFromDesc(ctx, r.execCfg.JobRegistry, r.execCfg.Codec, txn, r.job.Payload().Username, typ)
+				if err != nil {
+					return err
+				}
+				newDescriptorChangeJobs = append(newDescriptorChangeJobs, typJob)
+			}
+		}
+
 		for _, tenant := range details.Tenants {
 			if err := sql.ActivateTenant(ctx, r.execCfg, txn, tenant.ID); err != nil {
 				return err
@@ -1327,7 +1346,7 @@ func (r *restoreResumer) publishTables(ctx context.Context) error {
 		details.TablesPublished = true
 		details.TableDescs = newTables
 		if err := r.job.WithTxn(txn).SetDetails(ctx, details); err != nil {
-			for _, newJob := range newSchemaChangeJobs {
+			for _, newJob := range newDescriptorChangeJobs {
 				if cleanupErr := newJob.CleanupOnRollback(ctx); cleanupErr != nil {
 					log.Warningf(ctx, "failed to clean up job %d: %v", newJob.ID(), cleanupErr)
 				}
@@ -1342,7 +1361,7 @@ func (r *restoreResumer) publishTables(ctx context.Context) error {
 	}
 
 	// Start the schema change jobs we created.
-	for _, newJob := range newSchemaChangeJobs {
+	for _, newJob := range newDescriptorChangeJobs {
 		if _, err := newJob.Start(ctx); err != nil {
 			return err
 		}
@@ -1354,9 +1373,6 @@ func (r *restoreResumer) publishTables(ctx context.Context) error {
 	for i := range r.tables {
 		r.execCfg.StatsRefresher.NotifyMutation(r.tables[i].GetID(), math.MaxInt32 /* rowsAffected */)
 	}
-
-	// TODO (rohany): Once types have type schema change jobs, we need to create
-	//  jobs for pending type changes here.
 
 	return nil
 }

--- a/pkg/sql/sqlbase/type_desc.go
+++ b/pkg/sql/sqlbase/type_desc.go
@@ -56,6 +56,7 @@ type TypeDescriptorInterface interface {
 	TypeDesc() *TypeDescriptor
 	HydrateTypeInfoWithName(ctx context.Context, typ *types.T, name *tree.TypeName, res TypeDescriptorResolver) error
 	MakeTypesT(ctx context.Context, name *tree.TypeName, res TypeDescriptorResolver) (*types.T, error)
+	HasPendingSchemaChanges() bool
 }
 
 var _ TypeDescriptorInterface = (*ImmutableTypeDescriptor)(nil)
@@ -643,6 +644,24 @@ func (desc *TypeDescriptor) IsCompatibleWith(other *TypeDescriptor) error {
 		return nil
 	default:
 		return errors.Newf("compatibility comparison unsupported for type kind %s", desc.Kind.String())
+	}
+}
+
+// HasPendingSchemaChanges returns whether or not this descriptor has schema
+// changes that need to be completed.
+func (desc *TypeDescriptor) HasPendingSchemaChanges() bool {
+	switch desc.Kind {
+	case TypeDescriptor_ENUM:
+		// If there are any non-public enum members, then a type schema change is
+		// needed to promote the members.
+		for i := range desc.EnumMembers {
+			if desc.EnumMembers[i].Capability != TypeDescriptor_EnumMember_ALL {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
 	}
 }
 

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -102,6 +102,9 @@ type typeSchemaChanger struct {
 type TypeSchemaChangerTestingKnobs struct {
 	// RunBeforeExec runs at the start of the typeSchemaChanger.
 	RunBeforeExec func() error
+	// RunBeforeEnumMemberPromotion runs before enum members are promoted from
+	// readable to all permissions in the typeSchemaChanger.
+	RunBeforeEnumMemberPromotion func()
 }
 
 // ModuleTestingKnobs implements the ModuleTestingKnobs interface.
@@ -163,6 +166,9 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 			}
 		}
 		if hasNonPublic {
+			if fn := t.execCfg.TypeSchemaChangerTestingKnobs.RunBeforeEnumMemberPromotion; fn != nil {
+				fn()
+			}
 			// The version of the array type needs to get bumped as well so that
 			// changes to the underlying type are picked up.
 			update := func(_ *kv.Txn, descs map[sqlbase.ID]catalog.MutableDescriptor) error {


### PR DESCRIPTION
Fixes #50322.

This commit teaches restore to create type schema change jobs for
restored type descriptors that were backed up in the middle of a type
schema change.

Release note: None