### PR TITLE
colexec,execinfrapb: preliminary changes for default aggregate function

### DIFF
--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -59,7 +59,7 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 	b.allocator.PerformOperation(
 		[]coldata.Vec{output},
 		func() {
-			b.toDatumConverter.convertBatch(batch)
+			b.toDatumConverter.convertBatchAndDeselect(batch)
 			for i := 0; i < n; i++ {
 				hasNulls := false
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
@@ -94,16 +94,19 @@ func genVecToDatum(inputFileContents string, wr io.Writer) error {
 	r := strings.NewReplacer(
 		"_HAS_NULLS", "$.HasNulls",
 		"_HAS_SEL", "$.HasSel",
+		"_DESELECT", "$.Deselect",
 		"_TYPE_FAMILY", "{{.TypeFamily}}",
 		"_TYPE_WIDTH", typeWidthReplacement,
 		"_VEC_METHOD", "{{.VecMethod}}",
 	)
 	s := r.Replace(inputFileContents)
 
-	setTupleIdx := makeFunctionRegex("_SET_TUPLE_IDX", 4)
-	s = setTupleIdx.ReplaceAllString(s, `{{template "setTupleIdx" buildDict "HasSel" $4}}`)
-	vecToDatum := makeFunctionRegex("_VEC_TO_DATUM", 7)
-	s = vecToDatum.ReplaceAllString(s, `{{template "vecToDatum" buildDict "Global" . "HasNulls" $6 "HasSel" $7}}`)
+	setDestIdx := makeFunctionRegex("_SET_DEST_IDX", 5)
+	s = setDestIdx.ReplaceAllString(s, `{{template "setDestIdx" buildDict "HasSel" $4 "Deselect" $5}}`)
+	setSrcIdx := makeFunctionRegex("_SET_SRC_IDX", 4)
+	s = setSrcIdx.ReplaceAllString(s, `{{template "setSrcIdx" buildDict "HasSel" $4}}`)
+	vecToDatum := makeFunctionRegex("_VEC_TO_DATUM", 8)
+	s = vecToDatum.ReplaceAllString(s, `{{template "vecToDatum" buildDict "Global" . "HasNulls" $6 "HasSel" $7 "Deselect" $8}}`)
 
 	assignConvertedRe := makeFunctionRegex("_ASSIGN_CONVERTED", 4)
 	s = assignConvertedRe.ReplaceAllString(s, makeTemplateFunctionCall("AssignConverted", 4))

--- a/pkg/sql/colexec/expr.go
+++ b/pkg/sql/colexec/expr.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -61,7 +60,7 @@ func NewExprHelper(exprDeserialization ExprDeserialization) ExprHelper {
 // defaultExprHelper is an ExprHelper that takes advantage of already present
 // well-typed expression in LocalExpr when set.
 type defaultExprHelper struct {
-	helper execinfra.ExprHelper
+	helper execinfrapb.ExprHelper
 }
 
 var _ ExprHelper = &defaultExprHelper{}
@@ -83,14 +82,14 @@ func (h *defaultExprHelper) ProcessExpr(
 	}
 	h.helper.Types = typs
 	tempVars := tree.MakeIndexedVarHelper(&h.helper, len(typs))
-	return execinfra.DeserializeExpr(expr.Expr, semaCtx, evalCtx, &tempVars)
+	return execinfrapb.DeserializeExpr(expr.Expr, semaCtx, evalCtx, &tempVars)
 }
 
 // forcedDeserializationExprHelper is an ExprHelper that always deserializes
 // (namely, parses, type-checks, and evaluates the constants) the provided
 // expression, completely ignoring LocalExpr field if set.
 type forcedDeserializationExprHelper struct {
-	helper execinfra.ExprHelper
+	helper execinfrapb.ExprHelper
 }
 
 var _ ExprHelper = &forcedDeserializationExprHelper{}
@@ -103,7 +102,7 @@ func (h *forcedDeserializationExprHelper) ProcessExpr(
 ) (tree.TypedExpr, error) {
 	h.helper.Types = typs
 	tempVars := tree.MakeIndexedVarHelper(&h.helper, len(typs))
-	return execinfra.DeserializeExpr(expr.Expr, semaCtx, evalCtx, &tempVars)
+	return execinfrapb.DeserializeExpr(expr.Expr, semaCtx, evalCtx, &tempVars)
 }
 
 // Remove unused warning.

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -102,6 +102,10 @@ type hashAggregator struct {
 	hashAlloc   hashAggFuncsAlloc
 }
 
+// Remove unused warning.
+// TODO(yuzefovich): remove this once it is used by the hash aggregator.
+var _ = (&vecToDatumConverter{}).convertBatch
+
 var _ colexecbase.Operator = &hashAggregator{}
 
 // hashAggregatorAllocSize determines the allocation size used by the hash

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -226,7 +226,7 @@ func (m *Materializer) next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadat
 				return nil, m.DrainHelper()
 			}
 			m.curIdx = 0
-			m.converter.convertBatch(m.batch)
+			m.converter.convertBatchAndDeselect(m.batch)
 		}
 
 		for colIdx := range m.typs {

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -209,8 +209,8 @@ func TestRandomComparisons(t *testing.T) {
 				},
 			)
 		}
-		PhysicalTypeColVecToDatum(lDatums, lVec, numTuples, nil /* sel */, &da)
-		PhysicalTypeColVecToDatum(rDatums, rVec, numTuples, nil /* sel */, &da)
+		ColVecToDatumAndDeselect(lDatums, lVec, numTuples, nil /* sel */, &da)
+		ColVecToDatumAndDeselect(rDatums, rVec, numTuples, nil /* sel */, &da)
 		supportedCmpOps := []tree.ComparisonOperator{tree.EQ, tree.NE, tree.LT, tree.LE, tree.GT, tree.GE}
 		if typ.Family() == types.JsonFamily {
 			supportedCmpOps = []tree.ComparisonOperator{tree.EQ, tree.NE}

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -939,7 +939,7 @@ func (rf *cFetcher) pushState(state fetcherState) {
 // This function is meant for tracing and should not be used in hot paths.
 func (rf *cFetcher) getDatumAt(colIdx int, rowIdx int) tree.Datum {
 	res := []tree.Datum{nil}
-	colexec.PhysicalTypeColVecToDatum(res, rf.machine.colvecs[colIdx], 1 /* length */, []int{rowIdx}, &rf.table.da)
+	colexec.ColVecToDatumAndDeselect(res, rf.machine.colvecs[colIdx], 1 /* length */, []int{rowIdx}, &rf.table.da)
 	return res[0]
 }
 

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -85,6 +85,7 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 
 	// The outbox uses this stopper to run a goroutine.
 	outboxStopper := stop.NewStopper()
+	defer outboxStopper.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		Cfg: &execinfra.ServerConfig{
 			Settings:   st,

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -49,10 +49,10 @@ type ProcOutputHelper struct {
 	output   RowReceiver
 	RowAlloc sqlbase.EncDatumRowAlloc
 
-	filter *ExprHelper
+	filter *execinfrapb.ExprHelper
 	// renderExprs has length > 0 if we have a rendering. Only one of renderExprs
 	// and outputCols can be set.
-	renderExprs []ExprHelper
+	renderExprs []execinfrapb.ExprHelper
 	// outputCols is non-nil if we have a projection. Only one of renderExprs and
 	// outputCols can be set. Note that 0-length projections are possible, in
 	// which case outputCols will be 0-length but non-nil.
@@ -108,7 +108,7 @@ func (h *ProcOutputHelper) Init(
 	h.output = output
 	h.numInternalCols = len(typs)
 	if post.Filter != (execinfrapb.Expression{}) {
-		h.filter = &ExprHelper{}
+		h.filter = &execinfrapb.ExprHelper{}
 		if err := h.filter.Init(post.Filter, typs, semaCtx, evalCtx); err != nil {
 			return err
 		}
@@ -137,7 +137,7 @@ func (h *ProcOutputHelper) Init(
 		if cap(h.renderExprs) >= nRenders {
 			h.renderExprs = h.renderExprs[:nRenders]
 		} else {
-			h.renderExprs = make([]ExprHelper, nRenders)
+			h.renderExprs = make([]execinfrapb.ExprHelper, nRenders)
 		}
 		if cap(h.OutputTypes) >= nRenders {
 			h.OutputTypes = h.OutputTypes[:nRenders]
@@ -145,7 +145,7 @@ func (h *ProcOutputHelper) Init(
 			h.OutputTypes = make([]*types.T, nRenders)
 		}
 		for i, expr := range post.RenderExprs {
-			h.renderExprs[i] = ExprHelper{}
+			h.renderExprs[i] = execinfrapb.ExprHelper{}
 			if err := h.renderExprs[i].Init(expr, typs, semaCtx, evalCtx); err != nil {
 				return err
 			}

--- a/pkg/sql/execinfrapb/expr.go
+++ b/pkg/sql/execinfrapb/expr.go
@@ -8,12 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package execinfra
+package execinfrapb
 
 import (
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -50,7 +49,7 @@ func (*ivarBinder) VisitPost(expr tree.Expr) tree.Expr { return expr }
 // processExpression parses the string expression inside an Expression,
 // and associates ordinal references (@1, @2, etc) with the given helper.
 func processExpression(
-	exprSpec execinfrapb.Expression,
+	exprSpec Expression,
 	evalCtx *tree.EvalContext,
 	semaCtx *tree.SemaContext,
 	h *tree.IndexedVarHelper,
@@ -148,7 +147,7 @@ func DeserializeExpr(
 		return nil, nil
 	}
 
-	deserializedExpr, err := processExpression(execinfrapb.Expression{Expr: expr}, evalCtx, semaCtx, vars)
+	deserializedExpr, err := processExpression(Expression{Expr: expr}, evalCtx, semaCtx, vars)
 	if err != nil {
 		return deserializedExpr, err
 	}
@@ -161,10 +160,7 @@ func DeserializeExpr(
 
 // Init initializes the ExprHelper.
 func (eh *ExprHelper) Init(
-	expr execinfrapb.Expression,
-	types []*types.T,
-	semaCtx *tree.SemaContext,
-	evalCtx *tree.EvalContext,
+	expr Expression, types []*types.T, semaCtx *tree.SemaContext, evalCtx *tree.EvalContext,
 ) error {
 	if expr.Empty() {
 		return nil

--- a/pkg/sql/execinfrapb/expr_test.go
+++ b/pkg/sql/execinfrapb/expr_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package execinfra
+package execinfrapb
 
 import (
 	"fmt"
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -40,7 +39,7 @@ func (d testVarContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 func TestProcessExpression(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	e := execinfrapb.Expression{Expr: "@1 * (@2 + @3) + @1"}
+	e := Expression{Expr: "@1 * (@2 + @3) + @1"}
 
 	h := tree.MakeIndexedVarHelper(testVarContainer{}, 4)
 	st := cluster.MakeTestingClusterSettings()
@@ -67,7 +66,7 @@ func TestProcessExpression(t *testing.T) {
 func TestProcessExpressionConstantEval(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	e := execinfrapb.Expression{Expr: "ARRAY[1:::INT,2:::INT]"}
+	e := Expression{Expr: "ARRAY[1:::INT,2:::INT]"}
 
 	h := tree.MakeIndexedVarHelper(nil, 0)
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/sql/execinfrapb/processors_sql.pb.go
+++ b/pkg/sql/execinfrapb/processors_sql.pb.go
@@ -64,7 +64,7 @@ func (x *ScanVisibility) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanVisibility) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{0}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{0}
 }
 
 // These mirror the aggregate functions supported by sql/parser. See
@@ -187,7 +187,7 @@ func (x *AggregatorSpec_Func) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Func) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{12, 0}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{12, 0}
 }
 
 type AggregatorSpec_Type int32
@@ -233,7 +233,7 @@ func (x *AggregatorSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{12, 1}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{12, 1}
 }
 
 type WindowerSpec_WindowFunc int32
@@ -297,7 +297,7 @@ func (x *WindowerSpec_WindowFunc) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_WindowFunc) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{15, 0}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{15, 0}
 }
 
 // Mode indicates which mode of framing is used.
@@ -341,7 +341,7 @@ func (x *WindowerSpec_Frame_Mode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Mode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{15, 1, 0}
 }
 
 // BoundType indicates which type of boundary is used.
@@ -388,7 +388,7 @@ func (x *WindowerSpec_Frame_BoundType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_BoundType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{15, 1, 1}
 }
 
 // Exclusion specifies the type of frame exclusion.
@@ -431,7 +431,7 @@ func (x *WindowerSpec_Frame_Exclusion) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Exclusion) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{15, 1, 2}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{15, 1, 2}
 }
 
 // ValuesCoreSpec is the core of a processor that has no inputs and generates
@@ -451,7 +451,7 @@ func (m *ValuesCoreSpec) Reset()         { *m = ValuesCoreSpec{} }
 func (m *ValuesCoreSpec) String() string { return proto.CompactTextString(m) }
 func (*ValuesCoreSpec) ProtoMessage()    {}
 func (*ValuesCoreSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{0}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{0}
 }
 func (m *ValuesCoreSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -562,7 +562,7 @@ func (m *TableReaderSpec) Reset()         { *m = TableReaderSpec{} }
 func (m *TableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*TableReaderSpec) ProtoMessage()    {}
 func (*TableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{1}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{1}
 }
 func (m *TableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -620,7 +620,7 @@ func (m *IndexSkipTableReaderSpec) Reset()         { *m = IndexSkipTableReaderSp
 func (m *IndexSkipTableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*IndexSkipTableReaderSpec) ProtoMessage()    {}
 func (*IndexSkipTableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{2}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{2}
 }
 func (m *IndexSkipTableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -730,7 +730,7 @@ func (m *JoinReaderSpec) Reset()         { *m = JoinReaderSpec{} }
 func (m *JoinReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*JoinReaderSpec) ProtoMessage()    {}
 func (*JoinReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{3}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{3}
 }
 func (m *JoinReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -774,7 +774,7 @@ func (m *SorterSpec) Reset()         { *m = SorterSpec{} }
 func (m *SorterSpec) String() string { return proto.CompactTextString(m) }
 func (*SorterSpec) ProtoMessage()    {}
 func (*SorterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{4}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{4}
 }
 func (m *SorterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -836,7 +836,7 @@ func (m *DistinctSpec) Reset()         { *m = DistinctSpec{} }
 func (m *DistinctSpec) String() string { return proto.CompactTextString(m) }
 func (*DistinctSpec) ProtoMessage()    {}
 func (*DistinctSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{5}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{5}
 }
 func (m *DistinctSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -871,7 +871,7 @@ func (m *OrdinalitySpec) Reset()         { *m = OrdinalitySpec{} }
 func (m *OrdinalitySpec) String() string { return proto.CompactTextString(m) }
 func (*OrdinalitySpec) ProtoMessage()    {}
 func (*OrdinalitySpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{6}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{6}
 }
 func (m *OrdinalitySpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -929,7 +929,7 @@ func (m *ZigzagJoinerSpec) Reset()         { *m = ZigzagJoinerSpec{} }
 func (m *ZigzagJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*ZigzagJoinerSpec) ProtoMessage()    {}
 func (*ZigzagJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{7}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{7}
 }
 func (m *ZigzagJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1005,7 +1005,7 @@ func (m *MergeJoinerSpec) Reset()         { *m = MergeJoinerSpec{} }
 func (m *MergeJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*MergeJoinerSpec) ProtoMessage()    {}
 func (*MergeJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{8}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{8}
 }
 func (m *MergeJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1092,7 +1092,7 @@ func (m *HashJoinerSpec) Reset()         { *m = HashJoinerSpec{} }
 func (m *HashJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*HashJoinerSpec) ProtoMessage()    {}
 func (*HashJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{9}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{9}
 }
 func (m *HashJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1186,7 +1186,7 @@ func (m *InvertedJoinerSpec) Reset()         { *m = InvertedJoinerSpec{} }
 func (m *InvertedJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedJoinerSpec) ProtoMessage()    {}
 func (*InvertedJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{10}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{10}
 }
 func (m *InvertedJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1239,7 +1239,7 @@ func (m *InvertedFiltererSpec) Reset()         { *m = InvertedFiltererSpec{} }
 func (m *InvertedFiltererSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedFiltererSpec) ProtoMessage()    {}
 func (*InvertedFiltererSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{11}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{11}
 }
 func (m *InvertedFiltererSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1285,7 +1285,7 @@ func (m *AggregatorSpec) Reset()         { *m = AggregatorSpec{} }
 func (m *AggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec) ProtoMessage()    {}
 func (*AggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{12}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{12}
 }
 func (m *AggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1336,7 +1336,7 @@ func (m *AggregatorSpec_Aggregation) Reset()         { *m = AggregatorSpec_Aggre
 func (m *AggregatorSpec_Aggregation) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec_Aggregation) ProtoMessage()    {}
 func (*AggregatorSpec_Aggregation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{12, 0}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{12, 0}
 }
 func (m *AggregatorSpec_Aggregation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1411,7 +1411,7 @@ func (m *InterleavedReaderJoinerSpec) Reset()         { *m = InterleavedReaderJo
 func (m *InterleavedReaderJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{13}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{13}
 }
 func (m *InterleavedReaderJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1467,7 +1467,7 @@ func (m *InterleavedReaderJoinerSpec_Table) Reset()         { *m = InterleavedRe
 func (m *InterleavedReaderJoinerSpec_Table) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec_Table) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec_Table) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{13, 0}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{13, 0}
 }
 func (m *InterleavedReaderJoinerSpec_Table) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1507,7 +1507,7 @@ func (m *ProjectSetSpec) Reset()         { *m = ProjectSetSpec{} }
 func (m *ProjectSetSpec) String() string { return proto.CompactTextString(m) }
 func (*ProjectSetSpec) ProtoMessage()    {}
 func (*ProjectSetSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{14}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{14}
 }
 func (m *ProjectSetSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1549,7 +1549,7 @@ func (m *WindowerSpec) Reset()         { *m = WindowerSpec{} }
 func (m *WindowerSpec) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec) ProtoMessage()    {}
 func (*WindowerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{15}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{15}
 }
 func (m *WindowerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1585,7 +1585,7 @@ func (m *WindowerSpec_Func) Reset()         { *m = WindowerSpec_Func{} }
 func (m *WindowerSpec_Func) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Func) ProtoMessage()    {}
 func (*WindowerSpec_Func) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{15, 0}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{15, 0}
 }
 func (m *WindowerSpec_Func) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1621,7 +1621,7 @@ func (m *WindowerSpec_Frame) Reset()         { *m = WindowerSpec_Frame{} }
 func (m *WindowerSpec_Frame) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame) ProtoMessage()    {}
 func (*WindowerSpec_Frame) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{15, 1}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{15, 1}
 }
 func (m *WindowerSpec_Frame) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1662,7 +1662,7 @@ func (m *WindowerSpec_Frame_Bound) Reset()         { *m = WindowerSpec_Frame_Bou
 func (m *WindowerSpec_Frame_Bound) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bound) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bound) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{15, 1, 0}
 }
 func (m *WindowerSpec_Frame_Bound) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1698,7 +1698,7 @@ func (m *WindowerSpec_Frame_Bounds) Reset()         { *m = WindowerSpec_Frame_Bo
 func (m *WindowerSpec_Frame_Bounds) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bounds) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bounds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{15, 1, 1}
 }
 func (m *WindowerSpec_Frame_Bounds) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1748,7 +1748,7 @@ func (m *WindowerSpec_WindowFn) Reset()         { *m = WindowerSpec_WindowFn{} }
 func (m *WindowerSpec_WindowFn) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_WindowFn) ProtoMessage()    {}
 func (*WindowerSpec_WindowFn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_2f2ce35b700353f8, []int{15, 2}
+	return fileDescriptor_processors_sql_f19ad398db9f02d4, []int{15, 2}
 }
 func (m *WindowerSpec_WindowFn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8090,10 +8090,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_2f2ce35b700353f8)
+	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_f19ad398db9f02d4)
 }
 
-var fileDescriptor_processors_sql_2f2ce35b700353f8 = []byte{
+var fileDescriptor_processors_sql_f19ad398db9f02d4 = []byte{
 	// 2700 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x5a, 0x4b, 0x73, 0xdb, 0xd6,
 	0xf5, 0x17, 0xf8, 0x90, 0xc8, 0xc3, 0x87, 0xae, 0xaf, 0x95, 0x98, 0x51, 0xfe, 0x7f, 0x59, 0x66,

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -618,6 +618,9 @@ message AggregatorSpec {
     JSONB_OBJECT_AGG = 28;
     VAR_POP = 29;
     STDDEV_POP = 30;
+    // NOTE: if you're adding a new aggregate function here, make sure to add
+    // an appropriate entry in execinfrapb.AggregateFuncToNumArguments map.
+    // Also, please keep this note at the very bottom of this enum.
   }
 
   enum Type {

--- a/pkg/sql/rowcontainer/datum_row_container.go
+++ b/pkg/sql/rowcontainer/datum_row_container.go
@@ -12,20 +12,12 @@ package rowcontainer
 
 import (
 	"context"
-	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
-)
-
-const (
-	// SizeOfDatum is the memory size of a Datum reference.
-	SizeOfDatum = int64(unsafe.Sizeof(tree.Datum(nil)))
-	// SizeOfDatums is the memory size of a Datum slice.
-	SizeOfDatums = int64(unsafe.Sizeof(tree.Datums(nil)))
 )
 
 // RowContainer is a container for rows of Datums which tracks the
@@ -138,8 +130,8 @@ func (c *RowContainer) Init(acc mon.BoundAccount, ti sqlbase.ColTypeInfo, rowCap
 
 	// Precalculate the memory used for a chunk, specifically by the Datums in the
 	// chunk and the slice pointing at the chunk.
-	c.chunkMemSize = SizeOfDatum * int64(c.rowsPerChunk*c.numCols)
-	c.chunkMemSize += SizeOfDatums
+	c.chunkMemSize = tree.SizeOfDatum * int64(c.rowsPerChunk*c.numCols)
+	c.chunkMemSize += tree.SizeOfDatums
 }
 
 // Clear resets the container and releases the associated memory. This allows

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -70,7 +70,7 @@ type invertedJoiner struct {
 	// the table column that was indexed.
 	invertedColID descpb.ColumnID
 
-	onExprHelper execinfra.ExprHelper
+	onExprHelper execinfrapb.ExprHelper
 	combinedRow  sqlbase.EncDatumRow
 
 	joinType descpb.JoinType
@@ -229,7 +229,7 @@ func newInvertedJoiner(
 	ij.combinedRow = make(sqlbase.EncDatumRow, 0, len(onExprColTypes))
 
 	if ij.datumsToInvertedExpr == nil {
-		var invertedExprHelper execinfra.ExprHelper
+		var invertedExprHelper execinfrapb.ExprHelper
 		if err := invertedExprHelper.Init(spec.InvertedExpr, onExprColTypes, semaCtx, ij.EvalCtx); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -25,7 +25,7 @@ type joinerBase struct {
 	execinfra.ProcessorBase
 
 	joinType    descpb.JoinType
-	onCond      execinfra.ExprHelper
+	onCond      execinfrapb.ExprHelper
 	emptyLeft   sqlbase.EncDatumRow
 	emptyRight  sqlbase.EncDatumRow
 	combinedRow sqlbase.EncDatumRow

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -33,7 +33,7 @@ type projectSetProcessor struct {
 	// in the ROWS FROM syntax. This can contain many kinds of expressions
 	// (anything that is "function-like" including COALESCE, NULLIF) not just
 	// SRFs.
-	exprHelpers []*execinfra.ExprHelper
+	exprHelpers []*execinfrapb.ExprHelper
 
 	// funcs contains a valid pointer to a SRF FuncExpr for every entry
 	// in `exprHelpers` that is actually a SRF function application.
@@ -77,7 +77,7 @@ func newProjectSetProcessor(
 	ps := &projectSetProcessor{
 		input:       input,
 		spec:        spec,
-		exprHelpers: make([]*execinfra.ExprHelper, len(spec.Exprs)),
+		exprHelpers: make([]*execinfrapb.ExprHelper, len(spec.Exprs)),
 		funcs:       make([]*tree.FuncExpr, len(spec.Exprs)),
 		rowBuffer:   make(sqlbase.EncDatumRow, len(outputTypes)),
 		gens:        make([]tree.ValueGenerator, len(spec.Exprs)),
@@ -99,7 +99,7 @@ func newProjectSetProcessor(
 	// Initialize exprHelpers.
 	semaCtx := ps.FlowCtx.TypeResolverFactory.NewSemaContext(ps.EvalCtx.Txn)
 	for i, expr := range ps.spec.Exprs {
-		var helper execinfra.ExprHelper
+		var helper execinfrapb.ExprHelper
 		err := helper.Init(expr, ps.input.OutputTypes(), semaCtx, ps.EvalCtx)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -291,8 +291,7 @@ var aggregates = map[string]builtinDefinition{
 
 	"final_stddev": makePrivate(makeBuiltin(aggProps(),
 		makeAggOverload(
-			[]*types.T{types.Decimal,
-				types.Decimal, types.Int},
+			[]*types.T{types.Decimal, types.Decimal, types.Int},
 			types.Decimal,
 			newDecimalFinalStdDevAggregate,
 			"Calculates the standard deviation from the selected locally-computed squared difference values.",

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -155,6 +155,13 @@ type Datum interface {
 // Datums is a slice of Datum values.
 type Datums []Datum
 
+const (
+	// SizeOfDatum is the memory size of a Datum reference.
+	SizeOfDatum = int64(unsafe.Sizeof(Datum(nil)))
+	// SizeOfDatums is the memory size of a Datum slice.
+	SizeOfDatums = int64(unsafe.Sizeof(Datums(nil)))
+)
+
 // Len returns the number of Datum values.
 func (d Datums) Len() int { return len(d) }
 


### PR DESCRIPTION
**execinfrapb: move ExprHelper and introduce a helper method**

This commit moves `execinfra.ExprHelper` into `execinfrapb` package and
adds a helper method that processes the specification of a single
serialized aggregate function (the method will be used by both `rowexec`
and `colexec`). It also does a few minor changes.

Release note: None

**colexec: extend vecToDatumConverter to not perform deselection step**

`vecToDatumConverter` only had support for "dense" conversion when
selection vector is present on the batch (meaning it would populate
`converted` columns with only selected values). This, however, is
insufficient for the hash aggregator use case because that operator
applies a selection vector-"lense" on top of already present vector. In
order to support that use case, this commit extends the converter to
support "sparse" conversion as well.

Release note: None