### PR TITLE
sql: improve overload selection when multiple candidates require the same type

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -759,6 +759,20 @@ eq [type=bool]
       ├── const: 'bar' [type=string]
       └── const: 'baz' [type=string]
 
+build-scalar
+'{"x": "bar"}' -> 'x'
+----
+fetch-val [type=jsonb]
+ ├── const: '{"x": "bar"}' [type=jsonb]
+ └── const: 'x' [type=string]
+
+build-scalar
+('{"x": "bar"}') -> 'x'
+----
+fetch-val [type=jsonb]
+ ├── const: '{"x": "bar"}' [type=jsonb]
+ └── const: 'x' [type=string]
+
 build-scalar vars=(json)
 @1->>'a' = 'b'
 ----

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -176,6 +176,9 @@ func TestTypeCheck(t *testing.T) {
 		{`((ROW (1) AS a)).*`, `((1:::INT8,) AS a)`},
 		{`((('1'||'', 1+1) AS a, b)).*`, `(('1':::STRING || '':::STRING, 1:::INT8 + 1:::INT8) AS a, b)`},
 
+		{`'{"x": "bar"}' -> 'x'`, `'{"x": "bar"}':::JSONB->'x':::STRING`},
+		{`('{"x": "bar"}') -> 'x'`, `'{"x": "bar"}':::JSONB->'x':::STRING`},
+
 		// These outputs, while bizarre looking, are correct and expected. The
 		// type annotation is caused by the call to tree.Serialize, which formats the
 		// output using the Parseable formatter which inserts type annotations


### PR DESCRIPTION
Our type checking cannot deal with expression `('{"x": "bar"}') -> 'x'`.
This works without the parens because literal constants are treated as
a special case. It used to work with parens because of some constant
folding that was done before type-checking (which was removed).

A principled fix would require big changes in type-checking. However,
I did notice that some of the logic for filtering overloads is too
restrictive. We only try to `TypeCheck` binary op arguments with a
specific type when we have a single candidate overload left. This is
why we don't try to type-check `('{"x": "bar"}')` as a Jsonb.

This change improves this heuristic: instead of checking whether we
have a single remaining candidate, check if all remaining candidates
require the same type for that argument. This is a net improvement
that happens to help in this particular case (where we have two
variants for `->`, both taking a Jsonb on the left).

Fixes #52043.

Release note: None