### PR TITLE
parser,backupccl: switch RESTORE from kv_option to hardcoded options

### DIFF
--- a/docs/generated/sql/bnf/restore.bnf
+++ b/docs/generated/sql/bnf/restore.bnf
@@ -1,10 +1,4 @@
 restore_stmt ::=
-	'RESTORE' 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause 'WITH' kv_option_list
-	| 'RESTORE' 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause 
-	| 'RESTORE' 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause 
-	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause 'WITH' kv_option_list
-	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause 
-	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause 
-	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' string_or_placeholder 'IN' list_of_string_or_placeholder_opt_list opt_as_of_clause 'WITH' kv_option_list
-	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' string_or_placeholder 'IN' list_of_string_or_placeholder_opt_list opt_as_of_clause 
-	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' string_or_placeholder 'IN' list_of_string_or_placeholder_opt_list opt_as_of_clause 
+	'RESTORE' 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
+	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
+	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' string_or_placeholder 'IN' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -156,9 +156,9 @@ reset_stmt ::=
 	| reset_csetting_stmt
 
 restore_stmt ::=
-	'RESTORE' 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_options
-	| 'RESTORE' targets 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_options
-	| 'RESTORE' targets 'FROM' string_or_placeholder 'IN' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_options
+	'RESTORE' 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
+	| 'RESTORE' targets 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
+	| 'RESTORE' targets 'FROM' string_or_placeholder 'IN' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
 
 resume_stmt ::=
 	resume_jobs_stmt
@@ -477,6 +477,11 @@ reset_csetting_stmt ::=
 list_of_string_or_placeholder_opt_list ::=
 	( string_or_placeholder_opt_list ) ( ( ',' string_or_placeholder_opt_list ) )*
 
+opt_with_restore_options ::=
+	'WITH' restore_options_list
+	| 'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 
+
 resume_jobs_stmt ::=
 	'RESUME' 'JOB' a_expr
 	| 'RESUME' 'JOBS' select_stmt
@@ -783,6 +788,7 @@ unreserved_keyword ::=
 	| 'INJECT'
 	| 'INSERT'
 	| 'INTERLEAVE'
+	| 'INTO_DB'
 	| 'INVERTED'
 	| 'ISOLATION'
 	| 'JOB'
@@ -907,6 +913,10 @@ unreserved_keyword ::=
 	| 'SHOW'
 	| 'SIMPLE'
 	| 'SKIP'
+	| 'SKIP_MISSING_FOREIGN_KEYS'
+	| 'SKIP_MISSING_SEQUENCES'
+	| 'SKIP_MISSING_SEQUENCE_OWNERS'
+	| 'SKIP_MISSING_VIEWS'
 	| 'SNAPSHOT'
 	| 'SPLIT'
 	| 'SQL'
@@ -1272,6 +1282,9 @@ session_var ::=
 var_name ::=
 	name
 	| name attrs
+
+restore_options_list ::=
+	( restore_options ) ( ( ',' restore_options ) )*
 
 opt_scrub_options_clause ::=
 	'WITH' 'OPTIONS' scrub_option_list
@@ -1714,6 +1727,14 @@ column_name ::=
 
 attrs ::=
 	( '.' unrestricted_name ) ( ( '.' unrestricted_name ) )*
+
+restore_options ::=
+	'ENCRYPTION_PASSPHRASE' '=' string_or_placeholder
+	| 'INTO_DB' '=' string_or_placeholder
+	| 'SKIP_MISSING_FOREIGN_KEYS'
+	| 'SKIP_MISSING_SEQUENCES'
+	| 'SKIP_MISSING_SEQUENCE_OWNERS'
+	| 'SKIP_MISSING_VIEWS'
 
 scrub_option_list ::=
 	( scrub_option ) ( ( ',' scrub_option ) )*

