### PR TITLE
sql: infect more things with sqlbase.TableDescriptor interface

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -542,7 +542,7 @@ func restore(
 
 	pkIDs := make(map[uint64]bool)
 	for _, tbl := range tables {
-		pkIDs[roachpb.BulkOpSummaryID(uint64(tbl.GetID()), uint64(tbl.TableDesc().PrimaryIndex.ID))] = true
+		pkIDs[roachpb.BulkOpSummaryID(uint64(tbl.GetID()), uint64(tbl.GetPrimaryIndexID()))] = true
 	}
 
 	g := ctxgroup.WithContext(restoreCtx)

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -585,7 +585,9 @@ func ensureInterleavesIncluded(tables []sqlbase.TableDescriptor) error {
 	}
 
 	for _, table := range tables {
-		if err := table.ForeachNonDropIndex(func(index *descpb.IndexDescriptor) error {
+		if err := table.ForeachIndex(sqlbase.IndexOpts{
+			AddMutations: true,
+		}, func(index *descpb.IndexDescriptor, _ bool) error {
 			for _, a := range index.Interleave.Ancestors {
 				if !inBackup[a.TableID] {
 					return errors.Errorf(

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -134,7 +134,7 @@ func makeBenchSink() *benchSink {
 func (s *benchSink) EmitRow(
 	ctx context.Context, table sqlbase.TableDescriptor, key, value []byte, updated hlc.Timestamp,
 ) error {
-	return s.emit(int64(len(k) + len(v)))
+	return s.emit(int64(len(key) + len(value)))
 }
 func (s *benchSink) EmitResolvedTimestamp(ctx context.Context, e Encoder, ts hlc.Timestamp) error {
 	var noTopic string

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -132,7 +132,7 @@ func makeBenchSink() *benchSink {
 }
 
 func (s *benchSink) EmitRow(
-	ctx context.Context, _ *descpb.TableDescriptor, k, v []byte, _ hlc.Timestamp,
+	ctx context.Context, table sqlbase.TableDescriptor, key, value []byte, updated hlc.Timestamp,
 ) error {
 	return s.emit(int64(len(k) + len(v)))
 }

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -267,7 +267,7 @@ func emitEntries(
 			}
 		}
 		if err := sink.EmitRow(
-			ctx, row.tableDesc.TableDesc(), keyCopy, valueCopy, row.updated,
+			ctx, row.tableDesc, keyCopy, valueCopy, row.updated,
 		); err != nil {
 			return err
 		}

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvfeed"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -35,7 +35,7 @@ func makeMetricsSink(metrics *Metrics, s Sink) *metricsSink {
 }
 
 func (s *metricsSink) EmitRow(
-	ctx context.Context, table *descpb.TableDescriptor, key, value []byte, updated hlc.Timestamp,
+	ctx context.Context, table sqlbase.TableDescriptor, key, value []byte, updated hlc.Timestamp,
 ) error {
 	start := timeutil.Now()
 	err := s.wrapped.EmitRow(ctx, table, key, value, updated)

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -390,13 +391,13 @@ func (s *cloudStorageSink) getOrCreateFile(
 
 // EmitRow implements the Sink interface.
 func (s *cloudStorageSink) EmitRow(
-	ctx context.Context, table *descpb.TableDescriptor, _, value []byte, updated hlc.Timestamp,
+	ctx context.Context, table sqlbase.TableDescriptor, key, value []byte, updated hlc.Timestamp,
 ) error {
 	if s.files == nil {
 		return errors.New(`cannot EmitRow on a closed sink`)
 	}
 
-	file := s.getOrCreateFile(table.Name, table.Version)
+	file := s.getOrCreateFile(table.GetName(), table.GetVersion())
 
 	// TODO(dan): Memory monitoring for this
 	if _, err := file.Write(value); err != nil {

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -110,7 +111,7 @@ func TestCloudStorageSink(t *testing.T) {
 	user := security.RootUser
 
 	t.Run(`golden`, func(t *testing.T) {
-		t1 := &descpb.TableDescriptor{Name: `t1`}
+		t1 := sqlbase.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
@@ -145,8 +146,8 @@ func TestCloudStorageSink(t *testing.T) {
 		for _, compression := range []string{"", "gzip"} {
 			opts[changefeedbase.OptCompression] = compression
 			t.Run("compress="+compression, func(t *testing.T) {
-				t1 := &descpb.TableDescriptor{Name: `t1`}
-				t2 := &descpb.TableDescriptor{Name: `t2`}
+				t1 := sqlbase.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
+				t2 := sqlbase.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t2`})
 
 				testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 				sf := span.MakeFrontier(testSpan)
@@ -221,7 +222,7 @@ func TestCloudStorageSink(t *testing.T) {
 	})
 
 	t.Run(`multi-node`, func(t *testing.T) {
-		t1 := &descpb.TableDescriptor{Name: `t1`}
+		t1 := sqlbase.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
 
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
@@ -302,7 +303,7 @@ func TestCloudStorageSink(t *testing.T) {
 	// This test is also sufficient for verifying the behavior of a multi-node
 	// changefeed using this sink. Ditto job restarts.
 	t.Run(`zombie`, func(t *testing.T) {
-		t1 := &descpb.TableDescriptor{Name: `t1`}
+		t1 := sqlbase.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
@@ -343,7 +344,7 @@ func TestCloudStorageSink(t *testing.T) {
 	})
 
 	t.Run(`bucketing`, func(t *testing.T) {
-		t1 := &descpb.TableDescriptor{Name: `t1`}
+		t1 := sqlbase.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
@@ -431,7 +432,7 @@ func TestCloudStorageSink(t *testing.T) {
 	})
 
 	t.Run(`file-ordering`, func(t *testing.T) {
-		t1 := &descpb.TableDescriptor{Name: `t1`}
+		t1 := sqlbase.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
@@ -490,7 +491,7 @@ func TestCloudStorageSink(t *testing.T) {
 	})
 
 	t.Run(`ordering-among-schema-versions`, func(t *testing.T) {
-		t1 := &descpb.TableDescriptor{Name: `t1`}
+		t1 := sqlbase.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: `t1`})
 		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
 		sf := span.MakeFrontier(testSpan)
 		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -53,8 +54,8 @@ func TestKafkaSink(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	table := func(name string) *descpb.TableDescriptor {
-		return &descpb.TableDescriptor{Name: name}
+	table := func(name string) *sqlbase.ImmutableTableDescriptor {
+		return sqlbase.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: name})
 	}
 
 	ctx := context.Background()
@@ -143,8 +144,8 @@ func TestKafkaSinkEscaping(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	table := func(name string) *descpb.TableDescriptor {
-		return &descpb.TableDescriptor{Name: name}
+	table := func(name string) *sqlbase.ImmutableTableDescriptor {
+		return sqlbase.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: name})
 	}
 
 	ctx := context.Background()
@@ -182,8 +183,8 @@ func TestSQLSink(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	table := func(name string) *descpb.TableDescriptor {
-		return &descpb.TableDescriptor{Name: name}
+	table := func(name string) *sqlbase.ImmutableTableDescriptor {
+		return sqlbase.NewImmutableTableDescriptor(descpb.TableDescriptor{Name: name})
 	}
 
 	ctx := context.Background()

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -880,7 +880,7 @@ func newTestSpec(t *testing.T, format roachpb.IOFileFormat, inputs ...string) te
 
 	// Initialize table descriptor for import. We need valid descriptor to run
 	// converters, even though we don't actually import anything in this test.
-	var descr *sqlbase.ImmutableTableDescriptor
+	var descr *sqlbase.MutableTableDescriptor
 	switch format.Format {
 	case roachpb.IOFileFormat_CSV:
 		descr = descForTable(t,

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -149,7 +149,7 @@ func MakeSimpleTableDescriptor(
 	}
 	affected := make(map[descpb.ID]*sqlbase.MutableTableDescriptor)
 
-	tableDesc, err := sql.MakeTableDesc(
+	tableDesc, err := sql.NewTableDesc(
 		ctx,
 		nil, /* txn */
 		fks.resolver,
@@ -169,18 +169,18 @@ func MakeSimpleTableDescriptor(
 	if err != nil {
 		return nil, err
 	}
-	if err := fixDescriptorFKState(tableDesc.TableDesc()); err != nil {
+	if err := fixDescriptorFKState(tableDesc); err != nil {
 		return nil, err
 	}
 
-	return &tableDesc, nil
+	return tableDesc, nil
 }
 
 // fixDescriptorFKState repairs validity and table states set during descriptor
-// creation. sql.MakeTableDesc and ResolveFK set the table to the ADD state
+// creation. sql.NewTableDesc and ResolveFK set the table to the ADD state
 // and mark references an validated. This function sets the table to PUBLIC
 // and the FKs to unvalidated.
-func fixDescriptorFKState(tableDesc *descpb.TableDescriptor) error {
+func fixDescriptorFKState(tableDesc *sqlbase.MutableTableDescriptor) error {
 	tableDesc.State = descpb.TableDescriptor_PUBLIC
 	for i := range tableDesc.OutboundFKs {
 		tableDesc.OutboundFKs[i].Validity = descpb.ConstraintValidity_Unvalidated

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -313,6 +313,8 @@ func (r fkResolver) LookupSchema(
 }
 
 // Implements the sql.SchemaResolver interface.
-func (r fkResolver) LookupTableByID(ctx context.Context, id descpb.ID) (catalog.TableEntry, error) {
-	return catalog.TableEntry{}, errSchemaResolver
+func (r fkResolver) LookupTableByID(
+	ctx context.Context, id descpb.ID,
+) (*sqlbase.ImmutableTableDescriptor, error) {
+	return nil, errSchemaResolver
 }

--- a/pkg/ccl/importccl/read_import_avro_test.go
+++ b/pkg/ccl/importccl/read_import_avro_test.go
@@ -198,12 +198,13 @@ func newTestHelper(t *testing.T, gens ...avroGen) *testHelper {
 	evalCtx := tree.MakeTestingEvalContext(st)
 
 	return &testHelper{
-		schemaJSON:  string(schemaJSON),
-		schemaTable: descForTable(t, createStmt, 10, 20, NoFKs),
-		codec:       codec,
-		gens:        gens,
-		settings:    st,
-		evalCtx:     evalCtx,
+		schemaJSON: string(schemaJSON),
+		schemaTable: descForTable(t, createStmt, 10, 20, NoFKs).
+			Immutable().(*sqlbase.ImmutableTableDescriptor),
+		codec:    codec,
+		gens:     gens,
+		settings: st,
+		evalCtx:  evalCtx,
 	}
 }
 

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -406,7 +406,6 @@ func mysqlTableToCockroach(
 			opts = tree.SequenceOptions{{Name: tree.SeqOptStart, IntVal: &startingValue}}
 			seqVals[id] = startingValue
 		}
-		var desc sqlbase.MutableTableDescriptor
 		var err error
 		if p != nil {
 			params := p.RunParams(ctx)
@@ -414,7 +413,7 @@ func mysqlTableToCockroach(
 				owner = params.SessionData().User
 			}
 			priv := descpb.NewDefaultPrivilegeDescriptor(owner)
-			desc, err = sql.MakeSequenceTableDesc(
+			seqDesc, err = sql.NewSequenceTableDesc(
 				seqName,
 				opts,
 				parentID,
@@ -427,7 +426,7 @@ func mysqlTableToCockroach(
 			)
 		} else {
 			priv := descpb.NewDefaultPrivilegeDescriptor(owner)
-			desc, err = sql.MakeSequenceTableDesc(
+			seqDesc, err = sql.NewSequenceTableDesc(
 				seqName,
 				opts,
 				parentID,
@@ -442,8 +441,7 @@ func mysqlTableToCockroach(
 		if err != nil {
 			return nil, nil, err
 		}
-		seqDesc = &desc
-		fks.resolver[seqName] = &desc
+		fks.resolver[seqName] = seqDesc
 		id++
 	}
 
@@ -565,7 +563,7 @@ func addDelayedFKs(
 		); err != nil {
 			return err
 		}
-		if err := fixDescriptorFKState(def.tbl.TableDesc()); err != nil {
+		if err := fixDescriptorFKState(def.tbl); err != nil {
 			return err
 		}
 		if err := def.tbl.AllocateIDs(); err != nil {

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -135,8 +135,8 @@ func TestMysqldumpSchemaReader(t *testing.T) {
 	fks := fkHandler{
 		allowed: true,
 		resolver: fkResolver(map[string]*sqlbase.MutableTableDescriptor{
-			referencedSimple.Name: sqlbase.NewMutableCreatedTableDescriptor(*referencedSimple.TableDesc())},
-		),
+			referencedSimple.Name: referencedSimple,
+		}),
 	}
 
 	t.Run("simple", func(t *testing.T) {

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -244,7 +244,7 @@ func readPostgresCreateTable(
 			}
 			for name, seq := range createSeq {
 				id := descpb.ID(int(defaultCSVTableID) + len(ret))
-				desc, err := sql.MakeSequenceTableDesc(
+				desc, err := sql.NewSequenceTableDesc(
 					name,
 					seq.Options,
 					parentID,
@@ -258,8 +258,8 @@ func readPostgresCreateTable(
 				if err != nil {
 					return nil, err
 				}
-				fks.resolver[desc.Name] = &desc
-				ret = append(ret, &desc)
+				fks.resolver[desc.Name] = desc
+				ret = append(ret, desc)
 			}
 			backrefs := make(map[descpb.ID]*sqlbase.MutableTableDescriptor)
 			for _, create := range createTbl {
@@ -288,7 +288,7 @@ func readPostgresCreateTable(
 						return nil, err
 					}
 				}
-				if err := fixDescriptorFKState(desc.TableDesc()); err != nil {
+				if err := fixDescriptorFKState(desc); err != nil {
 					return nil, err
 				}
 			}

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -36,7 +36,7 @@ import (
 
 func descForTable(
 	t *testing.T, create string, parent, id descpb.ID, fks fkHandler,
-) *sqlbase.ImmutableTableDescriptor {
+) *sqlbase.MutableTableDescriptor {
 	t.Helper()
 	parsed, err := parser.Parse(create)
 	if err != nil {
@@ -54,7 +54,7 @@ func descForTable(
 
 		ts := hlc.Timestamp{WallTime: nanos}
 		priv := descpb.NewDefaultPrivilegeDescriptor(security.AdminRole)
-		desc, err := sql.MakeSequenceTableDesc(
+		desc, err := sql.NewSequenceTableDesc(
 			name,
 			tree.SequenceOptions{},
 			parent,
@@ -68,7 +68,7 @@ func descForTable(
 		if err != nil {
 			t.Fatal(err)
 		}
-		fks.resolver[name] = &desc
+		fks.resolver[name] = desc
 	} else {
 		stmt = parsed[0].AST.(*tree.CreateTable)
 	}
@@ -77,10 +77,10 @@ func descForTable(
 	if err != nil {
 		t.Fatalf("could not interpret %q: %v", create, err)
 	}
-	if err := fixDescriptorFKState(table.TableDesc()); err != nil {
+	if err := fixDescriptorFKState(table); err != nil {
 		t.Fatal(err)
 	}
-	return table.Immutable().(*sqlbase.ImmutableTableDescriptor)
+	return table
 }
 
 var testEvalCtx = &tree.EvalContext{

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -271,7 +271,9 @@ func selectPartitionExprs(
 
 	a := &sqlbase.DatumAlloc{}
 	var prefixDatums []tree.Datum
-	if err := tableDesc.ForeachNonDropIndex(func(idxDesc *descpb.IndexDescriptor) error {
+	if err := tableDesc.ForeachIndex(sqlbase.IndexOpts{
+		AddMutations: true,
+	}, func(idxDesc *descpb.IndexDescriptor, _ bool) error {
 		genExpr := true
 		return selectPartitionExprsByName(
 			a, evalCtx, tableDesc, idxDesc, &idxDesc.Partitioning, prefixDatums, exprsByPartName, genExpr)

--- a/pkg/sql/catalog/catalog.go
+++ b/pkg/sql/catalog/catalog.go
@@ -61,18 +61,6 @@ type VirtualObject interface {
 	Desc() Descriptor
 }
 
-// TableEntry is the value type of FkTableMetadata: An optional table
-// descriptor, populated when the table is public/leasable, and an IsAdding
-// flag.
-type TableEntry struct {
-	// Desc is the descriptor of the table. This can be nil if eg.
-	// the table is not public.
-	Desc *sqlbase.ImmutableTableDescriptor
-
-	// IsAdding indicates the descriptor is being created.
-	IsAdding bool
-}
-
 // ResolvedObjectPrefix represents the resolved components of an object name
 // prefix. It contains the parent database and schema.
 type ResolvedObjectPrefix struct {

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -45,7 +45,7 @@ type SchemaResolver interface {
 	CurrentSearchPath() sessiondata.SearchPath
 	CommonLookupFlags(required bool) tree.CommonLookupFlags
 	ObjectLookupFlags(required bool, requireMutable bool) tree.ObjectLookupFlags
-	LookupTableByID(ctx context.Context, id descpb.ID) (catalog.TableEntry, error)
+	LookupTableByID(ctx context.Context, id descpb.ID) (*sqlbase.ImmutableTableDescriptor, error)
 }
 
 // ErrNoPrimaryKey is returned when resolving a table object and the

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -310,7 +310,7 @@ https://www.postgresql.org/docs/9.5/infoschema-check-constraints.html`,
 				// uses the format <namespace_oid>_<table_oid>_<col_idx>_not_null.
 				// We might as well do the same.
 				conNameStr := tree.NewDString(fmt.Sprintf(
-					"%s_%s_%d_not_null", h.NamespaceOid(db, scName), tableOid(table.GetID()), colNum,
+					"%s_%s_%d_not_null", h.NamespaceOid(db.GetID(), scName), tableOid(table.GetID()), colNum,
 				))
 				chkExprStr := tree.NewDString(fmt.Sprintf(
 					"%s IS NOT NULL", column.Name,
@@ -1259,7 +1259,7 @@ CREATE TABLE information_schema.table_constraints (
 					colNum++
 					// NOT NULL column constraints are implemented as a CHECK in postgres.
 					conNameStr := tree.NewDString(fmt.Sprintf(
-						"%s_%s_%d_not_null", h.NamespaceOid(db, scName), tableOid(table.GetID()), colNum,
+						"%s_%s_%d_not_null", h.NamespaceOid(db.GetID(), scName), tableOid(table.GetID()), colNum,
 					))
 					if !col.Nullable {
 						if err := addRow(

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -267,7 +267,7 @@ https://www.postgresql.org/docs/9.5/infoschema-check-constraints.html`,
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /* no constraints in virtual tables */, func(
 			db *sqlbase.ImmutableDatabaseDescriptor,
 			scName string,
-			table *sqlbase.ImmutableTableDescriptor,
+			table sqlbase.TableDescriptor,
 			tableLookup tableLookupFn,
 		) error {
 			conInfo, err := table.GetConstraintInfoWithLookup(tableLookup.getTableByID)
@@ -300,7 +300,7 @@ https://www.postgresql.org/docs/9.5/infoschema-check-constraints.html`,
 			// Cockroach doesn't track these constraints as check constraints,
 			// but we can pull them off of the table's column descriptors.
 			colNum := 0
-			return forEachColumnInTable(table, func(column *descpb.ColumnDescriptor) error {
+			return table.ForeachPublicColumn(func(column *descpb.ColumnDescriptor) error {
 				colNum++
 				// Only visible, non-nullable columns are included.
 				if column.Hidden || column.Nullable {
@@ -310,7 +310,7 @@ https://www.postgresql.org/docs/9.5/infoschema-check-constraints.html`,
 				// uses the format <namespace_oid>_<table_oid>_<col_idx>_not_null.
 				// We might as well do the same.
 				conNameStr := tree.NewDString(fmt.Sprintf(
-					"%s_%s_%d_not_null", h.NamespaceOid(db, scName), tableOid(table.ID), colNum,
+					"%s_%s_%d_not_null", h.NamespaceOid(db, scName), tableOid(table.GetID()), colNum,
 				))
 				chkExprStr := tree.NewDString(fmt.Sprintf(
 					"%s IS NOT NULL", column.Name,
@@ -333,25 +333,26 @@ https://www.postgresql.org/docs/9.5/infoschema-column-privileges.html`,
 	schema: vtable.InformationSchemaColumnPrivileges,
 	populate: func(ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, func(
-			db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor,
+			db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor,
 		) error {
 			dbNameStr := tree.NewDString(db.GetName())
 			scNameStr := tree.NewDString(scName)
 			columndata := privilege.List{privilege.SELECT, privilege.INSERT, privilege.UPDATE} // privileges for column level granularity
-			for _, u := range table.Privileges.Users {
+			for _, u := range table.GetPrivileges().Users {
 				for _, priv := range columndata {
 					if priv.Mask()&u.Privileges != 0 {
-						for i := range table.Columns {
-							cd := &table.Columns[i]
+						columns := table.GetPublicColumns()
+						for i := range columns {
+							cd := &columns[i]
 							if err := addRow(
-								tree.DNull,                     // grantor
-								tree.NewDString(u.User),        // grantee
-								dbNameStr,                      // table_catalog
-								scNameStr,                      // table_schema
-								tree.NewDString(table.Name),    // table_name
-								tree.NewDString(cd.Name),       // column_name
-								tree.NewDString(priv.String()), // privilege_type
-								tree.DNull,                     // is_grantable
+								tree.DNull,                       // grantor
+								tree.NewDString(u.User),          // grantee
+								dbNameStr,                        // table_catalog
+								scNameStr,                        // table_schema
+								tree.NewDString(table.GetName()), // table_name
+								tree.NewDString(cd.Name),         // column_name
+								tree.NewDString(priv.String()),   // privilege_type
+								tree.DNull,                       // is_grantable
 							); err != nil {
 								return err
 							}
@@ -371,11 +372,11 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 	schema: vtable.InformationSchemaColumns,
 	populate: func(ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, func(
-			db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor,
+			db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor,
 		) error {
 			dbNameStr := tree.NewDString(db.GetName())
 			scNameStr := tree.NewDString(scName)
-			return forEachColumnInTable(table, func(column *descpb.ColumnDescriptor) error {
+			return table.ForeachPublicColumn(func(column *descpb.ColumnDescriptor) error {
 				collationCatalog := tree.DNull
 				collationSchema := tree.DNull
 				collationName := tree.DNull
@@ -401,10 +402,10 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 					colComputed = tree.NewDString(colExpr)
 				}
 				return addRow(
-					dbNameStr,                    // table_catalog
-					scNameStr,                    // table_schema
-					tree.NewDString(table.Name),  // table_name
-					tree.NewDString(column.Name), // column_name
+					dbNameStr,                        // table_catalog
+					scNameStr,                        // table_schema
+					tree.NewDString(table.GetName()), // table_name
+					tree.NewDString(column.Name),     // column_name
 					tree.NewDInt(tree.DInt(column.GetPGAttributeNum())), // ordinal_position
 					colDefault,                    // column_default
 					yesOrNoDatum(column.Nullable), // is_nullable
@@ -607,7 +608,7 @@ CREATE TABLE information_schema.constraint_column_usage (
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /* no constraints in virtual tables */, func(
 			db *sqlbase.ImmutableDatabaseDescriptor,
 			scName string,
-			table *sqlbase.ImmutableTableDescriptor,
+			table sqlbase.TableDescriptor,
 			tableLookup tableLookupFn,
 		) error {
 			conInfo, err := table.GetConstraintInfoWithLookup(tableLookup.getTableByID)
@@ -631,7 +632,7 @@ CREATE TABLE information_schema.constraint_column_usage (
 						return err
 					}
 				}
-				tableNameStr := tree.NewDString(conTable.Name)
+				tableNameStr := tree.NewDString(conTable.GetName())
 				for _, col := range conCols {
 					if err := addRow(
 						dbNameStr,            // table_catalog
@@ -672,7 +673,7 @@ CREATE TABLE information_schema.key_column_usage (
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /* no constraints in virtual tables */, func(
 			db *sqlbase.ImmutableDatabaseDescriptor,
 			scName string,
-			table *sqlbase.ImmutableTableDescriptor,
+			table sqlbase.TableDescriptor,
 			tableLookup tableLookupFn,
 		) error {
 			conInfo, err := table.GetConstraintInfoWithLookup(tableLookup.getTableByID)
@@ -681,7 +682,7 @@ CREATE TABLE information_schema.key_column_usage (
 			}
 			dbNameStr := tree.NewDString(db.GetName())
 			scNameStr := tree.NewDString(scName)
-			tbNameStr := tree.NewDString(table.Name)
+			tbNameStr := tree.NewDString(table.GetName())
 			for conName, con := range conInfo {
 				// Only Primary Key, Foreign Key, and Unique constraints are included.
 				switch con.Kind {
@@ -822,14 +823,13 @@ CREATE TABLE information_schema.referential_constraints (
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /* no constraints in virtual tables */, func(
 			db *sqlbase.ImmutableDatabaseDescriptor,
 			scName string,
-			table *sqlbase.ImmutableTableDescriptor,
+			table sqlbase.TableDescriptor,
 			tableLookup tableLookupFn,
 		) error {
 			dbNameStr := tree.NewDString(db.GetName())
 			scNameStr := tree.NewDString(scName)
-			tbNameStr := tree.NewDString(table.Name)
-			for i := range table.OutboundFKs {
-				fk := &table.OutboundFKs[i]
+			tbNameStr := tree.NewDString(table.GetName())
+			return table.ForeachOutboundFK(func(fk *descpb.ForeignKeyConstraint) error {
 				refTable, err := tableLookup.getTableByID(fk.ReferencedTableID)
 				if err != nil {
 					return err
@@ -842,7 +842,7 @@ CREATE TABLE information_schema.referential_constraints (
 				if err != nil {
 					return err
 				}
-				if err := addRow(
+				return addRow(
 					dbNameStr,                           // constraint_catalog
 					scNameStr,                           // constraint_schema
 					tree.NewDString(fk.Name),            // constraint_name
@@ -854,11 +854,8 @@ CREATE TABLE information_schema.referential_constraints (
 					dStringForFKAction(fk.OnDelete),     // delete_rule
 					tbNameStr,                           // table_name
 					tree.NewDString(refTable.GetName()), // referenced_table_name
-				); err != nil {
-					return err
-				}
-			}
-			return nil
+				)
+			})
 		})
 	},
 }
@@ -1079,7 +1076,7 @@ CREATE TABLE information_schema.sequences (
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* no sequences in virtual schemas */
-			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor) error {
+			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor) error {
 				if !table.IsSequence() {
 					return nil
 				}
@@ -1091,10 +1088,10 @@ CREATE TABLE information_schema.sequences (
 					tree.NewDInt(64),                 // numeric precision
 					tree.NewDInt(2),                  // numeric precision radix
 					tree.NewDInt(0),                  // numeric scale
-					tree.NewDString(strconv.FormatInt(table.SequenceOpts.Start, 10)),     // start value
-					tree.NewDString(strconv.FormatInt(table.SequenceOpts.MinValue, 10)),  // min value
-					tree.NewDString(strconv.FormatInt(table.SequenceOpts.MaxValue, 10)),  // max value
-					tree.NewDString(strconv.FormatInt(table.SequenceOpts.Increment, 10)), // increment
+					tree.NewDString(strconv.FormatInt(table.GetSequenceOpts().Start, 10)),     // start value
+					tree.NewDString(strconv.FormatInt(table.GetSequenceOpts().MinValue, 10)),  // min value
+					tree.NewDString(strconv.FormatInt(table.GetSequenceOpts().MaxValue, 10)),  // max value
+					tree.NewDString(strconv.FormatInt(table.GetSequenceOpts().Increment, 10)), // increment
 					noString, // cycle
 				)
 			})
@@ -1124,7 +1121,7 @@ CREATE TABLE information_schema.statistics (
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual tables have no indexes */
-			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor) error {
+			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor) error {
 				dbNameStr := tree.NewDString(db.GetName())
 				scNameStr := tree.NewDString(scName)
 				tbNameStr := tree.NewDString(table.GetName())
@@ -1149,7 +1146,7 @@ CREATE TABLE information_schema.statistics (
 					)
 				}
 
-				return forEachIndexInTable(table, func(index *descpb.IndexDescriptor) error {
+				return table.ForeachIndex(sqlbase.IndexOpts{}, func(index *descpb.IndexDescriptor, _ bool) error {
 					// Columns in the primary key that aren't in index.ColumnNames or
 					// index.StoreColumnNames are implicit columns in the index.
 					var implicitCols map[string]struct{}
@@ -1164,7 +1161,7 @@ CREATE TABLE information_schema.statistics (
 					}
 					if hasImplicitCols {
 						implicitCols = make(map[string]struct{})
-						for _, col := range table.PrimaryIndex.ColumnNames {
+						for _, col := range table.GetPrimaryIndex().ColumnNames {
 							implicitCols[col] = struct{}{}
 						}
 					}
@@ -1225,7 +1222,7 @@ CREATE TABLE information_schema.table_constraints (
 			func(
 				db *sqlbase.ImmutableDatabaseDescriptor,
 				scName string,
-				table *sqlbase.ImmutableTableDescriptor,
+				table sqlbase.TableDescriptor,
 				tableLookup tableLookupFn,
 			) error {
 				conInfo, err := table.GetConstraintInfoWithLookup(tableLookup.getTableByID)
@@ -1235,7 +1232,7 @@ CREATE TABLE information_schema.table_constraints (
 
 				dbNameStr := tree.NewDString(db.GetName())
 				scNameStr := tree.NewDString(scName)
-				tbNameStr := tree.NewDString(table.Name)
+				tbNameStr := tree.NewDString(table.GetName())
 
 				for conName, c := range conInfo {
 					if err := addRow(
@@ -1258,11 +1255,11 @@ CREATE TABLE information_schema.table_constraints (
 				// Cockroach doesn't track these constraints as check constraints,
 				// but we can pull them off of the table's column descriptors.
 				colNum := 0
-				return forEachColumnInTable(table, func(col *descpb.ColumnDescriptor) error {
+				return table.ForeachPublicColumn(func(col *descpb.ColumnDescriptor) error {
 					colNum++
 					// NOT NULL column constraints are implemented as a CHECK in postgres.
 					conNameStr := tree.NewDString(fmt.Sprintf(
-						"%s_%s_%d_not_null", h.NamespaceOid(db, scName), tableOid(table.ID), colNum,
+						"%s_%s_%d_not_null", h.NamespaceOid(db, scName), tableOid(table.GetID()), colNum,
 					))
 					if !col.Nullable {
 						if err := addRow(
@@ -1346,13 +1343,13 @@ func populateTablePrivileges(
 	addRow func(...tree.Datum) error,
 ) error {
 	return forEachTableDesc(ctx, p, dbContext, virtualMany,
-		func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor) error {
+		func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor) error {
 			dbNameStr := tree.NewDString(db.GetName())
 			scNameStr := tree.NewDString(scName)
-			tbNameStr := tree.NewDString(table.Name)
+			tbNameStr := tree.NewDString(table.GetName())
 			// TODO(knz): This should filter for the current user, see
 			// https://github.com/cockroachdb/cockroach/issues/35572
-			for _, u := range table.Privileges.Show(privilege.Table) {
+			for _, u := range table.GetPrivileges().Show(privilege.Table) {
 				for _, priv := range u.Privileges {
 					if err := addRow(
 						tree.DNull,                     // grantor
@@ -1411,9 +1408,12 @@ https://www.postgresql.org/docs/9.5/infoschema-tables.html`,
 
 func addTablesTableRow(
 	addRow func(...tree.Datum) error,
-) func(db *sqlbase.ImmutableDatabaseDescriptor, scName string,
-	table *sqlbase.ImmutableTableDescriptor) error {
-	return func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor) error {
+) func(
+	db *sqlbase.ImmutableDatabaseDescriptor,
+	scName string,
+	table sqlbase.TableDescriptor,
+) error {
+	return func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor) error {
 		if table.IsSequence() {
 			return nil
 		}
@@ -1425,19 +1425,19 @@ func addTablesTableRow(
 		} else if table.IsView() {
 			tableType = tableTypeView
 			insertable = noString
-		} else if table.Temporary {
+		} else if table.IsTemporary() {
 			tableType = tableTypeTemporary
 		}
 		dbNameStr := tree.NewDString(db.GetName())
 		scNameStr := tree.NewDString(scName)
-		tbNameStr := tree.NewDString(table.Name)
+		tbNameStr := tree.NewDString(table.GetName())
 		return addRow(
-			dbNameStr,                              // table_catalog
-			scNameStr,                              // table_schema
-			tbNameStr,                              // table_name
-			tableType,                              // table_type
-			insertable,                             // is_insertable_into
-			tree.NewDInt(tree.DInt(table.Version)), // version
+			dbNameStr,  // table_catalog
+			scNameStr,  // table_schema
+			tbNameStr,  // table_name
+			tableType,  // table_type
+			insertable, // is_insertable_into
+			tree.NewDInt(tree.DInt(table.GetVersion())), // version
 		)
 	}
 }
@@ -1463,7 +1463,7 @@ CREATE TABLE information_schema.views (
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual schemas have no views */
-			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor) error {
+			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor) error {
 				if !table.IsView() {
 					return nil
 				}
@@ -1476,16 +1476,16 @@ CREATE TABLE information_schema.views (
 				// TODO(a-robinson): Insert column aliases into view query once we
 				// have a semantic query representation to work with (#10083).
 				return addRow(
-					tree.NewDString(db.GetName()),    // table_catalog
-					tree.NewDString(scName),          // table_schema
-					tree.NewDString(table.Name),      // table_name
-					tree.NewDString(table.ViewQuery), // view_definition
-					tree.DNull,                       // check_option
-					noString,                         // is_updatable
-					noString,                         // is_insertable_into
-					noString,                         // is_trigger_updatable
-					noString,                         // is_trigger_deletable
-					noString,                         // is_trigger_insertable_into
+					tree.NewDString(db.GetName()),         // table_catalog
+					tree.NewDString(scName),               // table_schema
+					tree.NewDString(table.GetName()),      // table_name
+					tree.NewDString(table.GetViewQuery()), // view_definition
+					tree.DNull,                            // check_option
+					noString,                              // is_updatable
+					noString,                              // is_insertable_into
+					noString,                              // is_trigger_updatable
+					noString,                              // is_trigger_deletable
+					noString,                              // is_trigger_insertable_into
 				)
 			})
 	},
@@ -1622,12 +1622,12 @@ func forEachTableDesc(
 	dbContext *sqlbase.ImmutableDatabaseDescriptor,
 	virtualOpts virtualOpts,
 	// TODO(ajwerner): Introduce TableDescriptor.
-	fn func(*sqlbase.ImmutableDatabaseDescriptor, string, *sqlbase.ImmutableTableDescriptor) error,
+	fn func(*sqlbase.ImmutableDatabaseDescriptor, string, sqlbase.TableDescriptor) error,
 ) error {
 	return forEachTableDescWithTableLookup(ctx, p, dbContext, virtualOpts, func(
 		db *sqlbase.ImmutableDatabaseDescriptor,
 		scName string,
-		table *sqlbase.ImmutableTableDescriptor,
+		table sqlbase.TableDescriptor,
 		_ tableLookupFn,
 	) error {
 		return fn(db, scName, table)
@@ -1652,14 +1652,14 @@ func forEachTableDescAll(
 	p *planner,
 	dbContext *sqlbase.ImmutableDatabaseDescriptor,
 	virtualOpts virtualOpts,
-	fn func(*sqlbase.ImmutableDatabaseDescriptor, string, *sqlbase.ImmutableTableDescriptor) error,
+	fn func(*sqlbase.ImmutableDatabaseDescriptor, string, sqlbase.TableDescriptor) error,
 ) error {
 	return forEachTableDescAllWithTableLookup(ctx,
 		p, dbContext, virtualOpts,
 		func(
 			db *sqlbase.ImmutableDatabaseDescriptor,
 			scName string,
-			table *sqlbase.ImmutableTableDescriptor,
+			table sqlbase.TableDescriptor,
 			_ tableLookupFn,
 		) error {
 			return fn(db, scName, table)
@@ -1673,7 +1673,7 @@ func forEachTableDescAllWithTableLookup(
 	p *planner,
 	dbContext *sqlbase.ImmutableDatabaseDescriptor,
 	virtualOpts virtualOpts,
-	fn func(*sqlbase.ImmutableDatabaseDescriptor, string, *sqlbase.ImmutableTableDescriptor, tableLookupFn) error,
+	fn func(*sqlbase.ImmutableDatabaseDescriptor, string, sqlbase.TableDescriptor, tableLookupFn) error,
 ) error {
 	return forEachTableDescWithTableLookupInternal(ctx,
 		p, dbContext, virtualOpts, true /* allowAdding */, fn)
@@ -1693,7 +1693,7 @@ func forEachTableDescWithTableLookup(
 	p *planner,
 	dbContext *sqlbase.ImmutableDatabaseDescriptor,
 	virtualOpts virtualOpts,
-	fn func(*sqlbase.ImmutableDatabaseDescriptor, string, *sqlbase.ImmutableTableDescriptor, tableLookupFn) error,
+	fn func(*sqlbase.ImmutableDatabaseDescriptor, string, sqlbase.TableDescriptor, tableLookupFn) error,
 ) error {
 	return forEachTableDescWithTableLookupInternal(ctx, p, dbContext, virtualOpts, false /* allowAdding */, fn)
 }
@@ -1732,7 +1732,7 @@ func forEachTableDescWithTableLookupInternal(
 	dbContext *sqlbase.ImmutableDatabaseDescriptor,
 	virtualOpts virtualOpts,
 	allowAdding bool,
-	fn func(*sqlbase.ImmutableDatabaseDescriptor, string, *ImmutableTableDescriptor, tableLookupFn) error,
+	fn func(*sqlbase.ImmutableDatabaseDescriptor, string, sqlbase.TableDescriptor, tableLookupFn) error,
 ) error {
 	descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	if err != nil {
@@ -1750,7 +1750,7 @@ func forEachTableDescWithTableLookupInternal(
 				e := vEntries[virtSchemaName]
 				for _, tName := range e.orderedDefNames {
 					te := e.defs[tName]
-					if err := fn(dbDesc, virtSchemaName, sqlbase.NewImmutableTableDescriptor(*te.desc), lCtx); err != nil {
+					if err := fn(dbDesc, virtSchemaName, te.desc, lCtx); err != nil {
 						return err
 					}
 				}
@@ -1791,53 +1791,6 @@ func forEachTableDescWithTableLookupInternal(
 			return errors.AssertionFailedf("schema id %d not found", table.GetParentSchemaID())
 		}
 		if err := fn(dbDesc, scName, table, lCtx); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func forEachIndexInTable(
-	table *sqlbase.ImmutableTableDescriptor, fn func(*descpb.IndexDescriptor) error,
-) error {
-	if table.IsPhysicalTable() {
-		if err := fn(&table.PrimaryIndex); err != nil {
-			return err
-		}
-	}
-	for i := range table.Indexes {
-		if err := fn(&table.Indexes[i]); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func forEachColumnInTable(
-	table *sqlbase.ImmutableTableDescriptor, fn func(*descpb.ColumnDescriptor) error,
-) error {
-	// Table descriptors already hold columns in-order.
-	for i := range table.Columns {
-		if err := fn(&table.Columns[i]); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func forEachColumnInIndex(
-	table *sqlbase.ImmutableTableDescriptor,
-	index *descpb.IndexDescriptor,
-	fn func(*descpb.ColumnDescriptor) error,
-) error {
-	colMap := make(map[descpb.ColumnID]*descpb.ColumnDescriptor, len(table.Columns))
-	for i := range table.Columns {
-		id := table.Columns[i].ID
-		colMap[id] = &table.Columns[i]
-	}
-	for _, columnID := range index.ColumnIDs {
-		column := colMap[columnID]
-		if err := fn(column); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/partition_utils.go
+++ b/pkg/sql/partition_utils.go
@@ -99,7 +99,9 @@ func GenerateSubzoneSpans(
 
 	var indexCovering covering.Covering
 	var partitionCoverings []covering.Covering
-	if err := tableDesc.ForeachNonDropIndex(func(idxDesc *descpb.IndexDescriptor) error {
+	if err := tableDesc.ForeachIndex(sqlbase.IndexOpts{
+		AddMutations: true,
+	}, func(idxDesc *descpb.IndexDescriptor, _ bool) error {
 		_, indexSubzoneExists := subzoneIndexByIndexID[idxDesc.ID]
 		if indexSubzoneExists {
 			idxSpan := tableDesc.IndexSpan(codec, idxDesc.ID)

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -398,11 +398,11 @@ CREATE TABLE pg_catalog.pg_attrdef (
 )`,
 	virtualMany, false, /* includesIndexEntries */
 	func(ctx context.Context, p *planner, h oidHasher, db *sqlbase.ImmutableDatabaseDescriptor, scName string,
-		table *sqlbase.ImmutableTableDescriptor,
+		table sqlbase.TableDescriptor,
 		lookup simpleSchemaResolver,
 		addRow func(...tree.Datum) error) error {
 		colNum := 0
-		return forEachColumnInTable(table, func(column *descpb.ColumnDescriptor) error {
+		return table.ForeachPublicColumn(func(column *descpb.ColumnDescriptor) error {
 			colNum++
 			if column.DefaultExpr == nil {
 				// pg_attrdef only expects rows for columns with default values.
@@ -425,8 +425,8 @@ CREATE TABLE pg_catalog.pg_attrdef (
 				defSrc = tree.NewDString(ctx.String())
 			}
 			return addRow(
-				h.ColumnOid(table.ID, column.ID),                    // oid
-				tableOid(table.ID),                                  // adrelid
+				h.ColumnOid(table.GetID(), column.ID),               // oid
+				tableOid(table.GetID()),                             // adrelid
 				tree.NewDInt(tree.DInt(column.GetPGAttributeNum())), // adnum
 				defSrc, // adbin
 				defSrc, // adsrc
@@ -466,7 +466,7 @@ CREATE TABLE pg_catalog.pg_attribute (
 )`,
 	virtualMany, true, /* includesIndexEntries */
 	func(ctx context.Context, p *planner, h oidHasher, db *sqlbase.ImmutableDatabaseDescriptor, scName string,
-		table *sqlbase.ImmutableTableDescriptor,
+		table sqlbase.TableDescriptor,
 		lookup simpleSchemaResolver,
 		addRow func(...tree.Datum) error) error {
 		// addColumn adds adds either a table or a index column to the pg_attribute table.
@@ -508,21 +508,24 @@ CREATE TABLE pg_catalog.pg_attribute (
 		}
 
 		// Columns for table.
-		if err := forEachColumnInTable(table, func(column *descpb.ColumnDescriptor) error {
-			tableID := tableOid(table.ID)
+		if err := table.ForeachPublicColumn(func(column *descpb.ColumnDescriptor) error {
+			tableID := tableOid(table.GetID())
 			return addColumn(column, tableID, column.GetPGAttributeNum())
 		}); err != nil {
 			return err
 		}
 
 		// Columns for each index.
-		return forEachIndexInTable(table, func(index *descpb.IndexDescriptor) error {
-			return forEachColumnInIndex(table, index,
-				func(column *descpb.ColumnDescriptor) error {
-					idxID := h.IndexOid(table.ID, index.ID)
-					return addColumn(column, idxID, column.GetPGAttributeNum())
-				},
-			)
+		columnIdxMap := table.ColumnIdxMap()
+		return table.ForeachIndex(sqlbase.IndexOpts{}, func(index *descpb.IndexDescriptor, _ bool) error {
+			for _, colID := range index.ColumnIDs {
+				idxID := h.IndexOid(table.GetID(), index.ID)
+				column := table.GetColumnAtIdx(columnIdxMap[colID])
+				if err := addColumn(column, idxID, column.GetPGAttributeNum()); err != nil {
+					return err
+				}
+			}
+			return nil
 		})
 	})
 
@@ -686,7 +689,7 @@ CREATE TABLE pg_catalog.pg_class (
 )`,
 	virtualMany, true, /* includesIndexEntries */
 	func(ctx context.Context, p *planner, h oidHasher, db *sqlbase.ImmutableDatabaseDescriptor, scName string,
-		table *sqlbase.ImmutableTableDescriptor, _ simpleSchemaResolver, addRow func(...tree.Datum) error) error {
+		table sqlbase.TableDescriptor, _ simpleSchemaResolver, addRow func(...tree.Datum) error) error {
 		// The only difference between tables, views and sequences are the relkind and relam columns.
 		relKind := relKindTable
 		relAm := forwardIndexOid
@@ -702,26 +705,26 @@ CREATE TABLE pg_catalog.pg_class (
 		}
 		namespaceOid := h.NamespaceOid(db, scName)
 		if err := addRow(
-			tableOid(table.ID),        // oid
-			tree.NewDName(table.Name), // relname
-			namespaceOid,              // relnamespace
-			oidZero,                   // reltype (PG creates a composite type in pg_type for each table)
-			oidZero,                   // reloftype (PG creates a composite type in pg_type for each table)
-			tree.DNull,                // relowner
-			relAm,                     // relam
-			oidZero,                   // relfilenode
-			oidZero,                   // reltablespace
-			tree.DNull,                // relpages
-			tree.DNull,                // reltuples
-			zeroVal,                   // relallvisible
-			oidZero,                   // reltoastrelid
+			tableOid(table.GetID()),        // oid
+			tree.NewDName(table.GetName()), // relname
+			namespaceOid,                   // relnamespace
+			oidZero,                        // reltype (PG creates a composite type in pg_type for each table)
+			oidZero,                        // reloftype (PG creates a composite type in pg_type for each table)
+			tree.DNull,                     // relowner
+			relAm,                          // relam
+			oidZero,                        // relfilenode
+			oidZero,                        // reltablespace
+			tree.DNull,                     // relpages
+			tree.DNull,                     // reltuples
+			zeroVal,                        // relallvisible
+			oidZero,                        // reltoastrelid
 			tree.MakeDBool(tree.DBool(table.IsPhysicalTable())), // relhasindex
 			tree.DBoolFalse,         // relisshared
 			relPersistencePermanent, // relPersistence
 			tree.DBoolFalse,         // relistemp
 			relKind,                 // relkind
-			tree.NewDInt(tree.DInt(len(table.Columns))), // relnatts
-			tree.NewDInt(tree.DInt(len(table.Checks))),  // relchecks
+			tree.NewDInt(tree.DInt(len(table.GetPublicColumns()))), // relnatts
+			tree.NewDInt(tree.DInt(len(table.GetChecks()))),        // relchecks
 			tree.DBoolFalse, // relhasoids
 			tree.MakeDBool(tree.DBool(table.IsPhysicalTable())), // relhaspkey
 			tree.DBoolFalse, // relhasrules
@@ -742,30 +745,30 @@ CREATE TABLE pg_catalog.pg_class (
 		}
 
 		// Indexes.
-		return forEachIndexInTable(table, func(index *descpb.IndexDescriptor) error {
+		return table.ForeachIndex(sqlbase.IndexOpts{}, func(index *descpb.IndexDescriptor, _ bool) error {
 			indexType := forwardIndexOid
 			if index.Type == descpb.IndexDescriptor_INVERTED {
 				indexType = invertedIndexOid
 			}
 			return addRow(
-				h.IndexOid(table.ID, index.ID), // oid
-				tree.NewDName(index.Name),      // relname
-				namespaceOid,                   // relnamespace
-				oidZero,                        // reltype
-				oidZero,                        // reloftype
-				tree.DNull,                     // relowner
-				indexType,                      // relam
-				oidZero,                        // relfilenode
-				oidZero,                        // reltablespace
-				tree.DNull,                     // relpages
-				tree.DNull,                     // reltuples
-				zeroVal,                        // relallvisible
-				oidZero,                        // reltoastrelid
-				tree.DBoolFalse,                // relhasindex
-				tree.DBoolFalse,                // relisshared
-				relPersistencePermanent,        // relPersistence
-				tree.DBoolFalse,                // relistemp
-				relKindIndex,                   // relkind
+				h.IndexOid(table.GetID(), index.ID), // oid
+				tree.NewDName(index.Name),           // relname
+				namespaceOid,                        // relnamespace
+				oidZero,                             // reltype
+				oidZero,                             // reloftype
+				tree.DNull,                          // relowner
+				indexType,                           // relam
+				oidZero,                             // relfilenode
+				oidZero,                             // reltablespace
+				tree.DNull,                          // relpages
+				tree.DNull,                          // reltuples
+				zeroVal,                             // relallvisible
+				oidZero,                             // reltoastrelid
+				tree.DBoolFalse,                     // relhasindex
+				tree.DBoolFalse,                     // relisshared
+				relPersistencePermanent,             // relPersistence
+				tree.DBoolFalse,                     // relistemp
+				relKindIndex,                        // relkind
 				tree.NewDInt(tree.DInt(len(index.ColumnNames))), // relnatts
 				zeroVal,         // relchecks
 				tree.DBoolFalse, // relhasoids
@@ -861,7 +864,7 @@ func populateTableConstraints(
 	h oidHasher,
 	db *sqlbase.ImmutableDatabaseDescriptor,
 	scName string,
-	table *sqlbase.ImmutableTableDescriptor,
+	table sqlbase.TableDescriptor,
 	tableLookup simpleSchemaResolver,
 	addRow func(...tree.Datum) error,
 ) error {
@@ -870,7 +873,7 @@ func populateTableConstraints(
 		return err
 	}
 	namespaceOid := h.NamespaceOid(db, scName)
-	tblOid := tableOid(table.ID)
+	tblOid := tableOid(table.GetID())
 	for conName, con := range conInfo {
 		oid := tree.DNull
 		contype := tree.DNull
@@ -891,7 +894,7 @@ func populateTableConstraints(
 		case descpb.ConstraintTypePK:
 			oid = h.PrimaryKeyConstraintOid(db, scName, table.TableDesc(), con.Index)
 			contype = conTypePKey
-			conindid = h.IndexOid(table.ID, con.Index.ID)
+			conindid = h.IndexOid(table.GetID(), con.Index.ID)
 
 			var err error
 			if conkey, err = colIDArrayToDatum(con.Index.ColumnIDs); err != nil {
@@ -944,7 +947,7 @@ func populateTableConstraints(
 		case descpb.ConstraintTypeUnique:
 			oid = h.UniqueConstraintOid(db, scName, table.TableDesc(), con.Index)
 			contype = conTypeUnique
-			conindid = h.IndexOid(table.ID, con.Index.ID)
+			conindid = h.IndexOid(table.GetID(), con.Index.ID)
 			var err error
 			if conkey, err = colIDArrayToDatum(con.Index.ColumnIDs); err != nil {
 				return err
@@ -1016,7 +1019,7 @@ func (r oneAtATimeSchemaResolver) getTableByID(id descpb.ID) (sqlbase.TableDescr
 	if err != nil {
 		return nil, err
 	}
-	return table.Desc, nil
+	return table, nil
 }
 
 func (r oneAtATimeSchemaResolver) getSchemaByID(
@@ -1047,14 +1050,14 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 	virtualOpts virtualOpts,
 	includesIndexEntries bool,
 	populateFromTable func(ctx context.Context, p *planner, h oidHasher, db *sqlbase.ImmutableDatabaseDescriptor,
-		scName string, table *sqlbase.ImmutableTableDescriptor, lookup simpleSchemaResolver,
+		scName string, table sqlbase.TableDescriptor, lookup simpleSchemaResolver,
 		addRow func(...tree.Datum) error,
 	) error,
 ) virtualSchemaTable {
 	populateAll := func(ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, virtualOpts,
-			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor, lookup tableLookupFn) error {
+			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor, lookup tableLookupFn) error {
 				return populateFromTable(ctx, p, h, db, scName, table, lookup, addRow)
 			})
 	}
@@ -1093,18 +1096,18 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 					}
 					// Don't include tables that aren't in the current database unless
 					// they're virtual, dropped tables, or ones that the user can't see.
-					if (!table.Desc.IsVirtualTable() && table.Desc.ParentID != db.GetID()) ||
-						table.Desc.Dropped() ||
-						!userCanSeeTable(ctx, p, table.Desc, true /*allowAdding*/) {
+					if (!table.IsVirtualTable() && table.GetParentID() != db.GetID()) ||
+						table.Dropped() ||
+						!userCanSeeTable(ctx, p, table, true /*allowAdding*/) {
 						return false, nil
 					}
 					h := makeOidHasher()
 					scResolver := oneAtATimeSchemaResolver{p: p, ctx: ctx}
-					sc, err := p.Descriptors().ResolveSchemaByID(ctx, p.txn, table.Desc.GetParentSchemaID())
+					sc, err := p.Descriptors().ResolveSchemaByID(ctx, p.txn, table.GetParentSchemaID())
 					if err != nil {
 						return false, err
 					}
-					if err := populateFromTable(ctx, p, h, db, sc.Name, table.Desc, scResolver,
+					if err := populateFromTable(ctx, p, h, db, sc.Name, table, scResolver,
 						addRow); err != nil {
 						return false, err
 					}
@@ -1317,15 +1320,15 @@ CREATE TABLE pg_catalog.pg_depend (
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /*virtual tables have no constraints*/, func(
 			db *sqlbase.ImmutableDatabaseDescriptor,
 			scName string,
-			table *sqlbase.ImmutableTableDescriptor,
+			table sqlbase.TableDescriptor,
 			tableLookup tableLookupFn,
 		) error {
 			pgConstraintTableOid := tableOid(pgConstraintsDesc.ID)
 			pgClassTableOid := tableOid(pgClassDesc.ID)
 			if table.IsSequence() &&
-				!table.SequenceOpts.SequenceOwner.Equal(descpb.TableDescriptor_SequenceOpts_SequenceOwner{}) {
-				refObjID := tableOid(table.SequenceOpts.SequenceOwner.OwnerTableID)
-				refObjSubID := tree.NewDInt(tree.DInt(table.SequenceOpts.SequenceOwner.OwnerColumnID))
+				!table.GetSequenceOpts().SequenceOwner.Equal(descpb.TableDescriptor_SequenceOpts_SequenceOwner{}) {
+				refObjID := tableOid(table.GetSequenceOpts().SequenceOwner.OwnerTableID)
+				refObjSubID := tree.NewDInt(tree.DInt(table.GetSequenceOpts().SequenceOwner.OwnerColumnID))
 				objID := tableOid(table.GetID())
 				return addRow(
 					pgConstraintTableOid, // classid
@@ -1653,9 +1656,9 @@ CREATE TABLE pg_catalog.pg_index (
 	populate: func(ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual tables do not have indexes */
-			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor) error {
-				tableOid := tableOid(table.ID)
-				return forEachIndexInTable(table, func(index *descpb.IndexDescriptor) error {
+			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor) error {
+				tableOid := tableOid(table.GetID())
+				return table.ForeachIndex(sqlbase.IndexOpts{}, func(index *descpb.IndexDescriptor, isPrimary bool) error {
 					isMutation, isWriteOnly :=
 						table.GetIndexMutationCapabilities(index.ID)
 					isReady := isMutation && isWriteOnly
@@ -1694,13 +1697,12 @@ CREATE TABLE pg_catalog.pg_index (
 					// TODO(bram): #27763 indclass still needs to be populated but it
 					// requires pg_catalog.pg_opclass first.
 					indclass, err := makeZeroedOidVector(len(index.ColumnIDs))
-					isPrimary := table.PrimaryIndex.ID == index.ID && table.IsPhysicalTable()
 					if err != nil {
 						return err
 					}
 					return addRow(
-						h.IndexOid(table.ID, index.ID), // indexrelid
-						tableOid,                       // indrelid
+						h.IndexOid(table.GetID(), index.ID), // indexrelid
+						tableOid,                            // indrelid
 						tree.NewDInt(tree.DInt(len(index.ColumnNames))), // indnatts
 						tree.MakeDBool(tree.DBool(index.Unique)),        // indisunique
 						tree.MakeDBool(tree.DBool(isPrimary)),           // indisprimary
@@ -1741,21 +1743,21 @@ CREATE TABLE pg_catalog.pg_indexes (
 	populate: func(ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual, /* virtual tables do not have indexes */
-			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor, tableLookup tableLookupFn) error {
+			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor, tableLookup tableLookupFn) error {
 				scNameName := tree.NewDName(scName)
-				tblName := tree.NewDName(table.Name)
-				return forEachIndexInTable(table, func(index *descpb.IndexDescriptor) error {
+				tblName := tree.NewDName(table.GetName())
+				return table.ForeachIndex(sqlbase.IndexOpts{}, func(index *descpb.IndexDescriptor, _ bool) error {
 					def, err := indexDefFromDescriptor(ctx, p, db, table, index, tableLookup)
 					if err != nil {
 						return err
 					}
 					return addRow(
-						h.IndexOid(table.ID, index.ID), // oid
-						scNameName,                     // schemaname
-						tblName,                        // tablename
-						tree.NewDName(index.Name),      // indexname
-						tree.DNull,                     // tablespace
-						tree.NewDString(def),           // indexdef
+						h.IndexOid(table.GetID(), index.ID), // oid
+						scNameName,                          // schemaname
+						tblName,                             // tablename
+						tree.NewDName(index.Name),           // indexname
+						tree.DNull,                          // tablespace
+						tree.NewDString(def),                // indexdef
 					)
 				})
 			})
@@ -1769,13 +1771,13 @@ func indexDefFromDescriptor(
 	ctx context.Context,
 	p *planner,
 	db *sqlbase.ImmutableDatabaseDescriptor,
-	table *sqlbase.ImmutableTableDescriptor,
+	table sqlbase.TableDescriptor,
 	index *descpb.IndexDescriptor,
 	tableLookup tableLookupFn,
 ) (string, error) {
 	indexDef := tree.CreateIndex{
 		Name:     tree.Name(index.Name),
-		Table:    tree.MakeTableName(tree.Name(db.GetName()), tree.Name(table.Name)),
+		Table:    tree.MakeTableName(tree.Name(db.GetName()), tree.Name(table.GetName())),
 		Unique:   index.Unique,
 		Columns:  make(tree.IndexElemList, len(index.ColumnNames)),
 		Storing:  make(tree.NameList, len(index.StoreColumnNames)),
@@ -2427,13 +2429,13 @@ CREATE TABLE pg_catalog.pg_sequence (
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual schemas do not have indexes */
-			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor) error {
+			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor) error {
 				if !table.IsSequence() {
 					return nil
 				}
-				opts := table.SequenceOpts
+				opts := table.GetSequenceOpts()
 				return addRow(
-					tableOid(table.ID),                      // seqrelid
+					tableOid(table.GetID()),                 // seqrelid
 					tree.NewDOid(tree.DInt(oid.T_int8)),     // seqtypid
 					tree.NewDInt(tree.DInt(opts.Start)),     // seqstart
 					tree.NewDInt(tree.DInt(opts.Increment)), // seqincrement
@@ -2561,15 +2563,15 @@ CREATE TABLE pg_catalog.pg_tables (
 		// empty -- listing tables across databases can yield duplicate
 		// schema/table names.
 		return forEachTableDesc(ctx, p, dbContext, virtualMany,
-			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table *sqlbase.ImmutableTableDescriptor) error {
+			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, table sqlbase.TableDescriptor) error {
 				if !table.IsTable() {
 					return nil
 				}
 				return addRow(
-					tree.NewDName(scName),     // schemaname
-					tree.NewDName(table.Name), // tablename
-					tree.DNull,                // tableowner
-					tree.DNull,                // tablespace
+					tree.NewDName(scName),          // schemaname
+					tree.NewDName(table.GetName()), // tablename
+					tree.DNull,                     // tableowner
+					tree.DNull,                     // tablespace
 					tree.MakeDBool(tree.DBool(table.IsPhysicalTable())), // hasindexes
 					tree.DBoolFalse, // hasrules
 					tree.DBoolFalse, // hastriggers
@@ -3077,7 +3079,7 @@ CREATE TABLE pg_catalog.pg_views (
 		// Note: pg_views is not well defined if the dbContext is empty,
 		// because it does not distinguish views in separate databases.
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /*virtual schemas do not have views*/
-			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, desc *sqlbase.ImmutableTableDescriptor) error {
+			func(db *sqlbase.ImmutableDatabaseDescriptor, scName string, desc sqlbase.TableDescriptor) error {
 				if !desc.IsView() {
 					return nil
 				}
@@ -3090,10 +3092,10 @@ CREATE TABLE pg_catalog.pg_views (
 				// TODO(a-robinson): Insert column aliases into view query once we
 				// have a semantic query representation to work with (#10083).
 				return addRow(
-					tree.NewDName(scName),           // schemaname
-					tree.NewDName(desc.Name),        // viewname
-					tree.DNull,                      // viewowner
-					tree.NewDString(desc.ViewQuery), // definition
+					tree.NewDName(scName),                // schemaname
+					tree.NewDName(desc.GetName()),        // viewname
+					tree.DNull,                           // viewowner
+					tree.NewDString(desc.GetViewQuery()), // definition
 				)
 			})
 	},

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -703,7 +703,7 @@ CREATE TABLE pg_catalog.pg_class (
 			relKind = relKindSequence
 			relAm = oidZero
 		}
-		namespaceOid := h.NamespaceOid(db, scName)
+		namespaceOid := h.NamespaceOid(db.GetID(), scName)
 		if err := addRow(
 			tableOid(table.GetID()),        // oid
 			tree.NewDName(table.GetName()), // relname
@@ -799,7 +799,7 @@ CREATE TABLE pg_catalog.pg_collation (
 	populate: func(ctx context.Context, p *planner, dbContext *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, false /* requiresPrivileges */, func(db *sqlbase.ImmutableDatabaseDescriptor) error {
-			namespaceOid := h.NamespaceOid(db, pgCatalogName)
+			namespaceOid := h.NamespaceOid(db.GetID(), pgCatalogName)
 			for _, tag := range collate.Supported() {
 				collName := tag.String()
 				if err := addRow(
@@ -872,7 +872,7 @@ func populateTableConstraints(
 	if err != nil {
 		return err
 	}
-	namespaceOid := h.NamespaceOid(db, scName)
+	namespaceOid := h.NamespaceOid(db.GetID(), scName)
 	tblOid := tableOid(table.GetID())
 	for conName, con := range conInfo {
 		oid := tree.DNull
@@ -892,7 +892,7 @@ func populateTableConstraints(
 		var err error
 		switch con.Kind {
 		case descpb.ConstraintTypePK:
-			oid = h.PrimaryKeyConstraintOid(db, scName, table.TableDesc(), con.Index)
+			oid = h.PrimaryKeyConstraintOid(db.GetID(), scName, table.GetID(), con.Index)
 			contype = conTypePKey
 			conindid = h.IndexOid(table.GetID(), con.Index.ID)
 
@@ -903,7 +903,7 @@ func populateTableConstraints(
 			condef = tree.NewDString(table.PrimaryKeyString())
 
 		case descpb.ConstraintTypeFK:
-			oid = h.ForeignKeyConstraintOid(db, scName, table.TableDesc(), con.FK)
+			oid = h.ForeignKeyConstraintOid(db.GetID(), scName, table.GetID(), con.FK)
 			contype = conTypeFK
 			// Foreign keys don't have a single linked index. Pick the first one
 			// that matches on the referenced table.
@@ -945,7 +945,7 @@ func populateTableConstraints(
 			condef = tree.NewDString(buf.String())
 
 		case descpb.ConstraintTypeUnique:
-			oid = h.UniqueConstraintOid(db, scName, table.TableDesc(), con.Index)
+			oid = h.UniqueConstraintOid(db.GetID(), scName, table.GetID(), con.Index.ID)
 			contype = conTypeUnique
 			conindid = h.IndexOid(table.GetID(), con.Index.ID)
 			var err error
@@ -959,7 +959,7 @@ func populateTableConstraints(
 			condef = tree.NewDString(f.CloseAndGetString())
 
 		case descpb.ConstraintTypeCheck:
-			oid = h.CheckConstraintOid(db, scName, table.TableDesc(), con.CheckConstraint)
+			oid = h.CheckConstraintOid(db.GetID(), scName, table.GetID(), con.CheckConstraint)
 			contype = conTypeCheck
 			if conkey, err = colIDArrayToDatum(con.CheckConstraint.ColumnIDs); err != nil {
 				return err
@@ -1362,7 +1362,7 @@ CREATE TABLE pg_catalog.pg_depend (
 				} else {
 					refObjID = h.IndexOid(con.ReferencedTable.ID, idx.ID)
 				}
-				constraintOid := h.ForeignKeyConstraintOid(db, scName, table.TableDesc(), con.FK)
+				constraintOid := h.ForeignKeyConstraintOid(db.GetID(), scName, table.GetID(), con.FK)
 
 				if err := addRow(
 					pgConstraintTableOid, // classid
@@ -1922,10 +1922,10 @@ CREATE TABLE pg_catalog.pg_namespace (
 			func(db *sqlbase.ImmutableDatabaseDescriptor) error {
 				return forEachSchemaName(ctx, p, db, func(s string, _ bool) error {
 					return addRow(
-						h.NamespaceOid(db, s), // oid
-						tree.NewDString(s),    // nspname
-						tree.DNull,            // nspowner
-						tree.DNull,            // nspacl
+						h.NamespaceOid(db.GetID(), s), // oid
+						tree.NewDString(s),            // nspname
+						tree.DNull,                    // nspowner
+						tree.DNull,                    // nspacl
 					)
 				})
 			})
@@ -1964,7 +1964,7 @@ CREATE TABLE pg_catalog.pg_operator (
 )`,
 	populate: func(ctx context.Context, p *planner, db *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		nspOid := h.NamespaceOid(db, pgCatalogName)
+		nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
 		addOp := func(opName string, kind tree.Datum, params tree.TypeList, returnTyper tree.ReturnTyper) error {
 			var leftType, rightType *tree.DOid
 			switch params.Length() {
@@ -2173,7 +2173,7 @@ CREATE TABLE pg_catalog.pg_proc (
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
 			func(db *sqlbase.ImmutableDatabaseDescriptor) error {
-				nspOid := h.NamespaceOid(db, pgCatalogName)
+				nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
 				for _, name := range builtins.AllBuiltinNames {
 					// parser.Builtins contains duplicate uppercase and lowercase keys.
 					// Only return the lowercase ones for compatibility with postgres.
@@ -2795,7 +2795,7 @@ CREATE TABLE pg_catalog.pg_type (
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
 			func(db *sqlbase.ImmutableDatabaseDescriptor) error {
-				nspOid := h.NamespaceOid(db, pgCatalogName)
+				nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
 
 				// Generate rows for all predefined types.
 				for _, typ := range types.OidToType {
@@ -2826,7 +2826,7 @@ CREATE TABLE pg_catalog.pg_type (
 				addRow func(...tree.Datum) error) (bool, error) {
 
 				h := makeOidHasher()
-				nspOid := h.NamespaceOid(db, pgCatalogName)
+				nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
 				coid := tree.MustBeDOid(constraint)
 				ooid := oid.Oid(int(coid.DInt))
 
@@ -3290,8 +3290,8 @@ func (h oidHasher) getOid() *tree.DOid {
 	return tree.NewDOid(tree.DInt(i))
 }
 
-func (h oidHasher) writeDB(db *sqlbase.ImmutableDatabaseDescriptor) {
-	h.writeUInt32(uint32(db.GetID()))
+func (h oidHasher) writeDB(dbID descpb.ID) {
+	h.writeUInt32(uint32(dbID))
 }
 
 func (h oidHasher) writeSchema(scName string) {
@@ -3316,9 +3316,9 @@ func (h oidHasher) writeForeignKeyConstraint(fk *descpb.ForeignKeyConstraint) {
 	h.writeStr(fk.Name)
 }
 
-func (h oidHasher) NamespaceOid(db *sqlbase.ImmutableDatabaseDescriptor, scName string) *tree.DOid {
+func (h oidHasher) NamespaceOid(dbID descpb.ID, scName string) *tree.DOid {
 	h.writeTypeTag(namespaceTypeTag)
-	h.writeDB(db)
+	h.writeDB(dbID)
 	h.writeSchema(scName)
 	return h.getOid()
 }
@@ -3338,58 +3338,46 @@ func (h oidHasher) ColumnOid(tableID descpb.ID, columnID descpb.ColumnID) *tree.
 }
 
 func (h oidHasher) CheckConstraintOid(
-	db *sqlbase.ImmutableDatabaseDescriptor,
-	scName string,
-	table *descpb.TableDescriptor,
-	check *descpb.TableDescriptor_CheckConstraint,
+	dbID descpb.ID, scName string, tableID descpb.ID, check *descpb.TableDescriptor_CheckConstraint,
 ) *tree.DOid {
 	h.writeTypeTag(checkConstraintTypeTag)
-	h.writeDB(db)
+	h.writeDB(dbID)
 	h.writeSchema(scName)
-	h.writeTable(table.ID)
+	h.writeTable(tableID)
 	h.writeCheckConstraint(check)
 	return h.getOid()
 }
 
 func (h oidHasher) PrimaryKeyConstraintOid(
-	db *sqlbase.ImmutableDatabaseDescriptor,
-	scName string,
-	table *descpb.TableDescriptor,
-	pkey *descpb.IndexDescriptor,
+	dbID descpb.ID, scName string, tableID descpb.ID, pkey *descpb.IndexDescriptor,
 ) *tree.DOid {
 	h.writeTypeTag(pKeyConstraintTypeTag)
-	h.writeDB(db)
+	h.writeDB(dbID)
 	h.writeSchema(scName)
-	h.writeTable(table.ID)
+	h.writeTable(tableID)
 	h.writeIndex(pkey.ID)
 	return h.getOid()
 }
 
 func (h oidHasher) ForeignKeyConstraintOid(
-	db *sqlbase.ImmutableDatabaseDescriptor,
-	scName string,
-	table *descpb.TableDescriptor,
-	fk *descpb.ForeignKeyConstraint,
+	dbID descpb.ID, scName string, tableID descpb.ID, fk *descpb.ForeignKeyConstraint,
 ) *tree.DOid {
 	h.writeTypeTag(fkConstraintTypeTag)
-	h.writeDB(db)
+	h.writeDB(dbID)
 	h.writeSchema(scName)
-	h.writeTable(table.ID)
+	h.writeTable(tableID)
 	h.writeForeignKeyConstraint(fk)
 	return h.getOid()
 }
 
 func (h oidHasher) UniqueConstraintOid(
-	db *sqlbase.ImmutableDatabaseDescriptor,
-	scName string,
-	table *descpb.TableDescriptor,
-	index *descpb.IndexDescriptor,
+	dbID descpb.ID, scName string, tableID descpb.ID, indexID descpb.IndexID,
 ) *tree.DOid {
 	h.writeTypeTag(uniqueConstraintTypeTag)
-	h.writeDB(db)
+	h.writeDB(dbID)
 	h.writeSchema(scName)
-	h.writeTable(table.ID)
-	h.writeIndex(index.ID)
+	h.writeTable(tableID)
+	h.writeIndex(indexID)
 	return h.getOid()
 }
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2810,7 +2810,7 @@ CREATE TABLE pg_catalog.pg_type (
 					if err != nil {
 						return err
 					}
-					nspOid := h.NamespaceOid(db, sc.Name)
+					nspOid := h.NamespaceOid(db.GetID(), sc.Name)
 					typ, err := typDesc.MakeTypesT(ctx, tree.NewUnqualifiedTypeName(tree.Name(typDesc.GetName())), p)
 					if err != nil {
 						return err
@@ -2855,7 +2855,7 @@ CREATE TABLE pg_catalog.pg_type (
 				if err != nil {
 					return false, err
 				}
-				nspOid = h.NamespaceOid(db, sc.Name)
+				nspOid = h.NamespaceOid(db.GetID(), sc.Name)
 				typ, err = typDesc.MakeTypesT(ctx, tree.NewUnqualifiedTypeName(tree.Name(typDesc.GetName())), p)
 				if err != nil {
 					return false, err

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1299,7 +1299,7 @@ func (rf *Fetcher) NextRowWithErrors(ctx context.Context) (sqlbase.EncDatumRow, 
 		rf.rowReadyTable.decodedRow[i] = row[i].Datum
 	}
 
-	if index.ID == table.GetPrimaryIndex().ID {
+	if index.ID == table.GetPrimaryIndexID() {
 		err = rf.checkPrimaryIndexDatumEncodings(ctx)
 	} else {
 		err = rf.checkSecondaryIndexDatumEncodings(ctx)

--- a/pkg/sql/rowexec/interleaved_reader_joiner_test.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner_test.go
@@ -39,7 +39,7 @@ import (
 // min and max are inclusive bounds on the root table's ID.
 // If min and/or max is -1, then no bound is used for that endpoint.
 func makeSpanWithRootBound(desc sqlbase.TableDescriptor, min int, max int) roachpb.Span {
-	keyPrefix := sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, desc, desc.GetPrimaryIndex().ID)
+	keyPrefix := sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, desc, desc.GetPrimaryIndexID())
 
 	startKey := roachpb.Key(append([]byte(nil), keyPrefix...))
 	if min != -1 {

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -213,7 +213,7 @@ func checkPrivilegeForSetZoneConfig(ctx context.Context, p *planner, zs tree.Zon
 		}
 		return err
 	}
-	if tableDesc.TableDesc().ParentID == keys.SystemDatabaseID {
+	if tableDesc.GetParentID() == keys.SystemDatabaseID {
 		return p.RequireAdminRole(ctx, "alter system tables")
 	}
 

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -211,7 +211,7 @@ func MakeSpanFromEncDatums(
 	alloc *DatumAlloc,
 	keyPrefix []byte,
 ) (_ roachpb.Span, containsNull bool, _ error) {
-	startKey, complete, containsNull, err := makeKeyFromEncDatums(values, types, dirs, tableDesc.TableDesc(), index, alloc, keyPrefix)
+	startKey, complete, containsNull, err := makeKeyFromEncDatums(values, types, dirs, tableDesc, index, alloc, keyPrefix)
 	if err != nil {
 		return roachpb.Span{}, false, err
 	}
@@ -408,7 +408,7 @@ func makeKeyFromEncDatums(
 	values EncDatumRow,
 	types []*types.T,
 	dirs []descpb.IndexDescriptor_Direction,
-	tableDesc *descpb.TableDescriptor,
+	tableDesc TableDescriptor,
 	index *descpb.IndexDescriptor,
 	alloc *DatumAlloc,
 	keyPrefix []byte,
@@ -459,7 +459,7 @@ func makeKeyFromEncDatums(
 			key = encoding.EncodeInterleavedSentinel(key)
 		}
 
-		key = EncodePartialTableIDIndexID(key, tableDesc.ID, index.ID)
+		key = EncodePartialTableIDIndexID(key, tableDesc.GetID(), index.ID)
 	}
 	var (
 		err error

--- a/pkg/sql/sqlbase/table_desc.go
+++ b/pkg/sql/sqlbase/table_desc.go
@@ -96,11 +96,9 @@ type TableDescriptor interface {
 
 	Validate(ctx context.Context, txn *kv.Txn, codec keys.SQLCodec) error
 
-	GetDependedOnBy() []descpb.TableDescriptor_Reference
 	ForeachDependedOnBy(f func(dep *descpb.TableDescriptor_Reference) error) error
 	GetDependsOn() []descpb.ID
 	GetConstraintInfoWithLookup(fn TableLookupFn) (map[string]descpb.ConstraintDetail, error)
-	GetOutboundFKs() []descpb.ForeignKeyConstraint
 	ForeachOutboundFK(f func(fk *descpb.ForeignKeyConstraint) error) error
 	GetChecks() []*descpb.TableDescriptor_CheckConstraint
 	AllActiveAndInactiveChecks() []*descpb.TableDescriptor_CheckConstraint

--- a/pkg/sql/sqlbase/table_desc.go
+++ b/pkg/sql/sqlbase/table_desc.go
@@ -24,6 +24,16 @@ import (
 var _ TableDescriptor = (*ImmutableTableDescriptor)(nil)
 var _ TableDescriptor = (*MutableTableDescriptor)(nil)
 
+// IndexOpts configures the behavior of TableDescriptor.ForeachIndex.
+type IndexOpts struct {
+	// NonPhysicalPrimaryIndex should be included.
+	NonPhysicalPrimaryIndex bool
+	// DropMutations should be included.
+	DropMutations bool
+	// AddMutations should be included.
+	AddMutations bool
+}
+
 // TableDescriptor is an interface around the table descriptor types.
 //
 // TODO(ajwerner): This interface likely belongs in a catalog/tabledesc package
@@ -35,37 +45,49 @@ type TableDescriptor interface {
 	TableDesc() *descpb.TableDescriptor
 
 	GetState() descpb.TableDescriptor_State
+	GetSequenceOpts() *descpb.TableDescriptor_SequenceOpts
+	GetViewQuery() string
+	GetLease() *descpb.TableDescriptor_SchemaChangeLease
+	GetDropTime() int64
+	GetFormatVersion() descpb.FormatVersion
 
-	HasPrimaryKey() bool
+	GetPrimaryIndexID() descpb.IndexID
 	GetPrimaryIndex() *descpb.IndexDescriptor
-	GetIndexes() []descpb.IndexDescriptor
+	GetPublicNonPrimaryIndexes() []descpb.IndexDescriptor
+	ForeachIndex(opts IndexOpts, f func(idxDesc *descpb.IndexDescriptor, isPrimary bool) error) error
+	AllNonDropIndexes() []*descpb.IndexDescriptor
 	ForeachNonDropIndex(f func(idxDesc *descpb.IndexDescriptor) error) error
 	IndexSpan(codec keys.SQLCodec, id descpb.IndexID) roachpb.Span
 	IsInterleaved() bool
 	FindIndexByID(id descpb.IndexID) (*descpb.IndexDescriptor, error)
 	FindIndexByName(name string) (_ *descpb.IndexDescriptor, dropped bool, _ error)
 	FindIndexesWithPartition(name string) []*descpb.IndexDescriptor
-	AllNonDropIndexes() []*descpb.IndexDescriptor
+	GetIndexMutationCapabilities(id descpb.IndexID) (isMutation, isWriteOnly bool)
 
+	HasPrimaryKey() bool
+	PrimaryKeyString() string
+
+	GetPublicColumns() []descpb.ColumnDescriptor
+	ForeachPublicColumn(f func(col *descpb.ColumnDescriptor) error) error
+	NamesForColumnIDs(ids descpb.ColumnIDs) ([]string, error)
 	FindColumnByName(name tree.Name) (*descpb.ColumnDescriptor, bool, error)
 	FindActiveColumnByID(id descpb.ColumnID) (*descpb.ColumnDescriptor, error)
 	FindColumnByID(id descpb.ColumnID) (*descpb.ColumnDescriptor, error)
-	NamesForColumnIDs(ids descpb.ColumnIDs) ([]string, error)
-
 	ColumnIdxMap() map[descpb.ColumnID]int
-	GetPublicColumns() []descpb.ColumnDescriptor
 	GetColumnAtIdx(idx int) *descpb.ColumnDescriptor
 	AllNonDropColumns() []descpb.ColumnDescriptor
-
+	VisibleColumns() []descpb.ColumnDescriptor
 	GetFamilies() []descpb.ColumnFamilyDescriptor
 
 	IsTable() bool
 	IsView() bool
 	MaterializedView() bool
 	IsSequence() bool
+	IsTemporary() bool
+	IsVirtualTable() bool
+	IsPhysicalTable() bool
 
 	GetMutationJobs() []descpb.TableDescriptor_MutationJob
-	GetDependedOnBy() []descpb.TableDescriptor_Reference
 
 	GetReplacementOf() descpb.TableDescriptor_Replacement
 	GetAllReferencedTypeIDs(
@@ -73,7 +95,16 @@ type TableDescriptor interface {
 	) (descpb.IDs, error)
 
 	Validate(ctx context.Context, txn *kv.Txn, codec keys.SQLCodec) error
-	IsVirtualTable() bool
+
+	GetDependedOnBy() []descpb.TableDescriptor_Reference
+	ForeachDependedOnBy(f func(dep *descpb.TableDescriptor_Reference) error) error
+	GetDependsOn() []descpb.ID
+	GetConstraintInfoWithLookup(fn TableLookupFn) (map[string]descpb.ConstraintDetail, error)
+	GetOutboundFKs() []descpb.ForeignKeyConstraint
+	ForeachOutboundFK(f func(fk *descpb.ForeignKeyConstraint) error) error
+	GetChecks() []*descpb.TableDescriptor_CheckConstraint
+	AllActiveAndInactiveChecks() []*descpb.TableDescriptor_CheckConstraint
+	ForeachInboundFK(f func(fk *descpb.ForeignKeyConstraint) error) error
 }
 
 // Immutable implements the MutableDescriptor interface.

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -42,7 +42,7 @@ func CreateTestTableDescriptor(
 	evalCtx := tree.MakeTestingEvalContext(st)
 	switch n := stmt.AST.(type) {
 	case *tree.CreateTable:
-		desc, err := MakeTableDesc(
+		desc, err := NewTableDesc(
 			ctx,
 			nil, /* txn */
 			nil, /* vs */
@@ -57,9 +57,9 @@ func CreateTestTableDescriptor(
 			&sessiondata.SessionData{}, /* sessionData */
 			tree.PersistencePermanent,
 		)
-		return &desc, err
+		return desc, err
 	case *tree.CreateSequence:
-		desc, err := MakeSequenceTableDesc(
+		desc, err := NewSequenceTableDesc(
 			n.Name.Table(),
 			n.Options,
 			parentID, keys.PublicSchemaID, id,
@@ -68,7 +68,7 @@ func CreateTestTableDescriptor(
 			tree.PersistencePermanent,
 			nil, /* params */
 		)
-		return &desc, err
+		return desc, err
 	default:
 		return nil, errors.Errorf("unexpected AST %T", stmt.AST)
 	}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -152,7 +152,7 @@ func (t virtualSchemaTable) initVirtualTableDesc(
 
 	// Virtual tables never use SERIAL so we need not process SERIAL
 	// types here.
-	mutDesc, err := MakeTableDesc(
+	mutDesc, err := NewTableDesc(
 		ctx,
 		nil, /* txn */
 		nil, /* vs */

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -323,7 +323,9 @@ func (v virtualSchemaEntry) GetObjectByName(
 	case tree.TableObject:
 		if def, ok := v.defs[name]; ok {
 			if flags.RequireMutable {
-				return mutableVirtualDefEntry{desc: def.desc}, nil
+				return mutableVirtualDefEntry{
+					desc: sqlbase.NewMutableExistingTableDescriptor(*def.desc.TableDesc()),
+				}, nil
 			}
 			return &def, nil
 		}
@@ -366,21 +368,21 @@ func (v virtualSchemaEntry) GetObjectByName(
 
 type virtualDefEntry struct {
 	virtualDef                 virtualSchemaDef
-	desc                       *descpb.TableDescriptor
+	desc                       *sqlbase.ImmutableTableDescriptor
 	comment                    string
 	validWithNoDatabaseContext bool
 }
 
 func (e virtualDefEntry) Desc() catalog.Descriptor {
-	return sqlbase.NewImmutableTableDescriptor(*e.desc)
+	return e.desc
 }
 
 type mutableVirtualDefEntry struct {
-	desc *descpb.TableDescriptor
+	desc *sqlbase.MutableTableDescriptor
 }
 
 func (e mutableVirtualDefEntry) Desc() catalog.Descriptor {
-	return sqlbase.NewMutableExistingTableDescriptor(*e.desc)
+	return e.desc
 }
 
 type virtualTypeEntry struct {
@@ -631,7 +633,7 @@ func NewVirtualSchemaHolder(
 
 			entry := virtualDefEntry{
 				virtualDef:                 def,
-				desc:                       &tableDesc,
+				desc:                       sqlbase.NewImmutableTableDescriptor(tableDesc),
 				validWithNoDatabaseContext: schema.validWithNoDatabaseContext,
 				comment:                    def.getComment(),
 			}
@@ -716,7 +718,7 @@ func (vs *VirtualSchemaHolder) getVirtualTableEntryByID(id descpb.ID) (virtualDe
 
 // VirtualTabler is used to fetch descriptors for virtual tables and databases.
 type VirtualTabler interface {
-	getVirtualTableDesc(tn *tree.TableName) (*descpb.TableDescriptor, error)
+	getVirtualTableDesc(tn *tree.TableName) (*sqlbase.ImmutableTableDescriptor, error)
 	getVirtualSchemaEntry(name string) (virtualSchemaEntry, bool)
 	getVirtualTableEntry(tn *tree.TableName) (virtualDefEntry, error)
 	getVirtualTableEntryByID(id descpb.ID) (virtualDefEntry, error)
@@ -729,7 +731,7 @@ type VirtualTabler interface {
 // getVirtualTableDesc is part of the VirtualTabler interface.
 func (vs *VirtualSchemaHolder) getVirtualTableDesc(
 	tn *tree.TableName,
-) (*descpb.TableDescriptor, error) {
+) (*sqlbase.ImmutableTableDescriptor, error) {
 	t, err := vs.getVirtualTableEntry(tn)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -313,7 +313,7 @@ func resolveSubzone(
 	indexName := string(zs.TableOrIndex.Index)
 	var index *descpb.IndexDescriptor
 	if indexName == "" {
-		index = &table.TableDesc().PrimaryIndex
+		index = table.GetPrimaryIndex()
 		indexName = index.Name
 	} else {
 		var err error


### PR DESCRIPTION
This works to adopt the interface rather than concrete implementation of
TableDescriptor inside of pg_catalog and crdb_internal. Also picks it up
in the virtualTabler and cleans up LookupTableByID.

Release note: None