### PR TITLE
release-19.2: build: ask tar to read to end

### DIFF
--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -45,7 +45,8 @@ docker_login_with_google
 gcr_repository="us.gcr.io/cockroach-cloud-images/cockroach"
 
 # TODO: update publish-provisional-artifacts with option to leave one or more cockroach binaries in the local filesystem
-curl -f -s -S -o- "https://${bucket}.s3.amazonaws.com/cockroach-${build_name}.linux-amd64.tgz" | tar xfz - --strip-components 1
+# HACK: we pipe though tac twice to reverse/un-reverse since that will read the whole buffer and make curl happy, even if tar closes early.
+curl -f -s -S -o- "https://${bucket}.s3.amazonaws.com/cockroach-${build_name}.linux-amd64.tgz" | tac | tac | tar xfz - --strip-components 1
 cp cockroach build/deploy/cockroach
 
 docker build --no-cache --tag="${gcr_repository}:${build_name}" build/deploy

--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -45,8 +45,9 @@ docker_login_with_google
 gcr_repository="us.gcr.io/cockroach-cloud-images/cockroach"
 
 # TODO: update publish-provisional-artifacts with option to leave one or more cockroach binaries in the local filesystem
-# HACK: we pipe though tac twice to reverse/un-reverse since that will read the whole buffer and make curl happy, even if tar closes early.
-curl -f -s -S -o- "https://${bucket}.s3.amazonaws.com/cockroach-${build_name}.linux-amd64.tgz" | tac | tac | tar xfz - --strip-components 1
+# NB: tar usually stops reading as soon as it sees an empty block but that makes
+# curl unhappy, so passing `i` will cause it to read to the end.
+curl -f -s -S -o- "https://${bucket}.s3.amazonaws.com/cockroach-${build_name}.linux-amd64.tgz" | tar ixfz - --strip-components 1
 cp cockroach build/deploy/cockroach
 
 docker build --no-cache --tag="${gcr_repository}:${build_name}" build/deploy


### PR DESCRIPTION
Backport:
  * 1/1 commits from "build: avoid errors when tar closes curl's pipe" (#52265)
  * 1/1 commits from "build: ask tar to read to end" (#52311)

Please see individual PRs for details.

/cc @cockroachdb/release
