### PR TITLE
geos: also look at paths parenting os.Argv[0]

### DIFF
--- a/pkg/geo/geos/geos_test.go
+++ b/pkg/geo/geos/geos_test.go
@@ -29,7 +29,7 @@ func TestInitGEOS(t *testing.T) {
 	})
 
 	t.Run("test valid initGEOS paths", func(t *testing.T) {
-		ret, loc, err := initGEOS(findLibraryDirectories(""))
+		ret, loc, err := initGEOS(findLibraryDirectories("", ""))
 		require.NoError(t, err)
 		require.NotEmpty(t, loc)
 		require.NotNil(t, ret)
@@ -38,16 +38,16 @@ func TestInitGEOS(t *testing.T) {
 
 func TestEnsureInit(t *testing.T) {
 	// Fetch at least once.
-	_, err := ensureInit(EnsureInitErrorDisplayPublic, "")
+	_, err := ensureInit(EnsureInitErrorDisplayPublic, "", "")
 	require.NoError(t, err)
 
 	fakeErr := errors.Newf("contain path info do not display me")
 	defer func() { geosOnce.err = nil }()
 
 	geosOnce.err = fakeErr
-	_, err = ensureInit(EnsureInitErrorDisplayPrivate, "")
+	_, err = ensureInit(EnsureInitErrorDisplayPrivate, "", "")
 	require.Contains(t, err.Error(), fakeErr.Error())
 
-	_, err = ensureInit(EnsureInitErrorDisplayPublic, "")
+	_, err = ensureInit(EnsureInitErrorDisplayPublic, "", "")
 	require.Equal(t, errors.Newf("geos: this operation is not available").Error(), err.Error())
 }


### PR DESCRIPTION
For cases like roachprod, the cockroach binary may be invoked from an
alternate directory. This may fail to find the appropriate GEOS library.
As such, also take into account os.Argv[0] when looking at parenting
directories.

Release note: None