### PR TITLE
sql: resolve public.geometry and public.geography as built-in types

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -183,6 +183,15 @@ func (p *planner) getSchemaIDForCreate(
 func getTableCreateParams(
 	params runParams, dbID descpb.ID, isTemporary bool, tableName *tree.TableName,
 ) (tKey sqlbase.DescriptorKey, schemaID descpb.ID, err error) {
+	// Check we are not creating a table which conflicts with an alias available
+	// as a built-in type in CockroachDB but an extension type on the public
+	// schema for PostgreSQL.
+	if tableName.Schema() == tree.PublicSchema {
+		if _, ok := types.PublicSchemaAliases[tableName.Object()]; ok {
+			return nil, 0, sqlbase.NewTypeAlreadyExistsError(tableName.String())
+		}
+	}
+
 	if isTemporary {
 		if !params.SessionData().TempTablesEnabled {
 			return nil, 0, errors.WithTelemetry(

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -37,6 +37,35 @@ CREATE TABLE geom_table_negative_values(
   a geometry(geometry, -1)
 )
 
+statement ok
+CREATE TABLE geom_table_public_schema (
+  geom public.geometry,
+  geog public.geography
+)
+
+statement ok
+INSERT INTO geom_table_public_schema VALUES ('POINT(1 0)', 'POINT(3 2)')
+
+query TT
+SELECT ST_AsText(geom), ST_AsText(geog) FROM geom_table_public_schema
+----
+POINT (1 0)  POINT (3 2)
+
+statement ok
+SET experimental_enable_enums = true
+
+statement error type .*geometry.* already exists
+CREATE TYPE geometry AS enum('no')
+
+statement error type .*geography.* already exists
+CREATE TYPE geography AS enum('no')
+
+statement error type .*geometry.* already exists
+CREATE TABLE geometry (a geometry)
+
+statement error type .*geography.* already exists
+CREATE TABLE geography (a geography)
+
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE geom_table_negative_values]
 ----

--- a/pkg/sql/types/alias.go
+++ b/pkg/sql/types/alias.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package types
+
+// PublicSchemaAliases contain a mapping from type name to builtin types
+// which are on the public schema on PostgreSQL as they are available
+// as an extension.
+var PublicSchemaAliases = map[string]*T{
+	"geometry":  Geometry,
+	"geography": Geography,
+}


### PR DESCRIPTION
To maintain compatability with PostGIS (especially backups), we need to
be able to resolve public.geometry and public.geography as the built-in
GEOMETRY and GEOGRAPHY types. Add that ability here.

Also prevent creating a type public.geometry and public.geography to
reduce the possible conflicts.

Release note: None

