### PR TITLE
build: downgrade to Go 1.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,9 +319,7 @@ endif
 # Force vendor directory to rebuild.
 .PHONY: vendor_rebuild
 vendor_rebuild: bin/.submodules-initialized
-	# Use -mod=mod, as -mod=vendor will try install from the vendor directory
-	# which may be mismatching upon rebuild.
-	$(GO_INSTALL) -v -mod=mod github.com/goware/modvendor
+	$(GO_INSTALL) -v github.com/goware/modvendor
 	./build/vendor_rebuild.sh
 
 # Tell Make to delete the target if its recipe fails. Otherwise, if a recipe

--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -46,9 +46,9 @@ sudo tar -C /usr -zxf /tmp/cmake.tgz && rm /tmp/cmake.tgz
 
 # Install Go.
 trap 'rm -f /tmp/go.tgz' EXIT
-curl -fsSL https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz > /tmp/go.tgz
+curl -fsSL https://dl.google.com/go/go1.13.14.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF
-7011af3bbc2ac108d1b82ea8abb87b2e63f78844f0259be20cde4d42c5c40584 /tmp/go.tgz
+32617db984b18308f2b00279c763bff060d2739229cb8037217a49c9e691b46a /tmp/go.tgz
 EOF
 sudo tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20200625-145628
+version=20200804-160354
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -197,8 +197,8 @@ RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-
 # releases of Go will no longer be run in CI once it is changed. Consider
 # bumping the minimum allowed version of Go in /build/go-version-chech.sh.
 RUN apt-get install -y --no-install-recommends golang \
- && curl -fsSL https://storage.googleapis.com/golang/go1.14.4.src.tar.gz -o golang.tar.gz \
- && echo '7011af3bbc2ac108d1b82ea8abb87b2e63f78844f0259be20cde4d42c5c40584 golang.tar.gz' | sha256sum -c - \
+ && curl -fsSL https://storage.googleapis.com/golang/go1.13.14.src.tar.gz -o golang.tar.gz \
+ && echo '197333e97290e9ea8796f738d61019dcba1c377c2f3961fd6a114918ecc7ab06 golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \

--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -6,7 +6,8 @@
 # To bump the required version of Go, edit the appropriate variables:
 
 required_version_major=1
-minimum_version_minor=14
+minimum_version_minor=13
+minimum_version_13_patch=4
 
 go=${1-go}
 

--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -32,7 +32,7 @@ run docker run \
   --rm \
   --volume="$(cd "$(dirname "$0")" && pwd):/work:ro" \
   --workdir="/work" \
-  golang:1.14-buster ./verify-archive.sh
+  golang:1.13-buster ./verify-archive.sh
 tc_end_block "Test archive"
 
 tc_start_block "Clean up"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/cockroach
 
-go 1.14
+go 1.13
 
 require (
 	cloud.google.com/go v0.34.0

--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -1,5 +1,5 @@
 # Build the test binary in a multistage build.
-FROM golang:1.14 AS builder
+FROM golang:1.13 AS builder
 WORKDIR /workspace
 COPY . .
 RUN go get -d -t -tags gss_compose

--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -130,7 +130,7 @@ func cStringToGoString(s C.DBString) string {
 		return ""
 	}
 	// Reinterpret the string as a slice, then cast to string which does a copy.
-	result := string(cSliceToUnsafeGoBytes(C.DBSlice(s)))
+	result := string(cSliceToUnsafeGoBytes(C.DBSlice{s.data, s.len}))
 	C.free(unsafe.Pointer(s.data))
 	return result
 }

--- a/pkg/cmd/roachprod/docker/Dockerfile
+++ b/pkg/cmd/roachprod/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.13
 WORKDIR /build
 COPY . .
 RUN ["/build/build.sh"]

