### PR TITLE
util/interval: load pkg/keys for pretty-printing

### DIFF
--- a/pkg/kv/kvserver/concurrency/lockstate_interval_btree_test.go
+++ b/pkg/kv/kvserver/concurrency/lockstate_interval_btree_test.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"testing"
 
+	// Load pkg/keys so that roachpb.Span.String() could be executed correctly.
+	_ "github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"testing"
 
+	// Load pkg/keys so that roachpb.Span.String() could be executed correctly.
+	_ "github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"

--- a/pkg/util/interval/generic/example_interval_btree_test.go
+++ b/pkg/util/interval/generic/example_interval_btree_test.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"testing"
 
+	// Load pkg/keys so that roachpb.Span.String() could be executed correctly.
+	_ "github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"testing"
 
+	// Load pkg/keys so that roachpb.Span.String() could be executed correctly.
+	_ "github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
`roachpb.PrettyPrintRange` function is initialized in `pkg/keys`. The
latter package wasn't being loaded when testing `util/interval/generic`
which resulted in malformed subtest names (nil pointer panic).

Release note: None