### PR TITLE
sql: fix stable column id

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -546,3 +546,17 @@ INSERT INTO t30 VALUES (e'a\\01');
 
 statement error pq: could not parse "a\\\\01" as type bytes: bytea encoded value ends with incomplete escape sequence
 ALTER TABLE t30 ALTER COLUMN x TYPE BYTES
+
+# Regression 52305.
+statement ok
+CREATE TABLE t52305(x INT)
+
+statement ok
+ALTER TABLE t52305 ALTER COLUMN x TYPE STRING
+
+let $table_id
+SELECT oid FROM pg_catalog.pg_class WHERE relname LIKE '%t52305%'
+
+# The ordinal id for the column should stay the same after the alter column type.
+statement ok
+SELECT * FROM [$table_id(1) as t]

--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -45,6 +45,11 @@ type Column interface {
 	// a different ID. See the comment for StableID for more detail.
 	ColID() StableID
 
+	// PhysicalColID returns the physical column ID of a column. This ID is not
+	// stable and can be changed for example through an ALTER COLUMN TYPE command.
+	// It is guaranteed that the PhysicalColID will not be reused.
+	PhysicalColID() tree.ColumnID
+
 	// ColName returns the name of the column.
 	ColName() tree.Name
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -611,7 +611,7 @@ func newOptTable(
 	// Create the table's column mapping from sqlbase.ColumnID to column ordinal.
 	ot.colMap = make(map[sqlbase.ColumnID]int, ot.ColumnCount())
 	for i, n := 0, ot.ColumnCount(); i < n; i++ {
-		ot.colMap[sqlbase.ColumnID(ot.Column(i).ColID())] = i
+		ot.colMap[sqlbase.ColumnID(ot.Column(i).PhysicalColID())] = i
 	}
 
 	// Build the indexes (add 1 to account for lack of primary index in
@@ -1628,6 +1628,11 @@ var _ cat.Column = optDummyVirtualPKColumn{}
 // ColID is part of the cat.Column interface.
 func (optDummyVirtualPKColumn) ColID() cat.StableID {
 	return math.MaxInt64
+}
+
+// PhysicalColID is part of the cat.Column interface.
+func (optDummyVirtualPKColumn) PhysicalColID() tree.ColumnID {
+	return math.MaxInt32
 }
 
 // ColName is part of the cat.Column interface.

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -4280,7 +4280,12 @@ func (desc *ColumnDescriptor) HasNullDefault() bool {
 
 // ColID is part of the cat.Column interface.
 func (desc *ColumnDescriptor) ColID() cat.StableID {
-	return cat.StableID(desc.ID)
+	return cat.StableID(desc.GetLogicalColumnID())
+}
+
+// PhysicalColID is part of the cat.Column interface.
+func (desc *ColumnDescriptor) PhysicalColID() tree.ColumnID {
+	return tree.ColumnID(desc.ID)
 }
 
 // ColName is part of the cat.Column interface.


### PR DESCRIPTION
ColumnDescriptor.ColID() was not updated to use LogicalColumnID
so the ordinal position of a column could be incorrect in some cases.

No release note since bug is not in production.

Release note: None

Fixes #52305