### PR TITLE
importccl: prevent glob-expanding to multiple pgdumps

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -275,6 +275,12 @@ func importPlanHook(
 			}
 		}
 
+		// Typically the SQL grammar means it is only possible to specifying exactly
+		// one pgdump/mysqldump URI, but glob-expansion could have changed that.
+		if importStmt.Bundle && len(files) != 1 {
+			return pgerror.New(pgcode.FeatureNotSupported, "SQL dump files must be imported individually")
+		}
+
 		table := importStmt.Table
 
 		var parentID, parentSchemaID descpb.ID

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -4470,6 +4470,11 @@ func TestImportPgDump(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("glob-multi", func(t *testing.T) {
+		sqlDB.ExpectErr(t, "SQL dump files must be imported individually", `IMPORT PGDUMP 'nodelocal://0/*'`)
+	})
+
 	t.Run("target-cols-reordered", func(t *testing.T) {
 		data := `
 				CREATE TABLE "t" ("a" INT, "b" INT DEFAULT 42, "c" INT);


### PR DESCRIPTION
Typically the SQL grammar makes it impossible to specify any
number of files to 'bundle'-style pgdump/mysqldump imports
other than one. However, using glob expansion in that one
could allow bundle imports to end up with multiple actual
input files and then hit various unsupported cases later in
the code.

Until multi-file bundle imports are supported (if ever), check
for and disallow bundle IMPORTs of multiple files.

Fixes #52498.

Release note (bug fix): reject specifying multiple files to IMPORT PGDUMP and IMPORT MYSQLDUMP