### PR TITLE
sql: drop the "experimental" in experimental_follower_read_timestamp

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -380,14 +380,7 @@ significant than <code>element</code> to zero (or one, for day and month)</p>
 <p>Compatible elements: millennium, century, decade, year, quarter, month,
 week, day, hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
-<tr><td><a name="experimental_follower_read_timestamp"></a><code>experimental_follower_read_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns a timestamp which is very likely to be safe to perform
-against a follower replica.</p>
-<p>This function is intended to be used with an AS OF SYSTEM TIME clause to perform
-historical reads against a time which is recent but sufficiently old for reads
-to be performed against the closest replica as opposed to the currently
-leaseholder for a given range.</p>
-<p>Note that this function requires an enterprise license on a CCL distribution to
-return without an error.</p>
+<tr><td><a name="experimental_follower_read_timestamp"></a><code>experimental_follower_read_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Same as follower_read_timestamp. This name is deprecated.</p>
 </span></td></tr>
 <tr><td><a name="experimental_strftime"></a><code>experimental_strftime(input: <a href="date.html">date</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>From <code>input</code>, extracts and formats the time as identified in <code>extract_format</code> using standard <code>strftime</code> notation (though not all formatting is supported).</p>
 </span></td></tr>
@@ -427,6 +420,15 @@ timezone, timezone_hour, timezone_minute</p>
 <tr><td><a name="extract_duration"></a><code>extract_duration(element: <a href="string.html">string</a>, input: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.
 Compatible elements: hour, minute, second, millisecond, microsecond.
 This is deprecated in favor of <code>extract</code> which supports duration.</p>
+</span></td></tr>
+<tr><td><a name="follower_read_timestamp"></a><code>follower_read_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns a timestamp which is very likely to be safe to perform
+against a follower replica.</p>
+<p>This function is intended to be used with an AS OF SYSTEM TIME clause to perform
+historical reads against a time which is recent but sufficiently old for reads
+to be performed against the closest replica as opposed to the currently
+leaseholder for a given range.</p>
+<p>Note that this function requires an enterprise license on a CCL distribution to
+return without an error.</p>
 </span></td></tr>
 <tr><td><a name="localtimestamp"></a><code>localtimestamp() &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
 <p>The value is based on a timestamp picked when the transaction starts

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -201,10 +201,10 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 	skip.UnderShort(t)
 
 	ctx := context.Background()
-	// The test uses experimental_follower_read_timestamp().
+	// The test uses follower_read_timestamp().
 	defer utilccl.TestingEnableEnterprise()()
 
-	historicalQuery := `SELECT * FROM test AS OF SYSTEM TIME experimental_follower_read_timestamp() WHERE k=2`
+	historicalQuery := `SELECT * FROM test AS OF SYSTEM TIME follower_read_timestamp() WHERE k=2`
 	recCh := make(chan tracing.Recording, 1)
 
 	var n2Addr, n3Addr syncutil.AtomicString
@@ -247,7 +247,7 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 	n1.Exec(t, `CREATE TABLE test (k INT PRIMARY KEY)`)
 	n1.Exec(t, `ALTER TABLE test EXPERIMENTAL_RELOCATE VALUES (ARRAY[1,2], 1)`)
 	// Speed up closing of timestamps, as we'll in order to be able to use
-	// experimental_follower_read_timestamp().
+	// follower_read_timestamp().
 	// Every 0.2s we'll close the timestamp from 0.4s ago. We'll attempt follower reads
 	// for anything below 0.4s * (1 + 0.5 * 20) = 4.4s.
 	n1.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '0.4s'`)

--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -7,4 +7,7 @@ statement ok
 INSERT INTO t VALUES (2)
 
 statement error pq: relation "t" does not exist
+SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp()
+
+statement error pq: relation "t" does not exist
 SELECT * FROM t AS OF SYSTEM TIME experimental_follower_read_timestamp()

--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -116,7 +116,7 @@ func runFollowerReadsTest(ctx context.Context, t *test, c *cluster) {
 		return func() error {
 			nodeDB := conns[node-1]
 			r := nodeDB.QueryRowContext(ctx, "SELECT v FROM test.test AS OF SYSTEM "+
-				"TIME experimental_follower_read_timestamp() WHERE k = $1", k)
+				"TIME follower_read_timestamp() WHERE k = $1", k)
 			var got int64
 			if err := r.Scan(&got); err != nil {
 				// Ignore errors due to cancellation.

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -24,7 +24,7 @@ SELECT * FROM t AS OF SYSTEM TIME -( ('1000' || 'us')::INTERVAL )
 ----
 2
 
-statement error pq: AS OF SYSTEM TIME: only constant expressions or experimental_follower_read_timestamp are allowed
+statement error pq: AS OF SYSTEM TIME: only constant expressions or follower_read_timestamp are allowed
 SELECT * FROM t AS OF SYSTEM TIME cluster_logical_timestamp()
 
 statement error pq: subqueries are not allowed in AS OF SYSTEM TIME
@@ -33,13 +33,16 @@ SELECT * FROM t AS OF SYSTEM TIME (SELECT '-1h'::INTERVAL)
 statement error pq: relation "t" does not exist
 SELECT * FROM t AS OF SYSTEM TIME '-1h'
 
-statement error pq: experimental_follower_read_timestamp\(\): experimental_follower_read_timestamp is only available in ccl distribution
+statement error pq: follower_read_timestamp\(\): follower_read_timestamp is only available in ccl distribution
+SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp()
+
+statement error pq: experimental_follower_read_timestamp\(\): follower_read_timestamp is only available in ccl distribution
 SELECT * FROM t AS OF SYSTEM TIME experimental_follower_read_timestamp()
 
-statement error pq: unknown signature: experimental_follower_read_timestamp\(string\) \(desired <timestamptz>\)
-SELECT * FROM t AS OF SYSTEM TIME experimental_follower_read_timestamp('boom')
+statement error pq: unknown signature: follower_read_timestamp\(string\) \(desired <timestamptz>\)
+SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp('boom')
 
-statement error pq: AS OF SYSTEM TIME: only constant expressions or experimental_follower_read_timestamp are allowed
+statement error pq: AS OF SYSTEM TIME: only constant expressions or follower_read_timestamp are allowed
 SELECT * FROM t AS OF SYSTEM TIME now()
 
 statement error cannot specify timestamp in the future

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2063,13 +2063,7 @@ CockroachDB supports the following flags:
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				ts, err := recentTimestamp(ctx)
-				if err != nil {
-					return nil, err
-				}
-				return tree.MakeDTimestampTZ(ts, time.Microsecond)
-			},
+			Fn:         followerReadTimestamp,
 			Info: `Returns a timestamp which is very likely to be safe to perform
 against a follower replica.
 
@@ -2080,6 +2074,17 @@ leaseholder for a given range.
 
 Note that this function requires an enterprise license on a CCL distribution to
 return without an error.`,
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+
+	tree.FollowerReadTimestampExperimentalFunctionName: makeBuiltin(
+		tree.FunctionProperties{},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.TimestampTZ),
+			Fn:         followerReadTimestamp,
+			Info:       fmt.Sprintf("Same as %s. This name is deprecated.", tree.FollowerReadTimestampFunctionName),
 			Volatility: tree.VolatilityVolatile,
 		},
 	),
@@ -6075,4 +6080,12 @@ func requireNonNull(d tree.Datum) error {
 		return errInvalidNull
 	}
 	return nil
+}
+
+func followerReadTimestamp(ctx *tree.EvalContext, _ tree.Datums) (tree.Datum, error) {
+	ts, err := recentTimestamp(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return tree.MakeDTimestampTZ(ts, time.Microsecond)
 }

--- a/pkg/sql/sem/tree/as_of.go
+++ b/pkg/sql/sem/tree/as_of.go
@@ -28,7 +28,11 @@ import (
 // FollowerReadTimestampFunctionName is the name of the function which can be
 // used with AOST clauses to generate a timestamp likely to be safe for follower
 // reads.
-const FollowerReadTimestampFunctionName = "experimental_follower_read_timestamp"
+const FollowerReadTimestampFunctionName = "follower_read_timestamp"
+
+// FollowerReadTimestampExperimentalFunctionName is the name of the old
+// "experimental_" function, which we keep for backwards compatibility.
+const FollowerReadTimestampExperimentalFunctionName = "experimental_follower_read_timestamp"
 
 var errInvalidExprForAsOf = errors.Errorf("AS OF SYSTEM TIME: only constant expressions or " +
 	FollowerReadTimestampFunctionName + " are allowed")
@@ -55,7 +59,8 @@ func EvalAsOfTimestamp(
 		if err != nil {
 			return hlc.Timestamp{}, errInvalidExprForAsOf
 		}
-		if def.Name != FollowerReadTimestampFunctionName {
+		if def.Name != FollowerReadTimestampFunctionName &&
+			def.Name != FollowerReadTimestampExperimentalFunctionName {
 			return hlc.Timestamp{}, errInvalidExprForAsOf
 		}
 		if te, err = fe.TypeCheck(ctx, semaCtx, types.TimestampTZ); err != nil {


### PR DESCRIPTION
The known badness with follower reads was fixed - most recently #49391, #44053
and #44878.

At this point, the "experimental" prefix doesn't serve any purpose, and
it unnecessarily raises questions.

The previous name stays as an alias for backwards compatibility.

Fixes #45243

Release note: The experimental_follower_read_timestamp() function was
renamed to follower_read_timestamp(), signifying more confidence in
CRDB's follower read implementation. The previous name remains a
supported alias.