### PR TITLE
sql: skip tenant prefix in spans in EXPLAIN

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -873,6 +873,9 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	// to transfer! It would be better if this responsibility remained
 	// around here.
 	planner.curPlan.flags.Set(planFlagExecDone)
+	if !planner.ExecCfg().Codec.ForSystemTenant() {
+		planner.curPlan.flags.Set(planFlagTenant)
+	}
 
 	if distributePlan {
 		planner.curPlan.flags.Set(planFlagDistributed)

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(50048)
+# LogicTest: !3node-tenant(52558)
 
 statement ok
 SET experimental_enable_hash_sharded_indexes = true

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant(50048)
 # a is the primary key so b gets optimized into a one column value. The c, d
 # family has two columns, so it's encoded as a tuple
 statement ok

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -532,6 +532,9 @@ const (
 	// planFlagVectorized is set if the plan is executed via the vectorized
 	// engine.
 	planFlagVectorized
+
+	// planFlagTenant is set if the plan is executed on behalf of a tenant.
+	planFlagTenant
 )
 
 func (pf planFlags) IsSet(flag planFlags) bool {


### PR DESCRIPTION
This was causing some logic tests to fail in the 3node-tenant configuration.

Release note: None