### PR TITLE
importccl: allow ALTER TABLE ... ALTER COLUMN ... SET NULL

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -875,6 +875,27 @@ COPY t (a, b, c) FROM stdin;
 			},
 		},
 		{
+			name: "ALTER COLUMN x SET NOT NULL",
+			typ:  "PGDUMP",
+			data: `
+				CREATE TABLE t (a INT8 PRIMARY KEY, b INT8);
+				ALTER TABLE t ALTER COLUMN a SET NOT NULL;
+			`,
+			query: map[string][][]string{
+				`SHOW CREATE TABLE t`: {
+					{
+						"t",
+						`CREATE TABLE public.t (
+	a INT8 NOT NULL,
+	b INT8 NULL,
+	CONSTRAINT "primary" PRIMARY KEY (a ASC),
+	FAMILY "primary" (a, b)
+)`,
+					},
+				},
+			},
+		},
+		{
 			name: "non-public schema",
 			typ:  "PGDUMP",
 			data: "create table s.t (i INT8)",

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -381,6 +381,15 @@ func readPostgresStmt(
 					return errors.Errorf("unsupported statement: %s", stmt)
 				}
 				create.Defs = append(create.Defs, cmd.ColumnDef)
+			case *tree.AlterTableSetNotNull:
+				for i, def := range create.Defs {
+					def, ok := def.(*tree.ColumnTableDef)
+					if !ok || def.Name != cmd.Column {
+						continue
+					}
+					def.Nullable.Nullability = tree.NotNull
+					create.Defs[i] = def
+				}
 			case *tree.AlterTableValidateConstraint:
 				// ignore
 			default:


### PR DESCRIPTION
Ensured the test passed by removing the skip and then putting the skip
back on.

Refs: #52382

Release note (sql change): Allow `ALTER TABLE ... ALTER COLUMN ... SET
NULL` syntax for `IMPORT PGDUMP` type backups.