### PR TITLE
opt: replace DPSub algorithm with DPHyp

### DIFF
--- a/pkg/sql/opt/citations.md
+++ b/pkg/sql/opt/citations.md
@@ -40,3 +40,9 @@ further information, and in some cases proofs, can be found.
     Proceedings of the ACM SIGMOD International Conference on Management of Data. 
     493-504. 10.1145/2463676.2465314. 
     https://www.researchgate.net/publication/262216932_On_the_correct_and_complete_enumeration_of_the_core_search_space
+    
+[9] Moerkotte, Guido & Neumann, Thomas. (2008). 
+    Dynamic Programming Strikes Back. 
+    Shasha, Dennis; Wang, Jason T. L.: Proceedings of the ACM SIGMOD 2008 International Conference on Management of Data, ACM, 539-552 (2008). 
+    10.1145/1376616.1376672. 
+    https://www.researchgate.net/publication/47862092_Dynamic_Programming_Strikes_Back

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -368,21 +368,21 @@ render                                            ·             ·
       └── render                                  ·             ·
            └── hash join                          ·             ·
                 │                                 type          inner
-                │                                 equality      (oid) = (relnamespace)
-                ├── filter                        ·             ·
-                │    │                            filter        nspname = 'public'
-                │    └── render                   ·             ·
-                │         └── virtual table       ·             ·
-                │                                 source        pg_namespace@primary
-                └── virtual table lookup join     ·             ·
-                     │                            table         pg_constraint@pg_constraint_conrelid_idx
-                     │                            type          inner
-                     │                            equality      (oid) = (conrelid)
-                     └── filter                   ·             ·
-                          │                       filter        relname = 'foo'
-                          └── render              ·             ·
-                               └── virtual table  ·             ·
-·                                                 source        pg_class@primary
+                │                                 equality      (relnamespace) = (oid)
+                ├── virtual table lookup join     ·             ·
+                │    │                            table         pg_constraint@pg_constraint_conrelid_idx
+                │    │                            type          inner
+                │    │                            equality      (oid) = (conrelid)
+                │    └── filter                   ·             ·
+                │         │                       filter        relname = 'foo'
+                │         └── render              ·             ·
+                │              └── virtual table  ·             ·
+                │                                 source        pg_class@primary
+                └── filter                        ·             ·
+                     │                            filter        nspname = 'public'
+                     └── render                   ·             ·
+                          └── virtual table       ·             ·
+·                                                 source        pg_namespace@primary
 
 query TTT
 EXPLAIN SHOW USERS

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -371,13 +371,13 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 7   ·                          type                inner
 7   ·                          equality            (oid) = (attrelid)
 8   virtual table lookup join  ·                   ·
-8   ·                          table               pg_class@pg_class_oid_idx
+8   ·                          table               pg_attribute@pg_attribute_attrelid_idx
 8   ·                          type                inner
-8   ·                          equality            (attrelid) = (oid)
+8   ·                          equality            (oid) = (attrelid)
 9   virtual table lookup join  ·                   ·
-9   ·                          table               pg_attribute@pg_attribute_attrelid_idx
+9   ·                          table               pg_class@pg_class_oid_idx
 9   ·                          type                inner
-9   ·                          equality            (confrelid) = (attrelid)
+9   ·                          equality            (confrelid) = (oid)
 10  virtual table lookup join  ·                   ·
 10  ·                          table               pg_constraint@pg_constraint_conrelid_idx
 10  ·                          type                inner

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -1445,17 +1445,17 @@ limit                                                                  ·       
                      │                                                 equality               (l_orderkey) = (l_orderkey)
                      │                                                 pred                   l_suppkey != l_suppkey
                      └── lookup join                                   ·                      ·
-                          │                                            table                  orders@primary
-                          │                                            type                   inner
-                          │                                            equality               (l_orderkey) = (o_orderkey)
-                          │                                            equality cols are key  ·
-                          │                                            parallel               ·
-                          │                                            pred                   o_orderstatus = 'F'
+                          │                                            table                  lineitem@primary
+                          │                                            type                   anti
+                          │                                            equality               (l_orderkey) = (l_orderkey)
+                          │                                            pred                   l_receiptdate > l_commitdate
                           └── lookup join                              ·                      ·
-                               │                                       table                  lineitem@primary
-                               │                                       type                   anti
-                               │                                       equality               (l_orderkey) = (l_orderkey)
-                               │                                       pred                   l_receiptdate > l_commitdate
+                               │                                       table                  orders@primary
+                               │                                       type                   inner
+                               │                                       equality               (l_orderkey) = (o_orderkey)
+                               │                                       equality cols are key  ·
+                               │                                       parallel               ·
+                               │                                       pred                   o_orderstatus = 'F'
                                └── render                              ·                      ·
                                     └── lookup join                    ·                      ·
                                          │                             table                  lineitem@primary

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -176,7 +176,7 @@ count                               ·                  ·
                      │              type               inner
                      │              equality           (a) = (a)
                      ├── scan       ·                  ·
-                     │              table              ab@primary
+                     │              table              ac@primary
                      │              spans              FULL SCAN
                      └── hash join  ·                  ·
                           │         type               inner
@@ -186,7 +186,7 @@ count                               ·                  ·
                           │         table              abc@primary
                           │         spans              FULL SCAN
                           └── scan  ·                  ·
-·                                   table              ac@primary
+·                                   table              ab@primary
 ·                                   spans              FULL SCAN
 
 # Make sure UPDATE ... FROM works with LATERAL.
@@ -217,7 +217,7 @@ run                                 ·                  ·
                      │              type               inner
                      │              equality           (a) = (a)
                      ├── scan       ·                  ·
-                     │              table              ab@primary
+                     │              table              ac@primary
                      │              spans              FULL SCAN
                      └── hash join  ·                  ·
                           │         type               inner
@@ -227,5 +227,5 @@ run                                 ·                  ·
                           │         table              abc@primary
                           │         spans              FULL SCAN
                           └── scan  ·                  ·
-·                                   table              ac@primary
+·                                   table              ab@primary
 ·                                   spans              FULL SCAN

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q02
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q02
@@ -116,9 +116,9 @@ project
       │         │    │    │    ├── save-table-name: q2_lookup_join_7
       │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:11(int!null) s_name:12(char!null) s_address:13(varchar!null) s_nationkey:14(int!null) s_phone:15(char!null) s_acctbal:16(float!null) s_comment:17(varchar!null) ps_partkey:19(int!null) ps_suppkey:20(int!null) ps_supplycost:22(float!null) n_nationkey:25(int!null) n_name:26(char!null) n_regionkey:27(int!null) r_regionkey:30(int!null) r_name:31(char!null) ps_partkey:34(int!null) ps_suppkey:35(int!null) ps_supplycost:37(float!null)
       │         │    │    │    ├── key columns: [1] = [34]
-      │         │    │    │    ├── stats: [rows=4452.37425, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=150, null(5)=0, distinct(6)=1, null(6)=0, distinct(11)=3587.31881, null(11)=0, distinct(12)=3592.54448, null(12)=0, distinct(13)=3593.28589, null(13)=0, distinct(14)=25, null(14)=0, distinct(15)=3593.28589, null(15)=0, distinct(16)=3590.83442, null(16)=0, distinct(17)=3588.36899, null(17)=0, distinct(19)=1333.31636, null(19)=0, distinct(20)=3587.31881, null(20)=0, distinct(22)=4355.01344, null(22)=0, distinct(25)=25, null(25)=0, distinct(26)=25, null(26)=0, distinct(27)=1, null(27)=0, distinct(30)=1, null(30)=0, distinct(31)=1, null(31)=0, distinct(34)=4401.6666, null(34)=0, distinct(35)=3587.31881, null(35)=0, distinct(37)=4355.01344, null(37)=0]
+      │         │    │    │    ├── stats: [rows=4496.93608, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=150, null(5)=0, distinct(6)=1, null(6)=0, distinct(11)=3615.70232, null(11)=0, distinct(12)=3621.01785, null(12)=0, distinct(13)=3621.77201, null(13)=0, distinct(14)=5, null(14)=0, distinct(15)=3621.77201, null(15)=0, distinct(16)=3619.27836, null(16)=0, distinct(17)=3616.77055, null(17)=0, distinct(19)=1333.31636, null(19)=0, distinct(20)=3615.70232, null(20)=0, distinct(22)=4397.56911, null(22)=0, distinct(25)=5, null(25)=0, distinct(26)=5, null(26)=0, distinct(27)=1, null(27)=0, distinct(30)=1, null(30)=0, distinct(31)=0.996222107, null(31)=0, distinct(34)=4444.6985, null(34)=0, distinct(35)=3615.70232, null(35)=0, distinct(37)=4397.56911, null(37)=0]
       │         │    │    │    ├── key: (20,34,35)
-      │         │    │    │    ├── fd: ()-->(6,31), (1)-->(3,5), (25)-->(26,27), (11)-->(12-17), (19,20)-->(22), (34,35)-->(37), (19)==(1,34), (34)==(1,19), (11)==(20), (20)==(11), (14)==(25), (25)==(14), (27)==(30), (30)==(27), (1)==(19,34)
+      │         │    │    │    ├── fd: ()-->(6,31), (1)-->(3,5), (11)-->(12-17), (19,20)-->(22), (34,35)-->(37), (19)==(1,34), (34)==(1,19), (11)==(20), (20)==(11), (25)-->(26,27), (27)==(30), (30)==(27), (14)==(25), (25)==(14), (1)==(19,34)
       │         │    │    │    ├── inner-join (hash)
       │         │    │    │    │    ├── save-table-name: q2_inner_join_8
       │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:11(int!null) s_name:12(char!null) s_address:13(varchar!null) s_nationkey:14(int!null) s_phone:15(char!null) s_acctbal:16(float!null) s_comment:17(varchar!null) ps_partkey:19(int!null) ps_suppkey:20(int!null) ps_supplycost:22(float!null) n_nationkey:25(int!null) n_name:26(char!null) n_regionkey:27(int!null) r_regionkey:30(int!null) r_name:31(char!null)
@@ -512,28 +512,28 @@ column_names       row_count  distinct_count  null_count
 {s_suppkey}        2568       548             0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{n_name}           4452.00        1.73           25.00               5.00 <==            0.00            1.00
-{n_nationkey}      4452.00        1.73           25.00               5.00 <==            0.00            1.00
-{n_regionkey}      4452.00        1.73           1.00                1.00                0.00            1.00
-{p_mfgr}           4452.00        1.73           5.00                1.00                0.00            1.00
-{p_partkey}        4452.00        1.73           1333.00             2.90 <==            0.00            1.00
-{p_size}           4452.00        1.73           1.00                1.00                0.00            1.00
-{p_type}           4452.00        1.73           150.00              5.00 <==            0.00            1.00
-{ps_partkey}       4452.00        1.73           1333.00             2.90 <==            0.00            1.00
-{ps_partkey_1}     4452.00        1.73           4402.00             9.57 <==            0.00            1.00
-{ps_suppkey}       4452.00        1.73           3587.00             6.55 <==            0.00            1.00
-{ps_suppkey_1}     4452.00        1.73           3587.00             2.16 <==            0.00            1.00
-{ps_supplycost}    4452.00        1.73           4355.00             6.80 <==            0.00            1.00
-{ps_supplycost_1}  4452.00        1.73           4355.00             2.39 <==            0.00            1.00
-{r_name}           4452.00        1.73           1.00                1.00                0.00            1.00
-{r_regionkey}      4452.00        1.73           1.00                1.00                0.00            1.00
-{s_acctbal}        4452.00        1.73           3591.00             6.55 <==            0.00            1.00
-{s_address}        4452.00        1.73           3593.00             6.56 <==            0.00            1.00
-{s_comment}        4452.00        1.73           3588.00             6.55 <==            0.00            1.00
-{s_name}           4452.00        1.73           3593.00             6.56 <==            0.00            1.00
-{s_nationkey}      4452.00        1.73           25.00               5.00 <==            0.00            1.00
-{s_phone}          4452.00        1.73           3593.00             6.56 <==            0.00            1.00
-{s_suppkey}        4452.00        1.73           3587.00             6.55 <==            0.00            1.00
+{n_name}           4497.00        1.75           5.00                1.00                0.00            1.00
+{n_nationkey}      4497.00        1.75           5.00                1.00                0.00            1.00
+{n_regionkey}      4497.00        1.75           1.00                1.00                0.00            1.00
+{p_mfgr}           4497.00        1.75           5.00                1.00                0.00            1.00
+{p_partkey}        4497.00        1.75           1333.00             2.90 <==            0.00            1.00
+{p_size}           4497.00        1.75           1.00                1.00                0.00            1.00
+{p_type}           4497.00        1.75           150.00              5.00 <==            0.00            1.00
+{ps_partkey}       4497.00        1.75           1333.00             2.90 <==            0.00            1.00
+{ps_partkey_1}     4497.00        1.75           4445.00             9.66 <==            0.00            1.00
+{ps_suppkey}       4497.00        1.75           3616.00             6.60 <==            0.00            1.00
+{ps_suppkey_1}     4497.00        1.75           3616.00             2.18 <==            0.00            1.00
+{ps_supplycost}    4497.00        1.75           4398.00             6.87 <==            0.00            1.00
+{ps_supplycost_1}  4497.00        1.75           4398.00             2.41 <==            0.00            1.00
+{r_name}           4497.00        1.75           1.00                1.00                0.00            1.00
+{r_regionkey}      4497.00        1.75           1.00                1.00                0.00            1.00
+{s_acctbal}        4497.00        1.75           3619.00             6.60 <==            0.00            1.00
+{s_address}        4497.00        1.75           3622.00             6.61 <==            0.00            1.00
+{s_comment}        4497.00        1.75           3617.00             6.60 <==            0.00            1.00
+{s_name}           4497.00        1.75           3621.00             6.61 <==            0.00            1.00
+{s_nationkey}      4497.00        1.75           5.00                1.00                0.00            1.00
+{s_phone}          4497.00        1.75           3622.00             6.61 <==            0.00            1.00
+{s_suppkey}        4497.00        1.75           3616.00             6.60 <==            0.00            1.00
 
 stats table=q2_inner_join_8
 ----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q05
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q05
@@ -75,15 +75,15 @@ sort
       │    │    │    ├── save-table-name: q5_lookup_join_5
       │    │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:10(int!null) o_custkey:11(int!null) o_orderdate:14(date!null) l_orderkey:20(int!null) l_suppkey:22(int!null) l_extendedprice:25(float!null) l_discount:26(float!null) n_nationkey:45(int!null) n_name:46(char!null) n_regionkey:47(int!null) r_regionkey:50(int!null) r_name:51(char!null)
       │    │    │    ├── key columns: [10] = [20]
-      │    │    │    ├── stats: [rows=296134.9, distinct(1)=27671.7064, null(1)=0, distinct(4)=5, null(4)=0, distinct(10)=64276.6285, null(10)=0, distinct(11)=27671.7064, null(11)=0, distinct(14)=365, null(14)=0, distinct(20)=64276.6285, null(20)=0, distinct(22)=9920, null(22)=0, distinct(25)=253449.774, null(25)=0, distinct(26)=11, null(26)=0, distinct(45)=5, null(45)=0, distinct(46)=5, null(46)=0, distinct(47)=1, null(47)=0, distinct(50)=1, null(50)=0, distinct(51)=0.996222107, null(51)=0]
-      │    │    │    ├── fd: ()-->(51), (10)-->(11,14), (1)-->(4), (45)-->(46,47), (47)==(50), (50)==(47), (4)==(45), (45)==(4), (1)==(11), (11)==(1), (10)==(20), (20)==(10)
+      │    │    │    ├── stats: [rows=296150.194, distinct(1)=27672.3293, null(1)=0, distinct(4)=5, null(4)=0, distinct(10)=166658.512, null(10)=0, distinct(11)=27672.3293, null(11)=0, distinct(14)=365, null(14)=0, distinct(20)=166658.512, null(20)=0, distinct(22)=9920, null(22)=0, distinct(25)=231693.035, null(25)=0, distinct(26)=11, null(26)=0, distinct(45)=5, null(45)=0, distinct(46)=5, null(46)=0, distinct(47)=1, null(47)=0, distinct(50)=1, null(50)=0, distinct(51)=0.996222107, null(51)=0]
+      │    │    │    ├── fd: ()-->(51), (1)-->(4), (45)-->(46,47), (47)==(50), (50)==(47), (4)==(45), (45)==(4), (10)-->(11,14), (10)==(20), (20)==(10), (1)==(11), (11)==(1)
       │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── save-table-name: q5_inner_join_6
       │    │    │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:10(int!null) o_custkey:11(int!null) o_orderdate:14(date!null) n_nationkey:45(int!null) n_name:46(char!null) n_regionkey:47(int!null) r_regionkey:50(int!null) r_name:51(char!null)
       │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-      │    │    │    │    ├── stats: [rows=75364.3969, distinct(1)=27672.3293, null(1)=0, distinct(4)=5, null(4)=0, distinct(10)=64276.6285, null(10)=0, distinct(11)=27672.3293, null(11)=0, distinct(14)=365, null(14)=0, distinct(45)=5, null(45)=0, distinct(46)=5, null(46)=0, distinct(47)=1, null(47)=0, distinct(50)=1, null(50)=0, distinct(51)=0.996222107, null(51)=0]
+      │    │    │    │    ├── stats: [rows=72267.3647, distinct(1)=53634.1183, null(1)=0, distinct(4)=25, null(4)=0, distinct(10)=65164.9394, null(10)=0, distinct(11)=53634.1183, null(11)=0, distinct(14)=365, null(14)=0, distinct(45)=25, null(45)=0, distinct(46)=25, null(46)=0, distinct(47)=1, null(47)=0, distinct(50)=1, null(50)=0, distinct(51)=1, null(51)=0]
       │    │    │    │    ├── key: (10)
-      │    │    │    │    ├── fd: ()-->(51), (10)-->(11,14), (1)-->(4), (45)-->(46,47), (47)==(50), (50)==(47), (4)==(45), (45)==(4), (1)==(11), (11)==(1)
+      │    │    │    │    ├── fd: ()-->(51), (1)-->(4), (45)-->(46,47), (4)==(45), (45)==(4), (10)-->(11,14), (1)==(11), (11)==(1), (47)==(50), (50)==(47)
       │    │    │    │    ├── index-join orders
       │    │    │    │    │    ├── save-table-name: q5_index_join_7
       │    │    │    │    │    ├── columns: o_orderkey:10(int!null) o_custkey:11(int!null) o_orderdate:14(date!null)
@@ -255,20 +255,20 @@ column_names       row_count  distinct_count  null_count
 {r_regionkey}      184082     1               0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_custkey}        296135.00      1.61           27672.00            1.60                0.00            1.00
-{c_nationkey}      296135.00      1.61           5.00                1.00                0.00            1.00
-{l_discount}       296135.00      1.61           11.00               1.00                0.00            1.00
-{l_extendedprice}  296135.00      1.61           253450.00           1.53                0.00            1.00
-{l_orderkey}       296135.00      1.61           64277.00            1.40                0.00            1.00
-{l_suppkey}        296135.00      1.61           9920.00             1.00                0.00            1.00
-{n_name}           296135.00      1.61           5.00                1.00                0.00            1.00
-{n_nationkey}      296135.00      1.61           5.00                1.00                0.00            1.00
-{n_regionkey}      296135.00      1.61           1.00                1.00                0.00            1.00
-{o_custkey}        296135.00      1.61           27672.00            1.60                0.00            1.00
-{o_orderdate}      296135.00      1.61           365.00              1.00                0.00            1.00
-{o_orderkey}       296135.00      1.61           64277.00            1.40                0.00            1.00
-{r_name}           296135.00      1.61           1.00                1.00                0.00            1.00
-{r_regionkey}      296135.00      1.61           1.00                1.00                0.00            1.00
+{c_custkey}        296150.00      1.61           27672.00            1.60                0.00            1.00
+{c_nationkey}      296150.00      1.61           5.00                1.00                0.00            1.00
+{l_discount}       296150.00      1.61           11.00               1.00                0.00            1.00
+{l_extendedprice}  296150.00      1.61           231693.00           1.40                0.00            1.00
+{l_orderkey}       296150.00      1.61           166659.00           3.63 <==            0.00            1.00
+{l_suppkey}        296150.00      1.61           9920.00             1.00                0.00            1.00
+{n_name}           296150.00      1.61           5.00                1.00                0.00            1.00
+{n_nationkey}      296150.00      1.61           5.00                1.00                0.00            1.00
+{n_regionkey}      296150.00      1.61           1.00                1.00                0.00            1.00
+{o_custkey}        296150.00      1.61           27672.00            1.60                0.00            1.00
+{o_orderdate}      296150.00      1.61           365.00              1.00                0.00            1.00
+{o_orderkey}       296150.00      1.61           166659.00           3.63 <==            0.00            1.00
+{r_name}           296150.00      1.61           1.00                1.00                0.00            1.00
+{r_regionkey}      296150.00      1.61           1.00                1.00                0.00            1.00
 
 stats table=q5_inner_join_6
 ----
