### PR TITLE
roachprod: fix log formatting in roachprod start

### DIFF
--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -157,7 +157,7 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 		//    need to explicitly initialize.
 		shouldInit := !h.useStartSingleNode(vers) && vers.AtLeast(version.MustParse("v20.1.0"))
 		if shouldInit {
-			fmt.Printf("%s: initializing cluster", h.c.Name)
+			fmt.Printf("%s: initializing cluster\n", h.c.Name)
 			initOut, err := h.initializeCluster(nodeIdx)
 			if err != nil {
 				log.Fatalf("unable to initialize cluster: %v", err)
@@ -188,7 +188,7 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 			}
 		}
 
-		fmt.Printf("%s: setting cluster settings", h.c.Name)
+		fmt.Printf("%s: setting cluster settings\n", h.c.Name)
 		clusterSettingsOut, err := h.setClusterSettings(nodeIdx)
 		if err != nil {
 			log.Fatalf("unable to set cluster settings: %v", err)


### PR DESCRIPTION
This commit adds newlines to the formatting of the logs printed by
roachprod start.

Before:
```
$ roachprod start local
local: starting nodes
local: initializing clusterwarning: --url [...]
Cluster successfully initialized
local: setting cluster settingsSET CLUSTER SETTING
```

After:
```
$ roachprod start local
local: starting nodes
local: initializing cluster
warning: --url [...]
Cluster successfully initialized
local: setting cluster settings
SET CLUSTER SETTING
```

Release note: None