### PR TITLE
sqlbase: fix diff output for failing TestSystemTableLiterals

### DIFF
--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -201,7 +201,7 @@ func TestSystemTableLiterals(t *testing.T) {
 		require.NoError(t, gen.ValidateTable())
 
 		if !proto.Equal(test.pkg.TableDesc(), gen.TableDesc()) {
-			diff := strings.Join(pretty.Diff(&test.pkg, &gen), "\n")
+			diff := strings.Join(pretty.Diff(test.pkg.TableDesc(), gen.TableDesc()), "\n")
 			t.Errorf("%s table descriptor generated from CREATE TABLE statement does not match "+
 				"hardcoded table descriptor:\n%s", test.pkg.Name, diff)
 		}


### PR DESCRIPTION
The diff was mangled due to not passing the protos.

Release note: None