@@ -285,16 +285,16 @@ column_names   row_count  distinct_count  null_count
 {r_regionkey}  46008      1               0
 ~~~~
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_custkey}    75364.00       1.64           27672.00            1.60                0.00            1.00
-{c_nationkey}  75364.00       1.64           5.00                1.00                0.00            1.00
-{n_name}       75364.00       1.64           5.00                1.00                0.00            1.00
-{n_nationkey}  75364.00       1.64           5.00                1.00                0.00            1.00
-{n_regionkey}  75364.00       1.64           1.00                1.00                0.00            1.00
-{o_custkey}    75364.00       1.64           27672.00            1.60                0.00            1.00
-{o_orderdate}  75364.00       1.64           365.00              1.00                0.00            1.00
-{o_orderkey}   75364.00       1.64           64277.00            1.40                0.00            1.00
-{r_name}       75364.00       1.64           1.00                1.00                0.00            1.00
-{r_regionkey}  75364.00       1.64           1.00                1.00                0.00            1.00
+{c_custkey}    72267.00       1.57           53634.00            3.10 <==            0.00            1.00
+{c_nationkey}  72267.00       1.57           25.00               5.00 <==            0.00            1.00
+{n_name}       72267.00       1.57           25.00               5.00 <==            0.00            1.00
+{n_nationkey}  72267.00       1.57           25.00               5.00 <==            0.00            1.00
+{n_regionkey}  72267.00       1.57           1.00                1.00                0.00            1.00
+{o_custkey}    72267.00       1.57           53634.00            3.10 <==            0.00            1.00
+{o_orderdate}  72267.00       1.57           365.00              1.00                0.00            1.00
+{o_orderkey}   72267.00       1.57           65165.00            1.42                0.00            1.00
+{r_name}       72267.00       1.57           1.00                1.00                0.00            1.00
+{r_regionkey}  72267.00       1.57           1.00                1.00                0.00            1.00
 
 stats table=q5_index_join_7
 ----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q07
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q07
@@ -98,15 +98,15 @@ sort
       │    │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:9(int!null) l_suppkey:11(int!null) l_extendedprice:14(float!null) l_discount:15(float!null) l_shipdate:19(date!null) o_orderkey:26(int!null) o_custkey:27(int!null) n1.n_nationkey:45(int!null) n1.n_name:46(char!null) n2.n_nationkey:50(int!null) n2.n_name:51(char!null)
       │    │    │    ├── key columns: [9] = [26]
       │    │    │    ├── lookup columns are key
-      │    │    │    ├── stats: [rows=101372.546, distinct(1)=529.630441, null(1)=0, distinct(4)=1.29975178, null(4)=0, distinct(9)=97145.926, null(9)=0, distinct(11)=529.630441, null(11)=0, distinct(14)=62473.272, null(14)=0, distinct(15)=11, null(15)=0, distinct(19)=731, null(19)=0, distinct(26)=97145.926, null(26)=0, distinct(27)=63672.0351, null(27)=0, distinct(45)=1.29975178, null(45)=0, distinct(46)=1.33333333, null(46)=0, distinct(50)=1.29975178, null(50)=0, distinct(51)=1.33333333, null(51)=0]
-      │    │    │    ├── fd: (26)-->(27), (1)-->(4), (45)-->(46), (50)-->(51), (4)==(45), (45)==(4), (1)==(11), (11)==(1), (9)==(26), (26)==(9)
+      │    │    │    ├── stats: [rows=101372.546, distinct(1)=529.630441, null(1)=0, distinct(4)=1.29975178, null(4)=0, distinct(9)=97145.926, null(9)=0, distinct(11)=529.630441, null(11)=0, distinct(14)=94863.2685, null(14)=0, distinct(15)=11, null(15)=0, distinct(19)=731, null(19)=0, distinct(26)=97145.926, null(26)=0, distinct(27)=63673.8739, null(27)=0, distinct(45)=1.29975178, null(45)=0, distinct(46)=1.33333333, null(46)=0, distinct(50)=1.29975178, null(50)=0, distinct(51)=1.33333333, null(51)=0]
+      │    │    │    ├── fd: (1)-->(4), (45)-->(46), (50)-->(51), (4)==(45), (45)==(4), (26)-->(27), (9)==(26), (26)==(9), (1)==(11), (11)==(1)
       │    │    │    ├── inner-join (lookup lineitem)
       │    │    │    │    ├── save-table-name: q7_lookup_join_7
       │    │    │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:9(int!null) l_suppkey:11(int!null) l_extendedprice:14(float!null) l_discount:15(float!null) l_shipdate:19(date!null) n1.n_nationkey:45(int!null) n1.n_name:46(char!null) n2.n_nationkey:50(int!null) n2.n_name:51(char!null)
       │    │    │    │    ├── key columns: [9 12] = [9 12]
       │    │    │    │    ├── lookup columns are key
-      │    │    │    │    ├── stats: [rows=101372.546, distinct(1)=529.630441, null(1)=0, distinct(4)=1.29975178, null(4)=0, distinct(9)=97145.926, null(9)=0, distinct(11)=529.630441, null(11)=0, distinct(14)=95536.4092, null(14)=0, distinct(15)=11, null(15)=0, distinct(19)=731, null(19)=0, distinct(45)=1.29975178, null(45)=0, distinct(46)=1.33333333, null(46)=0, distinct(50)=1.29975178, null(50)=0, distinct(51)=1.33333333, null(51)=0]
-      │    │    │    │    ├── fd: (1)-->(4), (45)-->(46), (50)-->(51), (4)==(45), (45)==(4), (1)==(11), (11)==(1)
+      │    │    │    │    ├── stats: [rows=101372.546, distinct(1)=6374.16727, null(1)=0, distinct(4)=25, null(4)=0, distinct(9)=96219.0928, null(9)=0, distinct(11)=6374.16727, null(11)=0, distinct(14)=94966.9274, null(14)=0, distinct(15)=11, null(15)=0, distinct(19)=731, null(19)=0, distinct(45)=25, null(45)=0, distinct(46)=2, null(46)=0, distinct(50)=25, null(50)=0, distinct(51)=2, null(51)=0]
+      │    │    │    │    ├── fd: (1)-->(4), (45)-->(46), (4)==(45), (45)==(4), (1)==(11), (11)==(1), (50)-->(51)
       │    │    │    │    ├── inner-join (lookup lineitem@l_sk)
       │    │    │    │    │    ├── save-table-name: q7_lookup_join_8
       │    │    │    │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:9(int!null) l_suppkey:11(int!null) l_linenumber:12(int!null) n1.n_nationkey:45(int!null) n1.n_name:46(char!null) n2.n_nationkey:50(int!null) n2.n_name:51(char!null)
@@ -267,7 +267,7 @@ column_names       row_count  distinct_count  null_count
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {l_discount}       101373.00      1.44           11.00               1.00                0.00            1.00
-{l_extendedprice}  101373.00      1.44           62473.00            2.09 <==            0.00            1.00
+{l_extendedprice}  101373.00      1.44           94863.00            1.38                0.00            1.00
 {l_orderkey}       101373.00      1.44           97146.00            1.30                0.00            1.00
 {l_shipdate}       101373.00      1.44           731.00              1.00                0.00            1.00
 {l_suppkey}        101373.00      1.44           530.00              1.51                0.00            1.00
@@ -275,7 +275,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {n_name_1}         101373.00      1.44           1.00                2.00 <==            0.00            1.00
 {n_nationkey}      101373.00      1.44           1.00                2.00 <==            0.00            1.00
 {n_nationkey_1}    101373.00      1.44           1.00                2.00 <==            0.00            1.00
-{o_custkey}        101373.00      1.44           63672.00            1.07                0.00            1.00
+{o_custkey}        101373.00      1.44           63674.00            1.07                0.00            1.00
 {o_orderkey}       101373.00      1.44           97146.00            1.30                0.00            1.00
 {s_nationkey}      101373.00      1.44           1.00                2.00 <==            0.00            1.00
 {s_suppkey}        101373.00      1.44           530.00              1.51                0.00            1.00
@@ -297,16 +297,16 @@ column_names       row_count  distinct_count  null_count
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {l_discount}       101373.00      1.44           11.00               1.00                0.00            1.00
-{l_extendedprice}  101373.00      1.44           95536.00            1.37                0.00            1.00
-{l_orderkey}       101373.00      1.44           97146.00            1.30                0.00            1.00
+{l_extendedprice}  101373.00      1.44           94967.00            1.37                0.00            1.00
+{l_orderkey}       101373.00      1.44           96219.00            1.31                0.00            1.00
 {l_shipdate}       101373.00      1.44           731.00              1.00                0.00            1.00
-{l_suppkey}        101373.00      1.44           530.00              1.51                0.00            1.00
-{n_name}           101373.00      1.44           1.00                2.00 <==            0.00            1.00
-{n_name_1}         101373.00      1.44           1.00                2.00 <==            0.00            1.00
-{n_nationkey}      101373.00      1.44           1.00                2.00 <==            0.00            1.00
-{n_nationkey_1}    101373.00      1.44           1.00                2.00 <==            0.00            1.00
-{s_nationkey}      101373.00      1.44           1.00                2.00 <==            0.00            1.00
-{s_suppkey}        101373.00      1.44           530.00              1.51                0.00            1.00
+{l_suppkey}        101373.00      1.44           6374.00             7.99 <==            0.00            1.00
+{n_name}           101373.00      1.44           2.00                1.00                0.00            1.00
+{n_name_1}         101373.00      1.44           2.00                1.00                0.00            1.00
+{n_nationkey}      101373.00      1.44           25.00               12.50 <==           0.00            1.00
+{n_nationkey_1}    101373.00      1.44           25.00               12.50 <==           0.00            1.00
+{s_nationkey}      101373.00      1.44           25.00               12.50 <==           0.00            1.00
+{s_suppkey}        101373.00      1.44           6374.00             7.99 <==            0.00            1.00
 
 stats table=q7_lookup_join_8
 ----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q21
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q21
@@ -80,32 +80,32 @@ limit
  │         ├── stats: [rows=8389.30056, distinct(2)=8389.30056, null(2)=0, distinct(75)=8389.30056, null(75)=0]
  │         ├── key: (2)
  │         ├── fd: (2)-->(75)
- │         ├── inner-join (lookup orders)
+ │         ├── anti-join (lookup lineitem)
  │         │    ├── save-table-name: q21_lookup_join_4
  │         │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:9(int!null) l1.l_suppkey:11(int!null) l1.l_commitdate:20(date!null) l1.l_receiptdate:21(date!null) o_orderkey:26(int!null) o_orderstatus:28(char!null) n_nationkey:36(int!null) n_name:37(char!null)
- │         │    ├── key columns: [9] = [26]
- │         │    ├── lookup columns are key
+ │         │    ├── key columns: [9] = [58]
  │         │    ├── stats: [rows=17924.776, distinct(1)=8350.92287, null(1)=0, distinct(2)=8389.30056, null(2)=0, distinct(4)=1, null(4)=0, distinct(9)=17713.0676, null(9)=0, distinct(11)=8350.92287, null(11)=0, distinct(20)=2464.51974, null(20)=0, distinct(21)=2552.02044, null(21)=0, distinct(26)=17713.0676, null(26)=0, distinct(28)=1, null(28)=0, distinct(36)=1, null(36)=0, distinct(37)=1, null(37)=0]
  │         │    ├── fd: ()-->(28,37), (1)-->(2,4), (9)==(26), (26)==(9), (1)==(11), (11)==(1), (4)==(36), (36)==(4)
- │         │    ├── anti-join (lookup lineitem)
+ │         │    ├── semi-join (lookup lineitem)
  │         │    │    ├── save-table-name: q21_lookup_join_5
- │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:9(int!null) l1.l_suppkey:11(int!null) l1.l_commitdate:20(date!null) l1.l_receiptdate:21(date!null) n_nationkey:36(int!null) n_name:37(char!null)
- │         │    │    ├── key columns: [9] = [58]
- │         │    │    ├── stats: [rows=17924.776, distinct(1)=399.934613, null(1)=0, distinct(2)=399.991883, null(2)=0, distinct(4)=1, null(4)=0, distinct(9)=17924.776, null(9)=0, distinct(11)=399.934613, null(11)=0, distinct(20)=2465.98023, null(20)=0, distinct(21)=2553.96876, null(21)=0, distinct(36)=1, null(36)=0, distinct(37)=1, null(37)=0]
- │         │    │    ├── fd: ()-->(37), (1)-->(2,4), (4)==(36), (36)==(4), (1)==(11), (11)==(1)
- │         │    │    ├── semi-join (lookup lineitem)
+ │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:9(int!null) l1.l_suppkey:11(int!null) l1.l_commitdate:20(date!null) l1.l_receiptdate:21(date!null) o_orderkey:26(int!null) o_orderstatus:28(char!null) n_nationkey:36(int!null) n_name:37(char!null)
+ │         │    │    ├── key columns: [9] = [41]
+ │         │    │    ├── stats: [rows=20161.2903, distinct(1)=399.934613, null(1)=0, distinct(2)=399.991883, null(2)=0, distinct(4)=1, null(4)=0, distinct(9)=19761.1976, null(9)=0, distinct(11)=399.934613, null(11)=0, distinct(20)=2465.30633, null(20)=0, distinct(21)=2553.04781, null(21)=0, distinct(26)=19761.1976, null(26)=0, distinct(28)=1, null(28)=0, distinct(36)=1, null(36)=0, distinct(37)=1, null(37)=0]
+ │         │    │    ├── fd: ()-->(28,37), (1)-->(2,4), (4)==(36), (36)==(4), (9)==(26), (26)==(9), (1)==(11), (11)==(1)
+ │         │    │    ├── inner-join (lookup orders)
  │         │    │    │    ├── save-table-name: q21_lookup_join_6
- │         │    │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:9(int!null) l1.l_suppkey:11(int!null) l1.l_commitdate:20(date!null) l1.l_receiptdate:21(date!null) n_nationkey:36(int!null) n_name:37(char!null)
- │         │    │    │    ├── key columns: [9] = [41]
- │         │    │    │    ├── stats: [rows=26887.164, distinct(1)=399.934613, null(1)=0, distinct(2)=399.991883, null(2)=0, distinct(4)=1, null(4)=0, distinct(9)=26887.164, null(9)=0, distinct(11)=399.934613, null(11)=0, distinct(20)=2465.99571, null(20)=0, distinct(21)=2553.99299, null(21)=0, distinct(36)=1, null(36)=0, distinct(37)=1, null(37)=0]
- │         │    │    │    ├── fd: ()-->(37), (1)-->(2,4), (4)==(36), (36)==(4), (1)==(11), (11)==(1)
+ │         │    │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:9(int!null) l1.l_suppkey:11(int!null) l1.l_commitdate:20(date!null) l1.l_receiptdate:21(date!null) o_orderkey:26(int!null) o_orderstatus:28(char!null) n_nationkey:36(int!null) n_name:37(char!null)
+ │         │    │    │    ├── key columns: [9] = [26]
+ │         │    │    │    ├── lookup columns are key
+ │         │    │    │    ├── stats: [rows=33144.2984, distinct(1)=399.934613, null(1)=0, distinct(2)=399.991883, null(2)=0, distinct(4)=1, null(4)=0, distinct(9)=32071.1941, null(9)=0, distinct(11)=399.934613, null(11)=0, distinct(20)=2465.99641, null(20)=0, distinct(21)=2553.9941, null(21)=0, distinct(26)=32071.1941, null(26)=0, distinct(28)=1, null(28)=0, distinct(36)=1, null(36)=0, distinct(37)=1, null(37)=0]
+ │         │    │    │    ├── fd: ()-->(28,37), (1)-->(2,4), (4)==(36), (36)==(4), (9)==(26), (26)==(9), (1)==(11), (11)==(1)
  │         │    │    │    ├── inner-join (lookup lineitem)
  │         │    │    │    │    ├── save-table-name: q21_lookup_join_7
  │         │    │    │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:9(int!null) l1.l_suppkey:11(int!null) l1.l_commitdate:20(date!null) l1.l_receiptdate:21(date!null) n_nationkey:36(int!null) n_name:37(char!null)
  │         │    │    │    │    ├── key columns: [9 12] = [9 12]
  │         │    │    │    │    ├── lookup columns are key
- │         │    │    │    │    ├── stats: [rows=80661.4919, distinct(1)=399.934613, null(1)=0, distinct(2)=399.991883, null(2)=0, distinct(4)=1, null(4)=0, distinct(9)=78049.9358, null(9)=0, distinct(11)=399.934613, null(11)=0, distinct(20)=2466, null(20)=0, distinct(21)=2554, null(21)=0, distinct(36)=1, null(36)=0, distinct(37)=1, null(37)=0]
- │         │    │    │    │    ├── fd: ()-->(37), (1)-->(2,4), (4)==(36), (36)==(4), (1)==(11), (11)==(1)
+ │         │    │    │    │    ├── stats: [rows=80661.4919, distinct(1)=9917.5305, null(1)=0, distinct(2)=9987.36419, null(2)=0, distinct(4)=1, null(4)=0, distinct(9)=78972.5618, null(9)=0, distinct(11)=9917.5305, null(11)=0, distinct(20)=2466, null(20)=0, distinct(21)=2554, null(21)=0, distinct(36)=1, null(36)=0, distinct(37)=1, null(37)=0]
+ │         │    │    │    │    ├── fd: ()-->(37), (1)-->(2,4), (1)==(11), (11)==(1), (4)==(36), (36)==(4)
  │         │    │    │    │    ├── inner-join (lookup lineitem@l_sk)
  │         │    │    │    │    │    ├── save-table-name: q21_lookup_join_8
  │         │    │    │    │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:9(int!null) l1.l_suppkey:11(int!null) l1.l_linenumber:12(int!null) n_nationkey:36(int!null) n_name:37(char!null)
@@ -150,12 +150,12 @@ limit
  │         │    │    │    │    └── filters
  │         │    │    │    │         └── l1.l_receiptdate:21 > l1.l_commitdate:20 [type=bool, outer=(20,21), constraints=(/20: (/NULL - ]; /21: (/NULL - ])]
  │         │    │    │    └── filters
- │         │    │    │         └── l2.l_suppkey:43 != l1.l_suppkey:11 [type=bool, outer=(11,43), constraints=(/11: (/NULL - ]; /43: (/NULL - ])]
+ │         │    │    │         └── o_orderstatus:28 = 'F' [type=bool, outer=(28), constraints=(/28: [/'F' - /'F']; tight), fd=()-->(28)]
  │         │    │    └── filters
- │         │    │         ├── l3.l_suppkey:60 != l1.l_suppkey:11 [type=bool, outer=(11,60), constraints=(/11: (/NULL - ]; /60: (/NULL - ])]
- │         │    │         └── l3.l_receiptdate:70 > l3.l_commitdate:69 [type=bool, outer=(69,70), constraints=(/69: (/NULL - ]; /70: (/NULL - ])]
+ │         │    │         └── l2.l_suppkey:43 != l1.l_suppkey:11 [type=bool, outer=(11,43), constraints=(/11: (/NULL - ]; /43: (/NULL - ])]
  │         │    └── filters
- │         │         └── o_orderstatus:28 = 'F' [type=bool, outer=(28), constraints=(/28: [/'F' - /'F']; tight), fd=()-->(28)]
+ │         │         ├── l3.l_suppkey:60 != l1.l_suppkey:11 [type=bool, outer=(11,60), constraints=(/11: (/NULL - ]; /60: (/NULL - ])]
+ │         │         └── l3.l_receiptdate:70 > l3.l_commitdate:69 [type=bool, outer=(69,70), constraints=(/69: (/NULL - ]; /70: (/NULL - ])]
  │         └── aggregations
  │              └── count-rows [as=count_rows:75, type=int]
  └── 100 [type=int]
@@ -221,50 +221,58 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 stats table=q21_lookup_join_5
 ----
 column_names     row_count  distinct_count  null_count
-{l_commitdate}   8357       2357            0
-{l_orderkey}     8357       8343            0
-{l_receiptdate}  8357       2379            0
-{l_suppkey}      8357       411             0
-{n_name}         8357       1               0
-{n_nationkey}    8357       1               0
-{s_name}         8357       411             0
-{s_nationkey}    8357       1               0
-{s_suppkey}      8357       411             0
+{l_commitdate}   73089      1242            0
+{l_orderkey}     73089      69412           0
+{l_receiptdate}  73089      1255            0
+{l_suppkey}      73089      411             0
+{n_name}         73089      1               0
+{n_nationkey}    73089      1               0
+{o_orderkey}     73089      69412           0
+{o_orderstatus}  73089      1               0
+{s_name}         73089      411             0
+{s_nationkey}    73089      1               0
+{s_suppkey}      73089      411             0
 ~~~~
 column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_commitdate}   17925.00       2.14 <==       2466.00             1.05                0.00            1.00
