### PR TITLE
ui: Define @cockroachlabs/crdb-protobuf-client package

### DIFF
--- a/pkg/ui/src/js/package.json
+++ b/pkg/ui/src/js/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@cockroachlabs/crdb-protobuf-client",
+  "version": "0.0.0",
+  "description": "Javascript client for use by CockroachDB UI",
+  "main": "./protos.js",
+  "types": "./protos.d.ts",
+  "license": "SEE LICENSE IN github.com/cockroachdb/cockroach/LICENSE",
+  "files": [
+    "protos.d.ts",
+    "protos.js"
+  ],
+  "peerDependencies": {
+    "protobufjs": "^6.8.8",
+    "typescript": "^3.7.5"
+  }
+}


### PR DESCRIPTION
The main idea is to have reusable protobuf client which can be used
outside of Admin UI.

Package can be published with following command:
```
yarn publish --access public --no-git-tag-version --patch
```

Release note: None