### PR TITLE
importccl: fix case sensitive INSERT INTO column names in PGDUMP

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -857,6 +857,17 @@ COPY t (a, b, c) FROM stdin;
 			},
 		},
 		{
+			name: "case sensitive table names",
+			typ:  "PGDUMP",
+			data: `
+				CREATE TABLE t ("sPoNgE" int8);
+				INSERT INTO t ("sPoNgE") VALUES (1337);
+			`,
+			query: map[string][][]string{
+				`SELECT * from t`: {{"1337"}},
+			},
+		},
+		{
 			name: "sequence",
 			typ:  "PGDUMP",
 			data: `

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -598,7 +598,7 @@ func (m *pgDumpReader) readFile(
 				targetColMapInd = make([]int, len(i.Columns))
 				conv.IsTargetCol = make(map[int]struct{}, len(i.Columns))
 				for j := range i.Columns {
-					colName := i.Columns[j].String()
+					colName := string(i.Columns[j])
 					ind, ok := m.colMap[conv][colName]
 					if !ok {
 						return errors.Newf("targeted column %q not found", colName)


### PR DESCRIPTION
Refs: #52382 

Tested by uncommenting out the skip and re-commenting it afterwards.

Release note (sql change, bug fix): When using `IMPORT PGDUMP` with
`INSERT INTO` clauses, specifying a column name that is case sensitive
(e.g. `"cApItAls"`)  would previously error specifying the column name
was not found. This has been rectified.