### PR TITLE
release-20.1: backupccl: add missing ExternalCloudStorage close

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -487,6 +487,7 @@ func (b *backupResumer) Resume(
 	if err != nil {
 		return errors.Wrapf(err, "make storage")
 	}
+	defer defaultStore.Close()
 	storageByLocalityKV := make(map[string]*roachpb.ExternalStorage)
 	for kv, uri := range details.URIsByLocalityKV {
 		conf, err := cloud.ExternalStorageConfFromURI(uri)
@@ -629,6 +630,7 @@ func (b *backupResumer) deleteCheckpoint(ctx context.Context, cfg *sql.ExecutorC
 		if err != nil {
 			return err
 		}
+		defer exportStore.Close()
 		return exportStore.Delete(ctx, BackupManifestCheckpointName)
 	}(); err != nil {
 		log.Warningf(ctx, "unable to delete checkpointed backup descriptor: %+v", err)


### PR DESCRIPTION
Backport 1/1 commits from #52242.

/cc @cockroachdb/release

---

When creating the external storage used to write the BACKUP checkpoints
and final manifest, we should also close it to avoid leaking resources.

Release note: None
