### PR TITLE
sql: support partial indexes and user defined types

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -145,7 +145,7 @@ type avroEnvelopeRecord struct {
 func columnDescToAvroSchema(colDesc *descpb.ColumnDescriptor) (*avroSchemaField, error) {
 	schema := &avroSchemaField{
 		Name:     SQLNameToAvroName(colDesc.Name),
-		Metadata: colDesc.SQLString(),
+		Metadata: colDesc.SQLStringNotHumanReadable(),
 		Default:  nil,
 		typ:      colDesc.Type,
 	}

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -195,7 +196,7 @@ func compareTables(t *testing.T, expected, got *descpb.TableDescriptor) {
 		)
 	}
 	for i := range expected.Columns {
-		e, g := expected.Columns[i].SQLString(), got.Columns[i].SQLString()
+		e, g := expected.Columns[i].SQLStringNotHumanReadable(), got.Columns[i].SQLStringNotHumanReadable()
 		if e != g {
 			t.Fatalf("column %d (%q): expected\n%s\ngot\n%s\n", i, expected.Columns[i].Name, e, g)
 		}

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -239,7 +239,7 @@ func alterColumnTypeGeneral(
 	var inverseExpr string
 	if using != nil {
 		// Validate the provided using expr and ensure it has the correct type.
-		typedExpr, _, err := schemaexpr.DequalifyAndValidateExpr(
+		expr, _, err := schemaexpr.DequalifyAndValidateExpr(
 			ctx,
 			tableDesc,
 			using,
@@ -253,8 +253,7 @@ func alterColumnTypeGeneral(
 		if err != nil {
 			return err
 		}
-		s := tree.Serialize(typedExpr)
-		newColComputeExpr = &s
+		newColComputeExpr = &expr
 
 		insertedValToString := tree.CastExpr{
 			Expr:       &tree.ColumnItem{ColumnName: tree.Name(col.Name)},

--- a/pkg/sql/catalog/descpb/column.go
+++ b/pkg/sql/catalog/descpb/column.go
@@ -128,8 +128,12 @@ func (desc ColumnDescriptor) GetPGAttributeNum() uint32 {
 	return uint32(desc.ID)
 }
 
-// SQLString returns the SQL statement describing the column.
-func (desc *ColumnDescriptor) SQLString() string {
+// SQLStringNotHumanReadable returns the SQL statement describing the column.
+//
+// Note that this function does not serialize user defined types into a human
+// readable format. schemaexpr.FormatColumnForDisplay should be used in cases
+// where human-readability is required.
+func (desc *ColumnDescriptor) SQLStringNotHumanReadable() string {
 	f := tree.NewFmtCtx(tree.FmtSimple)
 	f.FormatNameP(&desc.Name)
 	f.WriteByte(' ')

--- a/pkg/sql/catalog/descpb/index.go
+++ b/pkg/sql/catalog/descpb/index.go
@@ -153,50 +153,6 @@ func (desc *IndexDescriptor) ColNamesString() string {
 
 // TODO (tyler): Issue #39771 Same comment as ColNamesString above.
 
-// SQLString returns the SQL string describing this index. If non-empty,
-// "ON tableName" is included in the output in the correct place.
-func (desc *IndexDescriptor) SQLString(tableName *tree.TableName) string {
-	f := tree.NewFmtCtx(tree.FmtSimple)
-	if desc.Unique {
-		f.WriteString("UNIQUE ")
-	}
-	if desc.Type == IndexDescriptor_INVERTED {
-		f.WriteString("INVERTED ")
-	}
-	f.WriteString("INDEX ")
-	f.FormatNameP(&desc.Name)
-	if *tableName != AnonymousTable {
-		f.WriteString(" ON ")
-		f.FormatNode(tableName)
-	}
-	f.WriteString(" (")
-	desc.ColNamesFormat(f)
-	f.WriteByte(')')
-
-	if desc.IsSharded() {
-		fmt.Fprintf(f, " USING HASH WITH BUCKET_COUNT = %v",
-			desc.Sharded.ShardBuckets)
-	}
-
-	if len(desc.StoreColumnNames) > 0 {
-		f.WriteString(" STORING (")
-		for i := range desc.StoreColumnNames {
-			if i > 0 {
-				f.WriteString(", ")
-			}
-			f.FormatNameP(&desc.StoreColumnNames[i])
-		}
-		f.WriteByte(')')
-	}
-
-	if desc.IsPartial() {
-		f.WriteString(" WHERE ")
-		f.WriteString(desc.Predicate)
-	}
-
-	return f.CloseAndGetString()
-}
-
 // IsValidOriginIndex returns whether the index can serve as an origin index for a foreign
 // key constraint with the provided set of originColIDs.
 func (desc *IndexDescriptor) IsValidOriginIndex(originColIDs ColumnIDs) bool {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1495,7 +1495,7 @@ CREATE TABLE crdb_internal.create_statements (
 				return err
 			}
 			if err := showAlterStatementWithInterleave(ctx, &name, contextName, lookup, table.Indexes, table, alterStmts,
-				validateStmts); err != nil {
+				validateStmts, &p.semaCtx); err != nil {
 				return err
 			}
 			displayOptions.FKDisplayMode = IncludeFkClausesInCreate
@@ -1543,6 +1543,7 @@ func showAlterStatementWithInterleave(
 	table *sqlbase.ImmutableTableDescriptor,
 	alterStmts *tree.DArray,
 	validateStmts *tree.DArray,
+	semaCtx *tree.SemaContext,
 ) error {
 	for i := range table.OutboundFKs {
 		fk := &table.OutboundFKs[i]
@@ -1607,7 +1608,9 @@ func showAlterStatementWithInterleave(
 				sharedPrefixLen += int(ancestor.SharedPrefixLen)
 			}
 			// Write the CREATE INDEX statements.
-			showCreateIndexWithInterleave(f, idx, tableName, parentName, sharedPrefixLen)
+			if err := showCreateIndexWithInterleave(ctx, f, table, idx, tableName, parentName, sharedPrefixLen, semaCtx); err != nil {
+				return err
+			}
 			if err := alterStmts.Append(tree.NewDString(f.CloseAndGetString())); err != nil {
 				return err
 			}
@@ -1617,14 +1620,21 @@ func showAlterStatementWithInterleave(
 }
 
 func showCreateIndexWithInterleave(
+	ctx context.Context,
 	f *tree.FmtCtx,
+	table *sqlbase.ImmutableTableDescriptor,
 	idx *descpb.IndexDescriptor,
 	tableName tree.TableName,
 	parentName tree.TableName,
 	sharedPrefixLen int,
-) {
+	semaCtx *tree.SemaContext,
+) error {
 	f.WriteString("CREATE ")
-	f.WriteString(idx.SQLString(&tableName))
+	idxStr, err := schemaexpr.FormatIndexForDisplay(ctx, table, &tableName, idx, semaCtx)
+	if err != nil {
+		return err
+	}
+	f.WriteString(idxStr)
 	f.WriteString(" INTERLEAVE IN PARENT ")
 	parentName.Format(f)
 	f.WriteString(" (")
@@ -1636,6 +1646,7 @@ func showCreateIndexWithInterleave(
 		comma = ", "
 	}
 	f.WriteString(")")
+	return nil
 }
 
 // crdbInternalTableColumnsTable exposes the column descriptors.

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1666,11 +1666,11 @@ CREATE TABLE crdb_internal.table_columns (
 						col := &table.Columns[i]
 						defStr := tree.DNull
 						if col.DefaultExpr != nil {
-							def, err := schemaexpr.DeserializeTableDescExpr(ctx, &p.semaCtx, table, *col.DefaultExpr)
+							defExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, *col.DefaultExpr, &p.semaCtx)
 							if err != nil {
 								return err
 							}
-							defStr = tree.NewDString(tree.SerializeForDisplay(def))
+							defStr = tree.NewDString(defExpr)
 						}
 						row = row[:0]
 						row = append(row,

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -217,9 +217,7 @@ func MakeIndexDescriptor(
 		if err != nil {
 			return nil, err
 		}
-
-		// Store the serialized predicate expression in the IndexDescriptor.
-		indexDesc.Predicate = tree.Serialize(expr)
+		indexDesc.Predicate = expr
 	}
 
 	if err := indexDesc.FillColumns(n.Columns); err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1387,12 +1387,11 @@ func MakeTableDesc(
 				return desc, err
 			}
 
-			expr, err = schemaexpr.DequalifyColumnRefs(ctx, sourceInfo, expr)
+			deqExpr, err := schemaexpr.DequalifyColumnRefs(ctx, sourceInfo, expr)
 			if err != nil {
 				return desc, err
 			}
-			serialized := tree.Serialize(expr)
-			col.ComputeExpr = &serialized
+			col.ComputeExpr = &deqExpr
 		}
 	}
 
@@ -1488,9 +1487,7 @@ func MakeTableDesc(
 				if err != nil {
 					return desc, err
 				}
-
-				// Store the serialized predicate expression in the IndexDescriptor.
-				idx.Predicate = tree.Serialize(expr)
+				idx.Predicate = expr
 			}
 
 			if err := desc.AddIndex(idx, false); err != nil {
@@ -1535,9 +1532,7 @@ func MakeTableDesc(
 				if err != nil {
 					return desc, err
 				}
-
-				// Store the serialized predicate expression in the IndexDescriptor.
-				idx.Predicate = tree.Serialize(expr)
+				idx.Predicate = expr
 			}
 			if err := desc.AddIndex(idx, d.PrimaryKey); err != nil {
 				return desc, err

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -386,19 +386,19 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 				}
 				colDefault := tree.DNull
 				if column.DefaultExpr != nil {
-					colExpr, err := schemaexpr.DeserializeTableDescExpr(ctx, &p.semaCtx, table, *column.DefaultExpr)
+					colExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, *column.DefaultExpr, &p.semaCtx)
 					if err != nil {
 						return err
 					}
-					colDefault = tree.NewDString(tree.SerializeForDisplay(colExpr))
+					colDefault = tree.NewDString(colExpr)
 				}
 				colComputed := emptyString
 				if column.ComputeExpr != nil {
-					colExpr, err := schemaexpr.DeserializeTableDescExpr(ctx, &p.semaCtx, table, *column.ComputeExpr)
+					colExpr, err := schemaexpr.FormatExprForDisplayWithoutTypeAnnotations(ctx, table, *column.ComputeExpr, &p.semaCtx)
 					if err != nil {
 						return err
 					}
-					colComputed = tree.NewDString(tree.AsString(colExpr))
+					colComputed = tree.NewDString(colExpr)
 				}
 				return addRow(
 					dbNameStr,                    // table_catalog

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -284,7 +284,7 @@ INSERT INTO c VALUES (3, 30), (300, 3000)
 statement ok
 UPDATE c SET i = i + 1
 
-query II
+query II rowsort
 SELECT * FROM c@i_0_100_idx WHERE i > 0 AND i < 100
 ----
 3  31
@@ -605,17 +605,70 @@ INSERT INTO k VALUES (1, 1), (6, 6)
 statement ok
 TRUNCATE k
 
-query II
+query II rowsort
 SELECT * FROM k@a_b_gt_5 WHERE b > 5
 ----
 
 statement ok
 INSERT INTO k VALUES (1, 1), (7, 7)
 
-query II
+query II rowsort
 SELECT * FROM k@a_b_gt_5 WHERE b > 5
 ----
 7  7
+
+# Test partial indexes with an ENUM in the predicate.
+subtest enum
+
+statement ok
+CREATE TYPE enum_type AS ENUM ('foo', 'bar', 'baz');
+CREATE TABLE enum_table (
+    a INT PRIMARY KEY,
+    b enum_type,
+    INDEX i (a) WHERE b IN ('foo', 'bar')
+);
+
+statement ok
+INSERT INTO enum_table VALUES
+    (1, 'foo'),
+    (2, 'bar'),
+    (3, 'baz')
+
+query IT rowsort
+SELECT * FROM enum_table@i WHERE b IN ('foo', 'bar')
+----
+1  foo
+2  bar
+
+statement ok
+UPDATE enum_table SET b = 'baz' WHERE a = 1;
+UPDATE enum_table SET b = 'foo' WHERE a = 3;
+
+query IT rowsort
+SELECT * FROM enum_table@i WHERE b IN ('foo', 'bar')
+----
+2  bar
+3  foo
+
+statement ok
+DELETE FROM enum_table WHERE a = 2
+
+query IT rowsort
+SELECT * FROM enum_table@i WHERE b IN ('foo', 'bar')
+----
+3  foo
+
+statement ok
+UPSERT INTO enum_table VALUES
+   (1, 'foo'),
+    (2, 'bar'),
+    (3, 'baz')
+
+query IT rowsort
+SELECT * FROM enum_table@i WHERE b IN ('foo', 'bar')
+----
+1  foo
+2  bar
 
 # User defined types in partial index predicates should be human-readable.
 
@@ -639,6 +692,7 @@ enum_table_show  CREATE TABLE public.enum_table_show (
 
 # Regression tests for #52318. Mutations on partial indexes in the
 # DELETE_AND_WRITE_ONLY state should update the indexes correctly.
+subtest regression_52318
 
 statement ok
 CREATE TABLE t52318 (

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -617,6 +617,26 @@ SELECT * FROM k@a_b_gt_5 WHERE b > 5
 ----
 7  7
 
+# User defined types in partial index predicates should be human-readable.
+
+statement ok
+CREATE TABLE enum_table_show (
+    a INT,
+    b enum_type,
+    INDEX i (a) WHERE b IN ('foo', 'bar'),
+    FAMILY (a, b)
+)
+
+query TT
+SHOW CREATE TABLE enum_table_show
+----
+enum_table_show  CREATE TABLE public.enum_table_show (
+                 a INT8 NULL,
+                 b public.enum_type NULL,
+                 INDEX i (a ASC) WHERE b IN ('foo':::public.enum_type, 'bar':::public.enum_type),
+                 FAMILY fam_0_a_b_rowid (a, b, rowid)
+)
+
 # Regression tests for #52318. Mutations on partial indexes in the
 # DELETE_AND_WRITE_ONLY state should update the indexes correctly.
 

--- a/pkg/sql/schemaexpr/check_constraint.go
+++ b/pkg/sql/schemaexpr/check_constraint.go
@@ -89,7 +89,7 @@ func (b *CheckConstraintBuilder) Build(
 
 	// Verify that the expression results in a boolean and does not use
 	// invalid functions.
-	typedExpr, colIDs, err := DequalifyAndValidateExpr(
+	expr, colIDs, err := DequalifyAndValidateExpr(
 		b.ctx,
 		b.desc,
 		c.Expr,
@@ -104,7 +104,7 @@ func (b *CheckConstraintBuilder) Build(
 	}
 
 	return &descpb.TableDescriptor_CheckConstraint{
-		Expr:      tree.Serialize(typedExpr),
+		Expr:      expr,
 		Name:      name,
 		ColumnIDs: colIDs.Ordered(),
 		Hidden:    c.Hidden,

--- a/pkg/sql/schemaexpr/column_test.go
+++ b/pkg/sql/schemaexpr/column_test.go
@@ -66,14 +66,13 @@ func TestDequalifyColumnRefs(t *testing.T) {
 				),
 			)
 
-			r, err := DequalifyColumnRefs(ctx, source, expr)
+			deqExpr, err := DequalifyColumnRefs(ctx, source, expr)
 			if err != nil {
 				t.Fatalf("%s: expected success, but found error: %s", d.expr, err)
 			}
 
-			s := tree.Serialize(r)
-			if s != d.expected {
-				t.Errorf("%s: expected %q, got %q", d.expr, d.expected, s)
+			if deqExpr != d.expected {
+				t.Errorf("%s: expected %q, got %q", d.expr, d.expected, deqExpr)
 			}
 		})
 	}

--- a/pkg/sql/schemaexpr/expr_test.go
+++ b/pkg/sql/schemaexpr/expr_test.go
@@ -76,7 +76,7 @@ func TestValidateExpr(t *testing.T) {
 				t.Fatalf("%s: unexpected error: %s", d.expr, err)
 			}
 
-			expr, _, err = DequalifyAndValidateExpr(
+			deqExpr, _, err := DequalifyAndValidateExpr(
 				ctx,
 				&desc,
 				expr,
@@ -100,9 +100,8 @@ func TestValidateExpr(t *testing.T) {
 				t.Fatalf("%s: expected valid expression, but found error: %s", d.expr, err)
 			}
 
-			s := tree.Serialize(expr)
-			if s != d.expectedExpr {
-				t.Errorf("%s: expected %q, got %q", d.expr, d.expectedExpr, s)
+			if deqExpr != d.expectedExpr {
+				t.Errorf("%s: expected %q, got %q", d.expr, d.expectedExpr, deqExpr)
 			}
 		})
 	}

--- a/pkg/sql/schemaexpr/partial_index_test.go
+++ b/pkg/sql/schemaexpr/partial_index_test.go
@@ -12,8 +12,10 @@ package schemaexpr
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -107,6 +109,69 @@ func TestIndexPredicateValidator_Validate(t *testing.T) {
 
 			if deqExpr != d.expectedExpr {
 				t.Errorf("%s: expected %q, got %q", d.expr, d.expectedExpr, deqExpr)
+			}
+		})
+	}
+}
+
+func TestFormatIndexForDisplay(t *testing.T) {
+	ctx := context.Background()
+	semaCtx := tree.MakeSemaContext()
+
+	database := tree.Name("foo")
+	table := tree.Name("bar")
+	tableName := tree.MakeTableName(database, table)
+
+	colNames := []string{"a", "b"}
+	tableDesc := testTableDesc(
+		string(table),
+		[]testCol{{colNames[0], types.Int}, {colNames[1], types.Int}},
+		nil,
+	)
+
+	indexName := "baz"
+	baseIndex := descpb.IndexDescriptor{
+		Name:             indexName,
+		ID:               0x0,
+		ColumnNames:      colNames,
+		ColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC, descpb.IndexDescriptor_DESC},
+	}
+
+	uniqueIndex := baseIndex
+	uniqueIndex.Unique = true
+
+	invertedIndex := baseIndex
+	invertedIndex.Type = descpb.IndexDescriptor_INVERTED
+	invertedIndex.ColumnNames = []string{"a"}
+
+	storingIndex := baseIndex
+	storingIndex.StoreColumnNames = []string{"c"}
+
+	partialIndex := baseIndex
+	partialIndex.Predicate = "a > 1:::INT8"
+
+	testData := []struct {
+		index     descpb.IndexDescriptor
+		tableName tree.TableName
+		expected  string
+	}{
+		{baseIndex, descpb.AnonymousTable, "INDEX baz (a ASC, b DESC)"},
+		{baseIndex, tableName, "INDEX baz ON foo.public.bar (a ASC, b DESC)"},
+		{uniqueIndex, descpb.AnonymousTable, "UNIQUE INDEX baz (a ASC, b DESC)"},
+		{invertedIndex, descpb.AnonymousTable, "INVERTED INDEX baz (a)"},
+		{storingIndex, descpb.AnonymousTable, "INDEX baz (a ASC, b DESC) STORING (c)"},
+		{partialIndex, descpb.AnonymousTable, "INDEX baz (a ASC, b DESC) WHERE a > 1:::INT8"},
+	}
+
+	for testIdx, tc := range testData {
+		t.Run(strconv.Itoa(testIdx), func(t *testing.T) {
+			got, err := FormatIndexForDisplay(ctx, &tableDesc, &tc.tableName, &tc.index, &semaCtx)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if got != tc.expected {
+				t.Errorf("expected '%s', got '%s'", tc.expected, got)
 			}
 		})
 	}

--- a/pkg/sql/schemaexpr/partial_index_test.go
+++ b/pkg/sql/schemaexpr/partial_index_test.go
@@ -90,7 +90,7 @@ func TestIndexPredicateValidator_Validate(t *testing.T) {
 				t.Fatalf("%s: unexpected error: %s", d.expr, err)
 			}
 
-			r, err := validator.Validate(expr)
+			deqExpr, err := validator.Validate(expr)
 
 			if !d.expectedValid {
 				if err == nil {
@@ -105,9 +105,8 @@ func TestIndexPredicateValidator_Validate(t *testing.T) {
 				t.Fatalf("%s: expected valid expression, but found error: %s", d.expr, err)
 			}
 
-			s := tree.Serialize(r)
-			if s != d.expectedExpr {
-				t.Errorf("%s: expected %q, got %q", d.expr, d.expectedExpr, s)
+			if deqExpr != d.expectedExpr {
+				t.Errorf("%s: expected %q, got %q", d.expr, d.expectedExpr, deqExpr)
 			}
 		})
 	}

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -87,7 +87,7 @@ func ShowCreateTable(
 			f.WriteString(",")
 		}
 		f.WriteString("\n\t")
-		colstr, err := schemaexpr.FormatColumnForDisplay(ctx, &p.RunParams(ctx).p.semaCtx, desc, col)
+		colstr, err := schemaexpr.FormatColumnForDisplay(ctx, desc, col, &p.RunParams(ctx).p.semaCtx)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -143,7 +143,11 @@ func ShowCreateTable(
 		if idx.ID != desc.PrimaryIndex.ID && includeInterleaveClause {
 			// Showing the primary index is handled above.
 			f.WriteString(",\n\t")
-			f.WriteString(idx.SQLString(&descpb.AnonymousTable))
+			idxStr, err := schemaexpr.FormatIndexForDisplay(ctx, desc, &descpb.AnonymousTable, idx, &p.RunParams(ctx).p.semaCtx)
+			if err != nil {
+				return "", err
+			}
+			f.WriteString(idxStr)
 			// Showing the INTERLEAVE and PARTITION BY for the primary index are
 			// handled last.
 

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -416,11 +416,11 @@ func showConstraintClause(
 			f.WriteString(" ")
 		}
 		f.WriteString("CHECK (")
-		typed, err := schemaexpr.DeserializeTableDescExpr(ctx, semaCtx, desc, e.Expr)
+		expr, err := schemaexpr.FormatExprForDisplay(ctx, desc, e.Expr, semaCtx)
 		if err != nil {
 			return err
 		}
-		f.WriteString(tree.SerializeForDisplay(typed))
+		f.WriteString(expr)
 		f.WriteString(")")
 	}
 	f.WriteString("\n)")

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -1475,28 +1474,6 @@ func TestDefaultExprNil(t *testing.T) {
 			}
 		}
 	})
-}
-
-func TestSQLString(t *testing.T) {
-	colNames := []string{"derp", "foo"}
-	indexName := "idx"
-	tableName := tree.MakeTableName("DB", "t1")
-	tableName.ExplicitCatalog = false
-	tableName.ExplicitSchema = false
-	index := descpb.IndexDescriptor{Name: indexName,
-		ID:               0x0,
-		Unique:           false,
-		ColumnNames:      colNames,
-		ColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC, descpb.IndexDescriptor_ASC},
-	}
-	expected := fmt.Sprintf("INDEX %s ON t1 (%s ASC, %s ASC)", indexName, colNames[0], colNames[1])
-	if got := index.SQLString(&tableName); got != expected {
-		t.Errorf("Expected '%s', but got '%s'", expected, got)
-	}
-	expected = fmt.Sprintf("INDEX %s (%s ASC, %s ASC)", indexName, colNames[0], colNames[1])
-	if got := index.SQLString(&descpb.AnonymousTable); got != expected {
-		t.Errorf("Expected '%s', but got '%s'", expected, got)
-	}
 }
 
 func TestLogicalColumnID(t *testing.T) {


### PR DESCRIPTION
#### schemaexpr: return serialized expressions from schemaexpr functions

This commit updates most public functions within `schemaexpr` that
return `tree.Expr` or `tree.TypedExpr` to return serialized expressions
instead. These functions perform type-checking by replacing
`tree.ColumnItem`s with `dummyColumn`s, which do not support evaluation
and should not be leaked outside of this package. Additionally, all the
callers of these functions require only serialized expressions. These
changes result in a more safe and better encapsulated API.

Note that there are two public functions in `schemaexpr` that return
`tree.TypeExpr`, `MakeComputedExprs` and `MakePartialIndexExprs`. The
expressions returned from these functions do no contain `dummyColumn`s
and they do support evaluation, so these are an exception.

This commit also renames `ColumnDescriptor.SQLString` to make it clear
that it does not serialize user defined types in a human-readable
format, and to avoid giving the impression that it is meant to adhere to
interfaces that require a `SQLString()` function, like
`ResolvableTypeReference`. The `schemaexpr.FormatColumnForDisplay`
function should be used to format a `ColumnDesciptor` in cases where
human-readability is required.

Release note: None

#### sql: format human-readable UDTs in partial index predicates

This commit fixes the formatting of partial indexes in `SHOW CREATE`
statements so that user defined types are human readable. Prior to this
change, values and type annotations within partial index predicates were
not human readable. For example, an `ENUM` within a partial index
predicate would be formatted as:

    INDEX i (a) WHERE b = b'\x40':::@52

The new `schemaexpr.FormatIndexForDisplay` function relies on a
`tree.SemaContext`'s type resolver to make both the `ENUM` value and
type annotation more user friendly:

    INDEX i (a) WHERE b = 'foo':::my_enum

Release note: None

#### sql: add tests for enums within partial index predicates

This commit adds tests to ensure that partial indexes remain consistent
when their predicates expressions reference user defined types.

Fixes #51804

Release note: None
