### PR TITLE
sql: add memory accounting for fetches

### DIFF
--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -113,12 +113,14 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 
 	var rf row.Fetcher
 	if err := rf.Init(
+		context.TODO(),
 		c.codec,
 		false, /* reverse */
 		descpb.ScanLockingStrength_FOR_NONE,
 		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		&c.a,
+		nil, /* memMonitor */
 		row.FetcherTableArgs{
 			Spans:            tableDesc.AllIndexSpans(c.codec),
 			Desc:             tableDesc,

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -122,12 +122,15 @@ func (cb *ColumnBackfiller) init(
 		ValNeededForCol: valNeededForCol,
 	}
 	return cb.fetcher.Init(
+		evalCtx.Context,
 		evalCtx.Codec,
 		false, /* reverse */
 		descpb.ScanLockingStrength_FOR_NONE,
 		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		&cb.alloc,
+		// TODO(bulkio): plumb a memory monitor into here, and make sure to call cb.fetcher.Close().
+		nil, /* memMonitor */
 		tableArgs,
 	)
 }
@@ -558,12 +561,15 @@ func (ib *IndexBackfiller) init(
 		ValNeededForCol: valNeededForCol,
 	}
 	return ib.fetcher.Init(
+		evalCtx.Context,
 		evalCtx.Codec,
 		false, /* reverse */
 		descpb.ScanLockingStrength_FOR_NONE,
 		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		&ib.alloc,
+		// TODO(bulkio): plumb a memory monitor into here, and make sure to call cb.fetcher.Close().
+		nil, /* memMonitor */
 		tableArgs,
 	)
 }

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -535,6 +535,8 @@ func (rf *cFetcher) StartScan(
 		firstBatchLimit++
 	}
 
