### PR TITLE
geogen: tighten bounds of SRID 0 for coordinate generation

### DIFF
--- a/pkg/geo/geogen/geogen.go
+++ b/pkg/geo/geogen/geogen.go
@@ -185,8 +185,8 @@ func RandomGeomT(
 
 // RandomGeometry generates a random Geometry with the given SRID.
 func RandomGeometry(rng *rand.Rand, srid geopb.SRID) *geo.Geometry {
-	minX, maxX := -math.MaxFloat64, math.MaxFloat64
-	minY, maxY := -math.MaxFloat64, math.MaxFloat64
+	minX, maxX := -math.MaxFloat32, math.MaxFloat32
+	minY, maxY := -math.MaxFloat32, math.MaxFloat32
 	proj, ok := geoprojbase.Projections[srid]
 	if ok {
 		minX, maxX = proj.Bounds.MinX, proj.Bounds.MaxX


### PR DESCRIPTION
[`math.MaxFloat64 + math.MaxFloat64 =
Inf`](https://play.golang.org/p/kU9uLo5SCyo), so this was generating
invalid coordinate values. Loosen to float32 bounds.

Resolves #52290. 
Resolves #52291.

Release note: None