### PR TITLE
sql: new statement `SHOW ENUMS`

### DIFF
--- a/docs/generated/sql/bnf/show_var.bnf
+++ b/docs/generated/sql/bnf/show_var.bnf
@@ -5,6 +5,7 @@ show_stmt ::=
 	| show_create_stmt
 	| show_csettings_stmt
 	| show_databases_stmt
+	| show_enums_stmt
 	| show_grants_stmt
 	| show_indexes_stmt
 	| show_partitions_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -187,6 +187,7 @@ show_stmt ::=
 	| show_create_stmt
 	| show_csettings_stmt
 	| show_databases_stmt
+	| show_enums_stmt
 	| show_grants_stmt
 	| show_indexes_stmt
 	| show_partitions_stmt
@@ -536,6 +537,9 @@ show_csettings_stmt ::=
 show_databases_stmt ::=
 	'SHOW' 'DATABASES' with_comment
 
+show_enums_stmt ::=
+	'SHOW' 'ENUMS'
+
 show_grants_stmt ::=
 	'SHOW' 'GRANTS' opt_on_targets_roles for_grantee_clause
 
@@ -728,6 +732,7 @@ unreserved_keyword ::=
 	| 'ENCODING'
 	| 'ENCRYPTION_PASSPHRASE'
 	| 'ENUM'