-{l_orderkey}     17925.00       2.14 <==       17925.00            2.15 <==            0.00            1.00
-{l_receiptdate}  17925.00       2.14 <==       2554.00             1.07                0.00            1.00
-{l_suppkey}      17925.00       2.14 <==       400.00              1.03                0.00            1.00
-{n_name}         17925.00       2.14 <==       1.00                1.00                0.00            1.00
-{n_nationkey}    17925.00       2.14 <==       1.00                1.00                0.00            1.00
-{s_name}         17925.00       2.14 <==       400.00              1.03                0.00            1.00
-{s_nationkey}    17925.00       2.14 <==       1.00                1.00                0.00            1.00
-{s_suppkey}      17925.00       2.14 <==       400.00              1.03                0.00            1.00
+{l_commitdate}   20161.00       3.63 <==       2465.00             1.98 <==            0.00            1.00
+{l_orderkey}     20161.00       3.63 <==       19761.00            3.51 <==            0.00            1.00
+{l_receiptdate}  20161.00       3.63 <==       2553.00             2.03 <==            0.00            1.00
+{l_suppkey}      20161.00       3.63 <==       400.00              1.03                0.00            1.00
+{n_name}         20161.00       3.63 <==       1.00                1.00                0.00            1.00
+{n_nationkey}    20161.00       3.63 <==       1.00                1.00                0.00            1.00
+{o_orderkey}     20161.00       3.63 <==       19761.00            3.51 <==            0.00            1.00
+{o_orderstatus}  20161.00       3.63 <==       1.00                1.00                0.00            1.00
+{s_name}         20161.00       3.63 <==       400.00              1.03                0.00            1.00
+{s_nationkey}    20161.00       3.63 <==       1.00                1.00                0.00            1.00
+{s_suppkey}      20161.00       3.63 <==       400.00              1.03                0.00            1.00
 
 stats table=q21_lookup_join_6
 ----
 column_names     row_count  distinct_count  null_count
-{l_commitdate}   151237     2464            0
-{l_orderkey}     151237     144608          0
-{l_receiptdate}  151237     2512            0
-{l_suppkey}      151237     411             0
-{n_name}         151237     1               0
-{n_nationkey}    151237     1               0
-{s_name}         151237     411             0
-{s_nationkey}    151237     1               0
-{s_suppkey}      151237     411             0
+{l_commitdate}   75871      1245            0
+{l_orderkey}     75871      71921           0
+{l_receiptdate}  75871      1255            0
+{l_suppkey}      75871      411             0
+{n_name}         75871      1               0
+{n_nationkey}    75871      1               0
+{o_orderkey}     75871      71921           0
+{o_orderstatus}  75871      1               0
+{s_name}         75871      411             0
+{s_nationkey}    75871      1               0
+{s_suppkey}      75871      411             0
 ~~~~
 column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_commitdate}   26887.00       5.62 <==       2466.00             1.00                0.00            1.00
-{l_orderkey}     26887.00       5.62 <==       26887.00            5.38 <==            0.00            1.00
-{l_receiptdate}  26887.00       5.62 <==       2554.00             1.02                0.00            1.00
-{l_suppkey}      26887.00       5.62 <==       400.00              1.03                0.00            1.00
-{n_name}         26887.00       5.62 <==       1.00                1.00                0.00            1.00
-{n_nationkey}    26887.00       5.62 <==       1.00                1.00                0.00            1.00
-{s_name}         26887.00       5.62 <==       400.00              1.03                0.00            1.00
-{s_nationkey}    26887.00       5.62 <==       1.00                1.00                0.00            1.00
-{s_suppkey}      26887.00       5.62 <==       400.00              1.03                0.00            1.00
+{l_commitdate}   33144.00       2.29 <==       2466.00             1.98 <==            0.00            1.00
+{l_orderkey}     33144.00       2.29 <==       32071.00            2.24 <==            0.00            1.00
+{l_receiptdate}  33144.00       2.29 <==       2554.00             2.04 <==            0.00            1.00
+{l_suppkey}      33144.00       2.29 <==       400.00              1.03                0.00            1.00
+{n_name}         33144.00       2.29 <==       1.00                1.00                0.00            1.00
+{n_nationkey}    33144.00       2.29 <==       1.00                1.00                0.00            1.00
+{o_orderkey}     33144.00       2.29 <==       32071.00            2.24 <==            0.00            1.00
+{o_orderstatus}  33144.00       2.29 <==       1.00                1.00                0.00            1.00
+{s_name}         33144.00       2.29 <==       400.00              1.03                0.00            1.00
+{s_nationkey}    33144.00       2.29 <==       1.00                1.00                0.00            1.00
+{s_suppkey}      33144.00       2.29 <==       400.00              1.03                0.00            1.00
 
 stats table=q21_lookup_join_7
 ----
@@ -281,14 +289,14 @@ column_names     row_count  distinct_count  null_count
 ~~~~
 column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {l_commitdate}   80661.00       1.94 <==       2466.00             1.00                0.00            1.00
-{l_orderkey}     80661.00       1.94 <==       78050.00            1.92 <==            0.00            1.00
+{l_orderkey}     80661.00       1.94 <==       78973.00            1.90                0.00            1.00
 {l_receiptdate}  80661.00       1.94 <==       2554.00             1.02                0.00            1.00
-{l_suppkey}      80661.00       1.94 <==       400.00              1.03                0.00            1.00
+{l_suppkey}      80661.00       1.94 <==       9918.00             24.13 <==           0.00            1.00
 {n_name}         80661.00       1.94 <==       1.00                1.00                0.00            1.00
 {n_nationkey}    80661.00       1.94 <==       1.00                1.00                0.00            1.00
-{s_name}         80661.00       1.94 <==       400.00              1.03                0.00            1.00
+{s_name}         80661.00       1.94 <==       9987.00             24.30 <==           0.00            1.00
 {s_nationkey}    80661.00       1.94 <==       1.00                1.00                0.00            1.00
-{s_suppkey}      80661.00       1.94 <==       400.00              1.03                0.00            1.00
+{s_suppkey}      80661.00       1.94 <==       9918.00             24.13 <==           0.00            1.00
 
 stats table=q21_lookup_join_8
 ----

--- a/pkg/sql/opt/optbuilder/testdata/update_from
+++ b/pkg/sql/opt/optbuilder/testdata/update_from
@@ -214,16 +214,16 @@ update abc
       ├── grouping columns: abc.a:5!null
       ├── inner-join (hash)
       │    ├── columns: abc.a:5!null abc.b:6 abc.c:7 ab.a:9!null ab.b:10 ab.rowid:11!null ab.crdb_internal_mvcc_timestamp:12 ac.a:13!null ac.c:14 ac.rowid:15!null ac.crdb_internal_mvcc_timestamp:16
-      │    ├── scan ab
-      │    │    └── columns: ab.a:9 ab.b:10 ab.rowid:11!null ab.crdb_internal_mvcc_timestamp:12
+      │    ├── scan ac
+      │    │    └── columns: ac.a:13 ac.c:14 ac.rowid:15!null ac.crdb_internal_mvcc_timestamp:16
       │    ├── inner-join (hash)
-      │    │    ├── columns: abc.a:5!null abc.b:6 abc.c:7 ac.a:13!null ac.c:14 ac.rowid:15!null ac.crdb_internal_mvcc_timestamp:16
+      │    │    ├── columns: abc.a:5!null abc.b:6 abc.c:7 ab.a:9!null ab.b:10 ab.rowid:11!null ab.crdb_internal_mvcc_timestamp:12
       │    │    ├── scan abc
       │    │    │    └── columns: abc.a:5!null abc.b:6 abc.c:7
-      │    │    ├── scan ac
-      │    │    │    └── columns: ac.a:13 ac.c:14 ac.rowid:15!null ac.crdb_internal_mvcc_timestamp:16
+      │    │    ├── scan ab
+      │    │    │    └── columns: ab.a:9 ab.b:10 ab.rowid:11!null ab.crdb_internal_mvcc_timestamp:12
       │    │    └── filters
-      │    │         └── abc.a:5 = ac.a:13
+      │    │         └── abc.a:5 = ab.a:9
       │    └── filters
       │         └── ab.a:9 = ac.a:13
       └── aggregations
@@ -272,16 +272,16 @@ update abc
       ├── grouping columns: abc.a:5!null
       ├── inner-join (hash)
       │    ├── columns: abc.a:5!null abc.b:6 abc.c:7 ab.a:9!null ab.b:10 ac.a:13!null ac.c:14
-      │    ├── scan ab
-      │    │    └── columns: ab.a:9 ab.b:10
+      │    ├── scan ac
+      │    │    └── columns: ac.a:13 ac.c:14
       │    ├── inner-join (hash)
-      │    │    ├── columns: abc.a:5!null abc.b:6 abc.c:7 ac.a:13!null ac.c:14
+      │    │    ├── columns: abc.a:5!null abc.b:6 abc.c:7 ab.a:9!null ab.b:10
       │    │    ├── scan abc
       │    │    │    └── columns: abc.a:5!null abc.b:6 abc.c:7
-      │    │    ├── scan ac
-      │    │    │    └── columns: ac.a:13 ac.c:14
+      │    │    ├── scan ab
+      │    │    │    └── columns: ab.a:9 ab.b:10
       │    │    └── filters
-      │    │         └── abc.a:5 = ac.a:13
+      │    │         └── abc.a:5 = ab.a:9
       │    └── filters
       │         └── ab.a:9 = ac.a:13
       └── aggregations
@@ -321,16 +321,16 @@ update abc
       ├── grouping columns: abc.a:5!null
       ├── inner-join (hash)
       │    ├── columns: abc.a:5!null abc.b:6 abc.c:7 ab.a:9!null ab.b:10 ab.rowid:11!null ac.a:13!null ac.c:14 ac.rowid:15!null
-      │    ├── scan ab
-      │    │    └── columns: ab.a:9 ab.b:10 ab.rowid:11!null
+      │    ├── scan ac
+      │    │    └── columns: ac.a:13 ac.c:14 ac.rowid:15!null
       │    ├── inner-join (hash)
-      │    │    ├── columns: abc.a:5!null abc.b:6 abc.c:7 ac.a:13!null ac.c:14 ac.rowid:15!null
+      │    │    ├── columns: abc.a:5!null abc.b:6 abc.c:7 ab.a:9!null ab.b:10 ab.rowid:11!null
       │    │    ├── scan abc
       │    │    │    └── columns: abc.a:5!null abc.b:6 abc.c:7
-      │    │    ├── scan ac
-      │    │    │    └── columns: ac.a:13 ac.c:14 ac.rowid:15!null
+      │    │    ├── scan ab
+      │    │    │    └── columns: ab.a:9 ab.b:10 ab.rowid:11!null
       │    │    └── filters
-      │    │         └── abc.a:5 = ac.a:13
+      │    │         └── abc.a:5 = ab.a:9
       │    └── filters
       │         └── ab.a:9 = ac.a:13
       └── aggregations

--- a/pkg/sql/opt/testutils/opttester/testdata/explore-trace
+++ b/pkg/sql/opt/testutils/opttester/testdata/explore-trace
@@ -166,12 +166,12 @@ New expression 2 of 2:
   sort
    └── project
         └── inner-join (hash)
-             ├── scan child
              ├── inner-join (hash)
              │    ├── scan grandchild
              │    ├── scan parent
              │    └── filters
              │         └── grandchild.pid = parent.pid
+             ├── scan child
              └── filters
                   ├── grandchild.pid = child.pid
                   └── grandchild.cid = child.cid

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -185,7 +185,7 @@ project
  │    │    │         ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (73)~~>(74), (74)~~>(73), (78)-->(79), (98)-->(99), (126)-->(127,128), (130)-->(131), (131)-->(130)
  │    │    │         ├── right-join (hash)
  │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 i.inhrelid:41 i.inhparent:42 c2.oid:45 c2.relname:46 c2.relnamespace:47 indexrelid:78 indrelid:79 indisclustered:85 ci.oid:98 ci.relname:99 ftrelid:126 ftserver:127 ftoptions:128 fs.oid:130 srvname:131
- │    │    │         │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130), (78)-->(79), (1,78)-->(85,98,99), (98)-->(99), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+ │    │    │         │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (78)-->(79,98,99), (98)~~>(99), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130)
  │    │    │         │    ├── inner-join (hash)
  │    │    │         │    │    ├── columns: i.inhrelid:41!null i.inhparent:42!null c2.oid:45!null c2.relname:46!null c2.relnamespace:47!null
  │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -203,11 +203,11 @@ project
  │    │    │         │    │    ├── key columns: [78] = [98]
  │    │    │         │    │    ├── lookup columns are key
  │    │    │         │    │    ├── key: (1,78)
- │    │    │         │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130), (78)-->(79), (1,78)-->(34,35,85,98,99), (98)-->(99), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+ │    │    │         │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (78)-->(79,98,99), (98)~~>(99), (1,78)-->(85,126-128,130,131), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130)
  │    │    │         │    │    ├── right-join (hash)
  │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 indexrelid:78 indrelid:79 indisclustered:85 ftrelid:126 ftserver:127 ftoptions:128 fs.oid:130 srvname:131
  │    │    │         │    │    │    ├── key: (1,78)
- │    │    │         │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130), (78)-->(79), (1,78)-->(34,35,85), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+ │    │    │         │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (78)-->(79), (1,78)-->(85,126-128,130,131), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130)
  │    │    │         │    │    │    ├── select
  │    │    │         │    │    │    │    ├── columns: indexrelid:78!null indrelid:79!null indisclustered:85!null
  │    │    │         │    │    │    │    ├── key: (78)
@@ -218,24 +218,24 @@ project
  │    │    │         │    │    │    │    │    └── fd: (78)-->(79,85)
  │    │    │         │    │    │    │    └── filters
  │    │    │         │    │    │    │         └── indisclustered:85 = true [outer=(85), constraints=(/85: [/true - /true]; tight), fd=()-->(85)]
- │    │    │         │    │    │    ├── left-join (lookup pg_tablespace)
+ │    │    │         │    │    │    ├── left-join (lookup pg_foreign_server)
  │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 ftrelid:126 ftserver:127 ftoptions:128 fs.oid:130 srvname:131
- │    │    │         │    │    │    │    ├── key columns: [8] = [34]
+ │    │    │         │    │    │    │    ├── key columns: [127] = [130]
  │    │    │         │    │    │    │    ├── lookup columns are key
  │    │    │         │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
- │    │    │         │    │    │    │    ├── left-join (lookup pg_foreign_server)
- │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null ftrelid:126 ftserver:127 ftoptions:128 fs.oid:130 srvname:131
- │    │    │         │    │    │    │    │    ├── key columns: [127] = [130]
+ │    │    │         │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130)
+ │    │    │         │    │    │    │    ├── left-join (lookup pg_foreign_table)
+ │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 ftrelid:126 ftserver:127 ftoptions:128
+ │    │    │         │    │    │    │    │    ├── key columns: [1] = [126]
  │    │    │         │    │    │    │    │    ├── lookup columns are key
  │    │    │         │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130), (3)==(29), (29)==(3)
- │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_table)
- │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null ftrelid:126 ftserver:127 ftoptions:128
- │    │    │         │    │    │    │    │    │    ├── key columns: [1] = [126]
+ │    │    │         │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (126)-->(127,128)
+ │    │    │         │    │    │    │    │    ├── left-join (lookup pg_tablespace)
+ │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35
+ │    │    │         │    │    │    │    │    │    ├── key columns: [8] = [34]
  │    │    │         │    │    │    │    │    │    ├── lookup columns are key
  │    │    │         │    │    │    │    │    │    ├── key: (1)
- │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (3)==(29), (29)==(3)
+ │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34)
  │    │    │         │    │    │    │    │    │    ├── inner-join (hash)
  │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null
  │    │    │         │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -189,7 +189,7 @@ sort
       │    │    │         ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (73)~~>(74), (74)~~>(73), (78)-->(79), (98)-->(99), (126)-->(127,128), (130)-->(131), (131)-->(130)
       │    │    │         ├── right-join (hash)
       │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 i.inhrelid:41 i.inhparent:42 c2.oid:45 c2.relname:46 c2.relnamespace:47 indexrelid:78 indrelid:79 indisclustered:85 ci.oid:98 ci.relname:99 ftrelid:126 ftserver:127 ftoptions:128 fs.oid:130 srvname:131
-      │    │    │         │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130), (78)-->(79), (1,78)-->(85,98,99), (98)-->(99), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+      │    │    │         │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (45)-->(46,47), (46,47)-->(45), (42)==(45), (45)==(42), (78)-->(79,98,99), (98)~~>(99), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130)
       │    │    │         │    ├── inner-join (hash)
       │    │    │         │    │    ├── columns: i.inhrelid:41!null i.inhparent:42!null c2.oid:45!null c2.relname:46!null c2.relnamespace:47!null
       │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -207,11 +207,11 @@ sort
       │    │    │         │    │    ├── key columns: [78] = [98]
       │    │    │         │    │    ├── lookup columns are key
       │    │    │         │    │    ├── key: (1,78)
-      │    │    │         │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130), (78)-->(79), (1,78)-->(34,35,85,98,99), (98)-->(99), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+      │    │    │         │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (78)-->(79,98,99), (98)~~>(99), (1,78)-->(85,126-128,130,131), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130)
       │    │    │         │    │    ├── right-join (hash)
       │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 indexrelid:78 indrelid:79 indisclustered:85 ftrelid:126 ftserver:127 ftoptions:128 fs.oid:130 srvname:131
       │    │    │         │    │    │    ├── key: (1,78)
-      │    │    │         │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130), (78)-->(79), (1,78)-->(34,35,85), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
+      │    │    │         │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (78)-->(79), (1,78)-->(85,126-128,130,131), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130)
       │    │    │         │    │    │    ├── select
       │    │    │         │    │    │    │    ├── columns: indexrelid:78!null indrelid:79!null indisclustered:85!null
       │    │    │         │    │    │    │    ├── key: (78)
@@ -222,24 +222,24 @@ sort
       │    │    │         │    │    │    │    │    └── fd: (78)-->(79,85)
       │    │    │         │    │    │    │    └── filters
       │    │    │         │    │    │    │         └── indisclustered:85 = true [outer=(85), constraints=(/85: [/true - /true]; tight), fd=()-->(85)]
-      │    │    │         │    │    │    ├── left-join (lookup pg_tablespace)
+      │    │    │         │    │    │    ├── left-join (lookup pg_foreign_server)
       │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 ftrelid:126 ftserver:127 ftoptions:128 fs.oid:130 srvname:131
-      │    │    │         │    │    │    │    ├── key columns: [8] = [34]
+      │    │    │         │    │    │    │    ├── key columns: [127] = [130]
       │    │    │         │    │    │    │    ├── lookup columns are key
       │    │    │         │    │    │    │    ├── key: (1)
-      │    │    │         │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130), (34)-->(35), (35)-->(34), (3)==(29), (29)==(3)
-      │    │    │         │    │    │    │    ├── left-join (lookup pg_foreign_server)
-      │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null ftrelid:126 ftserver:127 ftoptions:128 fs.oid:130 srvname:131
-      │    │    │         │    │    │    │    │    ├── key columns: [127] = [130]
+      │    │    │         │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130)
+      │    │    │         │    │    │    │    ├── left-join (lookup pg_foreign_table)
+      │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35 ftrelid:126 ftserver:127 ftoptions:128
+      │    │    │         │    │    │    │    │    ├── key columns: [1] = [126]
       │    │    │         │    │    │    │    │    ├── lookup columns are key
       │    │    │         │    │    │    │    │    ├── key: (1)
-      │    │    │         │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128,130,131), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128,130,131), (130)~~>(131), (131)~~>(130), (3)==(29), (29)==(3)
-      │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_table)
-      │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null ftrelid:126 ftserver:127 ftoptions:128
-      │    │    │         │    │    │    │    │    │    ├── key columns: [1] = [126]
+      │    │    │         │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34), (126)-->(127,128)
+      │    │    │         │    │    │    │    │    ├── left-join (lookup pg_tablespace)
+      │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null t.oid:34 spcname:35
+      │    │    │         │    │    │    │    │    │    ├── key columns: [8] = [34]
       │    │    │         │    │    │    │    │    │    ├── lookup columns are key
       │    │    │         │    │    │    │    │    │    ├── key: (1)
-      │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,126-128), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (126)-->(127,128), (3)==(29), (29)==(3)
+      │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,29,30), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,34,35), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(29), (29)==(3), (34)-->(35), (35)-->(34)
       │    │    │         │    │    │    │    │    │    ├── inner-join (hash)
       │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:29!null n.nspname:30!null
       │    │    │         │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -780,34 +780,34 @@ project
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1,4-16,18-20,22-26,28-32,34-36,38-44,46-50,52-54)
- │    ├── inner-join (lookup address)
+ │    ├── inner-join (lookup zip_code)
  │    │    ├── columns: s_symb:1!null s_name:4!null s_ex_id:5!null s_co_id:6!null s_num_out:7!null s_start_date:8!null s_exch_date:9!null security.s_pe:10!null security.s_52wk_high:11!null s_52wk_high_date:12!null security.s_52wk_low:13!null s_52wk_low_date:14!null security.s_dividend:15!null security.s_yield:16!null co_id:18!null co_st_id:19!null co_name:20!null co_sp_rate:22!null co_ceo:23!null co_ad_id:24!null co_desc:25!null co_open_date:26!null ca.ad_id:28!null ca.ad_line1:29 ca.ad_line2:30 ca.ad_zc_code:31!null ca.ad_ctry:32 zca.zc_code:34!null zca.zc_town:35!null zca.zc_div:36!null ex_id:38!null ex_name:39!null ex_num_symb:40!null ex_open:41!null ex_close:42!null ex_desc:43 ex_ad_id:44!null ea.ad_id:46!null ea.ad_line1:47 ea.ad_line2:48 ea.ad_zc_code:49!null ea.ad_ctry:50
