### PR TITLE
security: don't load ca-server-tenant.crt on KV server config

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -41,18 +41,10 @@ The following certificates are required:
   authentication and authorization with the KV layer (as tenant X).
 - ca-server-tenant.crt: to authenticate KV layer.
 
-                 ca.crt        ca-client-tenant.crt        ca-server-tenant.crt
-user ---------------> sql server ----------------------------> kv
- client.Y.crt    node.crt      client-tenant.X.crt         server-tenant.crt
- client.Y.key    node.key      client-tenant.X.key         server-tenant.key
-
-Note that CA certificates need to be present on the "other" end of the arrow as
-well unless it can be verified using a trusted root certificate store. That is,
-
-- ca.crt needs to be passed in the Postgres connection string (sslrootcert) if
-  sslmode=verify-ca.
-- ca-server-tenant.crt needs to be present on the SQL server.
-- ca-client-tenant.crt needs to be present on the KV server.
+ ca.crt            ca-client.crt      ca-server-tenant.crt        ca-client-tenant.crt
+user -----------------> [   sql server    ]-------------------------> [ kv server ]
+ client.Y.crt      node.crt           client-tenant.X.crt         server-tenant.crt
+ client.Y.key      node.key           client-tenant.X.key         server-tenant.key
 `,
 	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runStartSQL),

--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -724,11 +724,6 @@ func (cm *CertificateManager) getEmbeddedTenantServerTLSConfig(
 		return cm.tenantServerConfig, nil
 	}
 
-	serverCA, err := cm.getTenantServerCACertLocked()
-	if err != nil {
-		return nil, err
-	}
-
 	serverCert, err := cm.getTenantServerCertLocked()
 	if err != nil {
 		return nil, err
@@ -742,7 +737,7 @@ func (cm *CertificateManager) getEmbeddedTenantServerTLSConfig(
 	cfg, err := newServerTLSConfig(
 		serverCert.FileContents,
 		serverCert.KeyFileContents,
-		serverCA.FileContents,
+		nil, // caPEM
 		tenantCA.FileContents)
 	if err != nil {
 		return nil, err

--- a/pkg/security/tls.go
+++ b/pkg/security/tls.go
@@ -85,7 +85,8 @@ func LoadServerTLSConfig(sslCA, sslClientCA, sslCert, sslCertKey string) (*tls.C
 // - the certificate of the cluster CA, used to verify other server certificates
 // - the certificate of the client CA, used to verify client certificates
 //
-// caClientPEM can be equal to caPEM (shared CA) or nil (use system CA pool).
+// caPEM and caClientPEM can be equal to caPEM (shared CA) or nil (use system CA
+// pool).
 func newServerTLSConfig(certPEM, keyPEM, caPEM, caClientPEM []byte) (*tls.Config, error) {
 	cfg, err := newBaseTLSConfigWithCertificate(certPEM, keyPEM, caPEM)
 	if err != nil {


### PR DESCRIPTION
This cert is only ever needed on outgoing tenant client configs.

Release note: None
