### PR TITLE
sql: fix internal error when trying to parse strings as arrays

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -240,6 +240,10 @@ SELECT ARRAY['a', 'b', 'c'][0]
 ----
 NULL
 
+# Regression test for #52134: make sure this is not an internal error.
+query error cannot subscript type string because it is not an array
+SELECT '{a,b,c}'[0]
+
 query T
 SELECT (ARRAY['a', 'b', 'c'])[2]
 ----

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -67,7 +67,7 @@ func typeCheckConstant(
 	ctx context.Context, semaCtx *SemaContext, c Constant, desired *types.T,
 ) (ret TypedExpr, err error) {
 	avail := c.AvailableTypes()
-	if desired.Family() != types.AnyFamily {
+	if !desired.IsAmbiguous() {
 		for _, typ := range avail {
 			if desired.Equivalent(typ) {
 				return c.ResolveAsType(ctx, semaCtx, desired)


### PR DESCRIPTION
The parse-constant-as-type code was allowing a desired type of `Array[Any]`, and
we can't parse elements as `Any`. This resulted in an internal error, rather
than a normal query error.

Fixes #52134.

Release note (bug fix): Fixed an internal error involving string literals used
as arrays.