+	| 'ENUMS'
 	| 'ESCAPE'
 	| 'EXCLUDE'
 	| 'EXCLUDING'

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -43,6 +43,9 @@ func TryDelegate(
 	case *tree.ShowDatabases:
 		return d.delegateShowDatabases(t)
 
+	case *tree.ShowEnums:
+		return d.delegateShowEnums(t)
+
 	case *tree.ShowCreate:
 		return d.delegateShowCreate(t)
 

--- a/pkg/sql/delegate/show_enums.go
+++ b/pkg/sql/delegate/show_enums.go
@@ -1,0 +1,25 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package delegate
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
+func (d *delegator) delegateShowEnums(n *tree.ShowEnums) (tree.Statement, error) {
+	query := `
+  SELECT type.typname AS name,
+         string_agg(enum.enumlabel, '|') AS value
+    FROM pg_enum AS enum
+    JOIN pg_type AS type ON (type.oid = enum.enumtypid)
+GROUP BY type.typname
+ORDER BY type.typname`
+
+	return parse(query)
+}

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1107,3 +1107,14 @@ local
 
 statement ok
 ROLLBACK
+
+query TT
+SHOW ENUMS
+----
+as_bytes   bytes
+dbs        postgres|mysql|spanner|cockroach
+farewell   bye|seeya
+greeting   hello|howdy|hi
+greeting2  hello
+int        Z|S of int
+notbad     dup|DUP

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -307,6 +307,8 @@ func TestContextualHelp(t *testing.T) {
 
 		{`SHOW DATABASES ??`, `SHOW DATABASES`},
 
+		{`SHOW ENUMS ??`, `SHOW ENUMS`},
+
 		{`SHOW GRANTS ON ??`, `SHOW GRANTS`},
 		{`SHOW GRANTS ON foo FOR ??`, `SHOW GRANTS`},
 		{`SHOW GRANTS ON foo FOR bar ??`, `SHOW GRANTS`},

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -499,6 +499,8 @@ func TestParse(t *testing.T) {
 
 		{`SHOW DATABASES`},
 		{`EXPLAIN SHOW DATABASES`},
+		{`SHOW ENUMS`},
+		{`EXPLAIN SHOW ENUMS`},
 		{`SHOW SCHEMAS`},
 		{`EXPLAIN SHOW SCHEMAS`},
 		{`SHOW SCHEMAS FROM a`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -578,7 +578,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 %token <str> DEALLOCATE DECLARE DEFERRABLE DEFERRED DELETE DESC DETACHED
 %token <str> DISCARD DISTINCT DO DOMAIN DOUBLE DROP
 
-%token <str> ELSE ENCODING ENCRYPTION_PASSPHRASE END ENUM ESCAPE EXCEPT EXCLUDE EXCLUDING
+%token <str> ELSE ENCODING ENCRYPTION_PASSPHRASE END ENUM ENUMS ESCAPE EXCEPT EXCLUDE EXCLUDING
 %token <str> EXISTS EXECUTE EXECUTION EXPERIMENTAL
 %token <str> EXPERIMENTAL_FINGERPRINTS EXPERIMENTAL_REPLICA
 %token <str> EXPERIMENTAL_AUDIT
@@ -822,6 +822,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 %type <tree.Statement> show_create_stmt
 %type <tree.Statement> show_csettings_stmt
 %type <tree.Statement> show_databases_stmt
+%type <tree.Statement> show_enums_stmt
 %type <tree.Statement> show_fingerprints_stmt
 %type <tree.Statement> show_grants_stmt
 %type <tree.Statement> show_histogram_stmt
@@ -3917,7 +3918,7 @@ zone_value:
 // %Category: Group
 // %Text:
 // SHOW BACKUP, SHOW CLUSTER SETTING, SHOW COLUMNS, SHOW CONSTRAINTS,
-// SHOW CREATE, SHOW DATABASES, SHOW HISTOGRAM, SHOW INDEXES, SHOW
+// SHOW CREATE, SHOW DATABASES, SHOW ENUMS, SHOW HISTOGRAM, SHOW INDEXES, SHOW
 // PARTITIONS, SHOW JOBS, SHOW QUERIES, SHOW RANGE, SHOW RANGES,
 // SHOW ROLES, SHOW SCHEMAS, SHOW SEQUENCES, SHOW SESSION, SHOW SESSIONS,
 // SHOW STATISTICS, SHOW SYNTAX, SHOW TABLES, SHOW TRACE SHOW TRANSACTION, SHOW USERS,
@@ -3929,6 +3930,7 @@ show_stmt:
 | show_create_stmt          // EXTEND WITH HELP: SHOW CREATE
 | show_csettings_stmt       // EXTEND WITH HELP: SHOW CLUSTER SETTING
 | show_databases_stmt       // EXTEND WITH HELP: SHOW DATABASES
+| show_enums_stmt           // EXTEND WITH HELP: SHOW ENUMS
 | show_fingerprints_stmt
 | show_grants_stmt          // EXTEND WITH HELP: SHOW GRANTS
 | show_histogram_stmt       // EXTEND WITH HELP: SHOW HISTOGRAM
@@ -4168,6 +4170,16 @@ show_databases_stmt:
     $$.val = &tree.ShowDatabases{WithComment: $3.bool()}
   }
 | SHOW DATABASES error // SHOW HELP: SHOW DATABASES
+
+// %Help: SHOW ENUMS - list defined enums
+// %Category: Misc
+// %Text: SHOW ENUMS
+show_enums_stmt:
+  SHOW ENUMS
+  {
+    $$.val = &tree.ShowEnums{}
+  }
+| SHOW ENUMS error // SHOW HELP: SHOW ENUMS
 
 // %Help: SHOW GRANTS - list grants
 // %Category: Priv
@@ -10890,6 +10902,7 @@ unreserved_keyword:
 | ENCODING
 | ENCRYPTION_PASSPHRASE
 | ENUM
+| ENUMS
 | ESCAPE
 | EXCLUDE
 | EXCLUDING

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -137,6 +137,14 @@ func (node *ShowDatabases) Format(ctx *FmtCtx) {
 	}
 }
 
+// ShowEnums represents a SHOW ENUMS statement.
+type ShowEnums struct{}
+
+// Format implements the NodeFormatter interface.
+func (node *ShowEnums) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW ENUMS")
+}
+
 // ShowTraceType is an enum of SHOW TRACE variants.
 type ShowTraceType string
 

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -762,6 +762,12 @@ func (*ShowDatabases) StatementType() StatementType { return Rows }
 func (*ShowDatabases) StatementTag() string { return "SHOW DATABASES" }
 
 // StatementType implements the Statement interface.
+func (*ShowEnums) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowEnums) StatementTag() string { return "SHOW ENUMS" }
+
+// StatementType implements the Statement interface.
 func (*ShowTraceForSession) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -1057,6 +1063,7 @@ func (n *ShowConstraints) String() string                { return AsString(n) }
 func (n *ShowCreate) String() string                     { return AsString(n) }
 func (n *ShowDatabases) String() string                  { return AsString(n) }
 func (n *ShowDatabaseIndexes) String() string            { return AsString(n) }
+func (n *ShowEnums) String() string                      { return AsString(n) }
 func (n *ShowGrants) String() string                     { return AsString(n) }
 func (n *ShowHistogram) String() string                  { return AsString(n) }
 func (n *ShowSchedules) String() string                  { return AsString(n) }


### PR DESCRIPTION
Fixes #52328 

Add `SHOW ENUMS` statement listing existing enums.

Release note (sql change): add new statement `SHOW ENUMS` which displays
the information on enums.