### PR TITLE
sql: support FOR {UPDATE,SHARE} NOWAIT

### DIFF
--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -115,6 +115,7 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 		c.codec,
 		false, /* reverse */
 		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		&c.a,
 		row.FetcherTableArgs{

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -122,6 +122,7 @@ func (cb *ColumnBackfiller) init(
 		evalCtx.Codec,
 		false, /* reverse */
 		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		&cb.alloc,
 		tableArgs,
@@ -559,6 +560,7 @@ func (ib *IndexBackfiller) init(
 		evalCtx.Codec,
 		false, /* reverse */
 		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		&ib.alloc,
 		tableArgs,

--- a/pkg/sql/catalog/descpb/locking.pb.go
+++ b/pkg/sql/catalog/descpb/locking.pb.go
@@ -152,11 +152,12 @@ func (x *ScanLockingStrength) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanLockingStrength) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_locking_ed2d621531b2095f, []int{0}
+	return fileDescriptor_locking_2399db643a0152e9, []int{0}
 }
 
-// ScanLockingWaitPolicy controls the policy used by scans for dealing with rows
-// being locked by FOR UPDATE/SHARE clauses.
+// LockingWaitPolicy controls the policy used for handling conflicting locks
+// held by other active transactions when attempting to lock rows due to FOR
+// UPDATE/SHARE clauses (i.e. it represents the NOWAIT and SKIP LOCKED options).
 type ScanLockingWaitPolicy int32
 
 const (
@@ -168,9 +169,6 @@ const (
 	// optimizer without throwing an error.
 	ScanLockingWaitPolicy_SKIP ScanLockingWaitPolicy = 1
 	// ERROR represents NOWAIT - raise an error if a row cannot be locked.
-	//
-	// NOTE: ERROR is not currently implemented and does not make it out of the
-	// SQL optimizer without throwing an error.
 	ScanLockingWaitPolicy_ERROR ScanLockingWaitPolicy = 2
 )
 
@@ -202,7 +200,7 @@ func (x *ScanLockingWaitPolicy) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanLockingWaitPolicy) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_locking_ed2d621531b2095f, []int{1}
+	return fileDescriptor_locking_2399db643a0152e9, []int{1}
 }
 
 func init() {
@@ -211,10 +209,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("sql/catalog/descpb/locking.proto", fileDescriptor_locking_ed2d621531b2095f)
+	proto.RegisterFile("sql/catalog/descpb/locking.proto", fileDescriptor_locking_2399db643a0152e9)
 }
 
-var fileDescriptor_locking_ed2d621531b2095f = []byte{
+var fileDescriptor_locking_2399db643a0152e9 = []byte{
 	// 248 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x28, 0x2e, 0xcc, 0xd1,
 	0x4f, 0x4e, 0x2c, 0x49, 0xcc, 0xc9, 0x4f, 0xd7, 0x4f, 0x49, 0x2d, 0x4e, 0x2e, 0x48, 0xd2, 0xcf,

--- a/pkg/sql/catalog/descpb/locking.proto
+++ b/pkg/sql/catalog/descpb/locking.proto
@@ -116,8 +116,9 @@ enum ScanLockingStrength {
   FOR_UPDATE = 4;
 }
   
-// ScanLockingWaitPolicy controls the policy used by scans for dealing with rows
-// being locked by FOR UPDATE/SHARE clauses.
+// LockingWaitPolicy controls the policy used for handling conflicting locks
+// held by other active transactions when attempting to lock rows due to FOR
+// UPDATE/SHARE clauses (i.e. it represents the NOWAIT and SKIP LOCKED options).
 enum ScanLockingWaitPolicy {
   // BLOCK represents the default - wait for the lock to become available.
   BLOCK = 0;
@@ -129,8 +130,5 @@ enum ScanLockingWaitPolicy {
   SKIP  = 1;
 
   // ERROR represents NOWAIT - raise an error if a row cannot be locked.
-  //
-  // NOTE: ERROR is not currently implemented and does not make it out of the
-  // SQL optimizer without throwing an error.
   ERROR = 2;
 }

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -180,7 +180,8 @@ func NewColBatchScan(
 	}
 	if _, _, err := initCRowFetcher(
 		flowCtx.Codec(), allocator, &fetcher, &spec.Table, int(spec.IndexIdx), columnIdxMap,
-		spec.Reverse, neededColumns, spec.Visibility, spec.LockingStrength, sysColDescs,
+		spec.Reverse, neededColumns, spec.Visibility, spec.LockingStrength, spec.LockingWaitPolicy,
+		sysColDescs,
 	); err != nil {
 		return nil, err
 	}
@@ -213,7 +214,8 @@ func initCRowFetcher(
 	reverseScan bool,
 	valNeededForCol util.FastIntSet,
 	scanVisibility execinfrapb.ScanVisibility,
-	lockStr descpb.ScanLockingStrength,
+	lockStrength descpb.ScanLockingStrength,
+	lockWaitPolicy descpb.ScanLockingWaitPolicy,
 	systemColumnDescs []descpb.ColumnDescriptor,
 ) (index *descpb.IndexDescriptor, isSecondaryIndex bool, err error) {
 	immutDesc := sqlbase.NewImmutableTableDescriptor(*desc)
@@ -237,7 +239,9 @@ func initCRowFetcher(
 		Cols:             cols,
 		ValNeededForCol:  valNeededForCol,
 	}
-	if err := fetcher.Init(codec, allocator, reverseScan, lockStr, tableArgs); err != nil {
+	if err := fetcher.Init(
+		codec, allocator, reverseScan, lockStrength, lockWaitPolicy, tableArgs,
+	); err != nil {
 		return nil, false, err
 	}
 

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -113,6 +113,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		// strength here. Consider hooking this in to the same knob that will
 		// control whether we perform locking implicitly during DELETEs.
 		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		params.p.alloc,
 		allTables...,

--- a/pkg/sql/execinfrapb/processors_sql.pb.go
+++ b/pkg/sql/execinfrapb/processors_sql.pb.go
@@ -64,7 +64,7 @@ func (x *ScanVisibility) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanVisibility) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{0}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{0}
 }
 
 // These mirror the aggregate functions supported by sql/parser. See
@@ -190,7 +190,7 @@ func (x *AggregatorSpec_Func) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Func) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{12, 0}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{12, 0}
 }
 
 type AggregatorSpec_Type int32
@@ -236,7 +236,7 @@ func (x *AggregatorSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{12, 1}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{12, 1}
 }
 
 type WindowerSpec_WindowFunc int32
@@ -300,7 +300,7 @@ func (x *WindowerSpec_WindowFunc) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_WindowFunc) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{15, 0}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{15, 0}
 }
 
 // Mode indicates which mode of framing is used.
