### PR TITLE
release-20.1: sql: properly reset extraTxnState in COPY

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -156,6 +156,10 @@ type copyTxnOpt struct {
 	txnTimestamp  time.Time
 	stmtTimestamp time.Time
 	resetPlanner  func(ctx context.Context, p *planner, txn *kv.Txn, txnTS time.Time, stmtTS time.Time)
+
+	// resetExecutor should be called upon completing a batch from the copy
+	// machine when the copy machine handles its own transaction.
+	resetExtraTxnState func(ctx context.Context) error
 }
 
 // run consumes all the copy-in data from the network connection and inserts it
@@ -307,8 +311,17 @@ func (p *planner) preparePlannerForCopy(
 	txnOpt.resetPlanner(ctx, p, txn, txnTs, stmtTs)
 	p.autoCommit = autoCommit
 
-	return func(ctx context.Context, err error) error {
-		if err == nil {
+	return func(ctx context.Context, prevErr error) (err error) {
+		// Ensure that we clean up any accumulated extraTxnState state if we've
+		// been handed a mechanism to do so.
+		if txnOpt.resetExtraTxnState != nil {
+			defer func() {
+				// Note: combine errors will return nil if both are nil and the
+				// non-nil error in the case that there's just one.
+				err = errors.CombineErrors(err, txnOpt.resetExtraTxnState(ctx))
+			}()
+		}
+		if prevErr == nil {
 			// Ensure that the txn is committed if the copyMachine is in charge of
 			// committing its transactions and the execution didn't already commit it
 			// (through the planner.autoCommit optimization).
@@ -317,8 +330,8 @@ func (p *planner) preparePlannerForCopy(
 			}
 			return nil
 		}
-		txn.CleanupOnError(ctx, err)
-		return err
+		txn.CleanupOnError(ctx, prevErr)
+		return prevErr
 	}
 }
 

--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -29,8 +30,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCopyNullInfNaN(t *testing.T) {
@@ -480,4 +483,47 @@ func TestCopyFKCheck(t *testing.T) {
 	if !testutils.IsError(err, "foreign key violation|violates foreign key constraint") {
 		t.Fatalf("expected FK error, got: %v", err)
 	}
+}
+
+// TestCopyInReleasesLeases is a regression test to ensure that the execution
+// of CopyIn does not retain table descriptor leases after completing by
+// attempting to run a schema change after performing a copy.
+func TestCopyInReleasesLeases(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := tests.CreateTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	tdb := sqlutils.MakeSQLRunner(db)
+	defer s.Stopper().Stop(context.Background())
+	tdb.Exec(t, `CREATE TABLE t (k INT8 PRIMARY KEY)`)
+	tdb.Exec(t, `CREATE USER foo WITH PASSWORD 'testabc'`)
+	tdb.Exec(t, `GRANT admin TO foo`)
+
+	userURL, cleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
+		s.ServingSQLAddr(), t.Name(), url.UserPassword("foo", "testabc"),
+		false /* withClientCerts */)
+	defer cleanupFn()
+	conn, err := pgxConn(t, userURL)
+	require.NoError(t, err)
+
+	tag, err := conn.CopyFromReader(strings.NewReader("1\n2\n"),
+		"copy t(k) from stdin")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), tag.RowsAffected())
+
+	// Prior to the bug fix which prompted this test, the below schema change
+	// would hang until the leases expire. Let's make sure it finishes "soon".
+	alterErr := make(chan error, 1)
+	go func() {
+		_, err := db.Exec(`ALTER TABLE t ADD COLUMN v INT NOT NULL DEFAULT 0`)
+		alterErr <- err
+	}()
+	select {
+	case err := <-alterErr:
+		require.NoError(t, err)
+	case <-time.After(testutils.DefaultSucceedsSoonDuration):
+		t.Fatal("alter did not complete")
+	}
+	require.NoError(t, conn.Close())
 }


### PR DESCRIPTION
Backport 1/1 commits from #52384.

/cc @cockroachdb/release

---

Apparently we support some sort of COPY protocol that I know nothing about.
We allow operations in that protocol in the open state and in the noTxn state
in the connExecutor. In the noTxn state we let the `copyMachine` handle its
transaction lifecycle all on its own. In that case, we also hand have the
`connExecutor` in a fresh state when calling `execCopyIn()`. During the
execution of `COPY`, it seems like sometime we can pick up table descriptor
leases. In the noTxn case we'd like to drop those leases and generally leave
the executor in the fresh state in which it was handed to us. To deal with
that, we call `resetExtraTxnState` before returning in the happy noTxn case.

Fixes #52065.

Release note (bug fix): Fixed a bug when using the COPY protocol which could
prevent schema changes for up to 5 minutes.
