### PR TITLE
release-20.1: pgwire: remove left over types refactor artifact

### DIFF
--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -219,7 +219,7 @@ func (r *commandResult) SetColumns(ctx context.Context, cols sqlbase.ResultColum
 	}
 	r.oids = make([]oid.Oid, len(cols))
 	for i, col := range cols {
-		r.oids[i] = mapResultOid(col.Typ.Oid())
+		r.oids[i] = col.Typ.Oid()
 	}
 }
 

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1277,7 +1277,7 @@ func (c *conn) writeRowDescription(
 		typ := pgTypeForParserType(column.Typ)
 		c.msgBuilder.putInt32(int32(column.TableID))        // Table OID (optional).
 		c.msgBuilder.putInt16(int16(column.PGAttributeNum)) // Column attribute ID (optional).
-		c.msgBuilder.putInt32(int32(mapResultOid(typ.oid)))
+		c.msgBuilder.putInt32(int32(typ.oid))
 		c.msgBuilder.putInt16(int16(typ.size))
 		c.msgBuilder.putInt32(column.GetTypeModifier()) // Type modifier
 		if formatCodes == nil {

--- a/pkg/sql/pgwire/testdata/pgtest/row_description
+++ b/pkg/sql/pgwire/testdata/pgtest/row_description
@@ -115,7 +115,47 @@ Query {"String": "SELECT b FROM tab3"}
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":58,"TableAttributeNumber":2,"DataTypeOID":25,"DataTypeSize":-1,"TypeModifier":12,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":58,"TableAttributeNumber":2,"DataTypeOID":1042,"DataTypeSize":-1,"TypeModifier":12,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"hello"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# tab4 is a regression test for #51360
+send
+Query {"String": "CREATE TABLE tab4 (a INT8 PRIMARY KEY, b VARCHAR(256)[] NOT NULL)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "INSERT INTO tab4 VALUES(4, ARRAY['hello', 'goodbye'])"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# 80 = ASCII 'P' for Portal
+send
+Parse {"Name": "s", "Query": "SELECT b FROM tab4"}
+Bind {"DestinationPortal": "p", "PreparedStatement": "s"}
+Describe {"ObjectType": 80, "Name": "p"}
+Execute {"Portal": "p"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":1015,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"{hello,goodbye}"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -64,30 +64,6 @@ func pgTypeForParserType(t *types.T) pgType {
 	}
 }
 
-var resultOidMap = map[oid.Oid]oid.Oid{
-	oid.T_bit:      oid.T_varbit,
-	oid.T__bit:     oid.T__varbit,
-	oid.T_bpchar:   oid.T_text,
-	oid.T__bpchar:  oid.T__text,
-	oid.T_char:     oid.T_text,
-	oid.T__char:    oid.T__text,
-	oid.T_varchar:  oid.T_text,
-	oid.T__varchar: oid.T__text,
-}
-
-// mapResultOid maps an Oid value returned by the server to an Oid value that is
-// backwards-compatible with previous versions of CRDB. See this issue for more
-// details: https://github.com/cockroachdb/cockroach/issues/36811
-//
-// TODO(andyk): Remove this once issue #36811 is resolved.
-func mapResultOid(o oid.Oid) oid.Oid {
-	mapped := resultOidMap[o]
-	if mapped != 0 {
-		return mapped
-	}
-	return o
-}
-
 func (b *writeBuffer) writeTextDatum(
 	ctx context.Context, d tree.Datum, conv sessiondata.DataConversionConfig,
 ) {

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -162,6 +162,8 @@ func toMessage(typ string) interface{} {
 		return &pgproto3.CommandComplete{}
 	case "DataRow":
 		return &pgproto3.DataRow{}
+	case "Describe":
+		return &pgproto3.Describe{}
 	case "ErrorResponse":
 		return &pgproto3.ErrorResponse{}
 	case "Execute":


### PR DESCRIPTION
Backport 1/1 commits from #51911 

/cc @cockroachdb/release

---

See #51360 

Also, add a regression test to make sure type OIDs are reported
correctly in the pgwire RowDescription.

Release note (bug fix): Type OIDs in the result metadata were incorrect
for the bit, bpchar, char(n), and varchar(n) types, as well as the
corresponding array types. They are now correct.
