### PR TITLE
kvserver: enable merges in kvnemesis

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -68,10 +68,6 @@ func TestKVNemesisMultiNode(t *testing.T) {
 
 	config := NewDefaultConfig()
 	config.NumNodes, config.NumReplicas = numNodes, 3
-	// kvnemesis found a rare bug with closed timestamps when merges happen
-	// on a multinode cluster. Disable the combo for now to keep the test
-	// from flaking. See #44878.
-	config.Ops.Merge = MergeConfig{}
 	rng, _ := randutil.NewPseudoRand()
 	ct := sqlClosedTimestampTargetInterval{sqlDBs: sqlDBs}
 	failures, err := RunNemesis(ctx, rng, ct, config, dbs...)


### PR DESCRIPTION
We had merges disabled because of the bugs tracked in #44878, but those have
since been fixed by #46085 and #50265.

Release note: None