### PR TITLE
backupccl: sanitize passphrase in BACKUP job description

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -307,12 +307,28 @@ func getURIsByLocalityKV(to []string, appendPath string) (string, map[string]str
 	return defaultURI, urisByLocalityKV, nil
 }
 
+func resolveOptionsForBackupJobDescription(opts tree.BackupOptions) (tree.BackupOptions, error) {
+	if opts.IsDefault() {
+		return opts, nil
+	}
+
+	newOpts := tree.BackupOptions{
+		CaptureRevisionHistory: opts.CaptureRevisionHistory,
+		Detached:               opts.Detached,
+	}
+
+	if opts.EncryptionPassphrase != nil {
+		newOpts.EncryptionPassphrase = tree.NewDString("redacted")
+	}
+
+	return newOpts, nil
+}
+
 func backupJobDescription(
 	p sql.PlanHookState, backup *tree.Backup, to []string, incrementalFrom []string,
 ) (string, error) {
 	b := &tree.Backup{
 		AsOf:    backup.AsOf,
-		Options: backup.Options,
 		Targets: backup.Targets,
 	}
 
@@ -331,6 +347,12 @@ func backupJobDescription(
 		}
 		b.IncrementalFrom = append(b.IncrementalFrom, tree.NewDString(sanitizedFrom))
 	}
+
+	resolvedOpts, err := resolveOptionsForBackupJobDescription(backup.Options)
+	if err != nil {
+		return "", err
+	}
+	b.Options = resolvedOpts
 
 	ann := p.ExtendedEvalContext().Annotations
 	return tree.AsStringWithFQNames(b, ann), nil


### PR DESCRIPTION
This change ensures that the passphrase used to encrypt a BACKUP
is redacted in the BACKUP job description.

Release note: None