### PR TITLE
sql: remove unnecessary mvcc column descriptor allocation

### DIFF
--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -605,7 +605,7 @@ func newOptTable(
 	// for migration purposes. We need to avoid adding the system column if the
 	// table has a column with this name for some reason.
 	if _, _, err := desc.FindColumnByName(sqlbase.MVCCTimestampColumnName); err != nil {
-		ot.systemColumnDescs = append(ot.systemColumnDescs, sqlbase.NewMVCCTimestampColumnDesc())
+		ot.systemColumnDescs = append(ot.systemColumnDescs, &sqlbase.MVCCTimestampColumnDesc)
 	}
 
 	// Create the table's column mapping from sqlbase.ColumnID to column ordinal.

--- a/pkg/sql/sqlbase/system_columns.go
+++ b/pkg/sql/sqlbase/system_columns.go
@@ -38,17 +38,14 @@ var MVCCTimestampColumnType = types.Decimal
 // system columns will have ID's that decrement from this value.
 const MVCCTimestampColumnID = math.MaxUint32
 
-// NewMVCCTimestampColumnDesc creates a column descriptor for the MVCC timestamp
-// system column.
-func NewMVCCTimestampColumnDesc() *ColumnDescriptor {
-	return &ColumnDescriptor{
-		Name:             MVCCTimestampColumnName,
-		Type:             MVCCTimestampColumnType,
-		Hidden:           true,
-		Nullable:         true,
-		SystemColumnKind: SystemColumnKind_MVCCTIMESTAMP,
-		ID:               MVCCTimestampColumnID,
-	}
+// MVCCTimestampColumnDesc is a column descriptor for the MVCC system column.
+var MVCCTimestampColumnDesc = ColumnDescriptor{
+	Name:             MVCCTimestampColumnName,
+	Type:             MVCCTimestampColumnType,
+	Hidden:           true,
+	Nullable:         true,
+	SystemColumnKind: SystemColumnKind_MVCCTIMESTAMP,
+	ID:               MVCCTimestampColumnID,
 }
 
 // IsColIDSystemColumn returns whether a column ID refers to a system column.
@@ -66,7 +63,7 @@ func IsColIDSystemColumn(colID ColumnID) bool {
 func GetSystemColumnDescriptorFromID(colID ColumnID) (*ColumnDescriptor, error) {
 	switch colID {
 	case MVCCTimestampColumnID:
-		return NewMVCCTimestampColumnDesc(), nil
+		return &MVCCTimestampColumnDesc, nil
 	default:
 		return nil, errors.AssertionFailedf("unsupported system column ID %d", colID)
 	}


### PR DESCRIPTION
Removes an unnecessary allocation of the MVCC column descriptor. Found
while looking at some profiles.

Release note: None