### PR TITLE
github: point bors to teamcity-compile-build

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -5,9 +5,17 @@
 #
 # This is left at being compile only as a rough heuristic to detect merge-skew.
 # We don't bother running/waiting on the full CI for merge commits.
-status = ["Compile Builds (Unit Tests)"]
+#
+# TODO(irfansharif): It'd be nice if we could use the build/builder.sh checkout
+# as pulled out in the github CI target, with pre-compiled C++ deps, etc. in
+# order to run the final `mkrelease` step. That would bring `bors r+` to merge
+# down to about a minute or so on our CI machines.
+status = ["Compile Build (Cockroach)"]
 
-# List of commit statuses that must pass on the PR commit when it is r+-ed.
+# List of commit statuses that must not be failing on the PR commit when it is
+# r+-ed. If it's still in progress (for e.g. if CI is still running), bors will
+# construct the merge commit in parallel and simply wait for success right
+# before merging.
 pr_status = ["license/cla", "GitHub CI (Cockroach)"]
 
 # List of PR labels that may not be attached to a PR when it is r+-ed.


### PR DESCRIPTION
This is the follow-up PR to #52441, and points bors to this newly
defined "Compile Build" github commit status, which is the only thing
we'll now run on merge commits (do check that it's set up correctly
on teamcity). It's wired up to `build/teamcity-compile-build.sh`, 
which only compiles a unix target.

It's fast-ish, taking about 10-15m to go from `bors r+` to merge.

Release note: None