### PR TITLE
cli: add telemetry for flag usage

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -458,10 +459,10 @@ func init() {
 		}
 	}
 
-	// Log flags.
-	logCmds := append(StartCmds, demoCmd)
-	logCmds = append(logCmds, demoCmd.Commands()...)
-	for _, cmd := range logCmds {
+	// Flags that apply to commands that start servers.
+	serverCmds := append(StartCmds, demoCmd)
+	serverCmds = append(serverCmds, demoCmd.Commands()...)
+	for _, cmd := range serverCmds {
 		f := cmd.Flags()
 		varFlag(f, &startCtx.logDir, cliflags.LogDir)
 		varFlag(f,
@@ -473,6 +474,21 @@ func init() {
 		varFlag(f,
 			pflag.PFlagFromGoFlag(flag.Lookup(logflags.LogFileVerbosityThresholdName)).Value,
 			cliflags.LogFileVerbosity)
+
+		// Report flag usage for server commands in telemetry. We do this
+		// only for server commands, as there is no point in accumulating
+		// telemetry if there's no telemetry reporting loop being started.
+		AddPersistentPreRunE(cmd, func(cmd *cobra.Command, _ []string) error {
+			prefix := "cli." + cmd.Name()
+			// Count flag usage.
+			cmd.Flags().Visit(func(fl *pflag.Flag) {
+				telemetry.Count(prefix + ".explicitflags." + fl.Name)
+			})
+			// Also report use of the command on its own. This is necessary
+			// so we can compute flag usage as a % of total command invocations.
+			telemetry.Count(prefix + ".runs")
+			return nil
+		})
 	}
 
 	for _, cmd := range certCmds {

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -90,6 +90,8 @@ proc send_eof {} {
 # in `server_pid`.
 proc start_server {argv} {
     report "BEGIN START SERVER"
+    # Note: when changing this command line, update the telemetry tests
+    # in test_flags.tcl.
     system "$argv start-single-node --insecure --max-sql-memory=128MB --pid-file=server_pid --listening-url-file=server_url --background -s=path=logs/db >>logs/expect-cmd.log 2>&1;
             $argv sql --insecure -e 'select 1'"
     report "START SERVER DONE"

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -79,7 +79,35 @@ eexpect "HINT: Consider using 'cockroach init' or 'cockroach start-single-node' 
 eexpect {Failed running "start"}
 end_test
 
+start_test "Check that demo start-up flags are reported to telemetry"
+send "$argv demo --empty --echo-sql --logtostderr=WARNING\r"
+eexpect "defaultdb>"
+send "SELECT * FROM crdb_internal.feature_usage WHERE feature_name LIKE 'cli.demo.%' ORDER BY 1;\r"
+eexpect feature_name
+eexpect "cli.demo.explicitflags.echo-sql"
+eexpect "cli.demo.explicitflags.empty"
+eexpect "cli.demo.explicitflags.logtostderr"
+eexpect "cli.demo.runs"
+eexpect "defaultdb>"
+interrupt
+eexpect ":/# "
+end_test
+
 start_server $argv
+
+start_test "Check that server start-up flags are reported to telemetry"
+send "$argv sql --insecure\r"
+eexpect "defaultdb>"
+send "SELECT * FROM crdb_internal.feature_usage WHERE feature_name LIKE 'cli.start-single-node.%' ORDER BY 1;\r"
+eexpect feature_name
+eexpect "cli.start-single-node.explicitflags.insecure"
+eexpect "cli.start-single-node.explicitflags.listening-url-file"
+eexpect "cli.start-single-node.explicitflags.max-sql-memory"
+eexpect "cli.start-single-node.runs"
+eexpect "defaultdb>"
+interrupt
+eexpect ":/# "
+end_test
 
 start_test "Check that a client can connect using the URL env var"
 send "export COCKROACH_URL=`cat server_url`;\r"


### PR DESCRIPTION
Fixes #52129

Requested by PM multiple times in the past.
Will inform future UX changes.

Mentions of any flag X in the command line will now be counted under
`cli.<cmdname>.explicitflags.X`.

Additionally, the invocations of commands is also counted via
`cli.<cmdname>.runs`. This can be used to compute the % of flag usage
relative to total command invocations.

The commands with flag telemetry are currently: `start`,
`start-single-node` and `demo`.

Release note: None