### PR TITLE
roachtest: don't run kv0bench tests nightly

### DIFF
--- a/pkg/cmd/roachtest/kvbench.go
+++ b/pkg/cmd/roachtest/kvbench.go
@@ -80,7 +80,13 @@ func registerKVBenchSpec(r *testRegistry, b kvBenchSpec) {
 	name := strings.Join(nameParts, "/")
 	nodes := makeClusterSpec(b.Nodes+1, opts...)
 	r.Add(testSpec{
-		Name:    name,
+		Name: name,
+		// These tests don't have pass/fail conditions so we don't want to run them
+		// nightly. Currently they're only good for printing the results of a search
+		// for --max-rate.
+		// TODO(andrei): output something to roachperf and start running them
+		// nightly.
+		Tags:    []string{"manual"},
 		Owner:   OwnerKV,
 		Cluster: nodes,
 		Run: func(ctx context.Context, t *test, c *cluster) {


### PR DESCRIPTION
We have a family of kv0bench tests that have been added for checking the
performance of shareded indexes. These tests don't have pass/fail
conditions and don't output to roachperf; they only print stuff. Let's
not run the automatically any more. They can be run manually.

Release note: None