### PR TITLE
geo/geomfn: implement ST_Scale

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1454,6 +1454,12 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 </span></td></tr>
 <tr><td><a name="st_relatematch"></a><code>st_relatematch(intersection_matrix: <a href="string.html">string</a>, pattern: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the given DE-9IM intersection matrix satisfies the given pattern.</p>
 </span></td></tr>
+<tr><td><a name="st_scale"></a><code>st_scale(g: geometry, factor: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified Geometry scaled by taking in a Geometry as the factor</p>
+</span></td></tr>
+<tr><td><a name="st_scale"></a><code>st_scale(g: geometry, factor: geometry, origin: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified Geometry scaled by the Geometry factor relative to a false origin</p>
+</span></td></tr>
+<tr><td><a name="st_scale"></a><code>st_scale(geometry: geometry, x_factor: <a href="float.html">float</a>, y_factor: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified Geometry scaled by the given factors</p>
+</span></td></tr>
 <tr><td><a name="st_segmentize"></a><code>st_segmentize(geography: geography, max_segment_length_meters: <a href="float.html">float</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns a modified Geography having no segment longer than the given max_segment_length meters.</p>
 <p>The calculations are done on a sphere.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>

--- a/pkg/geo/geomfn/scale.go
+++ b/pkg/geo/geomfn/scale.go
@@ -1,0 +1,181 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/errors"
+	"github.com/twpayne/go-geom"
+)
+
+// Scale returns a modified Geometry whose coordinates are multiplied by the factors.
+// If there are missing dimensions in factors, the corresponding dimensions are not scaled.
+func Scale(geometry *geo.Geometry, factors []float64) (*geo.Geometry, error) {
+	if geometry.Empty() {
+		return geometry, nil
+	}
+
+	g, err := geometry.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+
+	g, err = scale(g, factors, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return geo.NewGeometryFromGeomT(g)
+}
+
+// ScaleRelativeToOrigin returns a modified Geometry whose coordinates are multiplied by the factors relative to the origin
+func ScaleRelativeToOrigin(
+	geometry *geo.Geometry, factor *geo.Geometry, origin *geo.Geometry,
+) (*geo.Geometry, error) {
+	if geometry.Empty() {
+		return geometry, nil
+	}
+
+	g, err := geometry.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+
+	factorG, err := factor.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+
+	_, ok := factorG.(*geom.Point)
+	if !ok {
+		return nil, errors.Newf("the scaling factor must be a Point")
+	}
+
+	originG, err := origin.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+
+	_, ok = originG.(*geom.Point)
+	if !ok {
+		return nil, errors.Newf("the false origin must be a Point")
+	}
+
+	if factorG.Stride() != originG.Stride() {
+		err := geom.ErrStrideMismatch{
+			Got:  factorG.Stride(),
+			Want: originG.Stride(),
+		}
+		return nil, errors.Wrap(err, "number of dimensions for the scaling factor and origin must be equal")
+	}
+
+	g, err = scale(g, factorG.FlatCoords(), originG)
+	if err != nil {
+		return nil, err
+	}
+
+	return geo.NewGeometryFromGeomT(g)
+}
+
+func scale(g geom.T, factors []float64, origin geom.T) (geom.T, error) {
+	if geomCollection, ok := g.(*geom.GeometryCollection); ok {
+		return scaleCollection(geomCollection, factors, origin)
+	}
+
+	newCoords, err := scaleCoords(g, factors, origin)
+	if err != nil {
+		return nil, err
+	}
+
+	switch t := g.(type) {
+	case *geom.Point:
+		g = geom.NewPointFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.LineString:
+		g = geom.NewLineStringFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.Polygon:
+		g = geom.NewPolygonFlat(t.Layout(), newCoords, t.Ends()).SetSRID(g.SRID())
+	case *geom.MultiPoint:
+		g = geom.NewMultiPointFlat(t.Layout(), newCoords).SetSRID(g.SRID())
+	case *geom.MultiLineString:
+		g = geom.NewMultiLineStringFlat(t.Layout(), newCoords, t.Ends()).SetSRID(g.SRID())
+	case *geom.MultiPolygon:
+		g = geom.NewMultiPolygonFlat(t.Layout(), newCoords, t.Endss()).SetSRID(g.SRID())
+	default:
+		return nil, geom.ErrUnsupportedType{Value: g}
+	}
+
+	return g, nil
+}
+
+// scaleCoords multiplies g's coordinates relative to origin's coordinates.
+// If origin is nil, g's coordinates are just multiplied by the factors.
+// Note: M coordinates are not affected.
+func scaleCoords(g geom.T, factors []float64, origin geom.T) ([]float64, error) {
+	stride := g.Stride()
+	if stride < len(factors) {
+		err := geom.ErrStrideMismatch{
+			Got:  len(factors),
+			Want: stride,
+		}
+		return nil, errors.Wrap(err, "number of factors exceed number of dimensions")
+	}
+
+	var originCoords []float64
+	if origin != nil {
+		originCoords = origin.FlatCoords()
+	} else {
+		originCoords = make([]float64, len(factors))
+	}
+
+	coords := g.FlatCoords()
+	newCoords := make([]float64, len(coords))
+
+	for i := 0; i < len(coords); i += stride {
+		newCoords[i] = coords[i]*factors[0] - originCoords[0]
+		newCoords[i+1] = coords[i+1]*factors[1] - originCoords[1]
+
+		z := g.Layout().ZIndex()
+		if z != -1 {
+			newCoords[i+z] = coords[i+z]
+
+			if len(factors) > z {
+				newCoords[i+z] *= factors[z]
+				newCoords[i+z] -= originCoords[z]
+			}
+		}
+
+		// m coords are only copied over
+		m := g.Layout().MIndex()
+		if m != -1 {
+			newCoords[i+m] = factors[m]
+		}
+	}
+
+	return newCoords, nil
+}
+
+// scaleCollection iterates through a GeometryCollection and calls scale() on each item.
+func scaleCollection(
+	geomCollection *geom.GeometryCollection, factors []float64, origin geom.T,
+) (*geom.GeometryCollection, error) {
+	res := geom.NewGeometryCollection()
+	for _, subG := range geomCollection.Geoms() {
+		subGeom, err := scale(subG, factors, origin)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := res.Push(subGeom); err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}

--- a/pkg/geo/geomfn/scale_test.go
+++ b/pkg/geo/geomfn/scale_test.go
@@ -1,0 +1,244 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
+)
+
+func TestScale(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		input    geom.T
+		factors  []float64
+		expected geom.T
+	}{
+		{
+			desc:     "scale a 2D point",
+			input:    geom.NewPointFlat(geom.XY, []float64{10, 10}),
+			factors:  []float64{.75, 2.8},
+			expected: geom.NewPointFlat(geom.XY, []float64{7.5, 28.0}),
+		},
+		{
+			desc:     "scale a line string",
+			input:    geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2}),
+			factors:  []float64{.1, .5},
+			expected: geom.NewLineStringFlat(geom.XY, []float64{.1, .5, .2, 1.0}),
+		},
+		{
+			desc:     "scale a polygon",
+			input:    geom.NewPolygonFlat(geom.XY, []float64{0, 0, 5, 5, 0, 10, 0, 0}, []int{8}),
+			factors:  []float64{.75, 1.5},
+			expected: geom.NewPolygonFlat(geom.XY, []float64{0, 0, 3.75, 7.5, 0, 15, 0, 0}, []int{8}),
+		},
+		{
+			desc:     "scale multiple 2D points",
+			input:    geom.NewMultiPointFlat(geom.XY, []float64{5, 10, -30, 40}),
+			factors:  []float64{.8, 5},
+			expected: geom.NewMultiPointFlat(geom.XY, []float64{4, 50, -24, 200}),
+		},
+		{
+			desc:     "scale multiple line strings",
+			input:    geom.NewMultiLineStringFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3, 4, 4}, []int{4, 8}),
+			factors:  []float64{.5, 0},
+			expected: geom.NewMultiLineStringFlat(geom.XY, []float64{.5, 0, 1, 0, 1.5, 0, 2, 0}, []int{4, 8}),
+		},
+		{
+			desc:     "scale an empty line string",
+			input:    geom.NewLineString(geom.XY),
+			factors:  []float64{.5, .5},
+			expected: geom.NewLineString(geom.XY),
+		},
+		{
+			desc:     "scale an empty polygon",
+			input:    geom.NewPolygon(geom.XY),
+			factors:  []float64{1.5, 1.5},
+			expected: geom.NewPolygon(geom.XY),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			geometry, err := geo.NewGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+
+			got, err := Scale(geometry, tc.factors)
+			require.NoError(t, err)
+
+			want, err := geo.NewGeometryFromGeomT(tc.expected)
+			require.NoError(t, err)
+
+			require.Equal(t, want, got)
+			require.EqualValues(t, tc.input.SRID(), got.SRID())
+		})
+	}
+}
+
+func TestScaleRelativeToOrigin(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		input    geom.T
+		factor   geom.T
+		origin   geom.T
+		expected geom.T
+	}{
+		{
+			desc:     "scale a 2D point",
+			input:    geom.NewPointFlat(geom.XY, []float64{10, 10}),
+			factor:   geom.NewPointFlat(geom.XY, []float64{.75, 2.8}),
+			origin:   geom.NewPointFlat(geom.XY, []float64{1, 1}),
+			expected: geom.NewPointFlat(geom.XY, []float64{6.5, 27.0}),
+		},
+		{
+			desc:     "scale a line string",
+			input:    geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2}),
+			factor:   geom.NewPointFlat(geom.XY, []float64{2, 2}),
+			origin:   geom.NewPointFlat(geom.XY, []float64{1, 1}),
+			expected: geom.NewLineStringFlat(geom.XY, []float64{1, 1, 3, 3}),
+		},
+		{
+			desc:     "scale a polygon",
+			input:    geom.NewPolygonFlat(geom.XY, []float64{0, 0, 5, 5, 0, 10, 0, 0}, []int{8}),
+			factor:   geom.NewPointFlat(geom.XY, []float64{2, 2}),
+			origin:   geom.NewPointFlat(geom.XY, []float64{1, 1}),
+			expected: geom.NewPolygonFlat(geom.XY, []float64{-1, -1, 9, 9, -1, 19, -1, -1}, []int{8}),
+		},
+		{
+			desc:     "scale an empty 2D point",
+			input:    geom.NewPointEmpty(geom.XY),
+			factor:   geom.NewPointFlat(geom.XY, []float64{.5, .5}),
+			origin:   geom.NewPointFlat(geom.XY, []float64{1, 1}),
+			expected: geom.NewPointEmpty(geom.XY),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			geometry, err := geo.NewGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+
+			factor, err := geo.NewGeometryFromGeomT(tc.factor)
+			require.NoError(t, err)
+
+			origin, err := geo.NewGeometryFromGeomT(tc.origin)
+			require.NoError(t, err)
+
+			got, err := ScaleRelativeToOrigin(geometry, factor, origin)
+			require.NoError(t, err)
+
+			want, err := geo.NewGeometryFromGeomT(tc.expected)
+			require.NoError(t, err)
+
+			require.Equal(t, want, got)
+			require.EqualValues(t, tc.input.SRID(), got.SRID())
+		})
+	}
+}
+
+func TestCollectionScaleRelativeToOrigin(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		input    *geom.GeometryCollection
+		factor   geom.T
+		origin   geom.T
+		expected *geom.GeometryCollection
+	}{
+		{
+			desc: "scale non-empty collection",
+			input: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1, 2}),
+				geom.NewPointFlat(geom.XY, []float64{-2, 3}),
+			),
+			factor: geom.NewPointFlat(geom.XY, []float64{2, 2}),
+			origin: geom.NewPointFlat(geom.XY, []float64{1, 1}),
+			expected: geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{1, 3}),
+				geom.NewPointFlat(geom.XY, []float64{-5, 5}),
+			),
+		},
+		{
+			desc:     "scale empty collection",
+			input:    geom.NewGeometryCollection(),
+			factor:   geom.NewPointFlat(geom.XY, []float64{2, 2}),
+			origin:   geom.NewPointFlat(geom.XY, []float64{1, 1}),
+			expected: geom.NewGeometryCollection(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			geometry, err := geo.NewGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+
+			factor, err := geo.NewGeometryFromGeomT(tc.factor)
+			require.NoError(t, err)
+
+			origin, err := geo.NewGeometryFromGeomT(tc.origin)
+			require.NoError(t, err)
+
+			geometry, err = ScaleRelativeToOrigin(geometry, factor, origin)
+			require.NoError(t, err)
+
+			g, err := geometry.AsGeomT()
+			require.NoError(t, err)
+
+			gotCollection, ok := g.(*geom.GeometryCollection)
+			require.True(t, ok)
+
+			require.Equal(t, tc.expected, gotCollection)
+		})
+	}
+}
+
+func TestInvalidParametersWhenScalingRelativeToOrigin(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		input       geom.T
+		factor      geom.T
+		origin      geom.T
+		expectedErr string
+	}{
+		{
+			desc:        "scale using an invalid geometry as factor",
+			input:       geom.NewPointFlat(geom.XY, []float64{10, 10}),
+			factor:      geom.NewLineStringFlat(geom.XY, []float64{1, 1, 1, 1}),
+			origin:      geom.NewPointFlat(geom.XY, []float64{1, 1}),
+			expectedErr: "the scaling factor must be a Point",
+		},
+		{
+			desc:        "scale using an invalid geometry as origin",
+			input:       geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2}),
+			factor:      geom.NewPointFlat(geom.XY, []float64{2, 2}),
+			origin:      geom.NewLineStringFlat(geom.XY, []float64{1, 1, 1, 1}),
+			expectedErr: "the false origin must be a Point",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			geometry, err := geo.NewGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+
+			factor, err := geo.NewGeometryFromGeomT(tc.factor)
+			require.NoError(t, err)
+
+			origin, err := geo.NewGeometryFromGeomT(tc.origin)
+			require.NoError(t, err)
+
+			_, err = ScaleRelativeToOrigin(geometry, factor, origin)
+			require.EqualError(t, err, tc.expectedErr)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -3955,3 +3955,27 @@ SELECT ST_Intersects('abc'::string, 'POINT(1 0)'::string)
 
 statement error Unknown type: 'ABC'
 SELECT ST_Intersects('POINT(1 0)'::string, 'abc'::string)