--- a/pkg/storage/enginepb/mvcc3.pb.go
+++ b/pkg/storage/enginepb/mvcc3.pb.go
@@ -4207,9 +4207,7 @@ var (
 	ErrIntOverflowMvcc3   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() {
-	proto.RegisterFile("storage/enginepb/mvcc3.proto", fileDescriptor_mvcc3_9bc532bf92053320)
-}
+func init() { proto.RegisterFile("storage/enginepb/mvcc3.proto", fileDescriptor_mvcc3_9bc532bf92053320) }
 
 var fileDescriptor_mvcc3_9bc532bf92053320 = []byte{
 	// 1165 bytes of a gzipped FileDescriptorProto

--- a/pkg/storage/rocksdb.go
+++ b/pkg/storage/rocksdb.go
@@ -2417,7 +2417,7 @@ func cStringToGoString(s C.DBString) string {
 		return ""
 	}
 	// Reinterpret the string as a slice, then cast to string which does a copy.
-	result := string(cSliceToUnsafeGoBytes(C.DBSlice(s)))
+	result := string(cSliceToUnsafeGoBytes(C.DBSlice{s.data, s.len}))
 	C.free(unsafe.Pointer(s.data))
 	return result
 }
@@ -2599,7 +2599,7 @@ func dbGetProto(
 		// Make a byte slice that is backed by result.data. This slice
 		// cannot live past the lifetime of this method, but we're only
 		// using it to unmarshal the roachpb.
-		data := cSliceToUnsafeGoBytes(C.DBSlice(result))
+		data := cSliceToUnsafeGoBytes(C.DBSlice{data: result.data, len: result.len})
 		err = protoutil.Unmarshal(data, msg)
 	}
 	C.free(unsafe.Pointer(result.data))

--- a/pkg/util/hlc/timestamp.pb.go
+++ b/pkg/util/hlc/timestamp.pb.go
@@ -435,9 +435,7 @@ var (
 	ErrIntOverflowTimestamp   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() {
-	proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_7743fc20d6f93748)
-}
+func init() { proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_7743fc20d6f93748) }
 
 var fileDescriptor_timestamp_7743fc20d6f93748 = []byte{
 	// 191 bytes of a gzipped FileDescriptorProto


### PR DESCRIPTION
Reverts most of #50671.

We upgraded from Go1.13.9 to Go1.14.4 on June 29th in #50671. Since then we've seen a fair amount of fallout in our testing and build system. Most of this has been reasonable to manage.

However, we recently stumbled upon a concerning regression in the Go runtime that doesn't look easy to work around. Go1.14 included a full rewrite of the runtime timer implementation. This was mostly a positive change, but shortly after the 1.14 release, reports started coming in of multi-millisecond timer starvation. This is tracked in this upstream issue: https://github.com/golang/go/issues/38860. A few months later, when we upgraded Cockroach to use 1.14, some of our tests started hitting the same issue, but in our tests, the starvation was much more severe. In https://github.com/cockroachdb/cockroach/issues/50865, we saw instances of multi-second timer starvation, which wreaked havoc on the cluster's liveness mechanisms.

A partial fix to this runtime issue has landed for Go 1.15 (https://go-review.googlesource.com/c/go/+/232199/) and may be backported to 1.14, but there is currently no ETA on the backport and no guarantee that it will even happen. A more robust fix is scheduled for 1.16 and the PR is still open in the Go repo (https://go-review.googlesource.com/c/go/+/232298/).

As we approach the CockroachDB 20.2 stability period, it seems prudent to avoid the risk of downgrading our Go runtime version too late. For that reason, @lunevalex, @andy-kimball, @petermattis, and I recommend the following course of actions:

* Downgrade 20.2 to 1.13 immediately, so we go into the stability period with the right version of Go.
* Schedule the subsequent improvements to non-preemptable loops in CockroachDB itself in 21.1.
* At the beginning of the 21.1 cycle upgrade CRDB to 1.15 and effectively skip 1.14 all together.

This PR addresses the first of these steps. While here, it also picks up the latest patch release of Go 1.13, moving from 1.13.9 to 1.13.14.

Checklist:

* [X] Adjust version in Docker image ([source](./builder/Dockerfile#L199-L200)).
* [X] Rebuild and push the Docker image (following [Basic Process](#basic-process))
* [X] Bump the version in `builder.sh` accordingly ([source](./builder.sh#L6)).
* [X] Bump the version in `go-version-check.sh` ([source](./go-version-check.sh)), unless bumping to a new patch release.
* [X] Bump the go version in `go.mod`. You may also need to rerun `make vendor_rebuild` if vendoring has changed.
* [X] Bump the default installed version of Go in `bootstrap-debian.sh` ([source](./bootstrap/bootstrap-debian.sh#L40-42)).
* [X] Replace other mentions of the older version of go (grep for `golang:<old_version>` and `go<old_version>`).
* [x] Update the `builder.dockerImage` parameter in the TeamCity [`Cockroach`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Cockroach&tab=projectParams) and [`Internal`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Internal&tab=projectParams) projects.

(I will do the last step after this has merged)

Release note (general change): Revert the Go version back to 1.13.