### PR TITLE
sql: consider non-public indexes in partial index update helper

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -455,3 +455,38 @@ SELECT * FROM d@f_b_s_foo_idx WHERE b AND s = 'foo'
 100  110  100  foo  true
 300  330  300  foo  true
 400  400  400  foo  true
+
+# Regression tests for #52318. Mutations on partial indexes in the
+# DELETE_AND_WRITE_ONLY state should update the indexes correctly.
+
+statement ok
+CREATE TABLE t52318 (
+    a INT PRIMARY KEY,
+    b INT,
+    INDEX (a)
+)
+
+statement ok
+BEGIN; CREATE INDEX i ON t52318 (a) WHERE b > 5
+
+statement ok
+INSERT INTO t52318 (a, b) VALUES (1, 1), (6, 6)
+
+query II
+SELECT * FROM t52318 WHERE b > 5
+----
+6  6
+
+statement ok
+UPDATE t52318 SET b = b + 1
+
+query II
+SELECT * FROM t52318 WHERE b > 5
+----
+6  7
+
+statement ok
+DELETE FROM t52318
+
+statement ok
+COMMIT

--- a/pkg/sql/row/partial_index.go
+++ b/pkg/sql/row/partial_index.go
@@ -47,7 +47,7 @@ func (pm *PartialIndexUpdateHelper) Init(
 ) error {
 	colIdx := 0
 	partialIndexOrds := tabDesc.PartialIndexOrds()
-	indexes := tabDesc.Indexes
+	indexes := tabDesc.DeletableIndexes()
 
 	for i, ok := partialIndexOrds.Next(0); ok; i, ok = partialIndexOrds.Next(i + 1) {
 		index := &indexes[i]


### PR DESCRIPTION
This commit fixes a bug in `row.PartialIndexUpdateHelper` caused by the
helper attempting to access non-public indexes from a list of only
public indexes. Non-public partial indexes in the DELETE_AND_WRITE_ONLY
state must be updated during INSERTs, UPDATEs, DELETEs, etc. to remain
consistent.

Fixes #52318 

Release note: None