### PR TITLE
parser, backupccl: adds logic to support RESTORE of KMS encrypted BACKUPs

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1730,6 +1730,7 @@ attrs ::=
 
 restore_options ::=
 	'ENCRYPTION_PASSPHRASE' '=' string_or_placeholder
+	| 'KMS' '=' string_or_placeholder_opt_list
 	| 'INTO_DB' '=' string_or_placeholder
 	| 'SKIP_MISSING_FOREIGN_KEYS'
 	| 'SKIP_MISSING_SEQUENCES'

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2420,6 +2420,10 @@ restore_options:
   {
     $$.val = &tree.RestoreOptions{EncryptionPassphrase: $3.expr()}
   }
+| KMS '=' string_or_placeholder_opt_list
+	{
+    $$.val = &tree.RestoreOptions{DecryptionKMSURI: $3.stringOrPlaceholderOptList()}
+	}
 | INTO_DB '=' string_or_placeholder
   {
     $$.val = &tree.RestoreOptions{IntoDB: $3.expr()}

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -367,5 +367,12 @@ func (o *RestoreOptions) CombineWith(other *RestoreOptions) error {
 
 // IsDefault returns true if this backup options struct has default value.
 func (o RestoreOptions) IsDefault() bool {
-	return o == RestoreOptions{}
+	options := RestoreOptions{}
+	return o.SkipMissingFKs == options.SkipMissingFKs &&
+		o.SkipMissingSequences == options.SkipMissingSequences &&
+		o.SkipMissingSequenceOwners == options.SkipMissingSequenceOwners &&
+		o.SkipMissingViews == options.SkipMissingViews &&
+		cmp.Equal(o.DecryptionKMSURI, options.DecryptionKMSURI) &&
+		o.EncryptionPassphrase == options.EncryptionPassphrase &&
+		o.IntoDB == options.IntoDB
 }

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -100,6 +100,7 @@ func (node Backup) Coverage() DescriptorCoverage {
 // RestoreOptions describes options for the RESTORE execution.
 type RestoreOptions struct {
 	EncryptionPassphrase      Expr
+	DecryptionKMSURI          StringOrPlaceholderOptList
 	IntoDB                    Expr
 	SkipMissingFKs            bool
 	SkipMissingSequences      bool
@@ -276,6 +277,12 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 		o.EncryptionPassphrase.Format(ctx)
 	}
 
+	if o.DecryptionKMSURI != nil {
+		maybeAddSep()
+		ctx.WriteString("kms=")
+		o.DecryptionKMSURI.Format(ctx)
+	}
+
 	if o.IntoDB != nil {
 		maybeAddSep()
 		ctx.WriteString("into_db=")
@@ -310,6 +317,12 @@ func (o *RestoreOptions) CombineWith(other *RestoreOptions) error {
 		o.EncryptionPassphrase = other.EncryptionPassphrase
 	} else if other.EncryptionPassphrase != nil {
 		return errors.New("encryption_passphrase specified multiple times")
+	}
+
+	if o.DecryptionKMSURI == nil {
+		o.DecryptionKMSURI = other.DecryptionKMSURI
+	} else if other.DecryptionKMSURI != nil {
+		return errors.New("kms specified multiple times")
 	}
 
 	if o.IntoDB == nil {

--- a/pkg/storage/cloudimpl/kms.go
+++ b/pkg/storage/cloudimpl/kms.go
@@ -1,0 +1,30 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cloudimpl
+
+import "net/url"
+
+// RedactKMSURI redacts the Master Key ID and the ExternalStorage secret
+// credentials.
+func RedactKMSURI(kmsURI string) (string, error) {
+	sanitizedKMSURI, err := SanitizeExternalStorageURI(kmsURI, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Redact the path which contains the KMS Master Key identifier.
+	uri, err := url.ParseRequestURI(sanitizedKMSURI)
+	if err != nil {
+		return "", err
+	}
+	uri.Path = "/redacted"
+	return uri.String(), nil
+}


### PR DESCRIPTION
Commit 1: adds the KMS option to RESTORE grammar.

Commit 2: adds logic to RESTORE from encrypted BACKUPs. Adds redaction logic for BACKUP/RESTORE job descriptions written to system.jobs.

Informs: #50937 