### PR TITLE
ui: Upgrade admin-ui-components package

### DIFF
--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -13,7 +13,7 @@
     "cypress:update-snapshots": "yarn cypress run --env updateSnapshots=true --spec 'cypress/integration/**/*.visual.spec.ts'"
   },
   "dependencies": {
-    "@cockroachlabs/admin-ui-components": "^0.1.9",
+    "@cockroachlabs/admin-ui-components": "^0.1.10",
     "analytics-node": "^3.4.0-beta.1",
     "antd": "^3.25.2",
     "babel-polyfill": "^6.26.0",

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -1806,14 +1806,13 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@cockroachlabs/admin-ui-components@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/admin-ui-components/-/admin-ui-components-0.1.9.tgz#e43a2508bc258e368d0c50c5ecf5d5c7fcf72c53"
-  integrity sha512-qWp4K0ChHHrNQYVCMhZxX5Ugwqjgog6htBm24d7KWmiHtZmEeqRzowuiO1I6289LvRk885yQJouD9XRe+vqjXA==
+"@cockroachlabs/admin-ui-components@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/admin-ui-components/-/admin-ui-components-0.1.10.tgz#e71e7f00ba4a51e868b01bae3479e3b28cff5014"
+  integrity sha512-t0fza4KPVEdsgmcfY8WW3QUC5r2+PvzZgWCiHShzTKyElZTqyXYbqpzTDsrJoD+wNXqy5L5Y/7yBvrINWEpCYw==
   dependencies:
     "@cockroachlabs/icons" "^0.2.2"
     "@popperjs/core" "^2.4.0"
-    d3 "<4.0.0"
     long "^4.0.0"
     react-helmet "^5.2.0"
     react-popper "^2.2.3"


### PR DESCRIPTION
Resolves #52472
Depends on https://github.com/cockroachdb/yarn-vendored/pull/30

Due to the issue with d3 library that was initialized twice,
because `admin-ui-components` package included its own version
of D3 lib. That caused an issue with rendering charts on
Metrics page.

As a solution, `admin-ui-components` package requires D3 lib
as peer dependency (changed in 0.1.10 version), so it is only
one version of D3 is included in DOM.

Release note: None