### PR TITLE
sql: support alter type set schema

### DIFF
--- a/pkg/sql/alter_table_set_schema.go
+++ b/pkg/sql/alter_table_set_schema.go
@@ -52,6 +52,11 @@ func (p *planner) AlterTableSetSchema(
 		return newZeroNode(nil /* columns */), nil
 	}
 
+	if tableDesc.Temporary {
+		return nil, pgerror.Newf(pgcode.FeatureNotSupported,
+			"cannot move objects into or out of temporary schemas")
+	}
+
 	// The user needs DROP privilege on the table to set the schema.
 	err = p.CheckPrivilege(ctx, tableDesc, privilege.DROP)
 	if err != nil {
@@ -77,53 +82,16 @@ func (p *planner) AlterTableSetSchema(
 }
 
 func (n *alterTableSetSchemaNode) startExec(params runParams) error {
-	p := params.p
 	ctx := params.ctx
+	p := params.p
 	tableDesc := n.tableDesc
+	schemaID := tableDesc.GetParentSchemaID()
+	databaseID := tableDesc.GetParentID()
 
-	if tableDesc.Temporary {
-		return pgerror.Newf(pgcode.FeatureNotSupported,
-			"cannot move objects into or out of temporary schemas")
-	}
-
-	databaseID := n.tableDesc.GetParentID()
-	schemaID := n.tableDesc.GetParentSchemaID()
-
-	// Lookup the the schema we want to set to.
-	exists, res, err := params.p.LogicalSchemaAccessor().GetSchema(
-		ctx, p.txn,
-		p.ExecCfg().Codec,
-		databaseID,
-		n.newSchema,
-	)
+	desiredSchemaID, err := p.prepareSetSchema(ctx, tableDesc, n.newSchema)
 	if err != nil {
 		return err
 	}
-
-	if !exists {
-		return pgerror.Newf(pgcode.InvalidSchemaName,
-			"schema %s does not exist", n.newSchema)
-	}
-
-	switch res.Kind {
-	case sqlbase.SchemaTemporary:
-		return pgerror.Newf(pgcode.FeatureNotSupported,
-			"cannot move objects into or out of temporary schemas")
-	case sqlbase.SchemaVirtual:
-		return pgerror.Newf(pgcode.FeatureNotSupported,
-			"cannot move objects into or out of virtual schemas")
-	case sqlbase.SchemaPublic:
-		// We do not need to check for privileges on the public schema.
-	default:
-		// The user needs CREATE privilege on the target schema to move a table
-		// to the schema.
-		err = p.CheckPrivilege(ctx, res.Desc, privilege.CREATE)
-		if err != nil {
-			return err
-		}
-	}
-
-	desiredSchemaID := res.ID
 
 	// If the schema being changed to is the same as the current schema for the
 	// table, do a no-op.
@@ -131,7 +99,7 @@ func (n *alterTableSetSchemaNode) startExec(params runParams) error {
 		return nil
 	}
 
-	exists, _, err = catalogkv.LookupObjectID(
+	exists, _, err := catalogkv.LookupObjectID(
 		ctx, p.txn, p.ExecCfg().Codec, databaseID, desiredSchemaID, tableDesc.Name,
 	)
 	if err == nil && exists {
@@ -149,7 +117,7 @@ func (n *alterTableSetSchemaNode) startExec(params runParams) error {
 	tableDesc.AddDrainingName(renameDetails)
 
 	// Set the tableDesc's new schema id to the desired schema's id.
-	n.tableDesc.SetParentSchemaID(desiredSchemaID)
+	tableDesc.SetParentSchemaID(desiredSchemaID)
 
 	if err := p.writeSchemaChange(
 		ctx, tableDesc, descpb.InvalidMutationID, tree.AsStringWithFQNames(n.n, params.Ann()),

--- a/pkg/sql/catalog/catalogkv/namespace.go
+++ b/pkg/sql/catalog/catalogkv/namespace.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"

--- a/pkg/sql/catalog/catalogkv/namespace.go
+++ b/pkg/sql/catalog/catalogkv/namespace.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -139,9 +139,6 @@ true true
 statement error pq: invalid input value for enum greeting: "notagreeting"
 SELECT 'hello'::greeting = 'notagreeting'
 
-statement error pq: unimplemented: ALTER TYPE SET SCHEMA unsupported
-ALTER TYPE greeting SET SCHEMA newschema
-
 # Tests for enum builtins.
 statement ok
 CREATE TYPE dbs AS ENUM ('postgres', 'mysql', 'spanner', 'cockroach')

--- a/pkg/sql/logictest/testdata/logic_test/set_schema
+++ b/pkg/sql/logictest/testdata/logic_test/set_schema
@@ -27,7 +27,7 @@ ALTER TABLE t SET SCHEMA does_not_exist
 statement ok
 CREATE TABLE s2.t();
 
-statement error pq: relation t already exists in schema s2
+statement error pq: relation "t" already exists
 ALTER TABLE t SET SCHEMA s2
 
 # Ensure we cannot set schema to a virtual schema.
@@ -186,18 +186,41 @@ ALTER VIEW seq_not_view SET SCHEMA s1
 statement error pq: cannot set schema on relation "for_view" because view "vx" depends on it
 ALTER TABLE for_view SET SCHEMA s2
 
-# Test SET SCHEMA inside a transaction.
-statement ok
-BEGIN
-
 statement ok
 CREATE TABLE s1.t3(x INT)
 
 statement ok
 INSERT INTO s1.t3 VALUES (1)
 
+# Test ALTER TABLE SET SCHEMA inside a transaction.
+statement ok
+BEGIN
+
 statement ok
 ALTER TABLE s1.t3 SET SCHEMA s2
+
+# ALTER TABLE SET SCHEMA changes should inside the transaction.
+query I rowsort
+SELECT * FROM s2.t3
+----
+1
+
+statement error pq: relation "s1.t2" does not exist
+SELECT * FROM s1.t2
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE s1.t3 SET SCHEMA s2
+
+statement ok
+COMMIT
+
+# ALTER TABLE SET SCHEMA changes should reflect after commit.
 
 query I rowsort
 SELECT * FROM s2.t3
@@ -207,9 +230,6 @@ SELECT * FROM s2.t3
 # Ensure we cannot select from the old table.
 statement error pq: relation "s1.t2" does not exist
 SELECT * FROM s1.t2
-
-statement ok
-COMMIT
 
 statement ok
 CREATE TABLE s1.t4(x INT)
@@ -251,3 +271,160 @@ user testuser
 
 statement error pq: user testuser does not have CREATE privilege on schema s1
 ALTER TABLE t5 SET SCHEMA s1
+
+# Sub-tests for ALTER TYPE SET SCHEMA.
+user root
+
+statement ok
+SET experimental_enable_enums = true
+
+statement ok
+CREATE TYPE typ AS ENUM ('hello')
+
+# Ensure setting the type to the same schema is valid.
+statement ok
+ALTER TYPE typ SET SCHEMA public
+
+# Cannot set schema to one that does not exist.
+statement error pq: schema does_not_exist does not exist
+ALTER TYPE typ SET SCHEMA does_not_exist
+
+# Ensure we cannot set schema if there is already a type with the same name
+# in the schema.
+statement ok
+CREATE TYPE s2.typ AS ENUM ()
+
+statement error type "typ" already exists
+ALTER TYPE typ SET SCHEMA s2
+
+# Ensure we cannot set schema to a virtual schema.
+statement error pq: cannot move objects into or out of virtual schemas
+ALTER TYPE typ SET SCHEMA information_schema
+
+# Ensure we cannot set schema to a temporary schema.
+let $temp_schema
+SELECT schema_name FROM [show schemas] WHERE schema_name LIKE '%pg_temp%'
+
+statement error pq: cannot move objects into or out of temporary schemas
+ALTER TYPE typ SET SCHEMA $temp_schema
+
+# Test setting a type from public to s1.
+
+statement ok
+ALTER TYPE typ SET SCHEMA s1
+
+# Ensure that the type is in the designated schema.
+statement ok
+SELECT 'hello'::s1.typ
+
+# Ensure the type does not exist in the public schema.
+statement error pq: type "public.typ" does not exist
+SELECT 'hello'::public.typ
+
+statement error pq: type "typ" does not exist
+SELECT 'hello'::typ
+
+# Testing setting a type to the public schema.
+
+statement ok
+ALTER TYPE s1.typ SET SCHEMA public
+
+# Check that the type is in the designated schema.
+statement ok
+SELECT 'hello'::public.typ
+
+# Ensure the type does not exist in the s1 schema.
+statement error pq: type "s1.typ" does not exist
+SELECT 'hello'::s1.typ
+
+# Test moving from one user defined schema to another.
+statement ok
+CREATE TYPE s1.typ2 AS ENUM ('hello')
+
+statement ok
+ALTER TYPE s1.typ2 SET SCHEMA s2
+
+statement ok
+SELECT 'hello'::s2.typ2
+
+# Ensure the type does not exist in the s1 schema.
+statement error pq: type "s1.typ2" does not exist
+SELECT 'hello'::s1.typ2
+
+statement ok
+CREATE TYPE s1.typ3 AS ENUM ('hello')
+
+# Test ALTER TYPE SET SCHEMA inside a transaction.
+statement ok
+BEGIN
+
+statement ok
+ALTER TYPE s1.typ3 SET SCHEMA s2
+
+# ALTER TYPE SET SCHEMA changes should reflect in the transaction.
+statement ok
+SELECT 'hello'::s2.typ3
+
+statement error pq: type "s1.typ3" does not exist
+SELECT 'hello'::s1.typ3
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TYPE s1.typ3 SET SCHEMA s2
+
+statement ok
+COMMIT
+
+# ALTER TYPE SET SCHEMA changes should reflect after commit.
+
+statement ok
+SELECT 'hello'::s2.typ3
+
+# Ensure the type does not exist in the s1 schema.
+statement error pq: type "s1.typ3" does not exist
+SELECT 'hello'::s1.typ3
+
+statement ok
+CREATE TYPE s1.typ4 AS ENUM ('hello')
+
+# Ensure set schema gets rolled back if the transaction is canceled.
+statement ok
+BEGIN
+
+statement ok
+ALTER TYPE s1.typ4 SET SCHEMA s2
+
+statement ok
+ROLLBACK
+
+# Ensure that the type is in the original schema.
+statement ok
+SELECT 'hello'::s1.typ4
+
+# Ensure that the type is not in the s2 schema.
+statement error pq: type "s2.typ4" does not exist
+SELECT 'hello'::s2.typ4
+
+statement ok
+CREATE TYPE typ5 AS ENUM ()
+
+user testuser
+
+# Ensure the user has DROP privilege on the type to set the schema.
+# TODO(richardjcai): This check should be added after #49806 is addressed.
+# statement error pq: user testuser does not have DROP privilege on type t5
+# ALTER TYPE typ5 SET SCHEMA s1
+
+# Ensure the user has CREATE privilege on the target schema.
+user root
+
+user testuser
+
+statement error pq: user testuser does not have CREATE privilege on schema s1
+ALTER TYPE typ5 SET SCHEMA s1
+

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -686,6 +686,11 @@ func (p *planner) SessionData() *sessiondata.SessionData {
 	return p.EvalContext().SessionData
 }
 
+// Ann is a shortcut for the Annotations from the eval context.
+func (p *planner) Ann() *tree.Annotations {
+	return p.ExtendedEvalContext().EvalContext.Annotations
+}
+
 // txnModesSetter is an interface used by SQL execution to influence the current
 // transaction.
 type txnModesSetter interface {

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -163,6 +163,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 		ParentSchemaID: parentSchemaID,
 		Name:           oldTn.Table()}
 	tableDesc.AddDrainingName(renameDetails)
+
 	if err := p.writeSchemaChange(
 		ctx, tableDesc, descpb.InvalidMutationID, tree.AsStringWithFQNames(n.n, params.Ann()),
 	); err != nil {

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -145,11 +145,23 @@ func (n *renameTableNode) startExec(params runParams) error {
 		return nil
 	}
 
+	exists, id, err := catalogkv.LookupPublicTableID(
+		params.ctx, params.p.txn, p.ExecCfg().Codec, targetDbDesc.GetID(), newTn.Table(),
+	)
+	if err == nil && exists {
+		// Try and see what kind of object we collided with.
+		desc, err := catalogkv.GetAnyDescriptorByID(
+			params.ctx, params.p.txn, p.ExecCfg().Codec, id, catalogkv.Immutable)
+		if err != nil {
+			return sqlbase.WrapErrorWhileConstructingObjectAlreadyExistsErr(err)
+		}
+		return sqlbase.MakeObjectAlreadyExistsError(desc.DescriptorProto(), newTn.Table())
+	} else if err != nil {
+		return err
+	}
+
 	tableDesc.SetName(newTn.Table())
 	tableDesc.ParentID = targetDbDesc.GetID()
-
-	newTbKey := catalogkv.MakeObjectNameKey(ctx, params.ExecCfg().Settings,
-		targetDbDesc.GetID(), tableDesc.GetParentSchemaID(), newTn.Table()).Key(p.ExecCfg().Codec)
 
 	if err := tableDesc.Validate(ctx, p.txn, p.ExecCfg().Codec); err != nil {
 		return err
@@ -170,22 +182,6 @@ func (n *renameTableNode) startExec(params runParams) error {
 		return err
 	}
 
-	// We update the descriptor to the new name, but also leave the mapping of the
-	// old name to the id, so that the name is not reused until the schema changer
-	// has made sure it's not in use any more.
-	b := &kv.Batch{}
-	if p.extendedEvalCtx.Tracing.KVTracingEnabled() {
-		log.VEventf(ctx, 2, "CPut %s -> %d", newTbKey, descID)
-	}
-	err := catalogkv.WriteDescToBatch(ctx, p.extendedEvalCtx.Tracing.KVTracingEnabled(),
-		p.EvalContext().Settings, b, p.ExecCfg().Codec, descID, tableDesc)
-	if err != nil {
-		return err
-	}
-
-	exists, id, err := catalogkv.LookupPublicTableID(
-		params.ctx, params.p.txn, p.ExecCfg().Codec, targetDbDesc.GetID(), newTn.Table(),
-	)
 	if err == nil && exists {
 		// Try and see what kind of object we collided with.
 		desc, err := catalogkv.GetAnyDescriptorByID(params.ctx, params.p.txn, p.ExecCfg().Codec, id, catalogkv.Immutable)
@@ -197,8 +193,10 @@ func (n *renameTableNode) startExec(params runParams) error {
 		return err
 	}
 
-	b.CPut(newTbKey, descID, nil)
-	return p.txn.Run(ctx, b)
+	newTbKey := catalogkv.MakeObjectNameKey(ctx, params.ExecCfg().Settings,
+		targetDbDesc.GetID(), tableDesc.GetParentSchemaID(), newTn.Table())
+
+	return p.writeNameKey(ctx, newTbKey, descID)
 }
 
 func (n *renameTableNode) Next(runParams) (bool, error) { return false, nil }
@@ -229,4 +227,16 @@ func (p *planner) dependentViewError(
 		sqlbase.NewDependentObjectErrorf("cannot %s %s %q because view %q depends on it",
 			op, typeName, objName, viewName),
 		"you can drop %s instead.", viewName)
+}
+
+// writeNameKey writes a name key to a batch and runs the batch.
+func (p *planner) writeNameKey(ctx context.Context, key sqlbase.DescriptorKey, ID descpb.ID) error {
+	marshalledKey := key.Key(p.ExecCfg().Codec)
+	b := &kv.Batch{}
+	if p.extendedEvalCtx.Tracing.KVTracingEnabled() {
+		log.VEventf(ctx, 2, "CPut %s -> %d", marshalledKey, ID)
+	}
+	b.CPut(marshalledKey, ID, nil)
+
+	return p.txn.Run(ctx, b)
 }

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -54,6 +54,9 @@ type (
 	// TypeDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	TypeDescriptor = descpb.TypeDescriptor
+	// MutableTypeDescriptor is provided for convenience and to make the
+	// interface definitions below more intuitive.
+	MutableTypeDescriptor = sqlbase.MutableTypeDescriptor
 	// ViewDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	ViewDescriptor = descpb.TableDescriptor

--- a/pkg/sql/set_schema.go
+++ b/pkg/sql/set_schema.go
@@ -1,0 +1,96 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// prepareSetSchema verifies that a table/type can be set to the desired
+// schema and returns the schema id of the desired schema.
+func (p *planner) prepareSetSchema(
+	ctx context.Context, desc catalog.MutableDescriptor, schema string,
+) (descpb.ID, error) {
+
+	if desc.DescriptorProto().GetType() != nil && desc.DescriptorProto().GetTable() != nil {
+		return 0, pgerror.New(
+			pgcode.InvalidParameterValue,
+			"no table or type was found for SET SCHEMA command",
+		)
+	}
+	databaseID := desc.GetParentID()
+	schemaID := desc.GetParentSchemaID()
+
+	// Lookup the the schema we want to set to.
+	exists, res, err := p.LogicalSchemaAccessor().GetSchema(
+		ctx, p.txn,
+		p.ExecCfg().Codec,
+		databaseID,
+
+		schema,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	if !exists {
+		return 0, pgerror.Newf(pgcode.InvalidSchemaName,
+			"schema %s does not exist", schema)
+	}
+
+	switch res.Kind {
+	case sqlbase.SchemaTemporary:
+		return 0, pgerror.Newf(pgcode.FeatureNotSupported,
+			"cannot move objects into or out of temporary schemas")
+	case sqlbase.SchemaVirtual:
+		return 0, pgerror.Newf(pgcode.FeatureNotSupported,
+			"cannot move objects into or out of virtual schemas")
+	case sqlbase.SchemaPublic:
+		// We do not need to check for privileges on the public schema.
+	default:
+		// The user needs CREATE privilege on the target schema to move an object
+		// to the schema.
+		err = p.CheckPrivilege(ctx, res.Desc, privilege.CREATE)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	desiredSchemaID := res.ID
+
+	// If the schema being changed to is the same as the current schema a no-op
+	// will happen so we don't have to check if there is an object in the schema
+	// with the same name.
+	if desiredSchemaID == schemaID {
+		return desiredSchemaID, nil
+	}
+
+	exists, id, err := sqlbase.LookupObjectID(
+		ctx, p.txn, p.ExecCfg().Codec, databaseID, desiredSchemaID, desc.GetName(),
+	)
+	if err == nil && exists {
+		collidingDesc, err := catalogkv.GetAnyDescriptorByID(ctx, p.txn, p.ExecCfg().Codec, id, catalogkv.Immutable)
+		if err != nil {
+			return 0, sqlbase.WrapErrorWhileConstructingObjectAlreadyExistsErr(err)
+		}
+		return 0, sqlbase.MakeObjectAlreadyExistsError(collidingDesc.DescriptorProto(), desc.GetName())
+	}
+
+	return desiredSchemaID, nil
+}

--- a/pkg/sql/sqlbase/type_desc.go
+++ b/pkg/sql/sqlbase/type_desc.go
@@ -355,6 +355,17 @@ func (desc *MutableTypeDescriptor) RemoveReferencingDescriptorID(remove descpb.I
 	}
 }
 
+// SetParentSchemaID sets the SchemaID of the type.
+func (desc *MutableTypeDescriptor) SetParentSchemaID(schemaID descpb.ID) {
+	desc.ParentSchemaID = schemaID
+}
+
+// AddDrainingName adds a draining name to the TypeDescriptor's slice of
+// draining names.
+func (desc *MutableTypeDescriptor) AddDrainingName(name descpb.NameInfo) {
+	desc.DrainingNames = append(desc.DrainingNames, name)
+}
+
 // EnumMembers is a sortable list of TypeDescriptor_EnumMember, sorted by the
 // physical representation.
 type EnumMembers []descpb.TypeDescriptor_EnumMember


### PR DESCRIPTION
Added support for ALTER TYPE SET SCHEMA.

We do not yet check for DROP privilege on the type to to able able to execute
the command since type privileges have not yet been implemented.

Release note (sql change): Added support for
ALTER TYPE SET SCHEMA command to set the schema of a
user defined type.

The user must have CREATE privilege on the schema and DROP privilege
on the type to set the schema.

Fixes https://github.com/cockroachdb/cockroach/issues/48671