### PR TITLE
github: make bors only compile on merge commits

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,12 +1,21 @@
-status = [
-  "GitHub CI (Cockroach)"
-]
-pr_status = [
-  "license/cla"
-]
-block_labels = [
-  "do-not-merge"
-]
+# See https://bors.tech/documentation/ for configuration details.
+
+# List of commit statuses that must pass on the merge commit before it is
+# pushed to master.
+#
+# This is left at being compile only as a rough heuristic to detect merge-skew.
+# We don't bother running/waiting on the full CI for merge commits.
+status = ["Compile Builds (Unit Tests)"]
+
+# List of commit statuses that must pass on the PR commit when it is r+-ed.
+pr_status = ["license/cla", "GitHub CI (Cockroach)"]
+
+# List of PR labels that may not be attached to a PR when it is r+-ed.
+block_labels = ["do-not-merge"]
+
+# Number of seconds from when a merge commit is created to when its statuses
+# must pass.
+#
 # Set to 4 hours
 timeout_sec = 14400
 


### PR DESCRIPTION
..instead of running the full CI. This should serve as a pretty good
heuristic for merge-skew. We also change things so that you actually
need to wait for CI to turn green before you're able to `bors r+`
anything.

Release note: None