### PR TITLE
bulkio: Correctly handle exhausting retries when reading from HTTP.

### DIFF
--- a/pkg/storage/cloudimpl/cloudimpltests/http_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/http_storage_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -338,4 +339,51 @@ func TestExternalStorageCanUseHTTPProxy(t *testing.T) {
 	require.NoError(t, err)
 
 	require.EqualValues(t, "proxied-http://my-server/file", string(data))
+}
+
+type alwaysRefuseConnectionDialer struct {
+	net.Dialer
+}
+
+func (d *alwaysRefuseConnectionDialer) DialContext(
+	_ context.Context, _, _ string,
+) (net.Conn, error) {
+	return nil, econnrefused
+}
+
+func TestExhaustRetries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Override DialContext implementation in http transport.
+	dialer := &alwaysRefuseConnectionDialer{}
+
+	// Override transport to return antagonistic connection.
+	transport := http.DefaultTransport.(*http.Transport)
+	transport.DialContext =
+		func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, addr)
+		}
+
+	defer func() {
+		transport.DialContext = nil
+	}()
+
+	// Override retry options to retry faster.
+	defer func(opts retry.Options) {
+		cloudimpl.HTTPRetryOptions = opts
+	}(cloudimpl.HTTPRetryOptions)
+
+	cloudimpl.HTTPRetryOptions.InitialBackoff = 1 * time.Microsecond
+	cloudimpl.HTTPRetryOptions.MaxBackoff = 10 * time.Millisecond
+	cloudimpl.HTTPRetryOptions.MaxRetries = 10
+
+	store, err := cloudimpl.MakeHTTPStorage(
+		"http://does.not.matter", testSettings, base.ExternalIODirConfig{})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, store.Close())
+	}()
+
+	_, err = store.ReadFile(context.Background(), "/something")
+	require.Error(t, err)
 }

--- a/pkg/storage/cloudimpl/http_storage.go
+++ b/pkg/storage/cloudimpl/http_storage.go
@@ -213,6 +213,10 @@ func (r *resumingHTTPReader) sendRequest(
 			return nil, err
 		}
 	}
+	if r.ctx.Err() == nil {
+		return nil, errors.New("too many retries; giving up")
+	}
+
 	return nil, r.ctx.Err()
 }
 


### PR DESCRIPTION
Fixes #52279

Return an error if we exhaust the retry budget when reading from HTTP.

Release Notes: None