### PR TITLE
opt: add SerializingProject exec primitive

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -347,24 +347,34 @@ func (e *distSQLSpecExecFactory) ConstructInvertedFilter(
 }
 
 func (e *distSQLSpecExecFactory) ConstructSimpleProject(
-	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string, reqOrdering exec.OutputOrdering,
+	n exec.Node, cols []exec.NodeColumnOrdinal, reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
 	physPlan, plan := getPhysPlan(n)
 	projection := make([]uint32, len(cols))
 	for i := range cols {
-		projection[i] = uint32(cols[i])
+		projection[i] = uint32(cols[physPlan.PlanToStreamColMap[i]])
+	}
+	physPlan.AddProjection(projection)
+	physPlan.ResultColumns = getResultColumnsForSimpleProject(
+		cols, nil /* colNames */, physPlan.ResultTypes, physPlan.ResultColumns,
+	)
+	physPlan.PlanToStreamColMap = identityMap(physPlan.PlanToStreamColMap, len(cols))
+	physPlan.SetMergeOrdering(e.dsp.convertOrdering(ReqOrdering(reqOrdering), physPlan.PlanToStreamColMap))
+	return plan, nil
+}
+
+func (e *distSQLSpecExecFactory) ConstructSerializingProject(
+	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string,
+) (exec.Node, error) {
+	physPlan, plan := getPhysPlan(n)
+	physPlan.EnsureSingleStreamOnGateway()
+	projection := make([]uint32, len(cols))
+	for i := range cols {
+		projection[i] = uint32(cols[physPlan.PlanToStreamColMap[i]])
 	}
 	physPlan.AddProjection(projection)
 	physPlan.ResultColumns = getResultColumnsForSimpleProject(cols, colNames, physPlan.ResultTypes, physPlan.ResultColumns)
 	physPlan.PlanToStreamColMap = identityMap(physPlan.PlanToStreamColMap, len(cols))
-	if reqOrdering == nil {
-		// When reqOrdering is nil, we're adding a top-level (i.e. "final")
-		// projection. In such scenario we need to be careful to not simply
-		// reset the merge ordering that is currently set on the plan - we do
-		// so by merging the streams on the gateway node.
-		physPlan.EnsureSingleStreamOnGateway()
-	}
-	physPlan.SetMergeOrdering(e.dsp.convertOrdering(ReqOrdering(reqOrdering), physPlan.PlanToStreamColMap))
 	return plan, nil
 }
 
@@ -719,16 +729,6 @@ func (e *distSQLSpecExecFactory) ConstructWindow(
 	input exec.Node, window exec.WindowInfo,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: window")
-}
-
-func (e *distSQLSpecExecFactory) ConstructRenameColumns(
-	input exec.Node, colNames []string,
-) (exec.Node, error) {
-	inputCols := input.(planMaybePhysical).physPlan.ResultColumns
-	for i := range inputCols {
-		inputCols[i].Name = colNames[i]
-	}
-	return input, nil
 }
 
 func (e *distSQLSpecExecFactory) ConstructPlan(

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -277,12 +277,10 @@ func constructVirtualScan(
 	if needed := params.NeededCols; needed.Len() != len(columns) {
 		// We are selecting a subset of columns; we need a projection.
 		cols := make([]exec.NodeColumnOrdinal, 0, needed.Len())
-		colNames := make([]string, len(cols))
 		for ord, ok := needed.Next(0); ok; ord, ok = needed.Next(ord + 1) {
 			cols = append(cols, exec.NodeColumnOrdinal(ord-1))
-			colNames = append(colNames, columns[ord-1].Name)
 		}
-		n, err = ef.ConstructSimpleProject(n, cols, colNames, nil /* reqOrdering */)
+		n, err = ef.ConstructSimpleProject(n, cols, nil /* reqOrdering */)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -54,7 +54,7 @@ func (b *Builder) buildMutationInput(
 		}
 	}
 
-	input, err = b.ensureColumns(input, colList, nil, inputExpr.ProvidedPhysical().Ordering)
+	input, err = b.ensureColumns(input, colList, inputExpr.ProvidedPhysical().Ordering)
 	if err != nil {
 		return execPlan{}, err
 	}

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -35,13 +35,7 @@ func (b *Builder) buildCreateTable(ct *memo.CreateTableExpr) (execPlan, error) {
 		// Impose ordering and naming on input columns, so that they match the
 		// order and names of the table columns into which values will be
 		// inserted.
-		colList := make(opt.ColList, len(ct.InputCols))
-		colNames := make([]string, len(ct.InputCols))
-		for i := range ct.InputCols {
-			colList[i] = ct.InputCols[i].ID
-			colNames[i] = ct.InputCols[i].Alias
-		}
-		input, err = b.ensureColumns(input, colList, colNames, nil /* provided */)
+		input, err = b.applyPresentation(input, ct.InputCols)
 		if err != nil {
 			return execPlan{}, err
 		}

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -35,8 +35,22 @@ define InvertedFilter {
 define SimpleProject {
     Input exec.Node
     Cols []exec.NodeColumnOrdinal
-    ColNames []string
     ReqOrdering exec.OutputOrdering
+}
+
+# SerializingProject is similar to SimpleProject, but it allows renaming of
+# columns and forces distributed execution to serialize (merge) any parallel
+# result streams into a single stream before the projection. This allows any
+# required output ordering of the input node to be "materialized", which is
+# important for cases where the projection no longer contains the ordering
+# columns (e.g. SELECT a FROM t ORDER BY b).
+#
+# Typically used as the "root" (top-level) operator to ensure the correct
+# ordering and naming of columns.
+define SerializingProject {
+    Input exec.Node
+    Cols []exec.NodeColumnOrdinal
+    ColNames []string
 }
 
 # Render applies a projection on the results of the given input node. The
@@ -321,12 +335,6 @@ define ProjectSet {
 define Window {
     Input exec.Node
     Window exec.WindowInfo
-}
-
-# RenameColumns modifies the column names of a node.
-define RenameColumns {
-    Input exec.Node
-    ColNames []string
 }
 
 # Explain implements EXPLAIN (OPT), showing information about the given plan.


### PR DESCRIPTION
The top-level projection of a query has a special property - it can project away
columns that we want an ordering on (e.g. `SELECT a FROM t ORDER BY b`).

The distsql physical planner was designed to tolerate such cases, as they were
much more common with the heuristic planner. But the new distsql exec factory
does not; it currently relies on a hack: it detects this case by checking if the
required output ordering is `nil`. This is fragile and doesn't work in all
cases.

This change adds a `SerializingProject` primitive which is like a SimpleProject
but it forces serialization of all parallel streams into one. The new primitive
is used to enforce the final query presentation. We only need to pass column
names for the presentation, so we remove `RenameColumns` and remove the column
names argument from `SimpleProject` (simplifying some execbuilder code).

We also fix a bug in `ConstructSimpleProject` where we weren't taking the
`PlanToStreamColMap` into account when building the projection.

Release note: None