- │    │    ├── key columns: [44] = [46]
+ │    │    ├── key columns: [31] = [34]
  │    │    ├── lookup columns are key
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1,4-16,18-20,22-26,28-32,34-36,38-44,46-50)
- │    │    ├── inner-join (lookup exchange)
- │    │    │    ├── columns: s_symb:1!null s_name:4!null s_ex_id:5!null s_co_id:6!null s_num_out:7!null s_start_date:8!null s_exch_date:9!null security.s_pe:10!null security.s_52wk_high:11!null s_52wk_high_date:12!null security.s_52wk_low:13!null s_52wk_low_date:14!null security.s_dividend:15!null security.s_yield:16!null co_id:18!null co_st_id:19!null co_name:20!null co_sp_rate:22!null co_ceo:23!null co_ad_id:24!null co_desc:25!null co_open_date:26!null ca.ad_id:28!null ca.ad_line1:29 ca.ad_line2:30 ca.ad_zc_code:31!null ca.ad_ctry:32 zca.zc_code:34!null zca.zc_town:35!null zca.zc_div:36!null ex_id:38!null ex_name:39!null ex_num_symb:40!null ex_open:41!null ex_close:42!null ex_desc:43 ex_ad_id:44!null
- │    │    │    ├── key columns: [5] = [38]
+ │    │    ├── inner-join (lookup address)
+ │    │    │    ├── columns: s_symb:1!null s_name:4!null s_ex_id:5!null s_co_id:6!null s_num_out:7!null s_start_date:8!null s_exch_date:9!null security.s_pe:10!null security.s_52wk_high:11!null s_52wk_high_date:12!null security.s_52wk_low:13!null s_52wk_low_date:14!null security.s_dividend:15!null security.s_yield:16!null co_id:18!null co_st_id:19!null co_name:20!null co_sp_rate:22!null co_ceo:23!null co_ad_id:24!null co_desc:25!null co_open_date:26!null ca.ad_id:28!null ca.ad_line1:29 ca.ad_line2:30 ca.ad_zc_code:31!null ca.ad_ctry:32 ex_id:38!null ex_name:39!null ex_num_symb:40!null ex_open:41!null ex_close:42!null ex_desc:43 ex_ad_id:44!null ea.ad_id:46!null ea.ad_line1:47 ea.ad_line2:48 ea.ad_zc_code:49!null ea.ad_ctry:50
+ │    │    │    ├── key columns: [44] = [46]
  │    │    │    ├── lookup columns are key
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(1,4-16,18-20,22-26,28-32,34-36,38-44)
- │    │    │    ├── inner-join (lookup zip_code)
- │    │    │    │    ├── columns: s_symb:1!null s_name:4!null s_ex_id:5!null s_co_id:6!null s_num_out:7!null s_start_date:8!null s_exch_date:9!null security.s_pe:10!null security.s_52wk_high:11!null s_52wk_high_date:12!null security.s_52wk_low:13!null s_52wk_low_date:14!null security.s_dividend:15!null security.s_yield:16!null co_id:18!null co_st_id:19!null co_name:20!null co_sp_rate:22!null co_ceo:23!null co_ad_id:24!null co_desc:25!null co_open_date:26!null ca.ad_id:28!null ca.ad_line1:29 ca.ad_line2:30 ca.ad_zc_code:31!null ca.ad_ctry:32 zca.zc_code:34!null zca.zc_town:35!null zca.zc_div:36!null
- │    │    │    │    ├── key columns: [31] = [34]
+ │    │    │    ├── fd: ()-->(1,4-16,18-20,22-26,28-32,38-44,46-50)
+ │    │    │    ├── inner-join (lookup address)
+ │    │    │    │    ├── columns: s_symb:1!null s_name:4!null s_ex_id:5!null s_co_id:6!null s_num_out:7!null s_start_date:8!null s_exch_date:9!null security.s_pe:10!null security.s_52wk_high:11!null s_52wk_high_date:12!null security.s_52wk_low:13!null s_52wk_low_date:14!null security.s_dividend:15!null security.s_yield:16!null co_id:18!null co_st_id:19!null co_name:20!null co_sp_rate:22!null co_ceo:23!null co_ad_id:24!null co_desc:25!null co_open_date:26!null ca.ad_id:28!null ca.ad_line1:29 ca.ad_line2:30 ca.ad_zc_code:31!null ca.ad_ctry:32 ex_id:38!null ex_name:39!null ex_num_symb:40!null ex_open:41!null ex_close:42!null ex_desc:43 ex_ad_id:44!null
+ │    │    │    │    ├── key columns: [24] = [28]
  │    │    │    │    ├── lookup columns are key
  │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(1,4-16,18-20,22-26,28-32,34-36)
- │    │    │    │    ├── inner-join (lookup address)
- │    │    │    │    │    ├── columns: s_symb:1!null s_name:4!null s_ex_id:5!null s_co_id:6!null s_num_out:7!null s_start_date:8!null s_exch_date:9!null security.s_pe:10!null security.s_52wk_high:11!null s_52wk_high_date:12!null security.s_52wk_low:13!null s_52wk_low_date:14!null security.s_dividend:15!null security.s_yield:16!null co_id:18!null co_st_id:19!null co_name:20!null co_sp_rate:22!null co_ceo:23!null co_ad_id:24!null co_desc:25!null co_open_date:26!null ca.ad_id:28!null ca.ad_line1:29 ca.ad_line2:30 ca.ad_zc_code:31!null ca.ad_ctry:32
- │    │    │    │    │    ├── key columns: [24] = [28]
+ │    │    │    │    ├── fd: ()-->(1,4-16,18-20,22-26,28-32,38-44)
+ │    │    │    │    ├── inner-join (lookup exchange)
+ │    │    │    │    │    ├── columns: s_symb:1!null s_name:4!null s_ex_id:5!null s_co_id:6!null s_num_out:7!null s_start_date:8!null s_exch_date:9!null security.s_pe:10!null security.s_52wk_high:11!null s_52wk_high_date:12!null security.s_52wk_low:13!null s_52wk_low_date:14!null security.s_dividend:15!null security.s_yield:16!null co_id:18!null co_st_id:19!null co_name:20!null co_sp_rate:22!null co_ceo:23!null co_ad_id:24!null co_desc:25!null co_open_date:26!null ex_id:38!null ex_name:39!null ex_num_symb:40!null ex_open:41!null ex_close:42!null ex_desc:43 ex_ad_id:44!null
+ │    │    │    │    │    ├── key columns: [5] = [38]
  │    │    │    │    │    ├── lookup columns are key
  │    │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    │    ├── key: ()
- │    │    │    │    │    ├── fd: ()-->(1,4-16,18-20,22-26,28-32)
+ │    │    │    │    │    ├── fd: ()-->(1,4-16,18-20,22-26,38-44)
  │    │    │    │    │    ├── inner-join (lookup company)
  │    │    │    │    │    │    ├── columns: s_symb:1!null s_name:4!null s_ex_id:5!null s_co_id:6!null s_num_out:7!null s_start_date:8!null s_exch_date:9!null security.s_pe:10!null security.s_52wk_high:11!null s_52wk_high_date:12!null security.s_52wk_low:13!null s_52wk_low_date:14!null security.s_dividend:15!null security.s_yield:16!null co_id:18!null co_st_id:19!null co_name:20!null co_sp_rate:22!null co_ceo:23!null co_ad_id:24!null co_desc:25!null co_open_date:26!null
  │    │    │    │    │    │    ├── key columns: [6] = [18]
@@ -3180,7 +3180,7 @@ project
  │    │    ├── lookup columns are key
  │    │    ├── cardinality: [0 - 50]
  │    │    ├── key: (1)
- │    │    ├── fd: ()-->(9), (17)-->(18), (20)-->(21), (1)-->(2-4,6,7,10,12), (25)-->(28,29), (6)==(25), (25)==(6), (4)==(20), (20)==(4), (3)==(17), (17)==(3)
+ │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12), (17)-->(18), (3)==(17), (17)==(3), (20)-->(21), (4)==(20), (20)==(4), (25)-->(28,29), (6)==(25), (25)==(6)
  │    │    ├── ordering: -2 opt(9) [actual: -2]
  │    │    ├── inner-join (lookup trade_type)
  │    │    │    ├── columns: t_id:1!null t_dts:2!null t_st_id:3!null t_tt_id:4!null t_s_symb:6!null t_qty:7!null t_ca_id:9!null t_exec_name:10!null trade.t_chrg:12!null st_id:17!null st_name:18!null tt_id:20!null tt_name:21!null

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -177,7 +177,7 @@ project
       │         │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null r_regionkey:30!null r_name:31!null ps_partkey:34!null ps_suppkey:35!null ps_supplycost:37!null
       │         │    │    │    ├── key columns: [1] = [34]
       │         │    │    │    ├── key: (20,34,35)
-      │         │    │    │    ├── fd: ()-->(6,31), (1)-->(3,5), (25)-->(26,27), (11)-->(12-17), (19,20)-->(22), (34,35)-->(37), (19)==(1,34), (34)==(1,19), (11)==(20), (20)==(11), (14)==(25), (25)==(14), (27)==(30), (30)==(27), (1)==(19,34)
+      │         │    │    │    ├── fd: ()-->(6,31), (1)-->(3,5), (11)-->(12-17), (19,20)-->(22), (34,35)-->(37), (19)==(1,34), (34)==(1,19), (11)==(20), (20)==(11), (25)-->(26,27), (27)==(30), (30)==(27), (14)==(25), (25)==(14), (1)==(19,34)
       │         │    │    │    ├── inner-join (hash)
       │         │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null r_regionkey:30!null r_name:31!null
       │         │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -522,12 +522,12 @@ sort
       │    │    ├── inner-join (lookup lineitem)
       │    │    │    ├── columns: c_custkey:1!null c_nationkey:4!null o_orderkey:10!null o_custkey:11!null o_orderdate:14!null l_orderkey:20!null l_suppkey:22!null l_extendedprice:25!null l_discount:26!null n_nationkey:45!null n_name:46!null n_regionkey:47!null r_regionkey:50!null r_name:51!null
       │    │    │    ├── key columns: [10] = [20]
-      │    │    │    ├── fd: ()-->(51), (10)-->(11,14), (1)-->(4), (45)-->(46,47), (47)==(50), (50)==(47), (4)==(45), (45)==(4), (1)==(11), (11)==(1), (10)==(20), (20)==(10)
+      │    │    │    ├── fd: ()-->(51), (1)-->(4), (45)-->(46,47), (47)==(50), (50)==(47), (4)==(45), (45)==(4), (10)-->(11,14), (10)==(20), (20)==(10), (1)==(11), (11)==(1)
       │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── columns: c_custkey:1!null c_nationkey:4!null o_orderkey:10!null o_custkey:11!null o_orderdate:14!null n_nationkey:45!null n_name:46!null n_regionkey:47!null r_regionkey:50!null r_name:51!null
       │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       │    │    │    │    ├── key: (10)
-      │    │    │    │    ├── fd: ()-->(51), (10)-->(11,14), (1)-->(4), (45)-->(46,47), (47)==(50), (50)==(47), (4)==(45), (45)==(4), (1)==(11), (11)==(1)
+      │    │    │    │    ├── fd: ()-->(51), (1)-->(4), (45)-->(46,47), (4)==(45), (45)==(4), (10)-->(11,14), (1)==(11), (11)==(1), (47)==(50), (50)==(47)
       │    │    │    │    ├── index-join orders
       │    │    │    │    │    ├── columns: o_orderkey:10!null o_custkey:11!null o_orderdate:14!null
       │    │    │    │    │    ├── key: (10)
@@ -712,12 +712,12 @@ sort
       │    │    │    ├── columns: s_suppkey:1!null s_nationkey:4!null l_orderkey:9!null l_suppkey:11!null l_extendedprice:14!null l_discount:15!null l_shipdate:19!null o_orderkey:26!null o_custkey:27!null n1.n_nationkey:45!null n1.n_name:46!null n2.n_nationkey:50!null n2.n_name:51!null
       │    │    │    ├── key columns: [9] = [26]
       │    │    │    ├── lookup columns are key
-      │    │    │    ├── fd: (26)-->(27), (1)-->(4), (45)-->(46), (50)-->(51), (4)==(45), (45)==(4), (1)==(11), (11)==(1), (9)==(26), (26)==(9)
+      │    │    │    ├── fd: (1)-->(4), (45)-->(46), (50)-->(51), (4)==(45), (45)==(4), (26)-->(27), (9)==(26), (26)==(9), (1)==(11), (11)==(1)
       │    │    │    ├── inner-join (lookup lineitem)
       │    │    │    │    ├── columns: s_suppkey:1!null s_nationkey:4!null l_orderkey:9!null l_suppkey:11!null l_extendedprice:14!null l_discount:15!null l_shipdate:19!null n1.n_nationkey:45!null n1.n_name:46!null n2.n_nationkey:50!null n2.n_name:51!null
       │    │    │    │    ├── key columns: [9 12] = [9 12]
       │    │    │    │    ├── lookup columns are key
-      │    │    │    │    ├── fd: (1)-->(4), (45)-->(46), (50)-->(51), (4)==(45), (45)==(4), (1)==(11), (11)==(1)
+      │    │    │    │    ├── fd: (1)-->(4), (45)-->(46), (4)==(45), (45)==(4), (1)==(11), (11)==(1), (50)-->(51)
       │    │    │    │    ├── inner-join (lookup lineitem@l_sk)
       │    │    │    │    │    ├── columns: s_suppkey:1!null s_nationkey:4!null l_orderkey:9!null l_suppkey:11!null l_linenumber:12!null n1.n_nationkey:45!null n1.n_name:46!null n2.n_nationkey:50!null n2.n_name:51!null
       │    │    │    │    │    ├── key columns: [1] = [11]
@@ -2330,24 +2330,24 @@ limit
  │         ├── grouping columns: s_name:2!null
  │         ├── key: (2)
  │         ├── fd: (2)-->(75)
- │         ├── inner-join (lookup orders)
+ │         ├── anti-join (lookup lineitem)
  │         │    ├── columns: s_suppkey:1!null s_name:2!null s_nationkey:4!null l1.l_orderkey:9!null l1.l_suppkey:11!null l1.l_commitdate:20!null l1.l_receiptdate:21!null o_orderkey:26!null o_orderstatus:28!null n_nationkey:36!null n_name:37!null
- │         │    ├── key columns: [9] = [26]
- │         │    ├── lookup columns are key
+ │         │    ├── key columns: [9] = [58]
  │         │    ├── fd: ()-->(28,37), (1)-->(2,4), (9)==(26), (26)==(9), (1)==(11), (11)==(1), (4)==(36), (36)==(4)
- │         │    ├── anti-join (lookup lineitem)
- │         │    │    ├── columns: s_suppkey:1!null s_name:2!null s_nationkey:4!null l1.l_orderkey:9!null l1.l_suppkey:11!null l1.l_commitdate:20!null l1.l_receiptdate:21!null n_nationkey:36!null n_name:37!null
- │         │    │    ├── key columns: [9] = [58]
- │         │    │    ├── fd: ()-->(37), (1)-->(2,4), (4)==(36), (36)==(4), (1)==(11), (11)==(1)
- │         │    │    ├── semi-join (lookup lineitem)
- │         │    │    │    ├── columns: s_suppkey:1!null s_name:2!null s_nationkey:4!null l1.l_orderkey:9!null l1.l_suppkey:11!null l1.l_commitdate:20!null l1.l_receiptdate:21!null n_nationkey:36!null n_name:37!null
- │         │    │    │    ├── key columns: [9] = [41]
- │         │    │    │    ├── fd: ()-->(37), (1)-->(2,4), (4)==(36), (36)==(4), (1)==(11), (11)==(1)
+ │         │    ├── semi-join (lookup lineitem)
+ │         │    │    ├── columns: s_suppkey:1!null s_name:2!null s_nationkey:4!null l1.l_orderkey:9!null l1.l_suppkey:11!null l1.l_commitdate:20!null l1.l_receiptdate:21!null o_orderkey:26!null o_orderstatus:28!null n_nationkey:36!null n_name:37!null
+ │         │    │    ├── key columns: [9] = [41]
+ │         │    │    ├── fd: ()-->(28,37), (1)-->(2,4), (4)==(36), (36)==(4), (9)==(26), (26)==(9), (1)==(11), (11)==(1)
+ │         │    │    ├── inner-join (lookup orders)
+ │         │    │    │    ├── columns: s_suppkey:1!null s_name:2!null s_nationkey:4!null l1.l_orderkey:9!null l1.l_suppkey:11!null l1.l_commitdate:20!null l1.l_receiptdate:21!null o_orderkey:26!null o_orderstatus:28!null n_nationkey:36!null n_name:37!null
+ │         │    │    │    ├── key columns: [9] = [26]
+ │         │    │    │    ├── lookup columns are key
+ │         │    │    │    ├── fd: ()-->(28,37), (1)-->(2,4), (4)==(36), (36)==(4), (9)==(26), (26)==(9), (1)==(11), (11)==(1)
  │         │    │    │    ├── inner-join (lookup lineitem)
  │         │    │    │    │    ├── columns: s_suppkey:1!null s_name:2!null s_nationkey:4!null l1.l_orderkey:9!null l1.l_suppkey:11!null l1.l_commitdate:20!null l1.l_receiptdate:21!null n_nationkey:36!null n_name:37!null
  │         │    │    │    │    ├── key columns: [9 12] = [9 12]
  │         │    │    │    │    ├── lookup columns are key
- │         │    │    │    │    ├── fd: ()-->(37), (1)-->(2,4), (4)==(36), (36)==(4), (1)==(11), (11)==(1)
+ │         │    │    │    │    ├── fd: ()-->(37), (1)-->(2,4), (1)==(11), (11)==(1), (4)==(36), (36)==(4)
  │         │    │    │    │    ├── inner-join (lookup lineitem@l_sk)
  │         │    │    │    │    │    ├── columns: s_suppkey:1!null s_name:2!null s_nationkey:4!null l1.l_orderkey:9!null l1.l_suppkey:11!null l1.l_linenumber:12!null n_nationkey:36!null n_name:37!null
  │         │    │    │    │    │    ├── key columns: [1] = [11]
@@ -2380,12 +2380,12 @@ limit
  │         │    │    │    │    └── filters
  │         │    │    │    │         └── l1.l_receiptdate:21 > l1.l_commitdate:20 [outer=(20,21), constraints=(/20: (/NULL - ]; /21: (/NULL - ])]
  │         │    │    │    └── filters
- │         │    │    │         └── l2.l_suppkey:43 != l1.l_suppkey:11 [outer=(11,43), constraints=(/11: (/NULL - ]; /43: (/NULL - ])]
+ │         │    │    │         └── o_orderstatus:28 = 'F' [outer=(28), constraints=(/28: [/'F' - /'F']; tight), fd=()-->(28)]
  │         │    │    └── filters
- │         │    │         ├── l3.l_suppkey:60 != l1.l_suppkey:11 [outer=(11,60), constraints=(/11: (/NULL - ]; /60: (/NULL - ])]
- │         │    │         └── l3.l_receiptdate:70 > l3.l_commitdate:69 [outer=(69,70), constraints=(/69: (/NULL - ]; /70: (/NULL - ])]
+ │         │    │         └── l2.l_suppkey:43 != l1.l_suppkey:11 [outer=(11,43), constraints=(/11: (/NULL - ]; /43: (/NULL - ])]
  │         │    └── filters
- │         │         └── o_orderstatus:28 = 'F' [outer=(28), constraints=(/28: [/'F' - /'F']; tight), fd=()-->(28)]
+ │         │         ├── l3.l_suppkey:60 != l1.l_suppkey:11 [outer=(11,60), constraints=(/11: (/NULL - ]; /60: (/NULL - ])]
+ │         │         └── l3.l_receiptdate:70 > l3.l_commitdate:69 [outer=(69,70), constraints=(/69: (/NULL - ]; /70: (/NULL - ])]
  │         └── aggregations
  │              └── count-rows [as=count_rows:75]
  └── 100

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -166,88 +166,99 @@ project
       │         ├── group-by
       │         │    ├── columns: p_partkey:1!null p_mfgr:3!null s_name:12!null s_address:13!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_name:26!null min:57!null
       │         │    ├── grouping columns: ps_partkey:19!null ps_suppkey:20!null
-      │         │    ├── internal-ordering: +(1|19|34),+(11|20) opt(6,31,54)
       │         │    ├── key: (19,20)
       │         │    ├── fd: (1)-->(3), (19,20)-->(1,3,12,13,15-17,22,26,57), (1)==(19), (19)==(1), (20)-->(12,13,15-17,26)
-      │         │    ├── inner-join (lookup region)
+      │         │    ├── inner-join (hash)
       │         │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null r_regionkey:30!null r_name:31!null ps_partkey:34!null ps_suppkey:35!null ps_supplycost:37!null s_suppkey:40!null s_nationkey:43!null n_nationkey:48!null n_regionkey:50!null r_regionkey:53!null r_name:54!null
-      │         │    │    ├── key columns: [50] = [53]
-      │         │    │    ├── lookup columns are key
+      │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       │         │    │    ├── key: (20,34,40)
       │         │    │    ├── fd: ()-->(6,31,54), (1)-->(3,5), (11)-->(12-17), (19,20)-->(22), (11)==(20), (20)==(11), (25)-->(26,27), (27)==(30), (30)==(27), (14)==(25), (25)==(14), (1)==(19,34), (19)==(1,34), (34,35)-->(37), (40)-->(43), (48)-->(50), (50)==(53), (53)==(50), (43)==(48), (48)==(43), (35)==(40), (40)==(35), (34)==(1,19)