+
+subtest scale_test
+
+query TTTT
+SELECT
+  ST_AsText(a.geom) d,
+  ST_AsText(ST_Scale(a.geom, .5 , 2)),
+  ST_AsText(ST_Scale(a.geom, 'Point(.25 3)')),
+  ST_AsText(ST_Scale(a.geom, 'Point(2 2)', 'Point(1 1)'))
+FROM geom_operators_test a
+ORDER BY d ASC
+----
+NULL                                                   NULL                                                   NULL                                                      NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))     GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (-1 -1)))
+GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY                                  GEOMETRYCOLLECTION EMPTY
+LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (-0.25 1, 0.25 1)                           LINESTRING (-0.125 1.5, 0.125 1.5)                        LINESTRING (-2 0, 0 0)
+LINESTRING EMPTY                                       LINESTRING EMPTY                                       LINESTRING EMPTY                                          LINESTRING EMPTY
+POINT (-0.5 0.5)                                       POINT (-0.25 1)                                        POINT (-0.125 1.5)                                        POINT (-2 0)
+POINT (0.5 0.5)                                        POINT (0.25 1)                                         POINT (0.125 1.5)                                         POINT (0 0)
+POINT (5 5)                                            POINT (2.5 10)                                         POINT (1.25 15)                                           POINT (9 9)
+POINT EMPTY                                            POINT EMPTY                                            POINT EMPTY                                               POINT EMPTY
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((-0.05 0, 0.5 0, 0.5 2, -0.05 2, -0.05 0))    POLYGON ((-0.025 0, 0.25 0, 0.25 3, -0.025 3, -0.025 0))  POLYGON ((-1.2 -1, 1 -1, 1 1, -1.2 1, -1.2 -1))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((-0.5 0, 0 0, 0 2, -0.5 2, -0.5 0))           POLYGON ((-0.25 0, 0 0, 0 3, -0.25 3, -0.25 0))           POLYGON ((-3 -1, -1 -1, -1 1, -3 1, -3 -1))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 0.5 0, 0.5 2, 0 2, 0 0))                POLYGON ((0 0, 0.25 0, 0.25 3, 0 3, 0 0))                 POLYGON ((-1 -1, 1 -1, 1 1, -1 1, -1 -1))


### PR DESCRIPTION
Implement ST_Scale which should adopt PostGIS behaviour; accepts the following parameter sets:
- {geometry g, float8 xFactor, float8 yFactor}
- {geometry g, geometry factor}
- {geometry g, geometry factor, geometry origin}

Release note (sql change): Implemented geometry builtin `ST_Scale`