### PR TITLE
dump: update dump roachtest to expect schema

### DIFF
--- a/pkg/cmd/roachtest/dump.go
+++ b/pkg/cmd/roachtest/dump.go
@@ -26,7 +26,7 @@ func runDumpBackwardsCompat(ctx context.Context, t *test, c *cluster, predecesso
 	FAMILY "primary" (x, y, rowid)
 );
 
-INSERT INTO t (x, y) VALUES
+INSERT INTO public.t (x, y) VALUES
 	(1, 1),
 	(2, 2);`
 	roachNodes := c.All()


### PR DESCRIPTION
Recently, dump was updated to support user defined schemas. This commit
updates the roachtest to be compatible with those changes.

Fixes #52396.

Release note: None