### PR TITLE
release-20.1: roachtest: don't rename log files to .failed.log on failed invocations

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2025,8 +2025,8 @@ func cmdLogFileName(t time.Time, nodes nodeListOption, args ...string) string {
 
 // RunE runs a command on the specified node, returning an error. The output
 // will be redirected to a file which is logged via the cluster-wide logger in
-// case of an error. Logs will sort chronologically and those belonging to
-// failing invocations will be suffixed `.failed.log`.
+// case of an error. Logs will sort chronologically. Failing invocations will
+// have an additional marker file with a `.failed` extension instead of `.log`.
 func (c *cluster) RunE(ctx context.Context, node nodeListOption, args ...string) error {
 	cmdString := strings.Join(args, " ")
 	logFile := cmdLogFileName(timeutil.Now(), node, args...)
@@ -2045,7 +2045,10 @@ func (c *cluster) RunE(ctx context.Context, node nodeListOption, args ...string)
 	physicalFileName := l.file.Name()
 	l.close()
 	if err != nil {
-		_ = os.Rename(physicalFileName, strings.TrimSuffix(physicalFileName, ".log")+".failed.log")
+		failedPhysicalFileName := strings.TrimSuffix(physicalFileName, ".log") + ".failed"
+		if failedFile, err2 := os.Create(failedPhysicalFileName); err2 != nil {
+			failedFile.Close()
+		}
 	}
 	err = errors.Wrapf(err, "output in %s", logFile)
 	return err


### PR DESCRIPTION
Backport 1/1 commits from #52151.

/cc @cockroachdb/release

---

Before:

The log file for failed invocations was renamed to have the suffix
`.failed.log`.

Why change?

The GCS artifacts plugin in TeamCity doesn't play well with renaming
artifact files. roachtest renames log files for commands that fail. This
made any run of the "Cockroach -> Unit Tests -> roachtests" build
configuration that had a failed command then fail its run (effectively
every run).

Now:

The log file for a failed run keeps its original name. A new (empty)
`.failed` file is created to maintain the signal that a command
invocation failed.

Release note: None
