### PR TITLE
release-20.1: sql: fix connection shutdown with temp tables

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -832,6 +832,28 @@ func (ex *connExecutor) closeWrapper(ctx context.Context, recovered interface{})
 func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 	ex.sessionEventf(ctx, "finishing connExecutor")
 
+	txnEv := noEvent
+	if _, noTxn := ex.machine.CurState().(stateNoTxn); !noTxn {
+		txnEv = txnRollback
+	}
+
+	if closeType == normalClose {
+		// We'll cleanup the SQL txn by creating a non-retriable (commit:true) event.
+		// This event is guaranteed to be accepted in every state.
+		ev := eventNonRetriableErr{IsCommit: fsm.True}
+		payload := eventNonRetriableErrPayload{err: pgerror.Newf(pgcode.AdminShutdown,
+			"connExecutor closing")}
+		if err := ex.machine.ApplyWithPayload(ctx, ev, payload); err != nil {
+			log.Warningf(ctx, "error while cleaning up connExecutor: %s", err)
+		}
+	} else if closeType == externalTxnClose {
+		ex.state.finishExternalTxn()
+	}
+
+	if err := ex.resetExtraTxnState(ctx, ex.server.dbCache, txnEv); err != nil {
+		log.Warningf(ctx, "error while cleaning up connExecutor: %s", err)
+	}
+
 	if ex.hasCreatedTemporarySchema && !ex.server.cfg.TestingKnobs.DisableTempObjectsCleanupOnSessionExit {
 		ie := MakeInternalExecutor(ctx, ex.server, MemoryMetrics{}, ex.server.cfg.Settings)
 		err := cleanupSessionTempObjects(
@@ -849,28 +871,6 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 				err,
 			)
 		}
-	}
-
-	ev := noEvent
-	if _, noTxn := ex.machine.CurState().(stateNoTxn); !noTxn {
-		ev = txnRollback
-	}
-
-	if closeType == normalClose {
-		// We'll cleanup the SQL txn by creating a non-retriable (commit:true) event.
-		// This event is guaranteed to be accepted in every state.
-		ev := eventNonRetriableErr{IsCommit: fsm.True}
-		payload := eventNonRetriableErrPayload{err: pgerror.Newf(pgcode.AdminShutdown,
-			"connExecutor closing")}
-		if err := ex.machine.ApplyWithPayload(ctx, ev, payload); err != nil {
-			log.Warningf(ctx, "error while cleaning up connExecutor: %s", err)
-		}
-	} else if closeType == externalTxnClose {
-		ex.state.finishExternalTxn()
-	}
-
-	if err := ex.resetExtraTxnState(ctx, ex.server.dbCache, ev); err != nil {
-		log.Warningf(ctx, "error while cleaning up connExecutor: %s", err)
 	}
 
 	if closeType != panicClose {

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -26,12 +27,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 // Test portal implicit destruction. Unless destroying a portal is explicitly
@@ -316,4 +319,61 @@ func startConnExecutor(
 		finished <- s.ServeConn(ctx, conn, mon.BoundAccount{}, nil /* cancel */)
 	}()
 	return buf, syncResults, finished, stopper, nil
+}
+
+// Test that a client session can close without deadlocking when the closing
+// needs to cleanup temp tables and the txn that has created these tables is
+// still open. The act of cleaning up used to block for the open transaction,
+// thus deadlocking.
+func TestSessionCloseWithPendingTempTableInTxn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	srv := s.SQLServer().(*Server)
+	stmtBuf := NewStmtBuf()
+	flushed := make(chan []resWithPos)
+	clientComm := &internalClientComm{
+		sync: func(res []resWithPos) {
+			flushed <- res
+		},
+	}
+	connHandler, err := srv.SetupConn(ctx, SessionArgs{User: security.RootUser}, stmtBuf, clientComm, MemoryMetrics{})
+	require.NoError(t, err)
+
+	stmts, err := parser.Parse(`
+SET experimental_enable_temp_tables = true;
+CREATE DATABASE test;
+USE test;
+BEGIN;
+CREATE TEMPORARY TABLE foo();
+`)
+	require.NoError(t, err)
+	for _, stmt := range stmts {
+		require.NoError(t, stmtBuf.Push(ctx, ExecStmt{Statement: stmt}))
+	}
+	require.NoError(t, stmtBuf.Push(ctx, Sync{}))
+
+	done := make(chan error)
+	go func() {
+		done <- srv.ServeConn(ctx, connHandler, mon.BoundAccount{}, nil /* cancel */)
+	}()
+	results := <-flushed
+	require.Len(t, results, 6) // We expect results for 5 statements + sync.
+	for _, res := range results {
+		require.NoError(t, res.err)
+	}
+
+	// Close the client connection and verify that ServeConn() returns.
+	stmtBuf.Close()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("session close timed out; connExecutor deadlocked?")
+	case err = <-done:
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #52148.

/cc @cockroachdb/release

---

Previously, shutting down a connection with an open transaction that had
active temp tables caused deadlocks or general brokenness. This was
because the table cleanup was done inside of the open transaction.

This commit moves the table cleanup to be after the user transaction is
shut down.

Fixes #52147

Release note (bug fix): prevent deadlocks on connection close with an
open user transaction and temp tables.
