### PR TITLE
sql:  add notice for Alter TYPE ADD VALUE IF NOT EXIST command

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/notice
+++ b/pkg/sql/logictest/testdata/logic_test/notice
@@ -33,3 +33,18 @@ ALTER TABLE d.t RENAME TO d.t2
 ----
 NOTICE: renaming tables with a qualification is deprecated
 HINT: use ALTER TABLE d.t RENAME TO t2 instead
+
+statement ok
+SET experimental_enable_enums=true;
+
+# Start off with an empty enum, and add values to it.
+statement ok
+CREATE TYPE color AS ENUM ()
+
+statement ok
+ALTER TYPE color ADD VALUE 'black'
+
+query T noticetrace
+ALTER TYPE color ADD VALUE IF NOT EXISTS 'black'
+----
+NOTICE: enum label "black" already exists, skipping

--- a/pkg/sql/sqlbase/type_desc.go
+++ b/pkg/sql/sqlbase/type_desc.go
@@ -254,25 +254,9 @@ func (desc *MutableTypeDescriptor) IsNew() bool {
 }
 
 // AddEnumValue adds an enum member to the type.
+// AddEnumValue assumes that the type is an enum, and that the new value
+// doesn't exist already in the enum.
 func (desc *MutableTypeDescriptor) AddEnumValue(node *tree.AlterTypeAddValue) error {
-	if desc.Kind != descpb.TypeDescriptor_ENUM {
-		return pgerror.Newf(pgcode.WrongObjectType, "%q is not an enum", desc.Name)
-	}
-	// See if the value already exists in the enum or not.
-	found := false
-	for _, member := range desc.EnumMembers {
-		if member.LogicalRepresentation == node.NewVal {
-			found = true
-			break
-		}
-	}
-	if found {
-		if node.IfNotExists {
-			return nil
-		}
-		return pgerror.Newf(pgcode.DuplicateObject, "enum label %q already exists", node.NewVal)
-	}
-
 	getPhysicalRep := func(idx int) []byte {
 		if idx < 0 || idx >= len(desc.EnumMembers) {
 			return nil


### PR DESCRIPTION
Fixes: #52327

Added a notice message similar to postgres if user tries to add a value in enum which already exists using IF NOT EXIST command.

> root@:26257/defaultdb> alter type color ADD VALUE IF NOT EXISTS 'black';
ALTER TYPE

> root@:26257/defaultdb> alter type color ADD VALUE IF NOT EXISTS 'black';
NOTICE: enum label "black" already exists, skipping 

However, I noticed similar behaviour in other command like ALTER TABLE command. Altering existing table with if not exist 
command doesn't shows any notice.

Release note (sql change): Show notice to user when user tries to add value which already exists in enum .

