### PR TITLE
build: ask tar to read to end

### DIFF
--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -45,8 +45,9 @@ docker_login_with_google
 gcr_repository="us.gcr.io/cockroach-cloud-images/cockroach"
 
 # TODO: update publish-provisional-artifacts with option to leave one or more cockroach binaries in the local filesystem
-# HACK: we pipe though tac twice to reverse/un-reverse since that will read the whole buffer and make curl happy, even if tar closes early.
-curl -f -s -S -o- "https://${bucket}.s3.amazonaws.com/cockroach-${build_name}.linux-amd64.tgz" | tac | tac | tar xfz - --strip-components 1
+# NB: tar usually stops reading as soon as it sees an empty block but that makes
+# curl unhappy, so passing `i` will cause it to read to the end.
+curl -f -s -S -o- "https://${bucket}.s3.amazonaws.com/cockroach-${build_name}.linux-amd64.tgz" | tar ixfz - --strip-components 1
 cp cockroach build/deploy/cockroach
 
 docker build --no-cache --tag="${gcr_repository}:${build_name}" build/deploy


### PR DESCRIPTION
tar typically stops reading as soon as it hits a zero block.
This can mean it closes its input before EOF, but that can make
the process sending that input, like curl, unhappy.

Instead, the -i option to tar instructs it to read to end of file.

Release note: none