### PR TITLE
acceptance: unflake Elixir tests

### DIFF
--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -60,8 +60,8 @@ func TestDockerElixir(t *testing.T) {
 	defer s.Close(t)
 
 	ctx := context.Background()
-	testDockerSuccess(ctx, t, "elixir", []string{"sh", "-c", "cd /mnt/data/elixir/test_crdb && mix local.hex --force && mix deps.get && psql -c 'CREATE DATABASE IF NOT EXISTS testdb' && mix test"})
-	testDockerFail(ctx, t, "elixir", []string{"sh", "-c", "cd /mnt/data/elixir/test_crdb && mix local.hex --force && mix deps.get && mix thisshouldfail"})
+	testDockerSuccess(ctx, t, "elixir", []string{"sh", "-c", "cd /mnt/data/elixir/test_crdb && cp -R /opt/mix/deps . && psql -c 'CREATE DATABASE IF NOT EXISTS testdb' && mix test"})
+	testDockerFail(ctx, t, "elixir", []string{"sh", "-c", "cd /mnt/data/elixir/test_crdb && cp -R /opt/mix/deps . && mix thisshouldfail"})
 }
 
 func TestDockerNodeJS(t *testing.T) {

--- a/pkg/acceptance/testdata/Dockerfile
+++ b/pkg/acceptance/testdata/Dockerfile
@@ -124,6 +124,9 @@ RUN xmlstarlet ed --inplace \
 RUN (cd /testdata/node && yarn install && mv node_modules /usr/lib/node) \
  && apt-get purge --yes yarn
 
+ENV MIX_HOME=/opt/mix
+RUN (cd /testdata/elixir/test_crdb && mix local.hex --force && mix deps.get && cp -R deps /opt/mix/deps)
+
 RUN apt-get purge --yes \
     curl \
     xmlstarlet \

--- a/pkg/acceptance/util_docker.go
+++ b/pkg/acceptance/util_docker.go
@@ -58,7 +58,7 @@ func testDockerSuccess(ctx context.Context, t *testing.T, name string, cmd []str
 const (
 	// Iterating against a locally built version of the docker image can be done
 	// by changing acceptanceImage to the hash of the container.
-	acceptanceImage = "docker.io/cockroachdb/acceptance:20200303-091324"
+	acceptanceImage = "docker.io/cockroachdb/acceptance:20200804-131910"
 )
 
 func testDocker(


### PR DESCRIPTION
Elixir tests previously relied on downloading dependencies at test time,
rather than being pre-built with the Docker container. As such, change
the Docker container to contain the pre-build dependencies and the test
should run assuming it is installed.

Resolves #52339

Release note: None