### PR TITLE
kvserver: remove unsafe recursive RLock acquisition

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -1350,8 +1350,6 @@ func TestStoreRangeMergeRHSLeaseExpiration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 52514)
-
 	ctx := context.Background()
 	storeCfg := kvserver.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableReplicateQueue = true

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -904,9 +904,7 @@ func (r *Replica) mergeInProgressRLocked() bool {
 	return r.mu.mergeComplete != nil
 }
 
-func (r *Replica) getFreezeStart() hlc.Timestamp {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+func (r *Replica) getFreezeStartRLocked() hlc.Timestamp {
 	return r.mu.freezeStart
 }
 
@@ -1210,7 +1208,7 @@ func (r *Replica) checkForPendingMergeRLocked(ba *roachpb.BatchRequest) error {
 
 	// The range is being merged into its left-hand neighbor.
 	if ba.IsReadOnly() {
-		freezeStart := r.getFreezeStart()
+		freezeStart := r.getFreezeStartRLocked()
 		ts := ba.Timestamp
 		if ba.Txn != nil {
 			ts.Forward(ba.Txn.MaxTimestamp)


### PR DESCRIPTION
Previously, in `checkExecutionCanProceed` we were acquiring an `RLock`
and then calling `getFreezeStart` which acquires the same `RLock`. This
kind of recursive RLock acquisition is unsafe because, to prevent
starvation of exclusive locks, an intervening `Lock()` call to the mutex
will prevent new readers from acquiring their `RLock` until the first
`RLock` is released. Thus, a goroutine that holds a read lock must not
depend on any future calls to `RLock()` succeeding until it releases
that read lock first.

See https://go-review.googlesource.com/c/go/+/23570/ for details.

Fixes #52514

Release note: None