### PR TITLE
builtins: implement regexp_split_to{table,array}

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1680,6 +1680,87 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 </span></td></tr></tbody>
 </table>
 
+### STRING[] functions
+
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><a name="regexp_split_to_array"></a><code>regexp_split_to_array(string: <a href="string.html">string</a>, pattern: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Split string using a POSIX regular expression as the delimiter.</p>
+</span></td></tr>
+<tr><td><a name="regexp_split_to_array"></a><code>regexp_split_to_array(string: <a href="string.html">string</a>, pattern: <a href="string.html">string</a>, flags: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Split string using a POSIX regular expression as the delimiter with flags.</p>
+<p>CockroachDB supports the following flags:</p>
+<table>
+<thead>
+<tr>
+<th>Flag</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>c</strong></td>
+<td>Case-sensitive matching</td>
+</tr>
+<tr>
+<td><strong>g</strong></td>
+<td>Global matching (match each substring instead of only the first)</td>
+</tr>
+<tr>
+<td><strong>i</strong></td>
+<td>Case-insensitive matching</td>
+</tr>
+<tr>
+<td><strong>m</strong> or <strong>n</strong></td>
+<td>Newline-sensitive (see below)</td>
+</tr>
+<tr>
+<td><strong>p</strong></td>
+<td>Partial newline-sensitive matching (see below)</td>
+</tr>
+<tr>
+<td><strong>s</strong></td>
+<td>Newline-insensitive (default)</td>
+</tr>
+<tr>
+<td><strong>w</strong></td>
+<td>Inverse partial newline-sensitive matching (see below)</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Mode</th>
+<th><code>.</code> and <code>[^...]</code> match newlines</th>
+<th><code>^</code> and <code>$</code> match line boundaries</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>s</td>
+<td>yes</td>
+<td>no</td>
+</tr>
+<tr>
+<td>w</td>
+<td>yes</td>
+<td>yes</td>
+</tr>
+<tr>
+<td>p</td>
+<td>no</td>
+<td>no</td>
+</tr>
+<tr>
+<td>m/n</td>
+<td>no</td>
+<td>yes</td>
+</tr>
+</tbody>
+</table>
+</span></td></tr></tbody>
+</table>
+
 ### Sequence functions
 
 <table>
@@ -1747,6 +1828,80 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 <tr><td><a name="jsonb_object_keys"></a><code>jsonb_object_keys(input: jsonb) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns sorted set of keys in the outermost JSON object.</p>
 </span></td></tr>
 <tr><td><a name="pg_get_keywords"></a><code>pg_get_keywords() &rarr; tuple{string AS word, string AS catcode, string AS catdesc}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the keywords known to the SQL parser.</p>
+</span></td></tr>
+<tr><td><a name="regexp_split_to_table"></a><code>regexp_split_to_table(string: <a href="string.html">string</a>, pattern: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Split string using a POSIX regular expression as the delimiter.</p>
+</span></td></tr>
+<tr><td><a name="regexp_split_to_table"></a><code>regexp_split_to_table(string: <a href="string.html">string</a>, pattern: <a href="string.html">string</a>, flags: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Split string using a POSIX regular expression as the delimiter with flags.</p>
+<p>CockroachDB supports the following flags:</p>
+<table>
+<thead>
+<tr>
+<th>Flag</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>c</strong></td>
+<td>Case-sensitive matching</td>
+</tr>
+<tr>
+<td><strong>g</strong></td>
+<td>Global matching (match each substring instead of only the first)</td>
+</tr>
+<tr>
+<td><strong>i</strong></td>
+<td>Case-insensitive matching</td>
+</tr>
+<tr>
+<td><strong>m</strong> or <strong>n</strong></td>
+<td>Newline-sensitive (see below)</td>
+</tr>
+<tr>
+<td><strong>p</strong></td>
+<td>Partial newline-sensitive matching (see below)</td>
+</tr>
+<tr>
+<td><strong>s</strong></td>
+<td>Newline-insensitive (default)</td>
+</tr>
+<tr>
+<td><strong>w</strong></td>
+<td>Inverse partial newline-sensitive matching (see below)</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Mode</th>
+<th><code>.</code> and <code>[^...]</code> match newlines</th>
+<th><code>^</code> and <code>$</code> match line boundaries</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>s</td>
+<td>yes</td>
+<td>no</td>
+</tr>
+<tr>
+<td>w</td>
+<td>yes</td>
+<td>yes</td>
+</tr>
+<tr>
+<td>p</td>
+<td>no</td>
+<td>no</td>
+</tr>
+<tr>
+<td>m/n</td>
+<td>no</td>
+<td>yes</td>
+</tr>
+</tbody>
+</table>
 </span></td></tr>
 <tr><td><a name="unnest"></a><code>unnest(anyelement[], anyelement[], anyelement[]...) &rarr; tuple</code></td><td><span class="funcdesc"><p>Returns the input arrays as a set of rows</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2758,6 +2758,8 @@ SELECT set_bit(b'', 0, 1)
 query error set_bit\(\): new bit must be 0 or 1.
 SELECT set_bit(b'\145\x6C\l', 0, 2)
 
+subtest num_nulls_test
+
 statement ok
 CREATE TABLE nulls_test(a INT, b STRING)
 
@@ -2771,6 +2773,8 @@ SELECT num_nulls(a, b), num_nonnulls(a, b) FROM nulls_test
 1  1
 1  1
 2  0
+
+subtest pb_to_json
 
 query T
 select crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)->'database'->>'name' from system.descriptor where id=1
@@ -2786,9 +2790,33 @@ SELECT (SELECT * FROM [SHOW crdb_version]) = version()
 ----
 true
 
-
 query B
 select crdb_internal.json_to_pb('cockroach.sql.sqlbase.Descriptor', crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)) = descriptor from system.descriptor where id = 1
 ----
 true
 
+subtest regexp_split
+
+query T
+SELECT regexp_split_to_table('3aa0AAa1', 'a+')
+----
+3
+0AA
+1
+
+query T
+SELECT regexp_split_to_table('3aa0AAa1', 'a+', 'i')
+----
+3
+0
+1
+
+query T
+SELECT regexp_split_to_array('3aa0AAa1', 'a+')
+----
+{3,0AA,1}
+
+query T
+SELECT regexp_split_to_array('3aaa0AAa1', 'a+', 'i')
+----
+{3,0,1}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -110,6 +110,27 @@ func categorizeType(t *types.T) string {
 
 var digitNames = [...]string{"zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"}
 
+const regexpFlagInfo = `
+
+CockroachDB supports the following flags:
+
+| Flag           | Description                                                       |
+|----------------|-------------------------------------------------------------------|
+| **c**          | Case-sensitive matching                                           |
+| **g**          | Global matching (match each substring instead of only the first)  |
+| **i**          | Case-insensitive matching                                         |
+| **m** or **n** | Newline-sensitive (see below)                                     |
+| **p**          | Partial newline-sensitive matching (see below)                    |
+| **s**          | Newline-insensitive (default)                                     |
+| **w**          | Inverse partial newline-sensitive matching (see below)            |
+
+| Mode | ` + "`.` and `[^...]` match newlines | `^` and `$` match line boundaries" + `|
+|------|----------------------------------|--------------------------------------|
+| s    | yes                              | no                                   |
+| w    | yes                              | yes                                  |
+| p    | no                               | no                                   |
+| m/n  | no                               | yes                                  |`
+
 // builtinDefinition represents a built-in function before it becomes
 // a tree.FunctionDefinition.
 type builtinDefinition struct {
@@ -1437,26 +1458,36 @@ var builtins = map[string]builtinDefinition{
 				return result, nil
 			},
 			Info: "Replaces matches for the regular expression `regex` in `input` with the regular " +
-				"expression `replace` using `flags`." + `
+				"expression `replace` using `flags`." + regexpFlagInfo,
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 
-CockroachDB supports the following flags:
-
-| Flag           | Description                                                       |
-|----------------|-------------------------------------------------------------------|
-| **c**          | Case-sensitive matching                                           |
-| **g**          | Global matching (match each substring instead of only the first)  |
-| **i**          | Case-insensitive matching                                         |
-| **m** or **n** | Newline-sensitive (see below)                                     |
-| **p**          | Partial newline-sensitive matching (see below)                    |
-| **s**          | Newline-insensitive (default)                                     |
-| **w**          | Inverse partial newline-sensitive matching (see below)            |
-
-| Mode | ` + "`.` and `[^...]` match newlines | `^` and `$` match line boundaries" + `|
-|------|----------------------------------|--------------------------------------|
-| s    | yes                              | no                                   |
-| w    | yes                              | yes                                  |
-| p    | no                               | no                                   |
-| m/n  | no                               | yes                                  |`,
+	"regexp_split_to_array": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"string", types.String},
+				{"pattern", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.MakeArray(types.String)),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return regexpSplitToArray(ctx, args, false /* hasFlags */)
+			},
+			Info:       "Split string using a POSIX regular expression as the delimiter.",
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"string", types.String},
+				{"pattern", types.String},
+				{"flags", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.MakeArray(types.String)),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return regexpSplitToArray(ctx, args, true /* hasFlags */)
+			},
+			Info:       "Split string using a POSIX regular expression as the delimiter with flags." + regexpFlagInfo,
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
@@ -5246,6 +5277,36 @@ type regexpFlagKey struct {
 // Pattern implements the RegexpCacheKey interface.
 func (k regexpFlagKey) Pattern() (string, error) {
 	return regexpEvalFlags(k.sqlPattern, k.sqlFlags)
+}
+
+func regexpSplit(ctx *tree.EvalContext, args tree.Datums, hasFlags bool) ([]string, error) {
+	s := string(tree.MustBeDString(args[0]))
+	pattern := string(tree.MustBeDString(args[1]))
+	sqlFlags := ""
+	if hasFlags {
+		sqlFlags = string(tree.MustBeDString(args[2]))
+	}
+	patternRe, err := ctx.ReCache.GetRegexp(regexpFlagKey{pattern, sqlFlags})
+	if err != nil {
+		return nil, err
+	}
+	return patternRe.Split(s, -1), nil
+}
+
+func regexpSplitToArray(
+	ctx *tree.EvalContext, args tree.Datums, hasFlags bool,
+) (tree.Datum, error) {
+	words, err := regexpSplit(ctx, args, hasFlags /* hasFlags */)
+	if err != nil {
+		return nil, err
+	}
+	result := tree.NewDArray(types.String)
+	for _, word := range words {
+		if err := result.Append(tree.NewDString(word)); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
 }
 
 func regexpReplace(ctx *tree.EvalContext, s, pattern, to, sqlFlags string) (tree.Datum, error) {


### PR DESCRIPTION
Refs: #51818

Release note (sql change): Implement the regexp_split_to_table and
regexp_split_to_array builtins.