@@ -344,7 +344,7 @@ func (x *WindowerSpec_Frame_Mode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Mode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{15, 1, 0}
 }
 
 // BoundType indicates which type of boundary is used.
@@ -391,7 +391,7 @@ func (x *WindowerSpec_Frame_BoundType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_BoundType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{15, 1, 1}
 }
 
 // Exclusion specifies the type of frame exclusion.
@@ -434,7 +434,7 @@ func (x *WindowerSpec_Frame_Exclusion) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Exclusion) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{15, 1, 2}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{15, 1, 2}
 }
 
 // ValuesCoreSpec is the core of a processor that has no inputs and generates
@@ -454,7 +454,7 @@ func (m *ValuesCoreSpec) Reset()         { *m = ValuesCoreSpec{} }
 func (m *ValuesCoreSpec) String() string { return proto.CompactTextString(m) }
 func (*ValuesCoreSpec) ProtoMessage()    {}
 func (*ValuesCoreSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{0}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{0}
 }
 func (m *ValuesCoreSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -548,12 +548,9 @@ type TableReaderSpec struct {
 	// Indicates the row-level locking strength to be used by the scan. If set to
 	// FOR_NONE, no row-level locking should be performed.
 	LockingStrength descpb.ScanLockingStrength `protobuf:"varint,10,opt,name=locking_strength,json=lockingStrength,enum=cockroach.sql.sqlbase.ScanLockingStrength" json:"locking_strength"`
-	// Indicates the policy to be used by the scan when dealing with rows being
-	// locked. Always set to BLOCK when locking_stength is FOR_NONE.
-	//
-	// NOTE: this is currently set but unused because only the BLOCK wait policy
-	// makes it out of the SQL optimizer without throwing an error. If/when other
-	// wait policies are supported, this field will be plumbed further.
+	// Indicates the policy to be used by the scan for handling conflicting locks
+	// held by other active transactions when attempting to lock rows. Always set
+	// to BLOCK when locking_stength is FOR_NONE.
 	LockingWaitPolicy descpb.ScanLockingWaitPolicy `protobuf:"varint,11,opt,name=locking_wait_policy,json=lockingWaitPolicy,enum=cockroach.sql.sqlbase.ScanLockingWaitPolicy" json:"locking_wait_policy"`
 	// Indicates what implicit system columns this TableReader is expected to
 	// synthesize. These system columns will be placed at the end of the row
@@ -565,7 +562,7 @@ func (m *TableReaderSpec) Reset()         { *m = TableReaderSpec{} }
 func (m *TableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*TableReaderSpec) ProtoMessage()    {}
 func (*TableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{1}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{1}
 }
 func (m *TableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -610,12 +607,9 @@ type IndexSkipTableReaderSpec struct {
 	// Indicates the row-level locking strength to be used by the scan. If set to
 	// FOR_NONE, no row-level locking should be performed.
 	LockingStrength descpb.ScanLockingStrength `protobuf:"varint,6,opt,name=locking_strength,json=lockingStrength,enum=cockroach.sql.sqlbase.ScanLockingStrength" json:"locking_strength"`
-	// Indicates the policy to be used by the scan when dealing with rows being
-	// locked. Always set to BLOCK when locking_stength is FOR_NONE.
-	//
-	// NOTE: this is currently set but unused because only the BLOCK wait policy
-	// makes it out of the SQL optimizer without throwing an error. If/when other
-	// wait policies are supported, this field will be plumbed further.
+	// Indicates the policy to be used by the scan for handling conflicting locks
+	// held by other active transactions when attempting to lock rows. Always set
+	// to BLOCK when locking_stength is FOR_NONE.
 	LockingWaitPolicy descpb.ScanLockingWaitPolicy `protobuf:"varint,7,opt,name=locking_wait_policy,json=lockingWaitPolicy,enum=cockroach.sql.sqlbase.ScanLockingWaitPolicy" json:"locking_wait_policy"`
 }
 
@@ -623,7 +617,7 @@ func (m *IndexSkipTableReaderSpec) Reset()         { *m = IndexSkipTableReaderSp
 func (m *IndexSkipTableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*IndexSkipTableReaderSpec) ProtoMessage()    {}
 func (*IndexSkipTableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{2}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{2}
 }
 func (m *IndexSkipTableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -708,12 +702,9 @@ type JoinReaderSpec struct {
 	// Indicates the row-level locking strength to be used by the join. If set to
 	// FOR_NONE, no row-level locking should be performed.
 	LockingStrength descpb.ScanLockingStrength `protobuf:"varint,9,opt,name=locking_strength,json=lockingStrength,enum=cockroach.sql.sqlbase.ScanLockingStrength" json:"locking_strength"`
-	// Indicates the policy to be used by the join when dealing with rows being
-	// locked. Always set to BLOCK when locking_stength is FOR_NONE.
-	//
-	// NOTE: this is currently set but unused because only the BLOCK wait policy
-	// makes it out of the SQL optimizer without throwing an error. If/when other
-	// wait policies are supported, this field will be plumbed further.
+	// Indicates the policy to be used by the join for handling conflicting locks
+	// held by other active transactions when attempting to lock rows. Always set
+	// to BLOCK when locking_stength is FOR_NONE.
 	LockingWaitPolicy descpb.ScanLockingWaitPolicy `protobuf:"varint,10,opt,name=locking_wait_policy,json=lockingWaitPolicy,enum=cockroach.sql.sqlbase.ScanLockingWaitPolicy" json:"locking_wait_policy"`
 	// Indicates that the join reader should maintain the ordering of the input
 	// stream. This is only applicable to lookup joins, where doing so is
@@ -733,7 +724,7 @@ func (m *JoinReaderSpec) Reset()         { *m = JoinReaderSpec{} }
 func (m *JoinReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*JoinReaderSpec) ProtoMessage()    {}
 func (*JoinReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{3}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{3}
 }
 func (m *JoinReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -777,7 +768,7 @@ func (m *SorterSpec) Reset()         { *m = SorterSpec{} }
 func (m *SorterSpec) String() string { return proto.CompactTextString(m) }
 func (*SorterSpec) ProtoMessage()    {}
 func (*SorterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{4}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{4}
 }
 func (m *SorterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -839,7 +830,7 @@ func (m *DistinctSpec) Reset()         { *m = DistinctSpec{} }
 func (m *DistinctSpec) String() string { return proto.CompactTextString(m) }
 func (*DistinctSpec) ProtoMessage()    {}
 func (*DistinctSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{5}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{5}
 }
 func (m *DistinctSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -874,7 +865,7 @@ func (m *OrdinalitySpec) Reset()         { *m = OrdinalitySpec{} }
 func (m *OrdinalitySpec) String() string { return proto.CompactTextString(m) }
 func (*OrdinalitySpec) ProtoMessage()    {}
 func (*OrdinalitySpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{6}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{6}
 }
 func (m *OrdinalitySpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -932,7 +923,7 @@ func (m *ZigzagJoinerSpec) Reset()         { *m = ZigzagJoinerSpec{} }
 func (m *ZigzagJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*ZigzagJoinerSpec) ProtoMessage()    {}
 func (*ZigzagJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{7}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{7}
 }
 func (m *ZigzagJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1008,7 +999,7 @@ func (m *MergeJoinerSpec) Reset()         { *m = MergeJoinerSpec{} }
 func (m *MergeJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*MergeJoinerSpec) ProtoMessage()    {}
 func (*MergeJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{8}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{8}
 }
 func (m *MergeJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1095,7 +1086,7 @@ func (m *HashJoinerSpec) Reset()         { *m = HashJoinerSpec{} }
 func (m *HashJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*HashJoinerSpec) ProtoMessage()    {}
 func (*HashJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{9}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{9}
 }
 func (m *HashJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1189,7 +1180,7 @@ func (m *InvertedJoinerSpec) Reset()         { *m = InvertedJoinerSpec{} }
 func (m *InvertedJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedJoinerSpec) ProtoMessage()    {}
 func (*InvertedJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{10}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{10}
 }
 func (m *InvertedJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1242,7 +1233,7 @@ func (m *InvertedFiltererSpec) Reset()         { *m = InvertedFiltererSpec{} }
 func (m *InvertedFiltererSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedFiltererSpec) ProtoMessage()    {}
 func (*InvertedFiltererSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{11}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{11}
 }
 func (m *InvertedFiltererSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1288,7 +1279,7 @@ func (m *AggregatorSpec) Reset()         { *m = AggregatorSpec{} }
 func (m *AggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec) ProtoMessage()    {}
 func (*AggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{12}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{12}
 }
 func (m *AggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1339,7 +1330,7 @@ func (m *AggregatorSpec_Aggregation) Reset()         { *m = AggregatorSpec_Aggre
 func (m *AggregatorSpec_Aggregation) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec_Aggregation) ProtoMessage()    {}
 func (*AggregatorSpec_Aggregation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{12, 0}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{12, 0}
 }
 func (m *AggregatorSpec_Aggregation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1393,13 +1384,9 @@ type InterleavedReaderJoinerSpec struct {
 	// Indicates the row-level locking strength to be used by the scan over the
 	// tables. If set to FOR_NONE, no row-level locking should be performed.
 	LockingStrength descpb.ScanLockingStrength `protobuf:"varint,6,opt,name=locking_strength,json=lockingStrength,enum=cockroach.sql.sqlbase.ScanLockingStrength" json:"locking_strength"`
-	// Indicates the policy to be used by the scan over the tables when dealing
-	// with rows being locked. Always set to BLOCK when locking_stength is
-	// FOR_NONE.
-	//
-	// NOTE: this is currently set but unused because only the BLOCK wait policy
-	// makes it out of the SQL optimizer without throwing an error. If/when other
-	// wait policies are supported, this field will be plumbed further.
+	// Indicates the policy to be used by the scan for handling conflicting locks
+	// held by other active transactions when attempting to lock rows. Always set
+	// to BLOCK when locking_stength is FOR_NONE.
 	LockingWaitPolicy descpb.ScanLockingWaitPolicy `protobuf:"varint,7,opt,name=locking_wait_policy,json=lockingWaitPolicy,enum=cockroach.sql.sqlbase.ScanLockingWaitPolicy" json:"locking_wait_policy"`
 	// "ON" expression (in addition to the equality constraints captured by the
 	// orderings). Assuming that the left table has N columns and the second
@@ -1414,7 +1401,7 @@ func (m *InterleavedReaderJoinerSpec) Reset()         { *m = InterleavedReaderJo
 func (m *InterleavedReaderJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{13}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{13}
 }
 func (m *InterleavedReaderJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1470,7 +1457,7 @@ func (m *InterleavedReaderJoinerSpec_Table) Reset()         { *m = InterleavedRe
 func (m *InterleavedReaderJoinerSpec_Table) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec_Table) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec_Table) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{13, 0}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{13, 0}
 }
 func (m *InterleavedReaderJoinerSpec_Table) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1510,7 +1497,7 @@ func (m *ProjectSetSpec) Reset()         { *m = ProjectSetSpec{} }
 func (m *ProjectSetSpec) String() string { return proto.CompactTextString(m) }
 func (*ProjectSetSpec) ProtoMessage()    {}
 func (*ProjectSetSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{14}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{14}
 }
 func (m *ProjectSetSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1552,7 +1539,7 @@ func (m *WindowerSpec) Reset()         { *m = WindowerSpec{} }
 func (m *WindowerSpec) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec) ProtoMessage()    {}
 func (*WindowerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{15}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{15}
 }
 func (m *WindowerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1588,7 +1575,7 @@ func (m *WindowerSpec_Func) Reset()         { *m = WindowerSpec_Func{} }
 func (m *WindowerSpec_Func) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Func) ProtoMessage()    {}
 func (*WindowerSpec_Func) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{15, 0}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{15, 0}
 }
 func (m *WindowerSpec_Func) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1624,7 +1611,7 @@ func (m *WindowerSpec_Frame) Reset()         { *m = WindowerSpec_Frame{} }
 func (m *WindowerSpec_Frame) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame) ProtoMessage()    {}
 func (*WindowerSpec_Frame) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{15, 1}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{15, 1}
 }
 func (m *WindowerSpec_Frame) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1665,7 +1652,7 @@ func (m *WindowerSpec_Frame_Bound) Reset()         { *m = WindowerSpec_Frame_Bou
 func (m *WindowerSpec_Frame_Bound) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bound) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bound) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{15, 1, 0}
 }
 func (m *WindowerSpec_Frame_Bound) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1701,7 +1688,7 @@ func (m *WindowerSpec_Frame_Bounds) Reset()         { *m = WindowerSpec_Frame_Bo
 func (m *WindowerSpec_Frame_Bounds) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bounds) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bounds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{15, 1, 1}
 }
 func (m *WindowerSpec_Frame_Bounds) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1751,7 +1738,7 @@ func (m *WindowerSpec_WindowFn) Reset()         { *m = WindowerSpec_WindowFn{} }
 func (m *WindowerSpec_WindowFn) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_WindowFn) ProtoMessage()    {}
 func (*WindowerSpec_WindowFn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_1877ce89820fdbbd, []int{15, 2}
+	return fileDescriptor_processors_sql_19cf765bd41c92c6, []int{15, 2}
 }
 func (m *WindowerSpec_WindowFn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8093,10 +8080,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_1877ce89820fdbbd)
+	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_19cf765bd41c92c6)
 }
 
-var fileDescriptor_processors_sql_1877ce89820fdbbd = []byte{
+var fileDescriptor_processors_sql_19cf765bd41c92c6 = []byte{
 	// 2712 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x5a, 0x4b, 0x73, 0xdb, 0xd6,
 	0xf5, 0x17, 0xf8, 0x90, 0xc8, 0xc3, 0x87, 0xae, 0xaf, 0x95, 0x98, 0x51, 0xfe, 0x7f, 0x59, 0x66,

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -130,12 +130,9 @@ message TableReaderSpec {
   // FOR_NONE, no row-level locking should be performed.
   optional sqlbase.ScanLockingStrength locking_strength = 10 [(gogoproto.nullable) = false];
 
-  // Indicates the policy to be used by the scan when dealing with rows being
-  // locked. Always set to BLOCK when locking_stength is FOR_NONE.
-  //
-  // NOTE: this is currently set but unused because only the BLOCK wait policy
-  // makes it out of the SQL optimizer without throwing an error. If/when other
-  // wait policies are supported, this field will be plumbed further.
+  // Indicates the policy to be used by the scan for handling conflicting locks
+  // held by other active transactions when attempting to lock rows. Always set
+  // to BLOCK when locking_stength is FOR_NONE.
   optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 11 [(gogoproto.nullable) = false];
 
   // Indicates what implicit system columns this TableReader is expected to
@@ -169,12 +166,9 @@ message IndexSkipTableReaderSpec {
   // FOR_NONE, no row-level locking should be performed.
   optional sqlbase.ScanLockingStrength locking_strength = 6 [(gogoproto.nullable) = false];
 
-  // Indicates the policy to be used by the scan when dealing with rows being
-  // locked. Always set to BLOCK when locking_stength is FOR_NONE.
-  //
-  // NOTE: this is currently set but unused because only the BLOCK wait policy
-  // makes it out of the SQL optimizer without throwing an error. If/when other
-  // wait policies are supported, this field will be plumbed further.
+  // Indicates the policy to be used by the scan for handling conflicting locks
+  // held by other active transactions when attempting to lock rows. Always set
+  // to BLOCK when locking_stength is FOR_NONE.
   optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 7 [(gogoproto.nullable) = false];
 }
 
@@ -250,12 +244,9 @@ message JoinReaderSpec {
   // FOR_NONE, no row-level locking should be performed.
   optional sqlbase.ScanLockingStrength locking_strength = 9 [(gogoproto.nullable) = false];
 
-  // Indicates the policy to be used by the join when dealing with rows being
-  // locked. Always set to BLOCK when locking_stength is FOR_NONE.
-  //
-  // NOTE: this is currently set but unused because only the BLOCK wait policy
-  // makes it out of the SQL optimizer without throwing an error. If/when other
-  // wait policies are supported, this field will be plumbed further.
+  // Indicates the policy to be used by the join for handling conflicting locks
+  // held by other active transactions when attempting to lock rows. Always set
+  // to BLOCK when locking_stength is FOR_NONE.
   optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 10 [(gogoproto.nullable) = false];
 
   // Indicates that the join reader should maintain the ordering of the input
@@ -738,13 +729,9 @@ message InterleavedReaderJoinerSpec {
   // tables. If set to FOR_NONE, no row-level locking should be performed.
   optional sqlbase.ScanLockingStrength locking_strength = 6 [(gogoproto.nullable) = false];
 
-  // Indicates the policy to be used by the scan over the tables when dealing
-  // with rows being locked. Always set to BLOCK when locking_stength is
-  // FOR_NONE.
-  //
-  // NOTE: this is currently set but unused because only the BLOCK wait policy
-  // makes it out of the SQL optimizer without throwing an error. If/when other
-  // wait policies are supported, this field will be plumbed further.
+  // Indicates the policy to be used by the scan for handling conflicting locks
+  // held by other active transactions when attempting to lock rows. Always set
+  // to BLOCK when locking_stength is FOR_NONE.
   optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 7 [(gogoproto.nullable) = false];
 
   // Joiner component

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -296,7 +296,7 @@ CREATE TABLE drop_index_test(a int); CREATE INDEX drop_index_test_index ON drop_
 NOTICE: the data for dropped indexes is reclaimed asynchronously
 HINT: The reclamation delay can be customized in the zone configuration for the table.
 
-# test correct error reporting from NewUniquenessConstraintViolationError; see #46376
+# test correct error reporting from NewUniquenessConstraintViolationError; see #46276
 subtest new_uniqueness_constraint_error
 
 statement ok
@@ -309,5 +309,5 @@ DROP INDEX t_secondary CASCADE;
 ALTER TABLE t DROP COLUMN b;
 INSERT INTO t SELECT a + 1 FROM t;
 
-statement error pq: duplicate key value
+statement error pgcode 23505 duplicate key value: decoding err=column-id "2" does not exist
 UPSERT INTO t SELECT a + 1 FROM t;

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -55,9 +55,9 @@ SELECT 1 FOR UPDATE OF public.a
 query error pgcode 42601 FOR UPDATE must specify unqualified relation names
 SELECT 1 FOR UPDATE OF db.public.a
 
-# We can't support SKIP LOCKED or NOWAIT, since they would actually behave
-# differently - NOWAIT returns an error to the client instead of blocking,
-# and SKIP LOCKED returns an inconsistent view.
+# We don't currently support SKIP LOCKED, since it returns an inconsistent view
+# and generally has strange semantics with respect to serializable isolation.
+# Support may be added in the future.
 
 query error unimplemented: SKIP LOCKED lock wait policy is not supported
 SELECT 1 FOR UPDATE SKIP LOCKED
@@ -80,23 +80,34 @@ SELECT 1 FOR UPDATE OF a SKIP LOCKED FOR NO KEY UPDATE OF b SKIP LOCKED
 query error unimplemented: SKIP LOCKED lock wait policy is not supported
 SELECT 1 FOR UPDATE OF a SKIP LOCKED FOR NO KEY UPDATE OF b NOWAIT
 
-query error unimplemented: NOWAIT lock wait policy is not supported
+query I
 SELECT 1 FOR UPDATE NOWAIT
+----
+1
 
-query error unimplemented: NOWAIT lock wait policy is not supported
+query I
 SELECT 1 FOR NO KEY UPDATE NOWAIT
+----
+1
 
-query error unimplemented: NOWAIT lock wait policy is not supported
+query I
 SELECT 1 FOR SHARE NOWAIT
+----
+1
 
-query error unimplemented: NOWAIT lock wait policy is not supported
+query I
 SELECT 1 FOR KEY SHARE NOWAIT
+----
+1
 
-query error unimplemented: NOWAIT lock wait policy is not supported
+query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
 SELECT 1 FOR UPDATE OF a NOWAIT
 
-query error unimplemented: NOWAIT lock wait policy is not supported
+query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
 SELECT 1 FOR UPDATE OF a NOWAIT FOR NO KEY UPDATE OF b NOWAIT
+
+query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
+SELECT 1 FOR UPDATE OF a NOWAIT FOR SHARE OF b, c NOWAIT FOR NO KEY UPDATE OF d NOWAIT  FOR KEY SHARE OF e, f NOWAIT 
 
 # Locking clauses both inside and outside of parenthesis are handled correctly.
 
@@ -220,13 +231,7 @@ SELECT * FROM t FOR SHARE
 
 user root
 
-statement ok
-DROP TABLE t
-
 # Use of SELECT FOR UPDATE/SHARE in ReadOnly Transaction
-
-statement ok
-CREATE TABLE t (i INT PRIMARY KEY)
 
 statement ok
 BEGIN READ ONLY
@@ -264,5 +269,77 @@ SELECT * FROM t FOR KEY SHARE
 statement ok
 ROLLBACK
 
+# The NOWAIT wait policy returns error when conflicting lock is encountered.
+
 statement ok
-DROP TABLE t
+INSERT INTO t VALUES (1, 1)
+
+statement ok
+BEGIN; UPDATE t SET v = 2 WHERE k = 1
+
+user testuser
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@primary
+SELECT * FROM t FOR UPDATE NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@primary
+SELECT * FROM t FOR SHARE FOR UPDATE OF t NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@primary
+SELECT * FROM t FOR SHARE NOWAIT FOR UPDATE OF t
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@primary
+BEGIN; SELECT * FROM t FOR UPDATE NOWAIT
+
+statement ok
+ROLLBACK
+
+user root
+
+statement ok
+ROLLBACK
+
+# The NOWAIT wait policy can be applied to a subset of the tables being locked.
+
+statement ok
+CREATE TABLE t2 (k INT PRIMARY KEY, v2 int)
+
+statement ok
+GRANT UPDATE ON t2 TO testuser
+
+statement ok
+INSERT INTO t2 VALUES (1, 11)
+
+statement ok
+BEGIN; UPDATE t SET v = 2 WHERE k = 1
+
+user testuser
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@primary
+SELECT v, v2 FROM t JOIN t2 USING (k) FOR SHARE FOR SHARE OF t NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@primary
+SELECT v, v2 FROM t JOIN t2 USING (k) FOR SHARE OF t2 FOR SHARE OF t NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@primary
+SELECT v, v2 FROM t JOIN t2 USING (k) FOR SHARE NOWAIT FOR SHARE OF t
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@primary
+SELECT v, v2 FROM t JOIN t2 USING (k) FOR SHARE NOWAIT FOR SHARE OF t2
+
+statement ok
+SET statement_timeout = '10ms'
+
+query error pgcode 57014 query execution canceled due to statement timeout
+SELECT v, v2 FROM t JOIN t2 USING (k) FOR SHARE FOR SHARE OF t2 NOWAIT
+
+query error pgcode 57014 query execution canceled due to statement timeout
+SELECT v, v2 FROM t JOIN t2 USING (k) FOR SHARE OF t FOR SHARE OF t2 NOWAIT
+
+statement ok
+SET statement_timeout = 0
+
+user root
+
+statement ok
+ROLLBACK

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_nowait_interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_nowait_interleaved
@@ -1,0 +1,113 @@
+# LogicTest: !3node-tenant(50050)
+#
+# TODO(nvanbenschoten): merge test cases back into select_for_update once #50050
+# is addressed.
+
+# The NOWAIT wait policy returns error indicating location of conflicting lock,
+# when possible. This is true even with interleaved scans, which complicate the
+# logic of mapping a WriteIntentError back to the corresponding table.
+
+statement ok
+CREATE TABLE p2 (i INT PRIMARY KEY, s STRING)
+
+statement ok
+CREATE TABLE p1_0 (
+  i INT PRIMARY KEY,
+  s1 STRING
+) INTERLEAVE IN PARENT p2 (i)
+
+statement ok
+CREATE TABLE p1_1 (
+  i INT PRIMARY KEY,
+  s2 STRING
+) INTERLEAVE IN PARENT p2 (i)
+
+statement ok
+GRANT UPDATE ON p2   TO testuser;
+GRANT UPDATE ON p1_0 TO testuser;
+GRANT UPDATE ON p1_1 TO testuser;
+
+statement ok
+INSERT INTO p2 VALUES (2, '2a'), (3, '3a'), (5, '5a'), (7, '7a')
+
+statement ok
+INSERT INTO p1_0 VALUES (2, '2b'), (3, '3b'), (5, '5b')
+
+statement ok
+INSERT INTO p1_1 VALUES (2, '2c'), (3, '3c')
+
+query TT
+SELECT s, s1 FROM p2 JOIN p1_0 USING (i) ORDER BY s
+----
+2a  2b
+3a  3b
+5a  5b
+
+# Conflict on parent table.
+statement ok
+BEGIN; UPDATE p2 SET s = '7a_update' WHERE i = 7
+
+user testuser
+
+query error pgcode 55P03 could not obtain lock on row \(i\)=\(7\) in p2@primary
+SELECT * FROM p2 FOR SHARE NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row in interleaved table
+SELECT * FROM p1_0 FOR SHARE NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row in interleaved table
+SELECT * FROM p1_1 FOR SHARE NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row \(i\)=\(7\) in p2@primary
+SELECT s, s1 FROM p2 JOIN p1_0 USING (i) ORDER BY s FOR SHARE NOWAIT
+
+user root
+
+statement ok
+ROLLBACK
+
+# Conflict on child table.
+statement ok
+BEGIN; UPDATE p1_0 SET s1 = '5b_update' WHERE i = 5
+
+user testuser
+
+query error pgcode 55P03 could not obtain lock on row in interleaved table
+SELECT * FROM p2 FOR SHARE NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row \(i\)=\(5\) in p1_0@primary
+SELECT * FROM p1_0 FOR SHARE NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row in interleaved table
+SELECT * FROM p1_1 FOR SHARE NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row \(i\)=\(5\) in p1_0@primary
+SELECT s, s1 FROM p2 JOIN p1_0 USING (i) ORDER BY s FOR SHARE NOWAIT
+
+user root
+
+statement ok
+ROLLBACK
+
+# Conflict on ignored child table.
+statement ok
+BEGIN; UPDATE p1_1 SET s2 = '3c_update' WHERE i = 3
+
+user testuser
+
+query error pgcode 55P03 could not obtain lock on row in interleaved table
+SELECT * FROM p2 FOR SHARE NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row in interleaved table
+SELECT * FROM p1_0 FOR SHARE NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row \(i\)=\(3\) in p1_1@primary
+SELECT * FROM p1_1 FOR SHARE NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row in interleaved table
+SELECT s, s1 FROM p2 JOIN p1_0 USING (i) ORDER BY s FOR SHARE NOWAIT
+
+user root
+
+statement ok
+ROLLBACK

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -1206,3 +1206,231 @@ cross join  ·                 ·
 ·           table             u@primary
 ·           spans             FULL SCAN
 ·           locking strength  for update
+
+# ------------------------------------------------------------------------------
+# Tests with the NOWAIT lock wait policy.
+# ------------------------------------------------------------------------------
+
+query TTT
+EXPLAIN SELECT * FROM t FOR UPDATE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                FULL SCAN
+·     locking strength     for update
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t FOR NO KEY UPDATE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                FULL SCAN
+·     locking strength     for no key update
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t FOR SHARE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                FULL SCAN
+·     locking strength     for share
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t FOR KEY SHARE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                FULL SCAN
+·     locking strength     for key share
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                FULL SCAN
+·     locking strength     for share
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                FULL SCAN
+·     locking strength     for no key update
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                FULL SCAN
+·     locking strength     for update
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t FOR UPDATE OF t NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                FULL SCAN
+·     locking strength     for update
+·     locking wait policy  nowait
+
+query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
+EXPLAIN SELECT * FROM t FOR UPDATE OF t2 NOWAIT
+
+query TTT
+EXPLAIN SELECT 1 FROM t FOR UPDATE OF t NOWAIT
+----
+·          distribution         local
+·          vectorized           true
+render     ·                    ·
+ └── scan  ·                    ·
+·          missing stats        ·
+·          table                t@primary
+·          spans                FULL SCAN
+·          locking strength     for update
+·          locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                /1-/1/#
+·     locking strength     for update
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                /1-/1/#
+·     locking strength     for no key update
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t WHERE a = 1 FOR SHARE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                /1-/1/#
+·     locking strength     for share
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                /1-/1/#
+·     locking strength     for key share
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                /1-/1/#
+·     locking strength     for share
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                /1-/1/#
+·     locking strength     for no key update
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                /1-/1/#
+·     locking strength     for update
+·     locking wait policy  nowait
+
+query TTT
+EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE OF t NOWAIT
+----
+·     distribution         local
+·     vectorized           true
+scan  ·                    ·
+·     missing stats        ·
+·     table                t@primary
+·     spans                /1-/1/#
+·     locking strength     for update
+·     locking wait policy  nowait
+
+query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
+EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2 NOWAIT
+
+query TTT
+EXPLAIN SELECT 1 FROM t WHERE a = 1 FOR UPDATE OF t NOWAIT
+----
+·          distribution         local
+·          vectorized           true
+render     ·                    ·
+ └── scan  ·                    ·
+·          missing stats        ·
+·          table                t@primary
+·          spans                /1-/1/#
+·          locking strength     for update
+·          locking wait policy  nowait

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1357,13 +1357,12 @@ func (b *Builder) validateLockingInFrom(
 		// Validating locking wait policy.
 		switch li.WaitPolicy {
 		case tree.LockWaitBlock:
-			// Default.
+			// Default. Block on conflicting locks.
 		case tree.LockWaitSkip:
 			panic(unimplementedWithIssueDetailf(40476, "",
 				"SKIP LOCKED lock wait policy is not supported"))
 		case tree.LockWaitError:
-			panic(unimplementedWithIssueDetailf(40476, "",
-				"NOWAIT lock wait policy is not supported"))
+			// Raise an error on conflicting locks.
 		default:
 			panic(errors.AssertionFailedf("unknown locking wait policy: %s", li.WaitPolicy))
 		}

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -937,3 +937,95 @@ build
 SELECT * FROM information_schema.columns FOR UPDATE
 ----
 error (42601): FOR UPDATE not allowed with virtual tables
+
+# ------------------------------------------------------------------------------
+# Tests with the NOWAIT lock wait policy.
+# ------------------------------------------------------------------------------
+
+build
+SELECT * FROM t FOR UPDATE NOWAIT
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3
+      └── locking: for-update,nowait
+
+build
+SELECT * FROM t FOR NO KEY UPDATE NOWAIT
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3
+      └── locking: for-no-key-update,nowait
+
+build
+SELECT * FROM t FOR SHARE NOWAIT
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3
+      └── locking: for-share,nowait
+
+build
+SELECT * FROM t FOR KEY SHARE NOWAIT
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3
+      └── locking: for-key-share,nowait
+
+build
+SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3
+      └── locking: for-share,nowait
+
+build
+SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3
+      └── locking: for-no-key-update,nowait
+
+build
+SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWAIT
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3
+      └── locking: for-update,nowait
+
+build
+SELECT * FROM t FOR UPDATE OF t NOWAIT
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3
+      └── locking: for-update,nowait
+
+build
+SELECT * FROM t FOR UPDATE OF t2 NOWAIT
+----
+error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
+
+build
+SELECT 1 FROM t FOR UPDATE OF t NOWAIT
+----
+project
+ ├── columns: "?column?":4!null
+ ├── scan t
+ │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3
+ │    └── locking: for-update,nowait
+ └── projections
+      └── 1 [as="?column?":4]

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -111,6 +111,7 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 		keys.SystemSQLCodec,
 		false, /* reverse */
 		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
 		true, /* isCheck */
 		&sqlbase.DatumAlloc{},
 		args...,

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -79,6 +79,7 @@ func initFetcher(
 		fetcherCodec,
 		reverseScan,
 		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		alloc,
 		fetcherArgs...,
@@ -1063,7 +1064,13 @@ func TestRowFetcherReset(t *testing.T) {
 
 	fetcherArgs := makeFetcherArgs(args)
 	if err := resetFetcher.Init(
-		keys.SystemSQLCodec, false /*reverse*/, 0 /* todo */, false /* isCheck */, &da, fetcherArgs...,
+		keys.SystemSQLCodec,
+		false, /*reverse*/
+		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
+		false, /* isCheck */
+		&da,
+		fetcherArgs...,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -40,10 +40,11 @@ func NewKVFetcher(
 	reverse bool,
 	useBatchLimit bool,
 	firstBatchLimit int64,
-	lockStr descpb.ScanLockingStrength,
+	lockStrength descpb.ScanLockingStrength,
+	lockWaitPolicy descpb.ScanLockingWaitPolicy,
 ) (*KVFetcher, error) {
 	kvBatchFetcher, err := makeKVBatchFetcher(
-		txn, spans, reverse, useBatchLimit, firstBatchLimit, lockStr,
+		txn, spans, reverse, useBatchLimit, firstBatchLimit, lockStrength, lockWaitPolicy,
 	)
 	return newKVFetcher(&kvBatchFetcher), err
 }

--- a/pkg/sql/rowexec/interleaved_reader_joiner.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner.go
@@ -376,7 +376,13 @@ func newInterleavedReaderJoiner(
 	}
 
 	if err := irj.initRowFetcher(
-		flowCtx, spec.Tables, tables, spec.Reverse, spec.LockingStrength, &irj.alloc,
+		flowCtx,
+		spec.Tables,
+		tables,
+		spec.Reverse,
+		spec.LockingStrength,
+		spec.LockingWaitPolicy,
+		&irj.alloc,
 	); err != nil {
 		return nil, err
 	}
@@ -413,7 +419,8 @@ func (irj *interleavedReaderJoiner) initRowFetcher(
 	tables []execinfrapb.InterleavedReaderJoinerSpec_Table,
 	tableInfos []tableInfo,
 	reverseScan bool,
-	lockStr descpb.ScanLockingStrength,
+	lockStrength descpb.ScanLockingStrength,
+	lockWaitPolicy descpb.ScanLockingWaitPolicy,
 	alloc *sqlbase.DatumAlloc,
 ) error {
 	args := make([]row.FetcherTableArgs, len(tables))
@@ -439,7 +446,8 @@ func (irj *interleavedReaderJoiner) initRowFetcher(
 	return irj.fetcher.Init(
 		flowCtx.Codec(),
 		reverseScan,
-		lockStr,
+		lockStrength,
+		lockWaitPolicy,
 		true, /* isCheck */
 		alloc,
 		args...,

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -258,7 +258,8 @@ func newInvertedJoiner(
 	_, _, err = initRowFetcher(
 		flowCtx, &fetcher, &ij.desc, int(spec.IndexIdx), ij.colIdxMap, false, /* reverse */
 		allIndexCols, false /* isCheck */, &ij.alloc, execinfra.ScanVisibilityPublic,
-		descpb.ScanLockingStrength_FOR_NONE, nil, /* systemColumns */
+		descpb.ScanLockingStrength_FOR_NONE, descpb.ScanLockingWaitPolicy_BLOCK,
+		nil, /* systemColumns */
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -231,7 +231,8 @@ func newJoinReader(
 
 	_, _, err = initRowFetcher(
 		flowCtx, &fetcher, &jr.desc, int(spec.IndexIdx), jr.colIdxMap, false, /* reverse */
-		rightCols, false /* isCheck */, &jr.alloc, spec.Visibility, spec.LockingStrength, sysColDescs,
+		rightCols, false /* isCheck */, &jr.alloc, spec.Visibility, spec.LockingStrength,
+		spec.LockingWaitPolicy, sysColDescs,
 	)
 
 	if err != nil {

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -64,7 +64,8 @@ func initRowFetcher(
 	isCheck bool,
 	alloc *sqlbase.DatumAlloc,
 	scanVisibility execinfrapb.ScanVisibility,
-	lockStr descpb.ScanLockingStrength,
+	lockStrength descpb.ScanLockingStrength,
+	lockWaitPolicy descpb.ScanLockingWaitPolicy,
 	systemColumns []descpb.ColumnDescriptor,
 ) (index *descpb.IndexDescriptor, isSecondaryIndex bool, err error) {
 	index, isSecondaryIndex, err = desc.FindIndexByIndexIdx(indexIdx)
@@ -90,7 +91,8 @@ func initRowFetcher(
 	if err := fetcher.Init(
 		flowCtx.Codec(),
 		reverseScan,
-		lockStr,
+		lockStrength,
+		lockWaitPolicy,
 		isCheck,
 		alloc,
 		tableArgs,

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -125,7 +125,8 @@ func newScrubTableReader(
 	if _, _, err := initRowFetcher(
 		flowCtx, &fetcher, &tr.tableDesc, int(spec.IndexIdx), tr.tableDesc.ColumnIdxMap(),
 		spec.Reverse, neededColumns, true /* isCheck */, &tr.alloc,
-		execinfra.ScanVisibilityPublic, spec.LockingStrength, nil, /* systemColumns */
+		execinfra.ScanVisibilityPublic, spec.LockingStrength, spec.LockingWaitPolicy,
+		nil, /* systemColumns */
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -138,6 +138,7 @@ func newTableReader(
 		&tr.alloc,
 		spec.Visibility,
 		spec.LockingStrength,
+		spec.LockingWaitPolicy,
 		sysColDescs,
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -464,6 +464,7 @@ func (z *zigzagJoiner) setupInfo(
 		// NB: zigzag joins are disabled when a row-level locking clause is
 		// supplied, so there is no locking strength on *ZigzagJoinerSpec.
 		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
 		nil, /* systemColumns */
 	)
 	if err != nil {

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -1027,9 +1027,10 @@ func (s LockingStrength) Max(s2 LockingStrength) LockingStrength {
 	return LockingStrength(max(byte(s), byte(s2)))
 }
 
-// LockingWaitPolicy represents the possible policies for dealing with rows
-// being locked by FOR UPDATE/SHARE clauses (i.e., it represents the NOWAIT
-// and SKIP LOCKED options).
+// LockingWaitPolicy represents the possible policies for handling conflicting
+// locks held by other active transactions when attempting to lock rows due to
+// FOR UPDATE/SHARE clauses (i.e. it represents the NOWAIT and SKIP LOCKED
+// options).
 type LockingWaitPolicy byte
 
 // The ordering of the variants is important, because the highest numerical

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -133,6 +133,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 		// strength here. Consider hooking this in to the same knob that will
 		// control whether we perform locking implicitly during DELETEs.
 		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		td.alloc,
 		tableArgs,
@@ -255,6 +256,7 @@ func (td *tableDeleter) deleteIndexScan(
 		// strength here. Consider hooking this in to the same knob that will
 		// control whether we perform locking implicitly during DELETEs.
 		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
 		false, /* isCheck */
 		td.alloc,
 		tableArgs,


### PR DESCRIPTION
Fixes half of #40476.

In #52388, we added support for a new `Error` wait policy to be attached
to BatchRequests. This wait policy dictates that if a request encounters
a conflicting locks held by another active transaction, it should raise
an error instead of blocking.

These semantics closely match those of FOR {UPDATE,SHARE} NOWAIT in
PostgreSQL. With NOWAIT, the statement reports an error, rather than
waiting, if a selected row cannot be locked immediately. This means that
we are able to use the new kv-level wait policy to implement NOWAIT in
SQL. Doing so is fairly mechanical, as a lot of the plumbing necessary
was already put into place in #44429.

The only difference I can see in the semantics is that in PostgreSQL,
rows that are being INSERTed by one transaction are not even considered
for locking by other transactions, so NOWAIT will not throw an error
when encountering these rows. Instead, it will silently ignore them.
This has less to do with NOWAIT itself, and more to do with a difference
in the concurrency control implementation between Cockroach and
PostgreSQL. Since this isn't specific to NOWAIT, I don't think it's a
blocker for this change.

Release note (sql change): SELECT ... FOR {UPDATE,SHARE} NOWAIT is now
supported. The option can be used to throw and error instead of blocking
on contended row-level lock acquisition.