+	// Note that we pass a nil memMonitor here, because the cfetcher does its own
+	// memory accounting.
 	f, err := row.NewKVFetcher(
 		txn,
 		spans,
@@ -543,6 +545,7 @@ func (rf *cFetcher) StartScan(
 		firstBatchLimit,
 		rf.lockStrength,
 		rf.lockWaitPolicy,
+		nil, /* memMonitor */
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -107,6 +107,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		}
 	}
 	if err := d.fetcher.Init(
+		params.ctx,
 		params.ExecCfg().Codec,
 		false, /* reverse */
 		// TODO(nvanbenschoten): it might make sense to use a FOR_UPDATE locking
@@ -116,6 +117,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		params.p.alloc,
+		nil, /* memMonitor */
 		allTables...,
 	); err != nil {
 		return err

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -194,12 +194,14 @@ func DecodeRowInfo(
 	}
 	rf.IgnoreUnexpectedNulls = true
 	if err := rf.Init(
+		ctx,
 		codec,
 		false, /* reverse */
 		descpb.ScanLockingStrength_FOR_NONE,
 		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		&rowenc.DatumAlloc{},
+		nil, /* memMonitor */
 		tableArgs,
 	); err != nil {
 		return nil, nil, nil, err

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -109,12 +109,14 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 	}
 	var rf row.Fetcher
 	if err := rf.Init(
+		ctx,
 		keys.SystemSQLCodec,
 		false, /* reverse */
 		descpb.ScanLockingStrength_FOR_NONE,
 		descpb.ScanLockingWaitPolicy_BLOCK,
 		true, /* isCheck */
 		&rowenc.DatumAlloc{},
+		nil, /* memMonitor */
 		args...,
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
 // KVFetcher wraps kvBatchFetcher, providing a NextKV interface that returns the
@@ -31,9 +32,11 @@ type KVFetcher struct {
 	bytesRead     int64
 	Span          roachpb.Span
 	newSpan       bool
+	acc           mon.BoundAccount
 }
 
 // NewKVFetcher creates a new KVFetcher.
+// If mon is non-nil, this fetcher will track its fetches and must be Closed.
 func NewKVFetcher(
 	txn *kv.Txn,
 	spans roachpb.Spans,
@@ -42,17 +45,22 @@ func NewKVFetcher(
 	firstBatchLimit int64,
 	lockStrength descpb.ScanLockingStrength,
 	lockWaitPolicy descpb.ScanLockingWaitPolicy,
+	mon *mon.BytesMonitor,
 ) (*KVFetcher, error) {
 	kvBatchFetcher, err := makeKVBatchFetcher(
-		txn, spans, reverse, useBatchLimit, firstBatchLimit, lockStrength, lockWaitPolicy,
+		txn, spans, reverse, useBatchLimit, firstBatchLimit, lockStrength, lockWaitPolicy, mon,
 	)
-	return newKVFetcher(&kvBatchFetcher), err
+	return newKVFetcher(&kvBatchFetcher, mon), err
 }
 
-func newKVFetcher(batchFetcher kvBatchFetcher) *KVFetcher {
-	return &KVFetcher{
+func newKVFetcher(batchFetcher kvBatchFetcher, mon *mon.BytesMonitor) *KVFetcher {
+	ret := &KVFetcher{
 		kvBatchFetcher: batchFetcher,
 	}
+	if mon != nil {
+		ret.acc = mon.MakeBoundAccount()
+	}
+	return ret
 }
 
 // GetBytesRead returns the number of bytes read by this fetcher.
@@ -108,16 +116,57 @@ func (f *KVFetcher) NextKV(
 			}, newSpan, nil
 		}
 
+		monitoring := f.acc.Monitor() != nil
+
+		const tokenFetchAllocation = 1 << 10
+		if monitoring && f.acc.Used() < tokenFetchAllocation {
+			// Pre-reserve a token fraction of the maximum amount of memory this scan
+			// could return. Most of the time, scans won't use this amount of memory,
+			// so it's unnecessary to reserve it all. We reserve something rather than
+			// nothing at all to preserve some accounting.
+			if err := f.acc.ResizeTo(ctx, tokenFetchAllocation); err != nil {
+				return ok, kv, false, err
+			}
+		}
 		ok, f.kvs, f.batchResponse, f.Span, err = f.nextBatch(ctx)
 		if err != nil {
 			return ok, kv, false, err
+		}
+		returnedBytes := int64(len(f.batchResponse))
+		if monitoring && returnedBytes > f.acc.Used() {
+			// Resize up to the actual amount of bytes we got back from the fetch,
+			// but don't ratchet down. We would much prefer to over-account, and the
+			// worst we can over-account by is around 10 MB, the maximum fetch size.
+			//
+			// The reason we don't want to precisely account here is to hopefully
+			// protect ourselves from "slop" in our memory handling. In general, we
+			// expect that all SQL operators that buffer data for longer than a single
+			// call to Next do their own accounting, so theoretically, by the time
+			// this fetch method is called again, all memory will either be released
+			// from the system or accounted for elsewhere. In reality, though, Go's
+			// garbage collector has some lag between when the memory is no longer
+			// referenced and when it is freed. Also, we're not perfect with
+			// accounting by any means. When we start doing large fetches, it's more
+			// likely that we'll expose ourselves to OOM conditions, so that's the
+			// reasoning for why we never ratchet this account down - only up, toward
+			// the maximum fetch size (maxScanResponseBytes).
+			if err := f.acc.ResizeTo(ctx, returnedBytes); err != nil {
+				return ok, kv, false, err
+			}
 		}
 		if !ok {
 			return false, kv, false, nil
 		}
 		f.newSpan = true
-		f.bytesRead += int64(len(f.batchResponse))
+		f.bytesRead += returnedBytes
 	}
+}
+
+// Close releases the resources held by this KVFetcher. It must be called
+// at the end of execution if the fetcher was provisioned with a memory
+// monitor.
+func (f *KVFetcher) Close(ctx context.Context) {
+	f.acc.Close(ctx)
 }
 
 // SpanKVFetcher is a kvBatchFetcher that returns a set slice of kvs.

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -257,7 +257,7 @@ func newInvertedJoiner(
 	// and so do not need to see in-progress schema changes.
 	_, _, err = initRowFetcher(
 		flowCtx, &fetcher, &ij.desc, int(spec.IndexIdx), ij.colIdxMap, false, /* reverse */
-		allIndexCols, false /* isCheck */, &ij.alloc, execinfra.ScanVisibilityPublic,
+		allIndexCols, false /* isCheck */, flowCtx.EvalCtx.Mon, &ij.alloc, execinfra.ScanVisibilityPublic,
 		descpb.ScanLockingStrength_FOR_NONE, descpb.ScanLockingWaitPolicy_BLOCK,
 		nil, /* systemColumns */
 	)
@@ -618,6 +618,9 @@ func (ij *invertedJoiner) ConsumerClosed() {
 
 func (ij *invertedJoiner) close() {
 	if ij.InternalClose() {
+		if ij.fetcher != nil {
+			ij.fetcher.Close(ij.Ctx)
+		}
 		if ij.keyRows != nil {
 			ij.keyRows.Close(ij.Ctx)
 		}

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -125,7 +125,7 @@ func newScrubTableReader(
 	var fetcher row.Fetcher
 	if _, _, err := initRowFetcher(
 		flowCtx, &fetcher, &tr.tableDesc, int(spec.IndexIdx), tr.tableDesc.ColumnIdxMap(),
-		spec.Reverse, neededColumns, true /* isCheck */, &tr.alloc,
+		spec.Reverse, neededColumns, true /* isCheck */, flowCtx.EvalCtx.Mon, &tr.alloc,
 		execinfra.ScanVisibilityPublic, spec.LockingStrength, spec.LockingWaitPolicy,
 		nil, /* systemColumns */
 	); err != nil {

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -128,6 +128,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 		ValNeededForCol: valNeededForCol,
 	}
 	if err := rf.Init(
+		ctx,
 		td.rd.Helper.Codec,
 		false, /* reverse */
 		// TODO(nvanbenschoten): it might make sense to use a FOR_UPDATE locking
@@ -137,6 +138,8 @@ func (td *tableDeleter) deleteAllRowsScan(
 		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		td.alloc,
+		// TODO(bulkio): this might need a memory monitor for the slow case of truncate.
+		nil, /* memMonitor */
 		tableArgs,
 	); err != nil {
 		return resume, err
@@ -255,6 +258,7 @@ func (td *tableDeleter) deleteIndexScan(
 		ValNeededForCol: valNeededForCol,
 	}
 	if err := rf.Init(
+		ctx,
 		td.rd.Helper.Codec,
 		false, /* reverse */
 		// TODO(nvanbenschoten): it might make sense to use a FOR_UPDATE locking
@@ -264,6 +268,8 @@ func (td *tableDeleter) deleteIndexScan(
 		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		td.alloc,
+		// TODO(bulkio): this might need a memory monitor.
+		nil, /* memMonitor */
 		tableArgs,
 	); err != nil {
 		return resume, err


### PR DESCRIPTION
This commit adds a memory monitor to the kv fetcher infrastructure
that's initialized by its users. When kv fetches occur, the new
infrastructure ensure that there's always at least 1 kilobyte allocated
for the fetch before it happens. Once the fetch returns, the accounting
is adjusted to include the entire size of the fetch. Subsequent fetches
that return less memory do *not* ratchet down the allocation size to
preserve safety and reduce some pointless allocation adjustment
churning.

Closes #51551.

Release note (sql change): the memory used by disk scans is accounted
for, reducing the likelihood of out of memory conditions that result in
process crashes as opposed to SQL out of memory error messages.

Release justification: fixes for high-priority bugs in existing functionality
