### PR TITLE
opt: do not assert volatility while building mutation partial index predicates

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1271,3 +1271,28 @@ insert partial_indexes
            ├── (column1:5 > column2:6) AND (column3:7 = 'bar') [as=column9:9]
            ├── column3:7 = 'delete-only' [as=column10:10]
            └── column3:7 = 'write-only' [as=column11:11]
+
+# Regression test for issue #52546. Building partial index predicate expressions
+# that are only a single column reference should not panic.
+
+exec-ddl
+CREATE TABLE t52546 (a INT, b BOOL, INDEX (a) WHERE b)
+----
+
+build
+INSERT INTO t52546 VALUES (1, true)
+----
+insert t52546
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column2:6 => b:2
+ │    └── column7:7 => rowid:3
+ ├── partial index put columns: column2:6
+ └── project
+      ├── columns: column7:7 column1:5!null column2:6!null
+      ├── values
+      │    ├── columns: column1:5!null column2:6!null
+      │    └── (1, true)
+      └── projections
+           └── unique_rowid() [as=column7:7]


### PR DESCRIPTION
This commit reverts changes made in #52214 that asserted the volatility
of partial index predicate expressions when building mutations. This
assertion caused issues with single boolean column predicate
expressions. A single-column reference is essentially a pass-through
projection with a nil scalar expression. Attempting to build shared
properties on nil, which are required for asserting volatility, led to a
nil pointer exception.

This issue could have been solved by only building shared properties
when the scalar expression of a projected partial index predicate column
is non-nil. This would not have weakened the assertion because a single
boolean column is always immutable.

However, I've opted to remove the assertion entirely because I don't
believe it provides enough benefit for the cost of the added complexity.
Partial index volatility is already verified when indexes are created.
Additional assertions in `optbuilder` when building `SELECT` and
mutation queries were added for extra safety. The idea was that if the
volatility of an operator within an existing partial index predicate
were to change in a future release, the `optbuilder` assertions would
prevent a user from using the index and receiving potentially incorrect
results from queries.

The assertions for `SELECT` queries alone should be enough to prevent a
user from using these newly invalid indexes. I've left those intact. By
removing the assertions for mutations, these newly invalid indexes could
be mutated into an undefined state. However, this is should not be an
issue, because the index cannot be used to satisfy queries (due to the
`SELECT` assertions) and the index must be dropped and recreated with
only immutable operators.

Fixes #52546

Release note: None