### PR TITLE
roachtest: deflake decommissioning roachtest

### DIFF
--- a/pkg/cmd/roachtest/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/mixed_version_decommission.go
@@ -265,16 +265,3 @@ func startVersion(nodes nodeListOption, version string) versionStep {
 		u.c.Start(ctx, t, nodes, args, startArgsDontEncrypt, roachprodArgOption{"--sequential=false"})
 	}
 }
-
-func registerDecommissionMixedVersion(r *testRegistry) {
-	r.Add(testSpec{
-		Name:       "decommission/mixed-versions",
-		Owner:      OwnerKV,
-		MinVersion: "v20.2.0",
-		Cluster:    makeClusterSpec(4),
-		Run: func(ctx context.Context, t *test, c *cluster) {
-			runDecommissionMixedVersions(ctx, t, c, r.buildVersion)
-		},
-	})
-
-}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -28,7 +28,6 @@ func registerTests(r *testRegistry) {
 	registerClockMonotonicTests(r)
 	registerCopy(r)
 	registerDecommission(r)
-	registerDecommissionMixedVersion(r)
 	registerDiskFull(r)
 	registerDiskStalledDetection(r)
 	registerDjango(r)


### PR DESCRIPTION
Fixes #52304. Also rename this test so it gets grouped with the other
decommissioning-related roachtests in the generated artifacts.

Release note: None