-      │         │    │    ├── ordering: +(1|19|34),+(11|20) opt(6,31,54) [actual: +1,+20]
-      │         │    │    ├── inner-join (lookup nation)
-      │         │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null r_regionkey:30!null r_name:31!null ps_partkey:34!null ps_suppkey:35!null ps_supplycost:37!null s_suppkey:40!null s_nationkey:43!null n_nationkey:48!null n_regionkey:50!null
-      │         │    │    │    ├── key columns: [43] = [48]
-      │         │    │    │    ├── lookup columns are key
+      │         │    │    ├── inner-join (hash)
+      │         │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null r_regionkey:30!null r_name:31!null ps_partkey:34!null ps_suppkey:35!null ps_supplycost:37!null s_suppkey:40!null s_nationkey:43!null
+      │         │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(exactly-one)
       │         │    │    │    ├── key: (20,34,40)
-      │         │    │    │    ├── fd: ()-->(6,31), (1)-->(3,5), (25)-->(26,27), (11)-->(12-17), (19,20)-->(22), (34,35)-->(37), (40)-->(43), (48)-->(50), (43)==(48), (48)==(43), (35)==(40), (40)==(35), (19)==(1,34), (34)==(1,19), (11)==(20), (20)==(11), (14)==(25), (25)==(14), (27)==(30), (30)==(27), (1)==(19,34)
-      │         │    │    │    ├── ordering: +(1|19|34),+(11|20) opt(6,31) [actual: +1,+20]
-      │         │    │    │    ├── inner-join (lookup supplier)
-      │         │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null r_regionkey:30!null r_name:31!null ps_partkey:34!null ps_suppkey:35!null ps_supplycost:37!null s_suppkey:40!null s_nationkey:43!null
-      │         │    │    │    │    ├── key columns: [35] = [40]
-      │         │    │    │    │    ├── lookup columns are key
-      │         │    │    │    │    ├── key: (20,34,40)
-      │         │    │    │    │    ├── fd: ()-->(6,31), (1)-->(3,5), (25)-->(26,27), (11)-->(12-17), (19,20)-->(22), (34,35)-->(37), (40)-->(43), (35)==(40), (40)==(35), (19)==(1,34), (34)==(1,19), (11)==(20), (20)==(11), (14)==(25), (25)==(14), (27)==(30), (30)==(27), (1)==(19,34)
-      │         │    │    │    │    ├── ordering: +(1|19|34),+(11|20) opt(6,31) [actual: +1,+20]
-      │         │    │    │    │    ├── inner-join (lookup partsupp)
-      │         │    │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null r_regionkey:30!null r_name:31!null ps_partkey:34!null ps_suppkey:35!null ps_supplycost:37!null
-      │         │    │    │    │    │    ├── key columns: [1] = [34]
-      │         │    │    │    │    │    ├── key: (20,34,35)
-      │         │    │    │    │    │    ├── fd: ()-->(6,31), (1)-->(3,5), (25)-->(26,27), (11)-->(12-17), (19,20)-->(22), (34,35)-->(37), (19)==(1,34), (34)==(1,19), (11)==(20), (20)==(11), (14)==(25), (25)==(14), (27)==(30), (30)==(27), (1)==(19,34)
-      │         │    │    │    │    │    ├── ordering: +(1|19|34),+(11|20) opt(6,31) [actual: +1,+20]
-      │         │    │    │    │    │    ├── inner-join (lookup region)
-      │         │    │    │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null r_regionkey:30!null r_name:31!null
-      │         │    │    │    │    │    │    ├── key columns: [27] = [30]
+      │         │    │    │    ├── fd: ()-->(6,31), (1)-->(3,5), (11)-->(12-17), (19,20)-->(22), (34,35)-->(37), (40)-->(43), (35)==(40), (40)==(35), (19)==(1,34), (34)==(1,19), (11)==(20), (20)==(11), (25)-->(26,27), (27)==(30), (30)==(27), (14)==(25), (25)==(14), (1)==(19,34)
+      │         │    │    │    ├── scan supplier@s_nk
+      │         │    │    │    │    ├── columns: s_suppkey:40!null s_nationkey:43!null
+      │         │    │    │    │    ├── key: (40)
+      │         │    │    │    │    └── fd: (40)-->(43)
+      │         │    │    │    ├── inner-join (merge)
+      │         │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null r_regionkey:30!null r_name:31!null ps_partkey:34!null ps_suppkey:35!null ps_supplycost:37!null
+      │         │    │    │    │    ├── left ordering: +1
+      │         │    │    │    │    ├── right ordering: +34
+      │         │    │    │    │    ├── key: (20,34,35)
+      │         │    │    │    │    ├── fd: ()-->(6,31), (1)-->(3,5), (11)-->(12-17), (19,20)-->(22), (34,35)-->(37), (19)==(1,34), (34)==(1,19), (11)==(20), (20)==(11), (25)-->(26,27), (27)==(30), (30)==(27), (14)==(25), (25)==(14), (1)==(19,34)
+      │         │    │    │    │    ├── inner-join (lookup region)
+      │         │    │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null r_regionkey:30!null r_name:31!null
+      │         │    │    │    │    │    ├── key columns: [27] = [30]
+      │         │    │    │    │    │    ├── lookup columns are key
+      │         │    │    │    │    │    ├── key: (19,20)
+      │         │    │    │    │    │    ├── fd: ()-->(6,31), (1)-->(3,5), (11)-->(12-17), (19,20)-->(22), (11)==(20), (20)==(11), (25)-->(26,27), (27)==(30), (30)==(27), (14)==(25), (25)==(14), (1)==(19), (19)==(1)
+      │         │    │    │    │    │    ├── ordering: +(1|19) opt(6,31) [actual: +1]
+      │         │    │    │    │    │    ├── inner-join (lookup nation)
+      │         │    │    │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null
+      │         │    │    │    │    │    │    ├── key columns: [14] = [25]
       │         │    │    │    │    │    │    ├── lookup columns are key
       │         │    │    │    │    │    │    ├── key: (19,20)
-      │         │    │    │    │    │    │    ├── fd: ()-->(6,31), (1)-->(3,5), (11)-->(12-17), (19,20)-->(22), (11)==(20), (20)==(11), (25)-->(26,27), (27)==(30), (30)==(27), (14)==(25), (25)==(14), (1)==(19), (19)==(1)
-      │         │    │    │    │    │    │    ├── ordering: +(1|19),+(11|20) opt(6,31) [actual: +1,+20]
-      │         │    │    │    │    │    │    ├── inner-join (lookup nation)
-      │         │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null n_nationkey:25!null n_name:26!null n_regionkey:27!null
-      │         │    │    │    │    │    │    │    ├── key columns: [14] = [25]
+      │         │    │    │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5), (11)-->(12-17), (19,20)-->(22), (11)==(20), (20)==(11), (25)-->(26,27), (14)==(25), (25)==(14), (1)==(19), (19)==(1)
+      │         │    │    │    │    │    │    ├── ordering: +(1|19) opt(6) [actual: +1]
+      │         │    │    │    │    │    │    ├── inner-join (lookup supplier)
+      │         │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null
+      │         │    │    │    │    │    │    │    ├── key columns: [20] = [11]
       │         │    │    │    │    │    │    │    ├── lookup columns are key
       │         │    │    │    │    │    │    │    ├── key: (19,20)
-      │         │    │    │    │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5), (19,20)-->(22), (11)-->(12-17), (25)-->(26,27), (14)==(25), (25)==(14), (11)==(20), (20)==(11), (1)==(19), (19)==(1)
-      │         │    │    │    │    │    │    │    ├── ordering: +(1|19),+(11|20) opt(6) [actual: +1,+20]
-      │         │    │    │    │    │    │    │    ├── inner-join (lookup supplier)
-      │         │    │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null s_suppkey:11!null s_name:12!null s_address:13!null s_nationkey:14!null s_phone:15!null s_acctbal:16!null s_comment:17!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null
-      │         │    │    │    │    │    │    │    │    ├── key columns: [20] = [11]
-      │         │    │    │    │    │    │    │    │    ├── lookup columns are key
+      │         │    │    │    │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5), (11)-->(12-17), (19,20)-->(22), (11)==(20), (20)==(11), (1)==(19), (19)==(1)
+      │         │    │    │    │    │    │    │    ├── ordering: +(1|19) opt(6) [actual: +1]
+      │         │    │    │    │    │    │    │    ├── inner-join (lookup partsupp)
+      │         │    │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null
+      │         │    │    │    │    │    │    │    │    ├── key columns: [1] = [19]
       │         │    │    │    │    │    │    │    │    ├── key: (19,20)
-      │         │    │    │    │    │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5), (11)-->(12-17), (19,20)-->(22), (11)==(20), (20)==(11), (1)==(19), (19)==(1)
-      │         │    │    │    │    │    │    │    │    ├── ordering: +(1|19),+(11|20) opt(6) [actual: +1,+20]
-      │         │    │    │    │    │    │    │    │    ├── sort
-      │         │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null
-      │         │    │    │    │    │    │    │    │    │    ├── key: (19,20)
-      │         │    │    │    │    │    │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5), (19,20)-->(22), (1)==(19), (19)==(1)
-      │         │    │    │    │    │    │    │    │    │    ├── ordering: +(1|19),+20 opt(6) [actual: +1,+20]
-      │         │    │    │    │    │    │    │    │    │    └── inner-join (lookup partsupp)
-      │         │    │    │    │    │    │    │    │    │         ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null ps_partkey:19!null ps_suppkey:20!null ps_supplycost:22!null
-      │         │    │    │    │    │    │    │    │    │         ├── key columns: [1] = [19]
-      │         │    │    │    │    │    │    │    │    │         ├── key: (19,20)
-      │         │    │    │    │    │    │    │    │    │         ├── fd: ()-->(6), (1)-->(3,5), (19,20)-->(22), (1)==(19), (19)==(1)
-      │         │    │    │    │    │    │    │    │    │         ├── select
-      │         │    │    │    │    │    │    │    │    │         │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null
-      │         │    │    │    │    │    │    │    │    │         │    ├── key: (1)
-      │         │    │    │    │    │    │    │    │    │         │    ├── fd: ()-->(6), (1)-->(3,5)
-      │         │    │    │    │    │    │    │    │    │         │    ├── scan part
-      │         │    │    │    │    │    │    │    │    │         │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null
-      │         │    │    │    │    │    │    │    │    │         │    │    ├── key: (1)
-      │         │    │    │    │    │    │    │    │    │         │    │    └── fd: (1)-->(3,5,6)
-      │         │    │    │    │    │    │    │    │    │         │    └── filters
-      │         │    │    │    │    │    │    │    │    │         │         ├── p_size:6 = 15 [outer=(6), constraints=(/6: [/15 - /15]; tight), fd=()-->(6)]
-      │         │    │    │    │    │    │    │    │    │         │         └── p_type:5 LIKE '%BRASS' [outer=(5), constraints=(/5: (/NULL - ])]
-      │         │    │    │    │    │    │    │    │    │         └── filters (true)
+      │         │    │    │    │    │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5), (19,20)-->(22), (1)==(19), (19)==(1)
+      │         │    │    │    │    │    │    │    │    ├── ordering: +(1|19) opt(6) [actual: +1]
+      │         │    │    │    │    │    │    │    │    ├── select
+      │         │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null
+      │         │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │         │    │    │    │    │    │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5)
+      │         │    │    │    │    │    │    │    │    │    ├── ordering: +1 opt(6) [actual: +1]
+      │         │    │    │    │    │    │    │    │    │    ├── scan part
+      │         │    │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_mfgr:3!null p_type:5!null p_size:6!null
+      │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │         │    │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(3,5,6)
+      │         │    │    │    │    │    │    │    │    │    │    └── ordering: +1 opt(6) [actual: +1]
+      │         │    │    │    │    │    │    │    │    │    └── filters
+      │         │    │    │    │    │    │    │    │    │         ├── p_size:6 = 15 [outer=(6), constraints=(/6: [/15 - /15]; tight), fd=()-->(6)]
+      │         │    │    │    │    │    │    │    │    │         └── p_type:5 LIKE '%BRASS' [outer=(5), constraints=(/5: (/NULL - ])]
       │         │    │    │    │    │    │    │    │    └── filters (true)
       │         │    │    │    │    │    │    │    └── filters (true)
