### PR TITLE
sqlbase,catalogkv: move more kv interactions to catalogkv

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -299,7 +299,7 @@ func WriteDescriptors(
 			// Depending on which cluster version we are restoring to, we decide which
 			// namespace table to write the descriptor into. This may cause wrong
 			// behavior if the cluster version is bumped DURING a restore.
-			dKey := sqlbase.MakeDatabaseNameKey(ctx, settings, desc.GetName())
+			dKey := catalogkv.MakeDatabaseNameKey(ctx, settings, desc.GetName())
 			b.CPut(dKey.Key(keys.SystemSQLCodec), desc.GetID(), nil)
 		}
 		for i := range tables {
@@ -343,7 +343,7 @@ func WriteDescriptors(
 			// Depending on which cluster version we are restoring to, we decide which
 			// namespace table to write the descriptor into. This may cause wrong
 			// behavior if the cluster version is bumped DURING a restore.
-			tkey := sqlbase.MakeObjectNameKey(
+			tkey := catalogkv.MakeObjectNameKey(
 				ctx,
 				settings,
 				table.GetParentID(),
@@ -368,7 +368,7 @@ func WriteDescriptors(
 			); err != nil {
 				return err
 			}
-			tkey := sqlbase.MakePublicTableNameKey(ctx, settings, typ.ParentID, typ.Name)
+			tkey := catalogkv.MakePublicTableNameKey(ctx, settings, typ.ParentID, typ.Name)
 			b.CPut(tkey.Key(keys.SystemSQLCodec), typ.ID, nil)
 		}
 
@@ -1114,7 +1114,7 @@ func (r *restoreResumer) publishDescriptors(ctx context.Context) error {
 				return err
 			}
 			newDescriptorChangeJobs = append(newDescriptorChangeJobs, newJobs...)
-			existingDescVal, err := sqlbase.ConditionalGetTableDescFromTxn(ctx, txn, r.execCfg.Codec, tbl)
+			existingDescVal, err := catalogkv.ConditionalGetTableDescFromTxn(ctx, txn, r.execCfg.Codec, tbl)
 			if err != nil {
 				return errors.Wrap(err, "validating table descriptor has not changed")
 			}
@@ -1232,11 +1232,11 @@ func (r *restoreResumer) dropTables(ctx context.Context, jr *jobs.Registry, txn 
 		prev := tableToDrop.Immutable().(sqlbase.TableDescriptor)
 		tableToDrop.Version++
 		tableToDrop.State = descpb.TableDescriptor_DROP
-		err := sqlbase.RemovePublicTableNamespaceEntry(ctx, txn, keys.SystemSQLCodec, tbl.ParentID, tbl.Name)
+		err := catalogkv.RemovePublicTableNamespaceEntry(ctx, txn, keys.SystemSQLCodec, tbl.ParentID, tbl.Name)
 		if err != nil {
 			return errors.Wrap(err, "dropping tables caused by restore fail/cancel from public namespace")
 		}
-		existingDescVal, err := sqlbase.ConditionalGetTableDescFromTxn(ctx, txn, r.execCfg.Codec, prev)
+		existingDescVal, err := catalogkv.ConditionalGetTableDescFromTxn(ctx, txn, r.execCfg.Codec, prev)
 		if err != nil {
 			return errors.Wrap(err, "dropping tables caused by restore fail/cancel")
 		}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -295,7 +295,7 @@ func allocateDescriptorRewrites(
 	if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		// Check that any DBs being restored do _not_ exist.
 		for name := range restoreDBNames {
-			found, _, err := sqlbase.LookupDatabaseID(ctx, txn, p.ExecCfg().Codec, name)
+			found, _, err := catalogkv.LookupDatabaseID(ctx, txn, p.ExecCfg().Codec, name)
 			if err != nil {
 				return err
 			}
@@ -350,7 +350,7 @@ func allocateDescriptorRewrites(
 			} else {
 				var parentID descpb.ID
 				{
-					found, newParentID, err := sqlbase.LookupDatabaseID(ctx, txn, p.ExecCfg().Codec, targetDB)
+					found, newParentID, err := catalogkv.LookupDatabaseID(ctx, txn, p.ExecCfg().Codec, targetDB)
 					if err != nil {
 						return err
 					}
@@ -415,7 +415,7 @@ func allocateDescriptorRewrites(
 				}
 
 				// Look up the parent database's ID.
-				found, parentID, err := sqlbase.LookupDatabaseID(ctx, txn, p.ExecCfg().Codec, targetDB)
+				found, parentID, err := catalogkv.LookupDatabaseID(ctx, txn, p.ExecCfg().Codec, targetDB)
 				if err != nil {
 					return err
 				}
@@ -431,7 +431,7 @@ func allocateDescriptorRewrites(
 				}
 
 				// See if there is an existing type with the same name.
-				found, id, err := sqlbase.LookupObjectID(ctx, txn, p.ExecCfg().Codec, parentID, keys.PublicSchemaID, typ.Name)
+				found, id, err := catalogkv.LookupObjectID(ctx, txn, p.ExecCfg().Codec, parentID, keys.PublicSchemaID, typ.Name)
 				if err != nil {
 					return err
 				}

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -660,7 +660,7 @@ func fullClusterTargets(
 func lookupDatabaseID(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, name string,
 ) (descpb.ID, error) {
-	found, id, err := sqlbase.LookupDatabaseID(ctx, txn, codec, name)
+	found, id, err := catalogkv.LookupDatabaseID(ctx, txn, codec, name)
 	if err != nil {
 		return descpb.InvalidID, err
 	}
@@ -680,7 +680,7 @@ func CheckObjectExists(
 	parentSchemaID descpb.ID,
 	name string,
 ) error {
-	found, id, err := sqlbase.LookupObjectID(ctx, txn, codec, parentID, parentSchemaID, name)
+	found, id, err := catalogkv.LookupObjectID(ctx, txn, codec, parentID, parentSchemaID, name)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -988,7 +988,7 @@ func prepareExistingTableDescForIngestion(
 	// upgrade and downgrade, because IMPORT does not operate in mixed-version
 	// states.
 	// TODO(jordan,lucy): remove this comment once 19.2 is released.
-	existingDesc, err := sqlbase.ConditionalGetTableDescFromTxn(ctx, txn, execCfg.Codec, existing)
+	existingDesc, err := catalogkv.ConditionalGetTableDescFromTxn(ctx, txn, execCfg.Codec, existing)
 	if err != nil {
 		return nil, errors.Wrap(err, "another operation is currently operating on the table")
 	}
@@ -1272,7 +1272,7 @@ func (r *importResumer) publishTables(ctx context.Context, execCfg *sql.Executor
 			// upgrade and downgrade, because IMPORT does not operate in mixed-version
 			// states.
 			// TODO(jordan,lucy): remove this comment once 19.2 is released.
-			existingDesc, err := sqlbase.ConditionalGetTableDescFromTxn(ctx, txn, execCfg.Codec, prevTableDesc)
+			existingDesc, err := catalogkv.ConditionalGetTableDescFromTxn(ctx, txn, execCfg.Codec, prevTableDesc)
 			if err != nil {
 				return errors.Wrap(err, "publishing tables")
 			}
@@ -1404,7 +1404,7 @@ func (r *importResumer) dropTables(
 			// possible. This is safe since the table data was never visible to users,
 			// and so we don't need to preserve MVCC semantics.
 			newTableDesc.DropTime = dropTime
-			if err := sqlbase.RemovePublicTableNamespaceEntry(
+			if err := catalogkv.RemovePublicTableNamespaceEntry(
 				ctx, txn, execCfg.Codec, newTableDesc.ParentID, newTableDesc.Name,
 			); err != nil {
 				return err
@@ -1418,7 +1418,7 @@ func (r *importResumer) dropTables(
 		// upgrade and downgrade, because IMPORT does not operate in mixed-version
 		// states.
 		// TODO(jordan,lucy): remove this comment once 19.2 is released.
-		existingDesc, err := sqlbase.ConditionalGetTableDescFromTxn(ctx, txn, execCfg.Codec, prevTableDesc)
+		existingDesc, err := catalogkv.ConditionalGetTableDescFromTxn(ctx, txn, execCfg.Codec, prevTableDesc)
 		if err != nil {
 			return errors.Wrap(err, "rolling back tables")
 		}

--- a/pkg/sql/alter_table_set_schema.go
+++ b/pkg/sql/alter_table_set_schema.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -130,7 +131,7 @@ func (n *alterTableSetSchemaNode) startExec(params runParams) error {
 		return nil
 	}
 
-	exists, _, err = sqlbase.LookupObjectID(
+	exists, _, err = catalogkv.LookupObjectID(
 		ctx, p.txn, p.ExecCfg().Codec, databaseID, desiredSchemaID, tableDesc.Name,
 	)
 	if err == nil && exists {
@@ -156,7 +157,7 @@ func (n *alterTableSetSchemaNode) startExec(params runParams) error {
 		return err
 	}
 
-	newTbKey := sqlbase.MakeObjectNameKey(ctx, p.ExecCfg().Settings,
+	newTbKey := catalogkv.MakeObjectNameKey(ctx, p.ExecCfg().Settings,
 		databaseID, desiredSchemaID, tableDesc.Name).Key(p.ExecCfg().Codec)
 
 	b := &kv.Batch{}

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -83,7 +83,7 @@ func (p *planner) addEnumValue(
 
 func (p *planner) renameType(params runParams, n *alterTypeNode, newName string) error {
 	// See if there is a name collision with the new name.
-	exists, id, err := sqlbase.LookupObjectID(
+	exists, id, err := catalogkv.LookupObjectID(
 		params.ctx,
 		p.txn,
 		p.ExecCfg().Codec,
@@ -155,7 +155,7 @@ func (p *planner) performRenameTypeDesc(
 	}
 	// Construct the new namespace key.
 	b := p.txn.NewBatch()
-	key := sqlbase.MakeObjectNameKey(
+	key := catalogkv.MakeObjectNameKey(
 		ctx,
 		p.ExecCfg().Settings,
 		desc.ParentID,

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1347,7 +1347,7 @@ func runSchemaChangesInTxn(
 		// Reclaim all the old names. Leave the data and descriptor
 		// cleanup for later.
 		for _, drain := range tableDesc.DrainingNames {
-			err := sqlbase.RemoveObjectNamespaceEntry(ctx, planner.Txn(), planner.ExecCfg().Codec,
+			err := catalogkv.RemoveObjectNamespaceEntry(ctx, planner.Txn(), planner.ExecCfg().Codec,
 				drain.ParentID, drain.ParentSchemaID, drain.Name, false /* KVTrace */)
 			if err != nil {
 				return err

--- a/pkg/sql/catalog/catalogkv/physical_accessor.go
+++ b/pkg/sql/catalog/catalogkv/physical_accessor.go
@@ -52,7 +52,7 @@ func (a UncachedPhysicalAccessor) GetDatabaseDesc(
 		return sysDB, nil
 	}
 
-	found, descID, err := sqlbase.LookupDatabaseID(ctx, txn, codec, name)
+	found, descID, err := LookupDatabaseID(ctx, txn, codec, name)
 	if err != nil {
 		return nil, err
 	} else if !found {
@@ -245,7 +245,7 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 	descID := sqlbase.LookupSystemTableDescriptorID(ctx, settings, codec, dbID, object)
 	if descID == descpb.InvalidID {
 		var found bool
-		found, descID, err = sqlbase.LookupObjectID(ctx, txn, codec, dbID, schema.ID, object)
+		found, descID, err = LookupObjectID(ctx, txn, codec, dbID, schema.ID, object)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1662,7 +1662,7 @@ func (m *Manager) resolveName(
 		txn.SetFixedTimestamp(ctx, timestamp)
 		var found bool
 		var err error
-		found, id, err = sqlbase.LookupObjectID(ctx, txn, m.storage.codec, parentID, parentSchemaID, name)
+		found, id, err = catalogkv.LookupObjectID(ctx, txn, m.storage.codec, parentID, parentSchemaID, name)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -47,7 +47,7 @@ func (p *planner) schemaExists(
 		}
 	}
 	// Now lookup in the namespace for other schemas.
-	exists, _, err := sqlbase.LookupObjectID(ctx, p.txn, p.ExecCfg().Codec, parentID, keys.RootNamespaceID, schema)
+	exists, _, err := catalogkv.LookupObjectID(ctx, p.txn, p.ExecCfg().Codec, parentID, keys.RootNamespaceID, schema)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -120,7 +120,7 @@ func doCreateSequence(
 	// makeSequenceTableDesc already validates the table. No call to
 	// desc.ValidateTable() needed here.
 
-	key := sqlbase.MakeObjectNameKey(
+	key := catalogkv.MakeObjectNameKey(
 		params.ctx,
 		params.ExecCfg().Settings,
 		dbDesc.GetID(),

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -214,10 +214,10 @@ func getTableCreateParams(
 		if err != nil {
 			return nil, 0, err
 		}
-		tKey = sqlbase.MakeObjectNameKey(params.ctx, params.ExecCfg().Settings, dbID, schemaID, tableName.Table())
+		tKey = catalogkv.MakeObjectNameKey(params.ctx, params.ExecCfg().Settings, dbID, schemaID, tableName.Table())
 	}
 
-	exists, id, err := sqlbase.LookupObjectID(
+	exists, id, err := catalogkv.LookupObjectID(
 		params.ctx, params.p.txn, params.ExecCfg().Codec, dbID, schemaID, tableName.Table())
 	if err == nil && exists {
 		// Try and see what kind of object we collided with.

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -84,8 +84,8 @@ func getCreateTypeParams(
 	if err != nil {
 		return nil, 0, err
 	}
-	typeKey = sqlbase.MakeObjectNameKey(params.ctx, params.ExecCfg().Settings, db.GetID(), schemaID, name.Type())
-	exists, collided, err := sqlbase.LookupObjectID(
+	typeKey = catalogkv.MakeObjectNameKey(params.ctx, params.ExecCfg().Settings, db.GetID(), schemaID, name.Type())
+	exists, collided, err := catalogkv.LookupObjectID(
 		params.ctx, params.p.txn, params.ExecCfg().Codec, db.GetID(), schemaID, name.Type())
 	if err == nil && exists {
 		// Try and see what kind of object we collided with.
@@ -111,7 +111,7 @@ func findFreeArrayTypeName(
 	arrayName := "_" + name
 	for {
 		// See if there is a collision with the current name.
-		exists, _, err := sqlbase.LookupObjectID(
+		exists, _, err := catalogkv.LookupObjectID(
 			ctx,
 			txn,
 			codec,
@@ -157,7 +157,7 @@ func (p *planner) createArrayType(
 	if err != nil {
 		return 0, err
 	}
-	arrayTypeKey := sqlbase.MakeObjectNameKey(params.ctx, params.ExecCfg().Settings, db.ID, schemaID, arrayTypeName)
+	arrayTypeKey := catalogkv.MakeObjectNameKey(params.ctx, params.ExecCfg().Settings, db.ID, schemaID, arrayTypeName)
 
 	// Generate the stable ID for the array type.
 	id, err := catalogkv.GenerateUniqueDescID(params.ctx, params.ExecCfg().DB, params.ExecCfg().Codec)

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -42,14 +42,14 @@ func (p *planner) renameDatabase(
 		return err
 	}
 
-	if exists, _, err := sqlbase.LookupDatabaseID(ctx, p.txn, p.ExecCfg().Codec, newName); err == nil && exists {
+	if exists, _, err := catalogkv.LookupDatabaseID(ctx, p.txn, p.ExecCfg().Codec, newName); err == nil && exists {
 		return pgerror.Newf(pgcode.DuplicateDatabase,
 			"the new database name %q already exists", newName)
 	} else if err != nil {
 		return err
 	}
 
-	newKey := sqlbase.MakeDatabaseNameKey(ctx, p.ExecCfg().Settings, newName).Key(p.ExecCfg().Codec)
+	newKey := catalogkv.MakeDatabaseNameKey(ctx, p.ExecCfg().Settings, newName).Key(p.ExecCfg().Codec)
 
 	descID := newDesc.GetID()
 	descKey := sqlbase.MakeDescMetadataKey(p.ExecCfg().Codec, descID)
@@ -62,7 +62,7 @@ func (p *planner) renameDatabase(
 	}
 	b.CPut(newKey, descID, nil)
 	b.Put(descKey, descDesc)
-	err := sqlbase.RemoveDatabaseNamespaceEntry(
+	err := catalogkv.RemoveDatabaseNamespaceEntry(
 		ctx, p.txn, p.ExecCfg().Codec, oldName, p.ExtendedEvalContext().Tracing.KVTracingEnabled(),
 	)
 	if err != nil {

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -55,7 +55,7 @@ func (p *planner) createDatabase(
 
 	dbName := string(database.Name)
 	shouldCreatePublicSchema := true
-	dKey := sqlbase.MakeDatabaseNameKey(ctx, p.ExecCfg().Settings, dbName)
+	dKey := catalogkv.MakeDatabaseNameKey(ctx, p.ExecCfg().Settings, dbName)
 	// TODO(solon): This conditional can be removed in 20.2. Every database
 	// is created with a public schema for cluster version >= 20.1, so we can remove
 	// the `shouldCreatePublicSchema` logic as well.
@@ -63,7 +63,7 @@ func (p *planner) createDatabase(
 		shouldCreatePublicSchema = false
 	}
 
-	if exists, _, err := sqlbase.LookupDatabaseID(ctx, p.txn, p.ExecCfg().Codec, dbName); err == nil && exists {
+	if exists, _, err := catalogkv.LookupDatabaseID(ctx, p.txn, p.ExecCfg().Codec, dbName); err == nil && exists {
 		if database.IfNotExists {
 			// Noop.
 			return nil, false, nil

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
@@ -264,7 +265,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 	b.Del(descKey)
 
 	for _, schemaToDelete := range n.schemasToDelete {
-		if err := sqlbase.RemoveSchemaNamespaceEntry(
+		if err := catalogkv.RemoveSchemaNamespaceEntry(
 			ctx,
 			p.txn,
 			p.ExecCfg().Codec,
@@ -275,7 +276,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		}
 	}
 
-	err := sqlbase.RemoveDatabaseNamespaceEntry(
+	err := catalogkv.RemoveDatabaseNamespaceEntry(
 		ctx, p.txn, p.ExecCfg().Codec, n.dbDesc.GetName(), p.ExtendedEvalContext().Tracing.KVTracingEnabled(),
 	)
 	if err != nil {

--- a/pkg/sql/namespace_test.go
+++ b/pkg/sql/namespace_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -100,7 +101,7 @@ func TestNamespaceTableSemantics(t *testing.T) {
 	}
 
 	txn := kvDB.NewTxn(ctx, "lookup-test-db-id")
-	found, dbID, err := sqlbase.LookupDatabaseID(ctx, txn, codec, "test")
+	found, dbID, err := catalogkv.LookupDatabaseID(ctx, txn, codec, "test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -148,7 +148,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 	tableDesc.SetName(newTn.Table())
 	tableDesc.ParentID = targetDbDesc.GetID()
 
-	newTbKey := sqlbase.MakeObjectNameKey(ctx, params.ExecCfg().Settings,
+	newTbKey := catalogkv.MakeObjectNameKey(ctx, params.ExecCfg().Settings,
 		targetDbDesc.GetID(), tableDesc.GetParentSchemaID(), newTn.Table()).Key(p.ExecCfg().Codec)
 
 	if err := tableDesc.Validate(ctx, p.txn, p.ExecCfg().Codec); err != nil {
@@ -182,7 +182,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 		return err
 	}
 
-	exists, id, err := sqlbase.LookupPublicTableID(
+	exists, id, err := catalogkv.LookupPublicTableID(
 		params.ctx, params.p.txn, p.ExecCfg().Codec, targetDbDesc.GetID(), newTn.Table(),
 	)
 	if err == nil && exists {

--- a/pkg/sql/schema_change_migrations_test.go
+++ b/pkg/sql/schema_change_migrations_test.go
@@ -887,7 +887,7 @@ func TestGCJobCreated(t *testing.T) {
 		if err := txn.SetSystemConfigTrigger(true /* forSystemTenant */); err != nil {
 			return err
 		}
-		if err := sqlbase.RemoveObjectNamespaceEntry(
+		if err := catalogkv.RemoveObjectNamespaceEntry(
 			ctx, txn, keys.SystemSQLCodec, tableDesc.ID, tableDesc.ParentID, tableDesc.Name, false, /* kvTrace */
 		); err != nil {
 			return err

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -372,7 +372,7 @@ func drainNamesForDescriptor(
 		func(txn *kv.Txn) error {
 			b := txn.NewBatch()
 			for _, drain := range namesToReclaim {
-				err := sqlbase.RemoveObjectNamespaceEntry(
+				err := catalogkv.RemoveObjectNamespaceEntry(
 					ctx, txn, codec, drain.ParentID, drain.ParentSchemaID, drain.Name, false, /* KVTrace */
 				)
 				if err != nil {

--- a/pkg/sql/sqlbase/helpers_test.go
+++ b/pkg/sql/sqlbase/helpers_test.go
@@ -15,9 +15,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 func testingGetDescriptor(
@@ -75,4 +78,103 @@ func TestingGetImmutableTableDescriptor(
 	kvDB *kv.DB, codec keys.SQLCodec, database string, table string,
 ) *ImmutableTableDescriptor {
 	return NewImmutableTableDescriptor(*TestingGetTableDescriptor(kvDB, codec, database, table))
+}
+
+// ExtractIndexKey constructs the index (primary) key for a row from any index
+// key/value entry, including secondary indexes.
+//
+// Don't use this function in the scan "hot path".
+func ExtractIndexKey(
+	a *DatumAlloc, codec keys.SQLCodec, tableDesc *ImmutableTableDescriptor, entry kv.KeyValue,
+) (roachpb.Key, error) {
+	indexID, key, err := DecodeIndexKeyPrefix(codec, tableDesc, entry.Key)
+	if err != nil {
+		return nil, err
+	}
+	if indexID == tableDesc.PrimaryIndex.ID {
+		return entry.Key, nil
+	}
+
+	index, err := tableDesc.FindIndexByID(indexID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the values for index.ColumnIDs.
+	indexTypes, err := GetColumnTypes(tableDesc, index.ColumnIDs)
+	if err != nil {
+		return nil, err
+	}
+	values := make([]EncDatum, len(index.ColumnIDs))
+	dirs := index.ColumnDirections
+	if len(index.Interleave.Ancestors) > 0 {
+		// TODO(dan): In the interleaved index case, we parse the key twice; once to
+		// find the index id so we can look up the descriptor, and once to extract
+		// the values. Only parse once.
+		var ok bool
+		_, ok, _, err = DecodeIndexKey(codec, tableDesc, index, indexTypes, values, dirs, entry.Key)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, errors.Errorf("descriptor did not match key")
+		}
+	} else {
+		key, _, err = DecodeKeyVals(indexTypes, values, dirs, key)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Extract the values for index.ExtraColumnIDs
+	extraTypes, err := GetColumnTypes(tableDesc, index.ExtraColumnIDs)
+	if err != nil {
+		return nil, err
+	}
+	extraValues := make([]EncDatum, len(index.ExtraColumnIDs))
+	dirs = make([]descpb.IndexDescriptor_Direction, len(index.ExtraColumnIDs))
+	for i := range index.ExtraColumnIDs {
+		// Implicit columns are always encoded Ascending.
+		dirs[i] = descpb.IndexDescriptor_ASC
+	}
+	extraKey := key
+	if index.Unique {
+		extraKey, err = entry.Value.GetBytes()
+		if err != nil {
+			return nil, err
+		}
+	}
+	_, _, err = DecodeKeyVals(extraTypes, extraValues, dirs, extraKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Encode the index key from its components.
+	colMap := make(map[descpb.ColumnID]int)
+	for i, columnID := range index.ColumnIDs {
+		colMap[columnID] = i
+	}
+	for i, columnID := range index.ExtraColumnIDs {
+		colMap[columnID] = i + len(index.ColumnIDs)
+	}
+	indexKeyPrefix := MakeIndexKeyPrefix(codec, tableDesc, tableDesc.PrimaryIndex.ID)
+
+	decodedValues := make([]tree.Datum, len(values)+len(extraValues))
+	for i, value := range values {
+		err := value.EnsureDecoded(indexTypes[i], a)
+		if err != nil {
+			return nil, err
+		}
+		decodedValues[i] = value.Datum
+	}
+	for i, value := range extraValues {
+		err := value.EnsureDecoded(extraTypes[i], a)
+		if err != nil {
+			return nil, err
+		}
+		decodedValues[len(values)+i] = value.Datum
+	}
+	indexKey, _, err := EncodeIndexKey(
+		tableDesc, &tableDesc.PrimaryIndex, colMap, decodedValues, indexKeyPrefix)
+	return indexKey, err
 }

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -719,105 +718,6 @@ func DecodeKeyVals(
 		}
 	}
 	return key, foundNull, nil
-}
-
-// ExtractIndexKey constructs the index (primary) key for a row from any index
-// key/value entry, including secondary indexes.
-//
-// Don't use this function in the scan "hot path".
-func ExtractIndexKey(
-	a *DatumAlloc, codec keys.SQLCodec, tableDesc *ImmutableTableDescriptor, entry kv.KeyValue,
-) (roachpb.Key, error) {
-	indexID, key, err := DecodeIndexKeyPrefix(codec, tableDesc, entry.Key)
-	if err != nil {
-		return nil, err
-	}
-	if indexID == tableDesc.PrimaryIndex.ID {
-		return entry.Key, nil
-	}
-
-	index, err := tableDesc.FindIndexByID(indexID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Extract the values for index.ColumnIDs.
-	indexTypes, err := GetColumnTypes(tableDesc, index.ColumnIDs)
-	if err != nil {
-		return nil, err
-	}
-	values := make([]EncDatum, len(index.ColumnIDs))
-	dirs := index.ColumnDirections
-	if len(index.Interleave.Ancestors) > 0 {
-		// TODO(dan): In the interleaved index case, we parse the key twice; once to
-		// find the index id so we can look up the descriptor, and once to extract
-		// the values. Only parse once.
-		var ok bool
-		_, ok, _, err = DecodeIndexKey(codec, tableDesc, index, indexTypes, values, dirs, entry.Key)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			return nil, errors.Errorf("descriptor did not match key")
-		}
-	} else {
-		key, _, err = DecodeKeyVals(indexTypes, values, dirs, key)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Extract the values for index.ExtraColumnIDs
-	extraTypes, err := GetColumnTypes(tableDesc, index.ExtraColumnIDs)
-	if err != nil {
-		return nil, err
-	}
-	extraValues := make([]EncDatum, len(index.ExtraColumnIDs))
-	dirs = make([]descpb.IndexDescriptor_Direction, len(index.ExtraColumnIDs))
-	for i := range index.ExtraColumnIDs {
-		// Implicit columns are always encoded Ascending.
-		dirs[i] = descpb.IndexDescriptor_ASC
-	}
-	extraKey := key
-	if index.Unique {
-		extraKey, err = entry.Value.GetBytes()
-		if err != nil {
-			return nil, err
-		}
-	}
-	_, _, err = DecodeKeyVals(extraTypes, extraValues, dirs, extraKey)
-	if err != nil {
-		return nil, err
-	}
-
-	// Encode the index key from its components.
-	colMap := make(map[descpb.ColumnID]int)
-	for i, columnID := range index.ColumnIDs {
-		colMap[columnID] = i
-	}
-	for i, columnID := range index.ExtraColumnIDs {
-		colMap[columnID] = i + len(index.ColumnIDs)
-	}
-	indexKeyPrefix := MakeIndexKeyPrefix(codec, tableDesc, tableDesc.PrimaryIndex.ID)
-
-	decodedValues := make([]tree.Datum, len(values)+len(extraValues))
-	for i, value := range values {
-		err := value.EnsureDecoded(indexTypes[i], a)
-		if err != nil {
-			return nil, err
-		}
-		decodedValues[i] = value.Datum
-	}
-	for i, value := range extraValues {
-		err := value.EnsureDecoded(extraTypes[i], a)
-		if err != nil {
-			return nil, err
-		}
-		decodedValues[len(values)+i] = value.Datum
-	}
-	indexKey, _, err := EncodeIndexKey(
-		tableDesc, &tableDesc.PrimaryIndex, colMap, decodedValues, indexKeyPrefix)
-	return indexKey, err
 }
 
 // IndexEntry represents an encoded key/value for an index entry.

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -202,7 +202,7 @@ func cleanupSessionTempObjects(
 			// itself may still exist (eg. a temporary table was created and then
 			// dropped). So we remove the namespace table entry of the temporary
 			// schema.
-			if err := sqlbase.RemoveSchemaNamespaceEntry(ctx, txn, codec, id, tempSchemaName); err != nil {
+			if err := catalogkv.RemoveSchemaNamespaceEntry(ctx, txn, codec, id, tempSchemaName); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -190,7 +190,7 @@ func (p *planner) truncateTable(
 	// structured.proto
 	//
 	// TODO(vivek): Fix properly along with #12123.
-	key := sqlbase.MakeObjectNameKey(
+	key := catalogkv.MakeObjectNameKey(
 		ctx, p.ExecCfg().Settings,
 		newTableDesc.ParentID,
 		newTableDesc.GetParentSchemaID(),
@@ -198,7 +198,7 @@ func (p *planner) truncateTable(
 	).Key(p.ExecCfg().Codec)
 
 	// Remove the old namespace entry.
-	if err := sqlbase.RemoveObjectNamespaceEntry(
+	if err := catalogkv.RemoveObjectNamespaceEntry(
 		ctx, p.txn, p.execCfg.Codec,
 		tableDesc.ParentID, tableDesc.GetParentSchemaID(), tableDesc.GetName(),
 		traceKV); err != nil {

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -283,7 +284,7 @@ func resolveZone(ctx context.Context, txn *kv.Txn, zs *tree.ZoneSpecifier) (desc
 	errMissingKey := errors.New("missing key")
 	id, err := zonepb.ResolveZoneSpecifier(zs,
 		func(parentID uint32, name string) (uint32, error) {
-			found, id, err := sqlbase.LookupPublicTableID(ctx, txn, keys.SystemSQLCodec, descpb.ID(parentID), name)
+			found, id, err := catalogkv.LookupPublicTableID(ctx, txn, keys.SystemSQLCodec, descpb.ID(parentID), name)
 			if err != nil {
 				return 0, err
 			}

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -1486,7 +1486,7 @@ func createSystemTable(ctx context.Context, r runner, desc sqlbase.TableDescript
 	// the reserved ID space. (The SQL layer doesn't allow this.)
 	err := r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		b := txn.NewBatch()
-		tKey := sqlbase.MakePublicTableNameKey(ctx, r.settings, desc.GetParentID(), desc.GetName())
+		tKey := catalogkv.MakePublicTableNameKey(ctx, r.settings, desc.GetParentID(), desc.GetName())
 		b.CPut(tKey.Key(r.codec), desc.GetID(), nil)
 		b.CPut(sqlbase.MakeDescMetadataKey(r.codec, desc.GetID()), desc.DescriptorProto(), nil)
 		if err := txn.SetSystemConfigTrigger(r.codec.ForSystemTenant()); err != nil {


### PR DESCRIPTION
At this point the only remaining kv interactions in sqlbase are during type
and table interactions though there are also usages through the protoGetter.

This is a minor change in the work to pick apart sqlbase.

Release note: None