### PR TITLE
roachtest: reflake (skip) disk-stalled test for release-19.1

### DIFF
--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -34,7 +34,7 @@ func registerDiskStalledDetection(r *testRegistry) {
 					affectsLogDir, affectsDataDir,
 				),
 				Owner:      OwnerKV,
-				MinVersion: "v19.1.0",
+				MinVersion: "v19.2.0",
 				Cluster:    makeClusterSpec(1),
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runDiskStalledDetection(ctx, t, c, affectsLogDir, affectsDataDir)


### PR DESCRIPTION
Fixes #52181. This test doesn't make use of all the `roachtest start`
smartness to figure out what sub-command to use and instead constructs
the raw start command by hand.

Given our support policy, let's just bump the minimum version this test
expects to run. This feels like another instance where #51897 would be 
nice to have.

Release note: None