-      │         │    │    │    │    │    │    └── filters
-      │         │    │    │    │    │    │         └── r_name:31 = 'EUROPE' [outer=(31), constraints=(/31: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(31)]
-      │         │    │    │    │    │    └── filters (true)
+      │         │    │    │    │    │    │    └── filters (true)
+      │         │    │    │    │    │    └── filters
+      │         │    │    │    │    │         └── r_name:31 = 'EUROPE' [outer=(31), constraints=(/31: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(31)]
+      │         │    │    │    │    ├── scan partsupp
+      │         │    │    │    │    │    ├── columns: ps_partkey:34!null ps_suppkey:35!null ps_supplycost:37!null
+      │         │    │    │    │    │    ├── key: (34,35)
+      │         │    │    │    │    │    ├── fd: (34,35)-->(37)
+      │         │    │    │    │    │    └── ordering: +34
       │         │    │    │    │    └── filters (true)
+      │         │    │    │    └── filters
+      │         │    │    │         └── s_suppkey:40 = ps_suppkey:35 [outer=(35,40), constraints=(/35: (/NULL - ]; /40: (/NULL - ]), fd=(35)==(40), (40)==(35)]
+      │         │    │    ├── inner-join (lookup nation@n_rk)
+      │         │    │    │    ├── columns: n_nationkey:48!null n_regionkey:50!null r_regionkey:53!null r_name:54!null
+      │         │    │    │    ├── key columns: [53] = [50]
+      │         │    │    │    ├── key: (48)
+      │         │    │    │    ├── fd: ()-->(54), (48)-->(50), (50)==(53), (53)==(50)
+      │         │    │    │    ├── select
+      │         │    │    │    │    ├── columns: r_regionkey:53!null r_name:54!null
+      │         │    │    │    │    ├── key: (53)
+      │         │    │    │    │    ├── fd: ()-->(54)
+      │         │    │    │    │    ├── scan region
+      │         │    │    │    │    │    ├── columns: r_regionkey:53!null r_name:54!null
+      │         │    │    │    │    │    ├── key: (53)
+      │         │    │    │    │    │    └── fd: (53)-->(54)
+      │         │    │    │    │    └── filters
+      │         │    │    │    │         └── r_name:54 = 'EUROPE' [outer=(54), constraints=(/54: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(54)]
       │         │    │    │    └── filters (true)
       │         │    │    └── filters
-      │         │    │         └── r_name:54 = 'EUROPE' [outer=(54), constraints=(/54: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(54)]
+      │         │    │         └── s_nationkey:43 = n_nationkey:48 [outer=(43,48), constraints=(/43: (/NULL - ]; /48: (/NULL - ]), fd=(43)==(48), (48)==(43)]
       │         │    └── aggregations
       │         │         ├── min [as=min:57, outer=(37)]
       │         │         │    └── ps_supplycost:37
@@ -696,24 +707,8 @@ group-by
  │         │    ├── fd: (1)-->(4), (26)-->(27), (36)-->(39), (45)-->(46), (50)-->(51), (39)==(50), (50)==(39), (27)==(36), (36)==(27), (9)==(26), (26)==(9), (1)==(11), (11)==(1), (4)==(45), (45)==(4)
  │         │    ├── inner-join (hash)
  │         │    │    ├── columns: s_suppkey:1!null s_nationkey:4!null l_orderkey:9!null l_suppkey:11!null l_extendedprice:14!null l_discount:15!null l_shipdate:19!null o_orderkey:26!null o_custkey:27!null n1.n_nationkey:45!null n1.n_name:46!null
- │         │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
- │         │    │    ├── fd: (26)-->(27), (1)-->(4), (45)-->(46), (4)==(45), (45)==(4), (1)==(11), (11)==(1), (9)==(26), (26)==(9)
- │         │    │    ├── inner-join (hash)
- │         │    │    │    ├── columns: l_orderkey:9!null l_suppkey:11!null l_extendedprice:14!null l_discount:15!null l_shipdate:19!null o_orderkey:26!null o_custkey:27!null
- │         │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
- │         │    │    │    ├── fd: (26)-->(27), (9)==(26), (26)==(9)
- │         │    │    │    ├── select
- │         │    │    │    │    ├── columns: l_orderkey:9!null l_suppkey:11!null l_extendedprice:14!null l_discount:15!null l_shipdate:19!null
- │         │    │    │    │    ├── scan lineitem
- │         │    │    │    │    │    └── columns: l_orderkey:9!null l_suppkey:11!null l_extendedprice:14!null l_discount:15!null l_shipdate:19!null
- │         │    │    │    │    └── filters
- │         │    │    │    │         └── (l_shipdate:19 >= '1995-01-01') AND (l_shipdate:19 <= '1996-12-31') [outer=(19), constraints=(/19: [/'1995-01-01' - /'1996-12-31']; tight)]
- │         │    │    │    ├── scan orders@o_ck
- │         │    │    │    │    ├── columns: o_orderkey:26!null o_custkey:27!null
- │         │    │    │    │    ├── key: (26)
- │         │    │    │    │    └── fd: (26)-->(27)
- │         │    │    │    └── filters
- │         │    │    │         └── o_orderkey:26 = l_orderkey:9 [outer=(9,26), constraints=(/9: (/NULL - ]; /26: (/NULL - ]), fd=(9)==(26), (26)==(9)]
+ │         │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(exactly-one)
+ │         │    │    ├── fd: (1)-->(4), (45)-->(46), (4)==(45), (45)==(4), (26)-->(27), (9)==(26), (26)==(9), (1)==(11), (11)==(1)
  │         │    │    ├── inner-join (merge)
  │         │    │    │    ├── columns: s_suppkey:1!null s_nationkey:4!null n1.n_nationkey:45!null n1.n_name:46!null
  │         │    │    │    ├── left ordering: +4
@@ -731,6 +726,22 @@ group-by
  │         │    │    │    │    ├── fd: (45)-->(46)
  │         │    │    │    │    └── ordering: +45
  │         │    │    │    └── filters (true)
+ │         │    │    ├── inner-join (hash)
+ │         │    │    │    ├── columns: l_orderkey:9!null l_suppkey:11!null l_extendedprice:14!null l_discount:15!null l_shipdate:19!null o_orderkey:26!null o_custkey:27!null
+ │         │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │         │    │    │    ├── fd: (26)-->(27), (9)==(26), (26)==(9)
+ │         │    │    │    ├── select
+ │         │    │    │    │    ├── columns: l_orderkey:9!null l_suppkey:11!null l_extendedprice:14!null l_discount:15!null l_shipdate:19!null
+ │         │    │    │    │    ├── scan lineitem
+ │         │    │    │    │    │    └── columns: l_orderkey:9!null l_suppkey:11!null l_extendedprice:14!null l_discount:15!null l_shipdate:19!null
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── (l_shipdate:19 >= '1995-01-01') AND (l_shipdate:19 <= '1996-12-31') [outer=(19), constraints=(/19: [/'1995-01-01' - /'1996-12-31']; tight)]
+ │         │    │    │    ├── scan orders@o_ck
+ │         │    │    │    │    ├── columns: o_orderkey:26!null o_custkey:27!null
+ │         │    │    │    │    ├── key: (26)
+ │         │    │    │    │    └── fd: (26)-->(27)
+ │         │    │    │    └── filters
+ │         │    │    │         └── o_orderkey:26 = l_orderkey:9 [outer=(9,26), constraints=(/9: (/NULL - ]; /26: (/NULL - ]), fd=(9)==(26), (26)==(9)]
  │         │    │    └── filters
  │         │    │         └── s_suppkey:1 = l_suppkey:11 [outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1)]
  │         │    ├── inner-join (merge)
@@ -838,26 +849,29 @@ sort
       │    │    │    │    ├── columns: p_partkey:1!null p_type:5!null s_suppkey:11!null s_nationkey:14!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_extendedprice:24!null l_discount:25!null o_orderkey:36!null o_custkey:37!null o_orderdate:40!null c_custkey:46!null c_nationkey:49!null n1.n_nationkey:55!null n1.n_regionkey:57!null n2.n_nationkey:60!null n2.n_name:61!null r_regionkey:65!null r_name:66!null
       │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       │    │    │    │    ├── fd: ()-->(5,66), (11)-->(14), (36)-->(37,40), (46)-->(49), (55)-->(57), (57)==(65), (65)==(57), (49)==(55), (55)==(49), (37)==(46), (46)==(37), (19)==(36), (36)==(19), (11)==(21), (21)==(11), (60)-->(61), (14)==(60), (60)==(14), (1)==(20), (20)==(1)
-      │    │    │    │    ├── inner-join (lookup nation)
+      │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    ├── columns: p_partkey:1!null p_type:5!null s_suppkey:11!null s_nationkey:14!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_extendedprice:24!null l_discount:25!null o_orderkey:36!null o_custkey:37!null o_orderdate:40!null c_custkey:46!null c_nationkey:49!null n2.n_nationkey:60!null n2.n_name:61!null
-      │    │    │    │    │    ├── key columns: [14] = [60]
-      │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │    ├── fd: ()-->(5), (46)-->(49), (36)-->(37,40), (11)-->(14), (60)-->(61), (14)==(60), (60)==(14), (11)==(21), (21)==(11), (19)==(36), (36)==(19), (37)==(46), (46)==(37), (1)==(20), (20)==(1)
-      │    │    │    │    │    ├── inner-join (lookup customer)
-      │    │    │    │    │    │    ├── columns: p_partkey:1!null p_type:5!null s_suppkey:11!null s_nationkey:14!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_extendedprice:24!null l_discount:25!null o_orderkey:36!null o_custkey:37!null o_orderdate:40!null c_custkey:46!null c_nationkey:49!null
-      │    │    │    │    │    │    ├── key columns: [37] = [46]
+      │    │    │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(exactly-one)
+      │    │    │    │    │    ├── fd: ()-->(5), (11)-->(14), (60)-->(61), (14)==(60), (60)==(14), (36)-->(37,40), (46)-->(49), (37)==(46), (46)==(37), (19)==(36), (36)==(19), (11)==(21), (21)==(11), (1)==(20), (20)==(1)
+      │    │    │    │    │    ├── scan customer@c_nk
+      │    │    │    │    │    │    ├── columns: c_custkey:46!null c_nationkey:49!null
+      │    │    │    │    │    │    ├── key: (46)
+      │    │    │    │    │    │    └── fd: (46)-->(49)
+      │    │    │    │    │    ├── inner-join (lookup orders)
+      │    │    │    │    │    │    ├── columns: p_partkey:1!null p_type:5!null s_suppkey:11!null s_nationkey:14!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_extendedprice:24!null l_discount:25!null o_orderkey:36!null o_custkey:37!null o_orderdate:40!null n2.n_nationkey:60!null n2.n_name:61!null
+      │    │    │    │    │    │    ├── key columns: [19] = [36]
       │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │    │    ├── fd: ()-->(5), (11)-->(14), (36)-->(37,40), (46)-->(49), (37)==(46), (46)==(37), (19)==(36), (36)==(19), (11)==(21), (21)==(11), (1)==(20), (20)==(1)
-      │    │    │    │    │    │    ├── inner-join (lookup supplier)
-      │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_type:5!null s_suppkey:11!null s_nationkey:14!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_extendedprice:24!null l_discount:25!null o_orderkey:36!null o_custkey:37!null o_orderdate:40!null
-      │    │    │    │    │    │    │    ├── key columns: [21] = [11]
+      │    │    │    │    │    │    ├── fd: ()-->(5), (11)-->(14), (60)-->(61), (14)==(60), (60)==(14), (36)-->(37,40), (19)==(36), (36)==(19), (11)==(21), (21)==(11), (1)==(20), (20)==(1)
+      │    │    │    │    │    │    ├── inner-join (lookup nation)
+      │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_type:5!null s_suppkey:11!null s_nationkey:14!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_extendedprice:24!null l_discount:25!null n2.n_nationkey:60!null n2.n_name:61!null
+      │    │    │    │    │    │    │    ├── key columns: [14] = [60]
       │    │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │    │    │    ├── fd: ()-->(5), (11)-->(14), (36)-->(37,40), (19)==(36), (36)==(19), (11)==(21), (21)==(11), (1)==(20), (20)==(1)
-      │    │    │    │    │    │    │    ├── inner-join (lookup orders)
-      │    │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_type:5!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_extendedprice:24!null l_discount:25!null o_orderkey:36!null o_custkey:37!null o_orderdate:40!null
-      │    │    │    │    │    │    │    │    ├── key columns: [19] = [36]
+      │    │    │    │    │    │    │    ├── fd: ()-->(5), (11)-->(14), (11)==(21), (21)==(11), (60)-->(61), (14)==(60), (60)==(14), (1)==(20), (20)==(1)
+      │    │    │    │    │    │    │    ├── inner-join (lookup supplier)
+      │    │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_type:5!null s_suppkey:11!null s_nationkey:14!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_extendedprice:24!null l_discount:25!null
+      │    │    │    │    │    │    │    │    ├── key columns: [21] = [11]
       │    │    │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(5), (36)-->(37,40), (19)==(36), (36)==(19), (1)==(20), (20)==(1)
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(5), (11)-->(14), (11)==(21), (21)==(11), (1)==(20), (20)==(1)
       │    │    │    │    │    │    │    │    ├── inner-join (lookup lineitem)
       │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:1!null p_type:5!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_extendedprice:24!null l_discount:25!null
       │    │    │    │    │    │    │    │    │    ├── key columns: [19 22] = [19 22]
@@ -880,11 +894,12 @@ sort
       │    │    │    │    │    │    │    │    │    │    │         └── p_type:5 = 'ECONOMY ANODIZED STEEL' [outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
       │    │    │    │    │    │    │    │    │    │    └── filters (true)
       │    │    │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         └── (o_orderdate:40 >= '1995-01-01') AND (o_orderdate:40 <= '1996-12-31') [outer=(40), constraints=(/40: [/'1995-01-01' - /'1996-12-31']; tight)]
+      │    │    │    │    │    │    │    │    └── filters (true)
       │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── (o_orderdate:40 >= '1995-01-01') AND (o_orderdate:40 <= '1996-12-31') [outer=(40), constraints=(/40: [/'1995-01-01' - /'1996-12-31']; tight)]
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── o_custkey:37 = c_custkey:46 [outer=(37,46), constraints=(/37: (/NULL - ]; /46: (/NULL - ]), fd=(37)==(46), (46)==(37)]
       │    │    │    │    ├── inner-join (lookup nation@n_rk)
       │    │    │    │    │    ├── columns: n1.n_nationkey:55!null n1.n_regionkey:57!null r_regionkey:65!null r_name:66!null
       │    │    │    │    │    ├── key columns: [65] = [57]
@@ -990,16 +1005,16 @@ sort
       │    │    │    ├── key columns: [19] = [42]
       │    │    │    ├── lookup columns are key
       │    │    │    ├── fd: (1)-->(2), (11)-->(14), (36,37)-->(39), (21)==(11,37), (37)==(11,21), (20)==(1,36), (36)==(1,20), (42)-->(46), (19)==(42), (42)==(19), (11)==(21,37), (1)==(20,36)
-      │    │    │    ├── inner-join (lookup part)
+      │    │    │    ├── inner-join (lookup supplier)
       │    │    │    │    ├── columns: p_partkey:1!null p_name:2!null s_suppkey:11!null s_nationkey:14!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_quantity:23!null l_extendedprice:24!null l_discount:25!null ps_partkey:36!null ps_suppkey:37!null ps_supplycost:39!null
-      │    │    │    │    ├── key columns: [20] = [1]
+      │    │    │    │    ├── key columns: [21] = [11]
       │    │    │    │    ├── lookup columns are key
       │    │    │    │    ├── fd: (1)-->(2), (11)-->(14), (36,37)-->(39), (21)==(11,37), (37)==(11,21), (20)==(1,36), (36)==(1,20), (11)==(21,37), (1)==(20,36)
-      │    │    │    │    ├── inner-join (lookup supplier)
-      │    │    │    │    │    ├── columns: s_suppkey:11!null s_nationkey:14!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_quantity:23!null l_extendedprice:24!null l_discount:25!null ps_partkey:36!null ps_suppkey:37!null ps_supplycost:39!null
-      │    │    │    │    │    ├── key columns: [21] = [11]
+      │    │    │    │    ├── inner-join (lookup part)
+      │    │    │    │    │    ├── columns: p_partkey:1!null p_name:2!null l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_quantity:23!null l_extendedprice:24!null l_discount:25!null ps_partkey:36!null ps_suppkey:37!null ps_supplycost:39!null
+      │    │    │    │    │    ├── key columns: [20] = [1]
       │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │    ├── fd: (11)-->(14), (36,37)-->(39), (21)==(11,37), (37)==(11,21), (20)==(36), (36)==(20), (11)==(21,37)
+      │    │    │    │    │    ├── fd: (1)-->(2), (36,37)-->(39), (21)==(37), (37)==(21), (20)==(1,36), (36)==(1,20), (1)==(20,36)
       │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    ├── columns: l_orderkey:19!null l_partkey:20!null l_suppkey:21!null l_quantity:23!null l_extendedprice:24!null l_discount:25!null ps_partkey:36!null ps_suppkey:37!null ps_supplycost:39!null
       │    │    │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
@@ -1013,9 +1028,9 @@ sort
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         ├── ps_suppkey:37 = l_suppkey:21 [outer=(21,37), constraints=(/21: (/NULL - ]; /37: (/NULL - ]), fd=(21)==(37), (37)==(21)]
       │    │    │    │    │    │         └── ps_partkey:36 = l_partkey:20 [outer=(20,36), constraints=(/20: (/NULL - ]; /36: (/NULL - ]), fd=(20)==(36), (36)==(20)]
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── filters
-      │    │    │    │         └── p_name:2 LIKE '%green%' [outer=(2), constraints=(/2: (/NULL - ])]
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── p_name:2 LIKE '%green%' [outer=(2), constraints=(/2: (/NULL - ])]
+      │    │    │    │    └── filters (true)
       │    │    │    └── filters (true)
       │    │    └── filters (true)
       │    └── projections

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -155,13 +155,9 @@ SELECT * FROM abc, stu, xyz WHERE abc.a=stu.s AND stu.s=xyz.x
 ----
 inner-join (merge)
  ├── columns: a:1!null b:2 c:3 s:6!null t:7!null u:8!null x:10!null y:11 z:12
- ├── left ordering: +6
- ├── right ordering: +10
+ ├── left ordering: +10
+ ├── right ordering: +6
  ├── fd: (6)==(1,10), (10)==(1,6), (1)==(6,10)
- ├── scan stu
- │    ├── columns: s:6!null t:7!null u:8!null
- │    ├── key: (6-8)
- │    └── ordering: +6
  ├── inner-join (merge)
  │    ├── columns: a:1!null b:2 c:3 x:10!null y:11 z:12
  │    ├── left ordering: +1
@@ -175,15 +171,19 @@ inner-join (merge)
  │    │    ├── columns: x:10 y:11 z:12
  │    │    └── ordering: +10
  │    └── filters (true)
+ ├── scan stu
+ │    ├── columns: s:6!null t:7!null u:8!null
+ │    ├── key: (6-8)
+ │    └── ordering: +6
  └── filters (true)
 
 memo expect=ReorderJoins
 SELECT * FROM abc, stu, xyz WHERE abc.a=stu.s AND stu.s=xyz.x
 ----
 memo (optimized, ~36KB, required=[presentation: a:1,b:2,c:3,s:6,t:7,u:8,x:10,y:11,z:12])
- ├── G1: (inner-join G2 G3 G4) (inner-join G5 G6 G7) (inner-join G8 G9 G7) (inner-join G3 G2 G4) (merge-join G2 G3 G10 inner-join,+1,+6) (inner-join G6 G5 G7) (merge-join G5 G6 G10 inner-join,+6,+10) (inner-join G9 G8 G7) (merge-join G8 G9 G10 inner-join,+6,+10) (lookup-join G8 G10 xyz@xy,keyCols=[6],outCols=(1-3,6-8,10-12)) (merge-join G3 G2 G10 inner-join,+6,+1) (lookup-join G3 G10 abc@ab,keyCols=[6],outCols=(1-3,6-8,10-12)) (merge-join G6 G5 G10 inner-join,+10,+6) (lookup-join G6 G10 stu,keyCols=[10],outCols=(1-3,6-8,10-12)) (merge-join G9 G8 G10 inner-join,+10,+6)
+ ├── G1: (inner-join G2 G3 G4) (inner-join G5 G6 G7) (inner-join G8 G9 G7) (inner-join G3 G2 G4) (merge-join G2 G3 G10 inner-join,+1,+6) (inner-join G6 G5 G7) (merge-join G5 G6 G10 inner-join,+6,+10) (lookup-join G5 G10 xyz@xy,keyCols=[6],outCols=(1-3,6-8,10-12)) (inner-join G9 G8 G7) (merge-join G8 G9 G10 inner-join,+10,+6) (lookup-join G8 G10 stu,keyCols=[10],outCols=(1-3,6-8,10-12)) (merge-join G3 G2 G10 inner-join,+6,+1) (lookup-join G3 G10 abc@ab,keyCols=[6],outCols=(1-3,6-8,10-12)) (merge-join G6 G5 G10 inner-join,+10,+6) (merge-join G9 G8 G10 inner-join,+6,+10)
  │    └── [presentation: a:1,b:2,c:3,s:6,t:7,u:8,x:10,y:11,z:12]
- │         ├── best: (merge-join G5="[ordering: +6]" G6="[ordering: +(1|10)]" G10 inner-join,+6,+10)
+ │         ├── best: (merge-join G8="[ordering: +(1|10)]" G9="[ordering: +6]" G10 inner-join,+10,+6)
  │         └── cost: 12980.08
  ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
  │    ├── [ordering: +1]
@@ -192,51 +192,51 @@ memo (optimized, ~36KB, required=[presentation: a:1,b:2,c:3,s:6,t:7,u:8,x:10,y:1
  │    └── []
  │         ├── best: (scan abc,cols=(1-3))
  │         └── cost: 1070.02
- ├── G3: (inner-join G5 G9 G7) (inner-join G9 G5 G7) (merge-join G5 G9 G10 inner-join,+6,+10) (lookup-join G5 G10 xyz@xy,keyCols=[6],outCols=(6-8,10-12)) (merge-join G9 G5 G10 inner-join,+10,+6) (lookup-join G9 G10 stu,keyCols=[10],outCols=(6-8,10-12))
+ ├── G3: (inner-join G9 G6 G7) (inner-join G6 G9 G7) (merge-join G9 G6 G10 inner-join,+6,+10) (lookup-join G9 G10 xyz@xy,keyCols=[6],outCols=(6-8,10-12)) (merge-join G6 G9 G10 inner-join,+10,+6) (lookup-join G6 G10 stu,keyCols=[10],outCols=(6-8,10-12))
  │    ├── [ordering: +(6|10)]
- │    │    ├── best: (merge-join G5="[ordering: +6]" G9="[ordering: +10]" G10 inner-join,+6,+10)
+ │    │    ├── best: (merge-join G9="[ordering: +6]" G6="[ordering: +10]" G10 inner-join,+6,+10)
  │    │    └── cost: 11880.05
  │    └── []
- │         ├── best: (merge-join G5="[ordering: +6]" G9="[ordering: +10]" G10 inner-join,+6,+10)
+ │         ├── best: (merge-join G9="[ordering: +6]" G6="[ordering: +10]" G10 inner-join,+6,+10)
  │         └── cost: 11880.05
  ├── G4: (filters G11)
- ├── G5: (scan stu,cols=(6-8)) (scan stu@uts,cols=(6-8))
- │    ├── [ordering: +6]
- │    │    ├── best: (scan stu,cols=(6-8))
- │    │    └── cost: 10600.02
- │    └── []
- │         ├── best: (scan stu,cols=(6-8))
- │         └── cost: 10600.02
- ├── G6: (inner-join G2 G9 G12) (inner-join G9 G2 G12) (merge-join G2 G9 G10 inner-join,+1,+10) (lookup-join G2 G10 xyz@xy,keyCols=[1],outCols=(1-3,10-12)) (merge-join G9 G2 G10 inner-join,+10,+1) (lookup-join G9 G10 abc@ab,keyCols=[10],outCols=(1-3,10-12))
- │    ├── [ordering: +(1|10)]
- │    │    ├── best: (merge-join G2="[ordering: +1]" G9="[ordering: +10]" G10 inner-join,+1,+10)
- │    │    └── cost: 2170.05
- │    └── []
- │         ├── best: (merge-join G2="[ordering: +1]" G9="[ordering: +10]" G10 inner-join,+1,+10)
- │         └── cost: 2170.05
- ├── G7: (filters G13)
- ├── G8: (inner-join G2 G5 G4) (inner-join G5 G2 G4) (merge-join G2 G5 G10 inner-join,+1,+6) (lookup-join G2 G10 stu,keyCols=[1],outCols=(1-3,6-8)) (merge-join G5 G2 G10 inner-join,+6,+1) (lookup-join G5 G10 abc@ab,keyCols=[6],outCols=(1-3,6-8))
+ ├── G5: (inner-join G2 G9 G4) (inner-join G9 G2 G4) (merge-join G2 G9 G10 inner-join,+1,+6) (lookup-join G2 G10 stu,keyCols=[1],outCols=(1-3,6-8)) (merge-join G9 G2 G10 inner-join,+6,+1) (lookup-join G9 G10 abc@ab,keyCols=[6],outCols=(1-3,6-8))
  │    ├── [ordering: +(1|6)]
- │    │    ├── best: (merge-join G2="[ordering: +1]" G5="[ordering: +6]" G10 inner-join,+1,+6)
+ │    │    ├── best: (merge-join G2="[ordering: +1]" G9="[ordering: +6]" G10 inner-join,+1,+6)
  │    │    └── cost: 11880.05
  │    └── []
- │         ├── best: (merge-join G2="[ordering: +1]" G5="[ordering: +6]" G10 inner-join,+1,+6)
+ │         ├── best: (merge-join G2="[ordering: +1]" G9="[ordering: +6]" G10 inner-join,+1,+6)
  │         └── cost: 11880.05
- ├── G9: (scan xyz,cols=(10-12)) (scan xyz@xy,cols=(10-12)) (scan xyz@yz,cols=(10-12))
+ ├── G6: (scan xyz,cols=(10-12)) (scan xyz@xy,cols=(10-12)) (scan xyz@yz,cols=(10-12))
  │    ├── [ordering: +10]
  │    │    ├── best: (scan xyz@xy,cols=(10-12))
  │    │    └── cost: 1070.02
  │    └── []
  │         ├── best: (scan xyz,cols=(10-12))
  │         └── cost: 1070.02
+ ├── G7: (filters G12)
+ ├── G8: (inner-join G2 G6 G13) (inner-join G6 G2 G13) (merge-join G2 G6 G10 inner-join,+1,+10) (lookup-join G2 G10 xyz@xy,keyCols=[1],outCols=(1-3,10-12)) (merge-join G6 G2 G10 inner-join,+10,+1) (lookup-join G6 G10 abc@ab,keyCols=[10],outCols=(1-3,10-12))
+ │    ├── [ordering: +(1|10)]
+ │    │    ├── best: (merge-join G2="[ordering: +1]" G6="[ordering: +10]" G10 inner-join,+1,+10)
+ │    │    └── cost: 2170.05
+ │    └── []
+ │         ├── best: (merge-join G2="[ordering: +1]" G6="[ordering: +10]" G10 inner-join,+1,+10)
+ │         └── cost: 2170.05
+ ├── G9: (scan stu,cols=(6-8)) (scan stu@uts,cols=(6-8))
+ │    ├── [ordering: +6]
+ │    │    ├── best: (scan stu,cols=(6-8))
+ │    │    └── cost: 10600.02
+ │    └── []
+ │         ├── best: (scan stu,cols=(6-8))
+ │         └── cost: 10600.02
  ├── G10: (filters)
  ├── G11: (eq G14 G15)
- ├── G12: (filters G16)
- ├── G13: (eq G15 G17)
+ ├── G12: (eq G15 G16)
+ ├── G13: (filters G17)
  ├── G14: (variable a)
  ├── G15: (variable s)
- ├── G16: (eq G14 G17)
- └── G17: (variable x)
+ ├── G16: (variable x)
+ └── G17: (eq G14 G16)
 
 # Regression test for #36226.
 exec-ddl
@@ -316,7 +316,7 @@ memo (optimized, ~34KB, required=[presentation: pid1:1,cid1:2,gcid1:3,gca1:4,ca1
  │    └── []
  │         ├── best: (project G2 G3 pid1 cid1 gcid1 gca1 ca1 pa1)
  │         └── cost: 2767.07
- ├── G2: (inner-join G4 G5 G6) (inner-join G7 G8 G9) (inner-join G10 G11 G9) (inner-join G5 G4 G6) (merge-join G4 G5 G12 inner-join,+1,+10) (lookup-join G4 G12 parent1,keyCols=[1],outCols=(1-4,6-8,10,11)) (inner-join G8 G7 G9) (merge-join G7 G8 G12 inner-join,+1,+2,+6,+7) (inner-join G11 G10 G9) (merge-join G10 G11 G12 inner-join,+6,+7,+1,+2) (merge-join G5 G4 G12 inner-join,+10,+1) (merge-join G8 G7 G12 inner-join,+6,+7,+1,+2) (lookup-join G8 G12 grandchild1,keyCols=[6 7],outCols=(1-4,6-8,10,11)) (merge-join G11 G10 G12 inner-join,+1,+2,+6,+7) (lookup-join G11 G12 child1,keyCols=[1 2],outCols=(1-4,6-8,10,11))
+ ├── G2: (inner-join G4 G5 G6) (inner-join G7 G8 G9) (inner-join G10 G11 G9) (inner-join G5 G4 G6) (merge-join G4 G5 G12 inner-join,+1,+10) (lookup-join G4 G12 parent1,keyCols=[1],outCols=(1-4,6-8,10,11)) (inner-join G8 G7 G9) (merge-join G7 G8 G12 inner-join,+1,+2,+6,+7) (inner-join G11 G10 G9) (merge-join G10 G11 G12 inner-join,+1,+2,+6,+7) (lookup-join G10 G12 child1,keyCols=[1 2],outCols=(1-4,6-8,10,11)) (merge-join G5 G4 G12 inner-join,+10,+1) (merge-join G8 G7 G12 inner-join,+6,+7,+1,+2) (lookup-join G8 G12 grandchild1,keyCols=[6 7],outCols=(1-4,6-8,10,11)) (merge-join G11 G10 G12 inner-join,+6,+7,+1,+2)
  │    ├── [ordering: +(1|6|10)]
  │    │    ├── best: (lookup-join G4="[ordering: +(1|6)]" G12 parent1,keyCols=[1],outCols=(1-4,6-8,10,11))
  │    │    └── cost: 2766.06
@@ -324,12 +324,12 @@ memo (optimized, ~34KB, required=[presentation: pid1:1,cid1:2,gcid1:3,gca1:4,ca1
  │         ├── best: (lookup-join G4 G12 parent1,keyCols=[1],outCols=(1-4,6-8,10,11))
  │         └── cost: 2766.06
  ├── G3: (projections)
- ├── G4: (inner-join G7 G10 G9) (inner-join G10 G7 G9) (merge-join G7 G10 G12 inner-join,+1,+2,+6,+7) (lookup-join G7 G12 child1,keyCols=[1 2],outCols=(1-4,6-8)) (merge-join G10 G7 G12 inner-join,+6,+7,+1,+2) (lookup-join G10 G12 grandchild1,keyCols=[6 7],outCols=(1-4,6-8))
+ ├── G4: (inner-join G7 G11 G9) (inner-join G11 G7 G9) (merge-join G7 G11 G12 inner-join,+1,+2,+6,+7) (lookup-join G7 G12 child1,keyCols=[1 2],outCols=(1-4,6-8)) (merge-join G11 G7 G12 inner-join,+6,+7,+1,+2) (lookup-join G11 G12 grandchild1,keyCols=[6 7],outCols=(1-4,6-8))
  │    ├── [ordering: +(1|6)]
- │    │    ├── best: (merge-join G7="[ordering: +1,+2]" G10="[ordering: +6,+7]" G12 inner-join,+1,+2,+6,+7)
+ │    │    ├── best: (merge-join G7="[ordering: +1,+2]" G11="[ordering: +6,+7]" G12 inner-join,+1,+2,+6,+7)
  │    │    └── cost: 2161.05
  │    └── []
- │         ├── best: (merge-join G7="[ordering: +1,+2]" G10="[ordering: +6,+7]" G12 inner-join,+1,+2,+6,+7)
+ │         ├── best: (merge-join G7="[ordering: +1,+2]" G11="[ordering: +6,+7]" G12 inner-join,+1,+2,+6,+7)
  │         └── cost: 2161.05
  ├── G5: (scan parent1,cols=(10,11))
  │    ├── [ordering: +10]
@@ -349,18 +349,28 @@ memo (optimized, ~34KB, required=[presentation: pid1:1,cid1:2,gcid1:3,gca1:4,ca1
  │    └── []
  │         ├── best: (scan grandchild1,cols=(1-4))
  │         └── cost: 1080.02
- ├── G8: (inner-join G10 G5 G14) (inner-join G5 G10 G14) (merge-join G10 G5 G12 inner-join,+6,+10) (lookup-join G10 G12 parent1,keyCols=[6],outCols=(6-8,10,11)) (merge-join G5 G10 G12 inner-join,+10,+6) (lookup-join G5 G12 child1,keyCols=[10],outCols=(6-8,10,11))
+ ├── G8: (inner-join G11 G5 G14) (inner-join G5 G11 G14) (merge-join G11 G5 G12 inner-join,+6,+10) (lookup-join G11 G12 parent1,keyCols=[6],outCols=(6-8,10,11)) (merge-join G5 G11 G12 inner-join,+10,+6) (lookup-join G5 G12 child1,keyCols=[10],outCols=(6-8,10,11))
  │    ├── [ordering: +(6|10),+7]
  │    │    ├── best: (sort G8)
  │    │    └── cost: 2360.34
  │    ├── [ordering: +(6|10)]
- │    │    ├── best: (merge-join G10="[ordering: +6]" G5="[ordering: +10]" G12 inner-join,+6,+10)
+ │    │    ├── best: (merge-join G11="[ordering: +6]" G5="[ordering: +10]" G12 inner-join,+6,+10)
  │    │    └── cost: 2130.05
  │    └── []
- │         ├── best: (merge-join G10="[ordering: +6]" G5="[ordering: +10]" G12 inner-join,+6,+10)
+ │         ├── best: (merge-join G11="[ordering: +6]" G5="[ordering: +10]" G12 inner-join,+6,+10)
  │         └── cost: 2130.05
  ├── G9: (filters G15 G16)
- ├── G10: (scan child1,cols=(6-8))
+ ├── G10: (inner-join G7 G5 G6) (inner-join G5 G7 G6) (merge-join G7 G5 G12 inner-join,+1,+10) (lookup-join G7 G12 parent1,keyCols=[1],outCols=(1-4,10,11)) (merge-join G5 G7 G12 inner-join,+10,+1) (lookup-join G5 G12 grandchild1,keyCols=[10],outCols=(1-4,10,11))
+ │    ├── [ordering: +(1|10),+2]
+ │    │    ├── best: (sort G10)
+ │    │    └── cost: 2380.34
+ │    ├── [ordering: +(1|10)]
+ │    │    ├── best: (merge-join G7="[ordering: +1]" G5="[ordering: +10]" G12 inner-join,+1,+10)
+ │    │    └── cost: 2150.05
+ │    └── []
+ │         ├── best: (merge-join G7="[ordering: +1]" G5="[ordering: +10]" G12 inner-join,+1,+10)
+ │         └── cost: 2150.05
+ ├── G11: (scan child1,cols=(6-8))
  │    ├── [ordering: +6,+7]
  │    │    ├── best: (scan child1,cols=(6-8))
  │    │    └── cost: 1060.02
@@ -370,16 +380,6 @@ memo (optimized, ~34KB, required=[presentation: pid1:1,cid1:2,gcid1:3,gca1:4,ca1
  │    └── []
  │         ├── best: (scan child1,cols=(6-8))
  │         └── cost: 1060.02
- ├── G11: (inner-join G7 G5 G6) (inner-join G5 G7 G6) (merge-join G7 G5 G12 inner-join,+1,+10) (lookup-join G7 G12 parent1,keyCols=[1],outCols=(1-4,10,11)) (merge-join G5 G7 G12 inner-join,+10,+1) (lookup-join G5 G12 grandchild1,keyCols=[10],outCols=(1-4,10,11))
- │    ├── [ordering: +(1|10),+2]
- │    │    ├── best: (sort G11)
- │    │    └── cost: 2380.34
- │    ├── [ordering: +(1|10)]
- │    │    ├── best: (merge-join G7="[ordering: +1]" G5="[ordering: +10]" G12 inner-join,+1,+10)
- │    │    └── cost: 2150.05
- │    └── []
- │         ├── best: (merge-join G7="[ordering: +1]" G5="[ordering: +10]" G12 inner-join,+1,+10)
- │         └── cost: 2150.05
  ├── G12: (filters)
  ├── G13: (eq G17 G18)
  ├── G14: (filters G19)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -83,20 +83,20 @@ inner-join (lookup cy)
 opt join-limit=2 expect=ReorderJoins
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-inner-join (lookup bx)
+inner-join (lookup cy)
  ├── columns: b:1!null x:2 c:4!null y:5 a:7!null b:8!null c:9!null d:10
- ├── key columns: [8] = [1]
+ ├── key columns: [9] = [4]
  ├── lookup columns are key
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1,2,4,5,7-10)
- ├── inner-join (lookup cy)
- │    ├── columns: cy.c:4!null y:5 a:7!null abc.b:8 abc.c:9!null d:10
- │    ├── key columns: [9] = [4]
+ ├── inner-join (lookup bx)
+ │    ├── columns: bx.b:1!null x:2 a:7!null abc.b:8!null abc.c:9 d:10
+ │    ├── key columns: [8] = [1]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
- │    ├── fd: ()-->(4,5,7-10)
+ │    ├── fd: ()-->(1,2,7-10)
  │    ├── scan abc
  │    │    ├── columns: a:7!null abc.b:8 abc.c:9 d:10
  │    │    ├── constraint: /7: [/1 - /1]
@@ -187,7 +187,6 @@ Source expression:
 
 New expression 1 of 1:
   inner-join (hash)
-   ├── scan cy
    ├── inner-join (hash)
    │    ├── scan bx
    │    ├── inner-join (lookup dz)
@@ -197,6 +196,7 @@ New expression 1 of 1:
    │    │    └── filters (true)
    │    └── filters
    │         └── abc.b = bx.b
+   ├── scan cy
    └── filters
         └── cy.c = dz.d
 ----
@@ -260,9 +260,9 @@ memo join-limit=2
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
 memo (optimized, ~35KB, required=[presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10])
- ├── G1: (inner-join G2 G3 G4) (inner-join G5 G6 G7) (inner-join G3 G2 G4) (merge-join G2 G3 G8 inner-join,+1,+8) (inner-join G6 G5 G7) (merge-join G5 G6 G8 inner-join,+4,+9) (lookup-join G3 G8 bx,keyCols=[8],outCols=(1,2,4,5,7-10)) (lookup-join G6 G8 cy,keyCols=[9],outCols=(1,2,4,5,7-10))
+ ├── G1: (inner-join G2 G3 G4) (inner-join G5 G6 G7) (inner-join G3 G2 G4) (merge-join G2 G3 G8 inner-join,+1,+8) (inner-join G6 G5 G7) (lookup-join G5 G8 cy,keyCols=[9],outCols=(1,2,4,5,7-10)) (lookup-join G3 G8 bx,keyCols=[8],outCols=(1,2,4,5,7-10)) (merge-join G6 G5 G8 inner-join,+4,+9)
  │    └── [presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10]
- │         ├── best: (lookup-join G3 G8 bx,keyCols=[8],outCols=(1,2,4,5,7-10))
+ │         ├── best: (lookup-join G5 G8 cy,keyCols=[9],outCols=(1,2,4,5,7-10))
  │         └── cost: 13.13
  ├── G2: (scan bx,cols=(1,2))
  │    ├── [ordering: +1]
@@ -271,31 +271,31 @@ memo (optimized, ~35KB, required=[presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10
  │    └── []
  │         ├── best: (scan bx,cols=(1,2))
  │         └── cost: 1040.02
- ├── G3: (inner-join G5 G9 G7) (inner-join G9 G5 G7) (merge-join G5 G9 G8 inner-join,+4,+9) (lookup-join G10 G7 abc,keyCols=[12],outCols=(4,5,7-10)) (lookup-join G9 G8 cy,keyCols=[9],outCols=(4,5,7-10))
+ ├── G3: (inner-join G6 G9 G7) (inner-join G9 G6 G7) (merge-join G6 G9 G8 inner-join,+4,+9) (lookup-join G10 G7 abc,keyCols=[12],outCols=(4,5,7-10)) (lookup-join G9 G8 cy,keyCols=[9],outCols=(4,5,7-10))
  │    └── []
  │         ├── best: (lookup-join G9 G8 cy,keyCols=[9],outCols=(4,5,7-10))
  │         └── cost: 7.13
  ├── G4: (filters G11)
- ├── G5: (scan cy,cols=(4,5))
+ ├── G5: (inner-join G2 G9 G4) (inner-join G9 G2 G4) (merge-join G2 G9 G8 inner-join,+1,+8) (lookup-join G12 G4 abc,keyCols=[13],outCols=(1,2,7-10)) (lookup-join G9 G8 bx,keyCols=[8],outCols=(1,2,7-10))
+ │    └── []
+ │         ├── best: (lookup-join G9 G8 bx,keyCols=[8],outCols=(1,2,7-10))
+ │         └── cost: 7.13
+ ├── G6: (scan cy,cols=(4,5))
  │    ├── [ordering: +4]
  │    │    ├── best: (scan cy,cols=(4,5))
  │    │    └── cost: 1040.02
  │    └── []
  │         ├── best: (scan cy,cols=(4,5))
  │         └── cost: 1040.02
- ├── G6: (inner-join G2 G9 G4) (inner-join G9 G2 G4) (merge-join G2 G9 G8 inner-join,+1,+8) (lookup-join G12 G4 abc,keyCols=[13],outCols=(1,2,7-10)) (lookup-join G9 G8 bx,keyCols=[8],outCols=(1,2,7-10))
- │    └── []
- │         ├── best: (lookup-join G9 G8 bx,keyCols=[8],outCols=(1,2,7-10))
- │         └── cost: 7.13
  ├── G7: (filters G13)
  ├── G8: (filters)
  ├── G9: (select G14 G15) (scan abc,cols=(7-10),constrained)
  │    └── []
  │         ├── best: (scan abc,cols=(7-10),constrained)
  │         └── cost: 1.09
- ├── G10: (project G5 G16 c y)
+ ├── G10: (project G6 G16 c y)
  │    └── []
- │         ├── best: (project G5 G16 c y)
+ │         ├── best: (project G6 G16 c y)
  │         └── cost: 1060.03
  ├── G11: (eq G17 G18)
  ├── G12: (project G2 G16 b x)
@@ -485,9 +485,9 @@ memo join-limit=3
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
 memo (optimized, ~51KB, required=[presentation: b:1,x:2,c:4,y:5,d:7,z:8,a:10,b:11,c:12,d:13])
- ├── G1: (inner-join G2 G3 G4) (inner-join G5 G6 G7) (inner-join G8 G9 G7) (inner-join G10 G11 G12) (inner-join G13 G14 G12) (inner-join G15 G16 G12) (inner-join G17 G18 G12) (inner-join G3 G2 G4) (inner-join G6 G5 G7) (inner-join G9 G8 G7) (inner-join G11 G10 G12) (inner-join G14 G13 G12) (inner-join G16 G15 G12) (inner-join G18 G17 G12) (lookup-join G17 G19 abc,keyCols=[8],outCols=(1,2,4,5,7,8,10-13)) (merge-join G11 G10 G19 inner-join,+10,+8) (merge-join G14 G13 G19 inner-join,+10,+8) (merge-join G16 G15 G19 inner-join,+10,+8) (merge-join G18 G17 G19 inner-join,+10,+8)
+ ├── G1: (inner-join G2 G3 G4) (inner-join G5 G6 G7) (inner-join G8 G9 G10) (inner-join G11 G12 G10) (inner-join G13 G14 G10) (inner-join G15 G16 G10) (inner-join G17 G18 G7) (inner-join G3 G2 G4) (inner-join G6 G5 G7) (inner-join G9 G8 G10) (inner-join G12 G11 G10) (lookup-join G11 G19 abc,keyCols=[8],outCols=(1,2,4,5,7,8,10-13)) (inner-join G14 G13 G10) (merge-join G13 G14 G19 inner-join,+10,+8) (inner-join G16 G15 G10) (merge-join G15 G16 G19 inner-join,+10,+8) (inner-join G18 G17 G7) (merge-join G9 G8 G19 inner-join,+10,+8) (merge-join G12 G11 G19 inner-join,+10,+8)
  │    └── [presentation: b:1,x:2,c:4,y:5,d:7,z:8,a:10,b:11,c:12,d:13]
- │         ├── best: (inner-join G8 G9 G7)
+ │         ├── best: (inner-join G5 G6 G7)
  │         └── cost: 5478.19
  ├── G2: (scan bx,cols=(1,2))
  │    ├── [ordering: +2]
@@ -496,102 +496,102 @@ memo (optimized, ~51KB, required=[presentation: b:1,x:2,c:4,y:5,d:7,z:8,a:10,b:1
  │    └── []
  │         ├── best: (scan bx,cols=(1,2))
  │         └── cost: 1040.02
- ├── G3: (inner-join G5 G9 G7) (inner-join G10 G14 G12) (inner-join G15 G18 G12) (inner-join G9 G5 G7) (inner-join G14 G10 G12) (inner-join G18 G15 G12) (lookup-join G15 G19 abc,keyCols=[8],outCols=(4,5,7,8,10-13)) (merge-join G14 G10 G19 inner-join,+10,+8) (merge-join G18 G15 G19 inner-join,+10,+8)
+ ├── G3: (inner-join G18 G6 G7) (inner-join G14 G12 G10) (inner-join G9 G16 G10) (inner-join G6 G18 G7) (inner-join G12 G14 G10) (lookup-join G14 G19 abc,keyCols=[8],outCols=(4,5,7,8,10-13)) (inner-join G16 G9 G10) (merge-join G9 G16 G19 inner-join,+10,+8) (merge-join G12 G14 G19 inner-join,+10,+8)
  │    └── []
- │         ├── best: (inner-join G5 G9 G7)
+ │         ├── best: (inner-join G18 G6 G7)
  │         └── cost: 3327.84
  ├── G4: (filters G20)
- ├── G5: (scan cy,cols=(4,5))
- │    ├── [ordering: +5]
- │    │    ├── best: (sort G5)
- │    │    └── cost: 1259.35
- │    └── []
- │         ├── best: (scan cy,cols=(4,5))
- │         └── cost: 1040.02
- ├── G6: (inner-join G2 G9 G21) (inner-join G10 G16 G12) (inner-join G13 G18 G12) (inner-join G9 G2 G21) (inner-join G16 G10 G12) (inner-join G18 G13 G12) (lookup-join G13 G19 abc,keyCols=[8],outCols=(1,2,7,8,10-13)) (merge-join G16 G10 G19 inner-join,+10,+8) (merge-join G18 G13 G19 inner-join,+10,+8)
- │    └── []
- │         ├── best: (inner-join G2 G9 G21)
- │         └── cost: 3327.84
- ├── G7: (filters G22)
- ├── G8: (inner-join G2 G5 G4) (inner-join G5 G2 G4)
+ ├── G5: (inner-join G2 G18 G4) (inner-join G18 G2 G4)
  │    ├── [ordering: +(2|5)]
+ │    │    ├── best: (sort G5)
+ │    │    └── cost: 5003.07
+ │    └── []
+ │         ├── best: (inner-join G2 G18 G4)
+ │         └── cost: 2208.07
+ ├── G6: (inner-join G16 G12 G10) (inner-join G12 G16 G10) (lookup-join G16 G19 abc,keyCols=[8],outCols=(7,8,10-13)) (merge-join G12 G16 G19 inner-join,+10,+8)
+ │    └── []
+ │         ├── best: (inner-join G16 G12 G10)
+ │         └── cost: 2159.96
+ ├── G7: (filters G21)
+ ├── G8: (inner-join G2 G16 G22) (inner-join G16 G2 G22)
+ │    ├── [ordering: +(2|8)]
  │    │    ├── best: (sort G8)
  │    │    └── cost: 5003.07
  │    └── []
- │         ├── best: (inner-join G2 G5 G4)
+ │         ├── best: (inner-join G2 G16 G22)
  │         └── cost: 2208.07
- ├── G9: (inner-join G10 G18 G12) (inner-join G18 G10 G12) (lookup-join G10 G19 abc,keyCols=[8],outCols=(7,8,10-13)) (merge-join G18 G10 G19 inner-join,+10,+8)
- │    └── []
- │         ├── best: (inner-join G10 G18 G12)
- │         └── cost: 2159.96
- ├── G10: (scan dz,cols=(7,8))
- │    ├── [ordering: +8]
- │    │    ├── best: (sort G10)
- │    │    └── cost: 1259.35
- │    └── []
- │         ├── best: (scan dz,cols=(7,8))
- │         └── cost: 1040.02
- ├── G11: (inner-join G2 G14 G4) (inner-join G5 G16 G4) (inner-join G8 G18 G23) (inner-join G14 G2 G4) (inner-join G16 G5 G4) (inner-join G18 G8 G23) (lookup-join G8 G19 abc,keyCols=[5],outCols=(1,2,4,5,10-13)) (merge-join G18 G8 G19 inner-join,+10,+5)
- │    ├── [ordering: +(2|5|10)]
- │    │    ├── best: (sort G11)
- │    │    └── cost: 6122.84
- │    └── []
- │         ├── best: (inner-join G2 G14 G4)
- │         └── cost: 3327.84
- ├── G12: (filters G24)
- ├── G13: (inner-join G2 G10 G21) (inner-join G10 G2 G21)
- │    ├── [ordering: +(2|8)]
- │    │    ├── best: (sort G13)
- │    │    └── cost: 5003.07
- │    └── []
- │         ├── best: (inner-join G2 G10 G21)
- │         └── cost: 2208.07
- ├── G14: (inner-join G5 G18 G23) (inner-join G18 G5 G23) (lookup-join G5 G19 abc,keyCols=[5],outCols=(4,5,10-13)) (merge-join G18 G5 G19 inner-join,+10,+5)
+ ├── G9: (inner-join G18 G12 G23) (inner-join G12 G18 G23) (lookup-join G18 G19 abc,keyCols=[5],outCols=(4,5,10-13)) (merge-join G12 G18 G19 inner-join,+10,+5)
  │    ├── [ordering: +(5|10)]
- │    │    ├── best: (merge-join G18="[ordering: +10]" G5="[ordering: +5]" G19 inner-join,+10,+5)
+ │    │    ├── best: (merge-join G12="[ordering: +10]" G18="[ordering: +5]" G19 inner-join,+10,+5)
  │    │    └── cost: 2369.28
  │    └── []
- │         ├── best: (inner-join G5 G18 G23)
+ │         ├── best: (inner-join G18 G12 G23)
  │         └── cost: 2159.96
- ├── G15: (inner-join G5 G10 G7) (inner-join G10 G5 G7)
- │    ├── [ordering: +(5|8)]
- │    │    ├── best: (sort G15)
- │    │    └── cost: 5003.07
- │    └── []
- │         ├── best: (inner-join G5 G10 G7)
- │         └── cost: 2208.07
- ├── G16: (inner-join G2 G18 G25) (inner-join G18 G2 G25) (lookup-join G2 G19 abc,keyCols=[2],outCols=(1,2,10-13)) (merge-join G18 G2 G19 inner-join,+10,+2)
- │    ├── [ordering: +(2|10)]
- │    │    ├── best: (merge-join G18="[ordering: +10]" G2="[ordering: +2]" G19 inner-join,+10,+2)
- │    │    └── cost: 2369.28
- │    └── []
- │         ├── best: (inner-join G2 G18 G25)
- │         └── cost: 2159.96
- ├── G17: (inner-join G2 G15 G4) (inner-join G5 G13 G7) (inner-join G8 G10 G7) (inner-join G15 G2 G4) (inner-join G13 G5 G7) (inner-join G10 G8 G7)
+ ├── G10: (filters G24)
+ ├── G11: (inner-join G2 G14 G4) (inner-join G5 G16 G7) (inner-join G8 G18 G7) (inner-join G14 G2 G4) (inner-join G16 G5 G7) (inner-join G18 G8 G7)
  │    ├── [ordering: +(2|5|8)]
- │    │    ├── best: (sort G17)
+ │    │    ├── best: (sort G11)
  │    │    └── cost: 38447.25
  │    └── []
- │         ├── best: (inner-join G8 G10 G7)
+ │         ├── best: (inner-join G5 G16 G7)
  │         └── cost: 4358.42
- ├── G18: (scan abc,cols=(10-13))
+ ├── G12: (scan abc,cols=(10-13))
  │    ├── [ordering: +10]
  │    │    ├── best: (scan abc,cols=(10-13))
  │    │    └── cost: 1080.02
  │    └── []
  │         ├── best: (scan abc,cols=(10-13))
  │         └── cost: 1080.02
+ ├── G13: (inner-join G2 G12 G25) (inner-join G12 G2 G25) (lookup-join G2 G19 abc,keyCols=[2],outCols=(1,2,10-13)) (merge-join G12 G2 G19 inner-join,+10,+2)
+ │    ├── [ordering: +(2|10)]
+ │    │    ├── best: (merge-join G12="[ordering: +10]" G2="[ordering: +2]" G19 inner-join,+10,+2)
+ │    │    └── cost: 2369.28
+ │    └── []
+ │         ├── best: (inner-join G2 G12 G25)
+ │         └── cost: 2159.96
+ ├── G14: (inner-join G18 G16 G7) (inner-join G16 G18 G7)
+ │    ├── [ordering: +(5|8)]
+ │    │    ├── best: (sort G14)
+ │    │    └── cost: 5003.07
+ │    └── []
+ │         ├── best: (inner-join G18 G16 G7)
+ │         └── cost: 2208.07
+ ├── G15: (inner-join G2 G9 G4) (inner-join G5 G12 G23) (inner-join G13 G18 G4) (inner-join G9 G2 G4) (inner-join G12 G5 G23) (lookup-join G5 G19 abc,keyCols=[5],outCols=(1,2,4,5,10-13)) (inner-join G18 G13 G4) (merge-join G12 G5 G19 inner-join,+10,+5)
+ │    ├── [ordering: +(2|5|10)]
+ │    │    ├── best: (sort G15)
+ │    │    └── cost: 6122.84
+ │    └── []
+ │         ├── best: (inner-join G2 G9 G4)
+ │         └── cost: 3327.84
+ ├── G16: (scan dz,cols=(7,8))
+ │    ├── [ordering: +8]
+ │    │    ├── best: (sort G16)
+ │    │    └── cost: 1259.35
+ │    └── []
+ │         ├── best: (scan dz,cols=(7,8))
+ │         └── cost: 1040.02
+ ├── G17: (inner-join G2 G6 G22) (inner-join G8 G12 G10) (inner-join G13 G16 G10) (inner-join G6 G2 G22) (inner-join G12 G8 G10) (lookup-join G8 G19 abc,keyCols=[8],outCols=(1,2,7,8,10-13)) (inner-join G16 G13 G10) (merge-join G13 G16 G19 inner-join,+10,+8) (merge-join G12 G8 G19 inner-join,+10,+8)
+ │    └── []
+ │         ├── best: (inner-join G2 G6 G22)
+ │         └── cost: 3327.84
+ ├── G18: (scan cy,cols=(4,5))
+ │    ├── [ordering: +5]
+ │    │    ├── best: (sort G18)
+ │    │    └── cost: 1259.35
+ │    └── []
+ │         ├── best: (scan cy,cols=(4,5))
+ │         └── cost: 1040.02
  ├── G19: (filters)
  ├── G20: (eq G26 G27)
- ├── G21: (filters G28)
- ├── G22: (eq G27 G29)
+ ├── G21: (eq G27 G28)
+ ├── G22: (filters G29)
  ├── G23: (filters G30)
- ├── G24: (eq G29 G31)
+ ├── G24: (eq G28 G31)
  ├── G25: (filters G32)
  ├── G26: (variable x)
  ├── G27: (variable y)
- ├── G28: (eq G26 G29)
- ├── G29: (variable z)
+ ├── G28: (variable z)
+ ├── G29: (eq G26 G28)
  ├── G30: (eq G27 G31)
  ├── G31: (variable a)
  └── G32: (eq G26 G31)
@@ -778,16 +778,16 @@ b = c [inner]
 c = d [inner]
 b = d [inner]
 
-----Joining AB----
-A B    refs [AB] [inner]
-----Joining AC----
-A C    refs [AC] [inner]
 ----Joining BC----
 B C    refs [BC] [inner]
+----Joining AC----
+A C    refs [AC] [inner]
+----Joining AB----
+A B    refs [AB] [inner]
 ----Joining ABC----
 A BC    refs [AB] [inner]
-B AC    refs [AB] [inner]
 AB C    refs [BC] [inner]
+AC B    refs [AB] [inner]
 
 Joins Considered: 6
 --------------------------------------------------------------------------------
@@ -869,10 +869,10 @@ scalar-group-by
 bx.b = cy.c [inner]
 y = max [inner]
 
-----Joining AB----
-A B    refs [AB] [inner]
 ----Joining BC----
 B C    refs [BC] [inner]
+----Joining AB----
+A B    refs [AB] [inner]
 ----Joining ABC----
 A BC    refs [AB] [inner]
 AB C    refs [BC] [inner]
@@ -921,29 +921,32 @@ y = max [inner]
 max = a [inner]
 y = a [inner]
 
-----Joining AB----
-A B    refs [AB] [inner]
-----Joining BC----
-B C    refs [BC] [inner]
-----Joining ABC----
-A BC    refs [AB] [inner]
-AB C    refs [BC] [inner]
-----Joining BD----
-B D    refs [BD] [inner]
-----Joining ABD----
-A BD    refs [AB] [inner]
-AB D    refs [BD] [inner]
 ----Joining CD----
 C D    refs [CD] [inner]
+----Joining BD----
+B D    refs [BD] [inner]
+----Joining BC----
+B C    refs [BC] [inner]
 ----Joining BCD----
 B CD    refs [BCD] [inner]
-C BD    refs [BC] [inner]
 BC D    refs [CD] [inner]
+BD C    refs [BC] [inner]
+----Joining AB----
+A B    refs [AB] [inner]
+----Joining ABC----
+A BC    refs [AB] [inner]
+----Joining ABD----
+A BD    refs [AB] [inner]
 ----Joining ABCD----
 A BCD    refs [AB] [inner]
+----Joining ABD----
+AB D    refs [BD] [inner]
+----Joining ABC----
+AB C    refs [BC] [inner]
+----Joining ABCD----
 AB CD    refs [BCD] [inner]
-C ABD    refs [BC] [inner]
 ABC D    refs [CD] [inner]
+ABD C    refs [BC] [inner]
 
 Joins Considered: 15
 --------------------------------------------------------------------------------
@@ -1051,16 +1054,16 @@ x = z [inner]
 x = a [inner]
 y = a [inner]
 
-----Joining AB----
-A B    refs [AB] [inner]
-----Joining AC----
-A C    refs [AC] [inner]
 ----Joining BC----
 B C    refs [BC] [inner]
+----Joining AC----
+A C    refs [AC] [inner]
+----Joining AB----
+A B    refs [AB] [inner]
 ----Joining ABC----
 A BC    refs [AB] [inner]
-B AC    refs [AB] [inner]
 AB C    refs [BC] [inner]
+AC B    refs [AB] [inner]
 
 Joins Considered: 6
 --------------------------------------------------------------------------------
@@ -1146,16 +1149,16 @@ y = z [inner]
 z = a [inner]
 y = a [inner]
 
-----Joining AB----
-A B    refs [AB] [inner]
-----Joining AC----
-A C    refs [AC] [inner]
 ----Joining BC----
 B C    refs [BC] [inner]
+----Joining AC----
+A C    refs [AC] [inner]
+----Joining AB----
+A B    refs [AB] [inner]
 ----Joining ABC----
 A BC    refs [AB] [inner]
-B AC    refs [AB] [inner]
 AB C    refs [BC] [inner]
+AC B    refs [AB] [inner]
 
 Joins Considered: 6
 --------------------------------------------------------------------------------
@@ -1194,16 +1197,16 @@ z = a [inner]
 cross [inner]
 y = a [inner]
 
-----Joining AB----
-A B    refs [AB] [inner]
-----Joining AC----
-A C    refs [AC] [inner]
 ----Joining BC----
 B C    refs [BC] [inner]
+----Joining AC----
+A C    refs [AC] [inner]
+----Joining AB----
+A B    refs [AB] [inner]
 ----Joining ABC----
 A BC    refs [AB] [inner]
-B AC    refs [AB] [inner]
 AB C    refs [BC] [inner]
+AC B    refs [AB] [inner]
 ----Joining DABC----
 D ABC    refs [] [inner]
 
@@ -1327,29 +1330,34 @@ a = z [inner]
 abc.b = bx.b [inner]
 abc.c = cy.c [inner]
 
-----Joining AB----
-A B    refs [AB] [inner]
-----Joining AC----
-A C    refs [AC] [inner]
-----Joining BC----
-B C    refs [BC] [inner]
-----Joining ABC----
-A BC    refs [ABC] [inner]
-B AC    refs [ABC] [inner]
-AB C    refs [ABC] [inner]
 ----Joining CD----
 C D    refs [CD] [inner]
-----Joining ACD----
-A CD    refs [AC] [inner]
-AC D    refs [CD] [inner]
+----Joining BC----
+B C    refs [BC] [inner]
 ----Joining BCD----
 B CD    refs [BC] [inner]
 BC D    refs [CD] [inner]
+----Joining AC----
+A C    refs [AC] [inner]
+----Joining ACD----
+A CD    refs [AC] [inner]
+----Joining AB----
+A B    refs [AB] [inner]
+----Joining ABC----
+A BC    refs [ABC] [inner]
 ----Joining ABCD----
 A BCD    refs [ABC] [inner]
-B ACD    refs [ABC] [inner]
+----Joining ABC----
+AB C    refs [ABC] [inner]
+----Joining ABCD----
 AB CD    refs [ABC] [inner]
+----Joining ACD----
+AC D    refs [CD] [inner]
+----Joining ABC----
+AC B    refs [ABC] [inner]
+----Joining ABCD----
 ABC D    refs [CD] [inner]
+ACD B    refs [ABC] [inner]
 
 Joins Considered: 15
 --------------------------------------------------------------------------------
@@ -1428,13 +1436,13 @@ scan dz
 b = c [inner]
 x = z [left]
 
-----Joining AB----
-A B    refs [AB] [inner]
 ----Joining AC----
 A C    refs [AC] [left]
+----Joining AB----
+A B    refs [AB] [inner]
 ----Joining ABC----
-B AC    refs [AB] [inner]
 AB C    refs [AC] [left]
+AC B    refs [AB] [inner]
 
 Joins Considered: 4
 --------------------------------------------------------------------------------
@@ -1507,13 +1515,13 @@ scan dz
 b = c [left]
 x = z [left]
 
-----Joining AB----
-A B    refs [AB] [left]
 ----Joining AC----
 A C    refs [AC] [left]
+----Joining AB----
+A B    refs [AB] [left]
 ----Joining ABC----
-AC B    refs [AB] [left]
 AB C    refs [AC] [left]
+AC B    refs [AB] [left]
 
 Joins Considered: 4
 --------------------------------------------------------------------------------
@@ -1589,10 +1597,10 @@ scan dz
 b = c [left]
 y = z [left]
 
-----Joining AB----
-A B    refs [AB] [left]
 ----Joining BC----
 B C    refs [BC] [left]
+----Joining AB----
+A B    refs [AB] [left]
 ----Joining ABC----
 A BC    refs [AB] [left]
 AB C    refs [BC] [left]
@@ -1671,13 +1679,13 @@ scan dz
 bx.b = a [anti]
 bx.b = dz.d [semi]
 
-----Joining AB----
-A B    refs [AB] [anti]
 ----Joining AC----
 A C    refs [AC] [semi]
+----Joining AB----
+A B    refs [AB] [anti]
 ----Joining ABC----
-AC B    refs [AB] [anti]
 AB C    refs [AC] [semi]
+AC B    refs [AB] [anti]
 
 Joins Considered: 4
 --------------------------------------------------------------------------------
@@ -1706,13 +1714,13 @@ scan dz
 bx.b = a [anti]
 bx.b = dz.d [inner]
 
-----Joining AB----
-A B    refs [AB] [anti]
 ----Joining AC----
 A C    refs [AC] [inner]
+----Joining AB----
+A B    refs [AB] [anti]
 ----Joining ABC----
-AC B    refs [AB] [anti]
 AB C    refs [AC] [inner]
+AC B    refs [AB] [anti]
 
 Joins Considered: 4
 --------------------------------------------------------------------------------
@@ -1749,39 +1757,39 @@ bx.b = a [anti]
 bx.b = dz.d [semi]
 bx.b = cy.c [left]
 
-----Joining AB----
-A B    refs [AB] [anti]
-----Joining AC----
-A C    refs [AC] [semi]
-----Joining ABC----
-AC B    refs [AB] [anti]
-AB C    refs [AC] [semi]
 ----Joining AD----
 A D    refs [AD] [left]
+----Joining AC----
+A C    refs [AC] [semi]
+----Joining AB----
+A B    refs [AB] [anti]
 ----Joining ABD----
-AD B    refs [AB] [anti]
 AB D    refs [AD] [left]
+----Joining ABC----
+AB C    refs [AC] [semi]
+----Joining ACD----
+AC D    refs [AD] [left]
+----Joining ABC----
+AC B    refs [AB] [anti]
+----Joining ABCD----
+ABC D    refs [AD] [left]
 ----Joining ACD----
 AD C    refs [AC] [semi]
-AC D    refs [AD] [left]
+----Joining ABD----
+AD B    refs [AB] [anti]
 ----Joining ABCD----
-ACD B    refs [AB] [anti]
 ABD C    refs [AC] [semi]
-ABC D    refs [AD] [left]
+ACD B    refs [AB] [anti]
 
 Joins Considered: 12
 --------------------------------------------------------------------------------
 ----Join Tree #5----
 inner-join (hash)
- ├── anti-join (hash)
- │    ├── left-join (hash)
- │    │    ├── scan bx
- │    │    ├── scan cy
- │    │    └── filters
- │    │         └── bx.b = cy.c
- │    ├── scan abc
+ ├── left-join (hash)
+ │    ├── scan bx
+ │    ├── scan cy
  │    └── filters
- │         └── bx.b = a
+ │         └── bx.b = cy.c
  ├── scan dz
  └── filters
       └── bx.b = dz.d
@@ -1793,43 +1801,86 @@ scan bx
 D:
 scan cy
 
-B:
-scan abc
-
 C:
 scan dz
 
 ----Edges----
 bx.b = cy.c [left]
-bx.b = a [anti]
 bx.b = dz.d [inner]
 
+----Joining AC----
+A C    refs [AC] [inner]
+----Joining AD----
+A D    refs [AD] [left]
+----Joining ADC----
+AD C    refs [AC] [inner]
+AC D    refs [AD] [left]
+
+Joins Considered: 4
+--------------------------------------------------------------------------------
+----Join Tree #6----
+inner-join (hash)
+ ├── left-join (hash)
+ │    ├── anti-join (hash)
+ │    │    ├── scan bx
+ │    │    ├── scan abc
+ │    │    └── filters
+ │    │         └── bx.b = a
+ │    ├── scan cy
+ │    └── filters
+ │         └── bx.b = cy.c
+ ├── scan dz
+ └── filters
+      └── bx.b = dz.d
+
+----Vertexes----
+A:
+scan bx
+
+B:
+scan abc
+
+D:
+scan cy
+
+C:
+scan dz
+
+----Edges----
+bx.b = a [anti]
+bx.b = cy.c [left]
+bx.b = dz.d [inner]
+
+----Joining AC----
+A C    refs [AC] [inner]
 ----Joining AD----
 A D    refs [AD] [left]
 ----Joining AB----
 A B    refs [AB] [anti]
-----Joining ADB----
+----Joining ABC----
+AB C    refs [AC] [inner]
+----Joining ABD----
 AB D    refs [AD] [left]
+----Joining ADC----
+AD C    refs [AC] [inner]
+----Joining ABD----
 AD B    refs [AB] [anti]
-----Joining AC----
-A C    refs [AC] [inner]
+----Joining ABDC----
+ABD C    refs [AC] [inner]
 ----Joining ADC----
 AC D    refs [AD] [left]
-AD C    refs [AC] [inner]
 ----Joining ABC----
 AC B    refs [AB] [anti]
-AB C    refs [AC] [inner]
-----Joining ADBC----
+----Joining ABDC----
 ABC D    refs [AD] [left]
 ADC B    refs [AB] [anti]
-ADB C    refs [AC] [inner]
 
 Joins Considered: 12
 --------------------------------------------------------------------------------
 ----Final Plan----
-semi-join (lookup dz)
+left-join (lookup cy)
  ├── lookup columns are key
- ├── left-join (lookup cy)
+ ├── semi-join (lookup dz)
  │    ├── lookup columns are key
  │    ├── anti-join (merge)
  │    │    ├── scan bx
@@ -1967,10 +2018,10 @@ scan dz
 b = c [full]
 y = z [full]
 
-----Joining AB----
-A B    refs [AB] [full]
 ----Joining BC----
 B C    refs [BC] [full]
+----Joining AB----
+A B    refs [AB] [full]
 ----Joining ABC----
 A BC    refs [AB] [full]
 AB C    refs [BC] [full]
@@ -2071,10 +2122,10 @@ scan a5
 a2.c = a5.c [semi]
 a1.a = a2.a [inner]
 
-----Joining CA----
-C A    refs [CA] [inner]
 ----Joining AB----
 A B    refs [AB] [semi]
+----Joining CA----
+C A    refs [CA] [inner]
 ----Joining CAB----
 C AB    refs [CA] [inner]
 CA B    refs [AB] [semi]
@@ -2108,10 +2159,10 @@ distinct-on
 a1.a = a2.a [inner]
 a2.c = a5.c [inner]
 
-----Joining CA----
-C A    refs [CA] [inner]
 ----Joining AB----
 A B    refs [AB] [inner]
+----Joining CA----
+C A    refs [CA] [inner]
 ----Joining CAB----
 C AB    refs [CA] [inner]
 CA B    refs [AB] [inner]
@@ -2151,10 +2202,10 @@ scan a3
 a1.a = a2.a [inner]
 a2.b = a3.b [inner]
 
-----Joining CA----
-C A    refs [CA] [inner]
 ----Joining AD----
 A D    refs [AD] [inner]
+----Joining CA----
+C A    refs [CA] [inner]
 ----Joining CAD----
 C AD    refs [CA] [inner]
 CA D    refs [AD] [inner]
@@ -2202,10 +2253,10 @@ scan a4
 a2.b = a3.b [inner]
 a3.a = a4.a [inner]
 
-----Joining CD----
-C D    refs [CD] [inner]
 ----Joining DE----
 D E    refs [DE] [inner]
+----Joining CD----
+C D    refs [CD] [inner]
 ----Joining CDE----
 C DE    refs [CD] [inner]
 CD E    refs [DE] [inner]


### PR DESCRIPTION
Previously, join-ordering enumeration was handled by the DPSub
algorithm, which iterates through all pairs of subsets of base relations
and checks whether a join between their respective plans is possible.

This patch replaces DPSub with DPHyp, which is a more efficient
graph-aware algorithm. DPHyp constructs connected-complement pairs
by enumerating connected sub-graphs from increasing sections of the
join graph. Connected sub-graphs are constructed by recursive graph
traversal, and duplicates are prevented by disallowing exploration
of certain nodes.

For join trees for which only a small number of orderings are valid
(chain graphs, trees with cross-products, etc.), DPHyp significantly
outperforms DPSub.

Release note: None