### PR TITLE
roachtest: use simple query method for tpcc chaos tests

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -333,9 +333,11 @@ func registerTPCC(r *testRegistry) {
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			duration := 30 * time.Minute
 			runTPCC(ctx, t, c, tpccOptions{
-				Warehouses:   100,
-				Duration:     duration,
-				ExtraRunArgs: "--wait=false --tolerate-errors",
+				Warehouses: 100,
+				Duration:   duration,
+				// For chaos tests, we don't want to use the default method because it
+				// involves preparing statements on all connections (see #51785).
+				ExtraRunArgs: "--method=simple --wait=false --tolerate-errors",
 				Chaos: func() Chaos {
 					return Chaos{
 						Timer: Periodic{
@@ -695,9 +697,15 @@ func loadTPCCBench(
 	// Split and scatter the tables. Ramp up to the expected load in the desired
 	// distribution. This should allow for load-based rebalancing to help
 	// distribute load. Optionally pass some load configuration-specific flags.
+	method := ""
+	if b.Chaos {
+		// For chaos tests, we don't want to use the default method because it
+		// involves preparing statements on all connections (see #51785).
+		method = "--method=simple"
+	}
 	cmd = fmt.Sprintf("./workload run tpcc --warehouses=%d --workers=%d --max-rate=%d "+
-		"--wait=false --duration=%s --scatter --tolerate-errors {pgurl%s}",
-		b.LoadWarehouses, b.LoadWarehouses, b.LoadWarehouses/2, rebalanceWait, roachNodes)
+		"--wait=false --duration=%s --scatter --tolerate-errors %s {pgurl%s}",
+		b.LoadWarehouses, b.LoadWarehouses, b.LoadWarehouses/2, rebalanceWait, method, roachNodes)
 	if out, err := c.RunWithBuffer(ctx, c.l, loadNode, cmd); err != nil {
 		return errors.Wrapf(err, "failed with output %q", string(out))
 	}
@@ -849,7 +857,11 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 				default:
 					panic("unexpected")
 				}
-
+				if b.Chaos {
+					// For chaos tests, we don't want to use the default method because it
+					// involves preparing statements on all connections (see #51785).
+					extraFlags += " --method=simple"
+				}
 				t.Status(fmt.Sprintf("running benchmark, warehouses=%d", warehouses))
 				histogramsPath := fmt.Sprintf("%s/warehouses=%d/stats.json", perfArtifactsDir, activeWarehouses)
 				cmd := fmt.Sprintf("./workload run tpcc --warehouses=%d --active-warehouses=%d "+


### PR DESCRIPTION
By default, the TPCC workload uses prepared statements (for a subset
of statements). All these statements are prepared on all connections
upfront, which can take a while. If nodes "fail" (due to chaos), this
process is restarted, which can happen over and over.

To avoid this issue, we pass `--method=simple` for chaos tpcc and
tpccbench tests. This means that the "simple" query protocol is used,
where all arguments are rendered inside the query string.

Fixes #52262.

Release note: None