### PR TITLE
release-19.2: backupccl: add missing ExternalCloudStorage close

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1327,6 +1327,7 @@ func (b *backupResumer) Resume(
 	if err != nil {
 		return errors.Wrapf(err, "make storage")
 	}
+	defer defaultStore.Close()
 	storageByLocalityKV := make(map[string]*roachpb.ExportStorage)
 	for kv, uri := range details.URIsByLocalityKV {
 		conf, err := storageccl.ExportStorageConfFromURI(uri)
@@ -1419,6 +1420,7 @@ func (b *backupResumer) OnTerminal(
 		if err != nil {
 			return err
 		}
+		defer exportStore.Close()
 		return exportStore.Delete(ctx, BackupDescriptorCheckpointName)
 	}(); err != nil {
 		log.Warningf(ctx, "unable to delete checkpointed backup descriptor: %+v", err)


### PR DESCRIPTION
Backport 1/1 commits from #52242.

/cc @cockroachdb/release

---

When creating the external storage used to write the BACKUP checkpoints
and final manifest, we should also close it to avoid leaking resources.

Release note: None
