### PR TITLE
acceptance: disable Elixir tests

### DIFF
--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -56,6 +57,8 @@ func TestDockerJava(t *testing.T) {
 }
 
 func TestDockerElixir(t *testing.T) {
+	skip.IgnoreLint(t, "Elixir requires network to run, which can flake. When attempting to update this (#52341), the new Elixir version does not work with CRDB/TLS.")
+
 	s := log.Scope(t)
 	defer s.Close(t)
 


### PR DESCRIPTION
Elixir requires network to install dependencies. This can be changed
(painfully), but an upgrade an Elixir is causing even more problems. I'm
in favour of removing the acceptance (which I wrote) to fix this for now
as I have plentiful unit tests covering the same thing. Maybe someone
can come back to this if it's a large issue...

Release note: None