### PR TITLE
sql: remove usage of OptionalNodeIDErr in createPlanForInterleavedJoin 

### DIFF
--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -269,10 +269,7 @@ func (dsp *DistSQLPlanner) createPlanForInterleavedJoin(
 	if err != nil {
 		return nil, err
 	}
-	plan.GatewayNodeID, err = planCtx.ExtendedEvalCtx.ExecCfg.NodeID.OptionalNodeIDErr(50050)
-	if err != nil {
-		return nil, err
-	}
+	plan.GatewayNodeID = dsp.gatewayNodeID
 	plan.AddNoInputStage(
 		corePlacement, post, resultTypes, dsp.convertOrdering(n.reqOrdering, joinToStreamColMap),
 	)

--- a/pkg/sql/logictest/testdata/logic_test/interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved_join
@@ -1,4 +1,4 @@
-# LogicTest: !local-spec-planning(47473) !fakedist-spec-planning(47473) !3node-tenant(50050)
+# LogicTest: !local-spec-planning(47473) !fakedist-spec-planning(47473)
 # The following tables form the interleaved hierarchy:
 #   name:             primary key:                # rows:   'a' = id mod X :
 #   parent1           (pid1)                      40        8


### PR DESCRIPTION
Depends on #52562 

The goal was to get the gateway node ID, which is already stored in the
physical planner as a SQLInstanceID. This was erroneously resulting in an
UnsupportedWithMultiTenancy error when attempting to execute an interleaved
join as a tenant.

Release note: None