### PR TITLE
importccl: add hint to line too long errors

### DIFF
--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -170,7 +170,9 @@ func (p *postgreStreamCopy) Next() (copyData, error) {
 	scanned := p.s.Scan()
 	if err := p.s.Err(); err != nil {
 		if errors.Is(err, bufio.ErrTooLong) {
-			err = errors.New("line too long")
+			err = wrapWithLineTooLongHint(
+				errors.New("line too long"),
+			)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Release note (sql change): Added a hint for "line too long"
errors when importing a backup with long lines.