### PR TITLE
release-20.1: pgwire: trim statements past the conn executor's rewind pos eagerly

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1577,7 +1577,22 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 		panic(fmt.Sprintf("unexpected advance code: %s", advInfo.code))
 	}
 
-	return ex.updateTxnRewindPosMaybe(ctx, cmd, pos, advInfo)
+	if err := ex.updateTxnRewindPosMaybe(ctx, cmd, pos, advInfo); err != nil {
+		return err
+	}
+
+	if rewindCapability, canRewind := ex.getRewindTxnCapability(); !canRewind {
+		// Trim statements that cannot be retried to reclaim memory.
+		ex.stmtBuf.ltrim(ctx, pos)
+	} else {
+		rewindCapability.close()
+	}
+
+	if ex.server.cfg.TestingKnobs.AfterExecCmd != nil {
+		ex.server.cfg.TestingKnobs.AfterExecCmd(ctx, cmd, ex.stmtBuf)
+	}
+
+	return nil
 }
 
 func (ex *connExecutor) idleConn() bool {

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -749,6 +749,52 @@ func TestErrorDuringPrepareInExplicitTransactionPropagates(t *testing.T) {
 	require.NoError(t, tx.Commit())
 }
 
+// TestTrimFlushedStatements verifies that the conn executor trims the
+// statements buffer once the corresponding results are returned to the user.
+func TestTrimFlushedStatements(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const (
+		countStmt = "SELECT count(*) FROM test"
+		// stmtBufMaxLen is the maximum length the statement buffer should be during
+		// execution of COUNT(*). This includes a SELECT COUNT(*) command as well
+		// as a Sync command.
+		stmtBufMaxLen = 2
+	)
+	// stmtBufLen is set to the length of the statement buffer after each SELECT
+	// COUNT(*) execution.
+	stmtBufLen := 0
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLExecutor: &sql.ExecutorTestingKnobs{
+				AfterExecCmd: func(_ context.Context, cmd sql.Command, buf *sql.StmtBuf) {
+					if strings.Contains(cmd.String(), countStmt) {
+						// Only compare statement buffer length on SELECT COUNT(*) queries.
+						stmtBufLen = buf.Len()
+					}
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	_, err := sqlDB.Exec("CREATE TABLE test (i int)")
+	require.NoError(t, err)
+
+	tx, err := sqlDB.Begin()
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		_, err := tx.Exec(countStmt)
+		require.NoError(t, err)
+		if stmtBufLen > stmtBufMaxLen {
+			t.Fatalf("statement buffer grew to %d (> %d) after %dth execution", stmtBufLen, stmtBufMaxLen, i)
+		}
+	}
+	require.NoError(t, tx.Commit())
+}
+
 // dynamicRequestFilter exposes a filter method which is a
 // storagebase.ReplicaRequestFilter but can be set dynamically.
 type dynamicRequestFilter struct {

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -549,6 +549,13 @@ func (buf *StmtBuf) Rewind(ctx context.Context, pos CmdPos) {
 	buf.mu.curPos = pos
 }
 
+// Len returns the buffer's length.
+func (buf *StmtBuf) Len() int {
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+	return buf.mu.data.Len()
+}
+
 // RowDescOpt specifies whether a result needs a row description message.
 type RowDescOpt bool
 
@@ -836,6 +843,11 @@ type rewindCapability struct {
 func (rc *rewindCapability) rewindAndUnlock(ctx context.Context) {
 	rc.cl.RTrim(ctx, rc.rewindPos)
 	rc.buf.Rewind(ctx, rc.rewindPos)
+	rc.cl.Close()
+}
+
+// close closes the underlying ClientLock.
+func (rc *rewindCapability) close() {
 	rc.cl.Close()
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -663,6 +663,9 @@ type ExecutorTestingKnobs struct {
 	// statement.
 	AfterExecute func(ctx context.Context, stmt string, err error)
 
+	// AfterExecCmd is called after successful execution of any command.
+	AfterExecCmd func(ctx context.Context, cmd Command, buf *StmtBuf)
+
 	// DisableAutoCommit, if set, disables the auto-commit functionality of some
 	// SQL statements. That functionality allows some statements to commit
 	// directly when they're executed in an implicit SQL txn, without waiting for


### PR DESCRIPTION
Backport 1/1 commits from #48859.

/cc @cockroachdb/release

---

Previously, the conn executor held on to all executed statements in case they
needed to be retried. These would only be discarded once the transaction
committed. This could lead to a memory blowup in some cases.

With the knowledge that statements whose results have been returned cannot be
retried, this commit eagerly discards those statements every time a command is
executed rather than waiting for the transaction to commit.

Release note (bug fix): executing a large number of statements in a transaction
without committing could previously crash a cockroach server, this is now
fixed.

Addresses #47969
