### PR TITLE
release-19.1: backupccl: add missing ExternalCloudStorage close

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1112,6 +1112,7 @@ func (b *backupResumer) Resume(
 	if err != nil {
 		return err
 	}
+	defer exportStore.Close()
 	var checkpointDesc *BackupDescriptor
 	if desc, err := readBackupDescriptor(ctx, exportStore, BackupDescriptorCheckpointName); err == nil {
 		// If the checkpoint is from a different cluster, it's meaningless to us.
@@ -1159,6 +1160,7 @@ func (b *backupResumer) OnTerminal(
 		if err != nil {
 			return err
 		}
+		defer exportStore.Close()
 		return exportStore.Delete(ctx, BackupDescriptorCheckpointName)
 	}(); err != nil {
 		log.Warningf(ctx, "unable to delete checkpointed backup descriptor: %+v", err)


### PR DESCRIPTION
Backport 1/1 commits from #52242.

/cc @cockroachdb/release

---

When creating the external storage used to write the BACKUP checkpoints
and final manifest, we should also close it to avoid leaking resources.

Release note: None
