### PR TITLE
server: clarify start-sql certs

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -31,6 +31,28 @@ var mtStartSQLCmd = &cobra.Command{
 Start a standalone SQL server.
 
 This functionality is **experimental** and for internal use only.
+
+The following certificates are required:
+
+- ca.crt, node.{crt,key}: CA cert and key pair for serving the SQL endpoint.
+  Note that under no circumstances should the node certs be shared with those of
+  the same name used at the KV layer, as this would pose a severe security risk.
+- ca-client-tenant.crt, client-tenant.X.{crt,key}: CA cert and key pair for
+  authentication and authorization with the KV layer (as tenant X).
+- ca-server-tenant.crt: to authenticate KV layer.
+
+                 ca.crt        ca-client-tenant.crt        ca-server-tenant.crt
+user ---------------> sql server ----------------------------> kv
+ client.Y.crt    node.crt      client-tenant.X.crt         server-tenant.crt
+ client.Y.key    node.key      client-tenant.X.key         server-tenant.key
+
+Note that CA certificates need to be present on the "other" end of the arrow as
+well unless it can be verified using a trusted root certificate store. That is,
+
+- ca.crt needs to be passed in the Postgres connection string (sslrootcert) if
+  sslmode=verify-ca.
+- ca-server-tenant.crt needs to be present on the SQL server.
+- ca-client-tenant.crt needs to be present on the KV server.
 `,
 	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runStartSQL),

--- a/pkg/security/securitytest/test_certs/regenerate.sh
+++ b/pkg/security/securitytest/test_certs/regenerate.sh
@@ -17,13 +17,4 @@ done
 ./cockroach mt cert --certs-dir="${dir_n}" --ca-key="${dir_n}/ca-server-tenant.key" create-tenant-server-ca
 ./cockroach mt cert --certs-dir="${dir_n}" --ca-key="${dir_n}/ca-server-tenant.key" create-tenant-server 127.0.0.1 ::1 localhost *.local
 
-# HACK(tbg): at the time of writing, the KV layer does not accept tenant client
-# certs yet, but tenants do use them. We overwrite the embedded tenant client
-# certs with those the internal node user would use to bridge this gap.
-# This can be used during local development.
-#
-# cat "${dir_n}/node.crt" > "${dir_n}/client-tenant.123456789.crt"
-# cat "${dir_n}/node.key" > "${dir_n}/client-tenant.123456789.key"
-# cat "${dir_n}/ca.crt" > "${dir_n}/ca-server-tenant.crt"
-
 make generate PKG=./pkg/security/securitytest

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -559,7 +560,7 @@ func makeSQLServerArgs(
 	// We don't need this for anything except some services that want a gRPC
 	// server to register against (but they'll never get RPCs at the time of
 	// writing): the blob service and DistSQL.
-	dummyRPCServer := rpc.NewServer(rpcContext)
+	dummyRPCServer := grpc.NewServer()
 	return sqlServerArgs{
 		sqlServerOptionalKVArgs: sqlServerOptionalKVArgs{
 			statusServer: serverpb.MakeOptionalStatusServer(nil),

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -792,6 +792,7 @@ func TestLint(t *testing.T) {
 			":!rpc/nodedialer/nodedialer_test.go",
 			":!util/grpcutil/grpc_util_test.go",
 			":!cli/systembench/network_test_server.go",
+			":!server/testserver.go",
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This PR is mostly documentation. A standalone SQL server requires a number of
certificates and there wasn't a single place that would explain their purpose.

This documentation now lives in `./cockroach mt start-sql --help`. I verified
that I was able to run a standalone SQL server and connect to it as the tenant
with the following script:

```bash
#!/bin/bash

set -euxo pipefail

killall -9 cockroach || true

rm -rf certs-{sql,kv,user} cockroach-data
mkdir -p certs-{sql,kv,user}
sql="certs-sql"
kv="certs-kv"

#### KV certs

./cockroach cert --certs-dir="${kv}" --ca-key="${kv}/ca.key" create-ca
./cockroach cert --certs-dir="${kv}" --ca-key="${kv}/ca.key" create-node 127.0.0.1 ::1 localhost *.local
# Used only to create the tenant.
./cockroach cert --certs-dir="${kv}" --ca-key="${kv}/ca.key" create-client root

./cockroach mt cert --certs-dir="${kv}" --ca-key="${kv}/ca-server-tenant.key" create-tenant-server-ca
cp "${kv}/ca-server-tenant.crt" "${sql}"
./cockroach mt cert --certs-dir="${kv}" --ca-key="${kv}/ca-server-tenant.key" create-tenant-server 127.0.0.1 ::1 localhost *.local

rm "${kv}"/ca*.key

#### SQL certs

./cockroach cert --certs-dir="${sql}" --ca-key="${sql}/ca.key" create-ca
./cockroach cert --certs-dir="${sql}" --ca-key="${sql}/ca.key" create-node 127.0.0.1 ::1 localhost *.local

./cockroach cert --certs-dir="${sql}" --ca-key="${sql}/ca.key" create-client root
mv "${sql}"/client.root.* certs-user
cp "${sql}/ca.crt" certs-user

./cockroach mt cert --certs-dir="${sql}" --ca-key="${sql}/ca-client-tenant.key" create-tenant-client-ca
cp "${sql}/ca-client-tenant.crt" "${kv}"
./cockroach mt cert --certs-dir="${sql}" --ca-key="${sql}/ca-client-tenant.key" create-tenant-client 10

rm "${sql}"/ca*.key

#### Start KV and create tenant

./cockroach start-single-node --tenant-addr 127.0.0.1:36257 --certs-dir certs-kv --host 127.0.0.1 --background
./cockroach sql --certs-dir certs-kv --host 127.0.0.1 -e 'select crdb_internal.create_tenant(10);'
rm certs-kv/client.root.*

#### Start SQL

./cockroach mt start-sql --certs-dir certs-sql --tenant-id 10 --kv-addrs 127.0.0.1:36257 --sql-addr 127.0.0.1:46257 &

#### Connect

sleep 1
./cockroach sql --url 'postgres://root@127.0.0.1:46257?sslmode=verify-ca&sslkey=certs-user/client.root.key&sslcert=certs-user/client.root.crt&sslrootcert=certs-user/ca.crt'
```

Release note: None
