### PR TITLE
backupccl: fix bug when scattering to nodes with double digit nodeIDs

### DIFF
--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -280,7 +280,7 @@ func runSplitAndScatter(
 func routingDatumsForNode(nodeID roachpb.NodeID) (sqlbase.EncDatum, sqlbase.EncDatum) {
 	routingBytes := roachpb.Key(fmt.Sprintf("node%d", nodeID))
 	startDatum := sqlbase.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(routingBytes)))
-	endDatum := sqlbase.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(routingBytes.PrefixEnd())))
+	endDatum := sqlbase.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(routingBytes.Next())))
 	return startDatum, endDatum
 }
 


### PR DESCRIPTION
Previously a RESTORE on a 10 node cluster would fail with an error
indicating that the spans provided to the SplitAndScatter's processor
were out of order.

The SplitAndScatter processor output router expects a sorted list of
spans, each represening a particular node in the cluster. Previously,
the span for a given node would be too wide and might cover spans
generated for other nodes. For example, the span for node 1 was
previously, `node{1-2}`. However this meant that this span would contain
the span for node 10. This change ensures that each span consists of the
start key until the next key, rather than ending at the start key's
`PrefixEnd`.

Fixes #52387.

Release note: None