### PR TITLE
sql: add event logging for type DDL statements

### DIFF
--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -280,13 +280,29 @@ func (p *planner) createEnum(params runParams, n *tree.CreateType) error {
 	typeDesc.ArrayTypeID = arrayTypeID
 
 	// Now create the type after the implicit array type as been created.
-	return p.createDescriptorWithID(
+	if err := p.createDescriptorWithID(
 		params.ctx,
 		typeKey.Key(params.ExecCfg().Codec),
 		id,
 		typeDesc,
 		params.EvalContext().Settings,
 		tree.AsStringWithFQNames(n, params.Ann()),
+	); err != nil {
+		return err
+	}
+
+	// Log the event.
+	return MakeEventLogger(p.ExecCfg()).InsertEventRecord(
+		params.ctx,
+		p.txn,
+		EventLogCreateType,
+		int32(typeDesc.GetID()),
+		int32(p.ExtendedEvalContext().NodeID.SQLInstanceID()),
+		struct {
+			TypeName  string
+			Statement string
+			User      string
+		}{typeName.FQString(), tree.AsStringWithFQNames(n, params.Ann()), p.User()},
 	)
 }
 

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -76,6 +76,13 @@ const (
 	// initiated schema change rollback has completed.
 	EventLogFinishSchemaRollback EventLogType = "finish_schema_change_rollback"
 
+	// EventLogCreateType is recorded when a type is created.
+	EventLogCreateType EventLogType = "create_type"
+	// EventLogDropType is recorded when a type is dropped.
+	EventLogDropType EventLogType = "drop_type"
+	// EventAlterType is recorded when a type is altered.
+	EventLogAlterType EventLogType = "alter_type"
+
 	// EventLogNodeJoin is recorded when a node joins the cluster.
 	EventLogNodeJoin EventLogType = "node_join"
 	// EventLogNodeRestart is recorded when an existing node rejoins the cluster


### PR DESCRIPTION
Fixes #52411.

This commit adds event logging for type DDL statements.

Release note: None