### PR TITLE
opt: duplicate all table metadata fields when duplicating a scan

### DIFF
--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -108,6 +108,9 @@ var tableAnnIDCount TableAnnID
 const maxTableAnnIDCount = 2
 
 // TableMeta stores information about one of the tables stored in the metadata.
+//
+// NOTE: Metadata.DuplicateTable must be kept in sync with changes to this
+// struct.
 type TableMeta struct {
 	// MetaID is the identifier for this table that is unique within the query
 	// metadata.
@@ -147,8 +150,8 @@ type TableMeta struct {
 	// Computed columns with non-immutable operators are omitted.
 	ComputedCols map[ColumnID]ScalarExpr
 
-	// PartialIndexPredicates is a map from an index ordinal on the table to
-	// a ScalarExpr representing the predicate on the corresponding partial
+	// PartialIndexPredicates is a map from index ordinals on the table to
+	// *FiltersExprs representing the predicate on the corresponding partial
 	// index. If an index is not a partial index, it will not have an entry in
 	// the map.
 	PartialIndexPredicates map[cat.IndexOrdinal]ScalarExpr

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2891,6 +2891,67 @@ project
            └── const-agg [as=v:3, outer=(3)]
                 └── v:3
 
+# Regression test for #52207. Partial index predicates in TableMeta must be
+# duplicated when TableMeta is duplicated.
+exec-ddl
+CREATE TABLE t52207 (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  INDEX idx_a (a) WHERE a > 0,
+  INDEX idx_b (b) WHERE b > 0
+)
+----
+
+opt expect=SplitDisjunction
+SELECT k FROM t52207 WHERE a = 1 OR b = 1
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── distinct-on
+      ├── columns: k:1!null a:2 b:3
+      ├── grouping columns: k:1!null
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
+      ├── union-all
+      │    ├── columns: k:1!null a:2 b:3
+      │    ├── left columns: k:1!null a:2 b:3
+      │    ├── right columns: k:5 a:6 b:7
+      │    ├── index-join t52207
+      │    │    ├── columns: k:1!null a:2!null b:3
+      │    │    ├── key: (1)
+      │    │    ├── fd: ()-->(2), (1)-->(3)
+      │    │    └── select
+      │    │         ├── columns: k:1!null a:2!null
+      │    │         ├── key: (1)
+      │    │         ├── fd: ()-->(2)
+      │    │         ├── scan t52207@idx_a,partial
+      │    │         │    ├── columns: k:1!null a:2
+      │    │         │    ├── key: (1)
+      │    │         │    └── fd: (1)-->(2)
+      │    │         └── filters
+      │    │              └── a:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      │    └── index-join t52207
+      │         ├── columns: k:5!null a:6 b:7!null
+      │         ├── key: (5)
+      │         ├── fd: ()-->(7), (5)-->(6)
+      │         └── select
+      │              ├── columns: k:5!null b:7!null
+      │              ├── key: (5)
+      │              ├── fd: ()-->(7)
+      │              ├── scan t52207@idx_b,partial
+      │              │    ├── columns: k:5!null b:7
+      │              │    ├── key: (5)
+      │              │    └── fd: (5)-->(7)
+      │              └── filters
+      │                   └── b:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      └── aggregations
+           ├── const-agg [as=a:2, outer=(2)]
+           │    └── a:2
+           └── const-agg [as=b:3, outer=(3)]
+                └── b:3
+
 # --------------------------------------------------
 # SplitDisjunctionAddKey
 # --------------------------------------------------


### PR DESCRIPTION
This commit fixes incorrect duplication of `TableMeta` when duplicating
scans, such as in the `SplitDisjuction` exploration rule. Previously,
`ScalarExpr`s in the table metadata were not being duplicated when the
table metadata was duplicated. This resulted in panics when trying to
access these fields.

All the fields of `TableMeta` are now duplicated correctly. Column IDs
in `ScalarExpr` fields are remapped to the newly generated column IDs.

This commit also simplifies the explanation for when column IDs can be
reused.

Fixes #52207

Release note: None