### PR TITLE
sql: improve error message when trying to create partial indexes

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -208,7 +207,8 @@ func MakeIndexDescriptor(
 	if n.Predicate != nil {
 		// TODO(mgartner): remove this once partial indexes are fully supported.
 		if !params.SessionData().PartialIndexes {
-			return nil, unimplemented.NewWithIssue(9683, "partial indexes are not supported")
+			return nil, pgerror.Newf(pgcode.FeatureNotSupported,
+				"session variable experimental_partial_indexes is set to false, cannot create a partial index")
 		}
 
 		idxValidator := schemaexpr.NewIndexPredicateValidator(params.ctx, n.Table, tableDesc, &params.p.semaCtx)

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1468,7 +1468,8 @@ func MakeTableDesc(
 			if d.Predicate != nil {
 				// TODO(mgartner): remove this once partial indexes are fully supported.
 				if !sessionData.PartialIndexes {
-					return desc, unimplemented.NewWithIssue(9683, "partial indexes are not supported")
+					return desc, pgerror.Newf(pgcode.FeatureNotSupported,
+						"session variable experimental_partial_indexes is set to false, cannot create a partial index")
 				}
 
 				expr, err := idxValidator.Validate(d.Predicate)
@@ -1514,7 +1515,8 @@ func MakeTableDesc(
 			if d.Predicate != nil {
 				// TODO(mgartner): remove this once partial indexes are fully supported.
 				if !sessionData.PartialIndexes {
-					return desc, unimplemented.NewWithIssue(9683, "partial indexes are not supported")
+					return desc, pgerror.Newf(pgcode.FeatureNotSupported,
+						"session variable experimental_partial_indexes is set to false, cannot create a partial index")
 				}
 
 				expr, err := idxValidator.Validate(d.Predicate)


### PR DESCRIPTION
This commit improves the error message when a user attempts to create a
partial index without previously setting the
`experimental_partial_indexes` session or cluster setting to true.

Fixes #52276 

Release note: None