--- a/pkg/internal/sqlsmith/bulkio.go
+++ b/pkg/internal/sqlsmith/bulkio.go
@@ -143,11 +143,8 @@ func makeRestore(s *Smither) (tree.Statement, bool) {
 		Targets: targets,
 		From:    []tree.StringOrPlaceholderOptList{{tree.NewStrVal(name)}},
 		AsOf:    makeAsOf(s),
-		Options: tree.KVOptions{
-			tree.KVOption{
-				Key:   "into_db",
-				Value: tree.NewStrVal(string(db)),
-			},
+		Options: tree.RestoreOptions{
+			IntoDB: tree.NewDString("into_db"),
 		},
 	}, true
 }

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1540,7 +1540,7 @@ func TestParse(t *testing.T) {
 		{`RESTORE TENANT 36 FROM ($1, $2) AS OF SYSTEM TIME '1'`},
 
 		{`BACKUP TABLE foo TO 'bar' WITH revision_history, detached`},
-		{`RESTORE TABLE foo FROM 'bar' WITH key1, key2 = 'value'`},
+		{`RESTORE TABLE foo FROM 'bar' WITH skip_missing_foreign_keys, skip_missing_sequences`},
 
 		{`IMPORT TABLE foo CREATE USING 'nodelocal://0/some/file' CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 		{`EXPLAIN IMPORT TABLE foo CREATE USING 'nodelocal://0/some/file' CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
@@ -2239,8 +2239,14 @@ $function$`,
 			`BACKUP TABLE foo TO 'bar' WITH revision_history, encryption_passphrase='secret', detached`},
 		{`BACKUP foo TO 'bar' WITH OPTIONS (detached, KMS = ('foo', 'bar'), revision_history)`,
 			`BACKUP TABLE foo TO 'bar' WITH revision_history, detached, kms=('foo', 'bar')`},
-		{`RESTORE foo FROM 'bar' WITH key1, key2 = 'value'`,
-			`RESTORE TABLE foo FROM 'bar' WITH key1, key2 = 'value'`},
+
+		{`RESTORE foo FROM 'bar' WITH OPTIONS (encryption_passphrase='secret', into_db='baz', 
+skip_missing_foreign_keys, skip_missing_sequences, skip_missing_sequence_owners, skip_missing_views)`,
+			`RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase='secret', into_db='baz', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views`},
+		{`RESTORE foo FROM 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', INTO_DB=baz, 
+SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS, SKIP_MISSING_VIEWS`,
+			`RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase='secret', into_db='baz', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views`},
+
 		{`CREATE CHANGEFEED FOR foo INTO 'sink'`, `CREATE CHANGEFEED FOR TABLE foo INTO 'sink'`},
 
 		{`GRANT SELECT ON foo TO root`,

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -485,6 +485,9 @@ func (u *sqlSymUnion) backupOptions() *tree.BackupOptions {
 func (u *sqlSymUnion) copyOptions() *tree.CopyOptions {
   return u.val.(*tree.CopyOptions)
 }
+func (u *sqlSymUnion) restoreOptions() *tree.RestoreOptions {
+  return u.val.(*tree.RestoreOptions)
+}
 func (u *sqlSymUnion) transactionModes() tree.TransactionModes {
     return u.val.(tree.TransactionModes)
 }
@@ -602,7 +605,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 %token <str> INET INET_CONTAINED_BY_OR_EQUALS
 %token <str> INET_CONTAINS_OR_EQUALS INDEX INDEXES INJECT INTERLEAVE INITIALLY
 %token <str> INNER INSERT INT INTEGER
-%token <str> INTERSECT INTERVAL INTO INVERTED IS ISERROR ISNULL ISOLATION
+%token <str> INTERSECT INTERVAL INTO INTO_DB INVERTED IS ISERROR ISNULL ISOLATION
 
 %token <str> JOB JOBS JOIN JSON JSONB JSON_SOME_EXISTS JSON_ALL_EXISTS
 
@@ -635,7 +638,8 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 
 %token <str> SAVEPOINT SCATTER SCHEDULE SCHEDULES SCHEMA SCHEMAS SCRUB SEARCH SECOND SELECT SEQUENCE SEQUENCES
 %token <str> SERIALIZABLE SERVER SESSION SESSIONS SESSION_USER SET SETTING SETTINGS
-%token <str> SHARE SHOW SIMILAR SIMPLE SKIP SMALLINT SMALLSERIAL SNAPSHOT SOME SPLIT SQL
+%token <str> SHARE SHOW SIMILAR SIMPLE SKIP SKIP_MISSING_FOREIGN_KEYS
+%token <str> SKIP_MISSING_SEQUENCES SKIP_MISSING_SEQUENCE_OWNERS SKIP_MISSING_VIEWS SMALLINT SMALLSERIAL SNAPSHOT SOME SPLIT SQL
 
 %token <str> START STATISTICS STATUS STDIN STRICT STRING STORAGE STORE STORED STORING SUBSTRING
 %token <str> SYMMETRIC SYNTAX SYSTEM SQRT SUBSCRIPTION
@@ -869,6 +873,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 %type <tree.KVOption> kv_option
 %type <[]tree.KVOption> kv_option_list opt_with_options var_set_list opt_with_schedule_options
 %type <*tree.BackupOptions> opt_with_backup_options backup_options backup_options_list
+%type <*tree.RestoreOptions> opt_with_restore_options restore_options restore_options_list
 %type <*tree.CopyOptions> opt_with_copy_options copy_options copy_options_list
 %type <str> import_format
 %type <tree.StorageParam> storage_parameter
@@ -2328,25 +2333,32 @@ opt_with_schedule_options:
 //
 // %SeeAlso: BACKUP, WEBDOCS/restore.html
 restore_stmt:
-  RESTORE FROM list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_options
+  RESTORE FROM list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
   {
     $$.val = &tree.Restore{
-      DescriptorCoverage: tree.AllDescriptors, From: $3.listOfStringOrPlaceholderOptList(),
-      AsOf: $4.asOfClause(), Options: $5.kvOptions(),
+    DescriptorCoverage: tree.AllDescriptors,
+    From: $3.listOfStringOrPlaceholderOptList(),
+    AsOf: $4.asOfClause(),
+    Options: *($5.restoreOptions()),
     }
   }
-| RESTORE targets FROM list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_options
+| RESTORE targets FROM list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
   {
     $$.val = &tree.Restore{
-      Targets: $2.targetList(), From: $4.listOfStringOrPlaceholderOptList(),
-      AsOf: $5.asOfClause(), Options: $6.kvOptions(),
-      }
+    Targets: $2.targetList(),
+    From: $4.listOfStringOrPlaceholderOptList(),
+    AsOf: $5.asOfClause(),
+    Options: *($6.restoreOptions()),
+    }
   }
-| RESTORE targets FROM string_or_placeholder IN list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_options
+| RESTORE targets FROM string_or_placeholder IN list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
   {
     $$.val = &tree.Restore{
-      Targets: $2.targetList(), Subdir: $4.expr(), From: $6.listOfStringOrPlaceholderOptList(),
-      AsOf: $7.asOfClause(), Options: $8.kvOptions(),
+      Targets: $2.targetList(),
+      Subdir: $4.expr(),
+      From: $6.listOfStringOrPlaceholderOptList(),
+      AsOf: $7.asOfClause(),
+      Options: *($8.restoreOptions()),
     }
   }
 | RESTORE error // SHOW HELP: RESTORE
@@ -2369,6 +2381,61 @@ list_of_string_or_placeholder_opt_list:
 | list_of_string_or_placeholder_opt_list ',' string_or_placeholder_opt_list
   {
     $$.val = append($1.listOfStringOrPlaceholderOptList(), $3.stringOrPlaceholderOptList())
+  }
+
+// Optional restore options.
+opt_with_restore_options:
+  WITH restore_options_list
+  {
+    $$.val = $2.restoreOptions()
+  }
+| WITH OPTIONS '(' restore_options_list ')'
+  {
+    $$.val = $4.restoreOptions()
+  }
+| /* EMPTY */
+  {
+    $$.val = &tree.RestoreOptions{}
+  }
+
+restore_options_list:
+  // Require at least one option
+  restore_options
+  {
+    $$.val = $1.restoreOptions()
+  }
+| restore_options_list ',' restore_options
+  {
+    if err := $1.restoreOptions().CombineWith($3.restoreOptions()); err != nil {
+      return setErr(sqllex, err)
+    }
+  }
+
+// List of valid restore options.
+restore_options:
+  ENCRYPTION_PASSPHRASE '=' string_or_placeholder
+  {
+    $$.val = &tree.RestoreOptions{EncryptionPassphrase: $3.expr()}
+  }
+| INTO_DB '=' string_or_placeholder
+  {
+    $$.val = &tree.RestoreOptions{IntoDB: $3.expr()}
+  }
+| SKIP_MISSING_FOREIGN_KEYS
+  {
+    $$.val = &tree.RestoreOptions{SkipMissingFKs: true}
+  }
+| SKIP_MISSING_SEQUENCES
+  {
+    $$.val = &tree.RestoreOptions{SkipMissingSequences: true}
+  }
+| SKIP_MISSING_SEQUENCE_OWNERS
+  {
+    $$.val = &tree.RestoreOptions{SkipMissingSequenceOwners: true}
+  }
+| SKIP_MISSING_VIEWS
+  {
+    $$.val = &tree.RestoreOptions{SkipMissingViews: true}
   }
 
 import_format:
@@ -10988,6 +11055,7 @@ unreserved_keyword:
 | INJECT
 | INSERT
 | INTERLEAVE
+| INTO_DB
 | INVERTED
 | ISOLATION
 | JOB
@@ -11112,6 +11180,10 @@ unreserved_keyword:
 | SHOW
 | SIMPLE
 | SKIP
+| SKIP_MISSING_FOREIGN_KEYS
+| SKIP_MISSING_SEQUENCES
+| SKIP_MISSING_SEQUENCE_OWNERS
+| SKIP_MISSING_VIEWS
 | SNAPSHOT
 | SPLIT
 | SQL

--- a/pkg/sql/parser/testdata/errors
+++ b/pkg/sql/parser/testdata/errors
@@ -692,3 +692,28 @@ at or near "detached": syntax error: detached option specified multiple times
 DETAIL: source SQL:
 BACKUP foo TO 'bar' WITH detached, revision_history, detached
                                                      ^
+
+error
+RESTORE foo FROM 'bar' WITH key1, key2 = 'value'
+----
+at or near "key1": syntax error
+DETAIL: source SQL:
+RESTORE foo FROM 'bar' WITH key1, key2 = 'value'
+                            ^
+HINT: try \h RESTORE
+
+error
+RESTORE foo FROM 'bar' WITH skip_missing_foreign_keys, skip_missing_foreign_keys
+----
+at or near "skip_missing_foreign_keys": syntax error: skip_missing_foreign_keys specified multiple times
+DETAIL: source SQL:
+RESTORE foo FROM 'bar' WITH skip_missing_foreign_keys, skip_missing_foreign_keys
+                                                       ^
+
+error
+RESTORE foo FROM 'bar' WITH skip_missing_sequences, skip_missing_views, skip_missing_sequences
+----
+at or near "skip_missing_sequences": syntax error: skip_missing_sequences specified multiple times
+DETAIL: source SQL:
+RESTORE foo FROM 'bar' WITH skip_missing_sequences, skip_missing_views, skip_missing_sequences
+                                                                        ^

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1980,7 +1980,7 @@ func (node *Restore) doc(p *PrettyCfg) pretty.Doc {
 	if node.AsOf.Expr != nil {
 		items = append(items, node.AsOf.docRow(p))
 	}
-	if node.Options != nil {
+	if !node.Options.IsDefault() {
 		items = append(items, p.row("WITH", p.Doc(&node.Options)))
 	}
 	return p.rlTable(items...)

--- a/pkg/sql/sem/tree/testdata/pretty/restore.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/restore.align-deindent.golden
@@ -12,7 +12,7 @@ FROM
 AS OF SYSTEM TIME
 	'2017-02-28 10:00:00'
 WITH
-	into_db = 'newdb'
+	into_db='newdb'
 
 17:
 -----------------
@@ -22,7 +22,7 @@ WITH
                   'gs://acme-co-backup/database-bank-2017-03-28-nightly',
                   'gs://acme-co-backup/database-bank-2017-03-29-nightly'
 AS OF SYSTEM TIME '2017-02-28 10:00:00'
-             WITH into_db = 'newdb'
+             WITH into_db='newdb'
 
 183:
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -30,10 +30,10 @@ AS OF SYSTEM TIME '2017-02-28 10:00:00'
             TABLE bank.customers
              FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly'
 AS OF SYSTEM TIME '2017-02-28 10:00:00'
-             WITH into_db = 'newdb'
+             WITH into_db='newdb'
 
 262:
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-RESTORE TABLE bank.customers FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly' AS OF SYSTEM TIME '2017-02-28 10:00:00' WITH into_db = 'newdb'
+RESTORE TABLE bank.customers FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly' AS OF SYSTEM TIME '2017-02-28 10:00:00' WITH into_db='newdb'
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/restore.align-deindent.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/restore.align-deindent.golden.short
@@ -8,6 +8,6 @@
                   'gs://acme-co-backup/database-bank-2017-03-28-nightly',
                   'gs://acme-co-backup/database-bank-2017-03-29-nightly'
 AS OF SYSTEM TIME '2017-02-28 10:00:00'
-             WITH into_db = 'newdb'
+             WITH into_db='newdb'
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/restore.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/restore.align-only.golden
@@ -12,7 +12,7 @@ FROM
 AS OF SYSTEM TIME
 	'2017-02-28 10:00:00'
 WITH
-	into_db = 'newdb'
+	into_db='newdb'
 
 17:
 -----------------
@@ -22,7 +22,7 @@ WITH
                   'gs://acme-co-backup/database-bank-2017-03-28-nightly',
                   'gs://acme-co-backup/database-bank-2017-03-29-nightly'
 AS OF SYSTEM TIME '2017-02-28 10:00:00'
-             WITH into_db = 'newdb'
+             WITH into_db='newdb'
 
 183:
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -30,10 +30,10 @@ AS OF SYSTEM TIME '2017-02-28 10:00:00'
             TABLE bank.customers
              FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly'
 AS OF SYSTEM TIME '2017-02-28 10:00:00'
-             WITH into_db = 'newdb'
+             WITH into_db='newdb'
 
 262:
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-RESTORE TABLE bank.customers FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly' AS OF SYSTEM TIME '2017-02-28 10:00:00' WITH into_db = 'newdb'
+RESTORE TABLE bank.customers FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly' AS OF SYSTEM TIME '2017-02-28 10:00:00' WITH into_db='newdb'
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/restore.align-only.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/restore.align-only.golden.short
@@ -8,6 +8,6 @@
                   'gs://acme-co-backup/database-bank-2017-03-28-nightly',
                   'gs://acme-co-backup/database-bank-2017-03-29-nightly'
 AS OF SYSTEM TIME '2017-02-28 10:00:00'
-             WITH into_db = 'newdb'
+             WITH into_db='newdb'
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/restore.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/restore.ref.golden
@@ -12,7 +12,7 @@ FROM
 AS OF SYSTEM TIME
 	'2017-02-28 10:00:00'
 WITH
-	into_db = 'newdb'
+	into_db='newdb'
 
 169:
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -24,10 +24,10 @@ FROM
 AS OF SYSTEM TIME
 	'2017-02-28 10:00:00'
 WITH
-	into_db = 'newdb'
+	into_db='newdb'
 
 262:
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-RESTORE TABLE bank.customers FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly' AS OF SYSTEM TIME '2017-02-28 10:00:00' WITH into_db = 'newdb'
+RESTORE TABLE bank.customers FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly' AS OF SYSTEM TIME '2017-02-28 10:00:00' WITH into_db='newdb'
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/restore.ref.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/restore.ref.golden.short
@@ -12,6 +12,6 @@ FROM
 AS OF SYSTEM TIME
 	'2017-02-28 10:00:00'
 WITH
-	into_db = 'newdb'
+	into_db='newdb'
 
 

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1032,7 +1032,6 @@ func (stmt *ParenSelect) walkStmt(v Visitor) Statement {
 func (stmt *Restore) copyNode() *Restore {
 	stmtCopy := *stmt
 	stmtCopy.From = append([]StringOrPlaceholderOptList(nil), stmt.From...)
-	stmtCopy.Options = append(KVOptions(nil), stmt.Options...)
 	return &stmtCopy
 }
 
@@ -1059,13 +1058,24 @@ func (stmt *Restore) walkStmt(v Visitor) Statement {
 			}
 		}
 	}
-	{
-		opts, changed := walkKVOptions(v, stmt.Options)
+
+	if stmt.Options.EncryptionPassphrase != nil {
+		pw, changed := WalkExpr(v, stmt.Options.EncryptionPassphrase)
 		if changed {
 			if ret == stmt {
 				ret = stmt.copyNode()
 			}
-			ret.Options = opts
+			ret.Options.EncryptionPassphrase = pw
+		}
+	}
+
+	if stmt.Options.IntoDB != nil {
+		intoDB, changed := WalkExpr(v, stmt.Options.IntoDB)
+		if changed {
+			if ret == stmt {
+				ret = stmt.copyNode()
+			}
+			ret.Options.IntoDB = intoDB
 		}
 	}
 	return ret


### PR DESCRIPTION
Following in the footsteps of BACKUP, this change switches RESTORE from
using KV option lists to hardcoded options.

The `WITH` clause no longer accepts any set of key/value pairs but only
accepts options allowed by the RESTORE statement.

This change does not introduce any new options but adds the following
enhancements:

1. Ensures that the option is only specified once, otherwise it errors
out.

2. Quoted option names are now disallowed.

Informs: #50735

Release note (backward-incompatible change): Improves WITH option
parsing for RESTORE.  Does not allow the same option to be specified
twice, and also prevents usage of quoted option names.