### PR TITLE
kvcoord,kvclient,gossip: gossip range lease acquisition

### DIFF
--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -163,7 +163,7 @@ func runTestImport(t *testing.T, batchSizeValue int64) {
 			// splits to exercise that codepath, but we also want to make sure we
 			// still handle an unexpected split, so we make our own range cache and
 			// only populate it with one of our two splits.
-			mockCache := kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, s.Stopper())
+			mockCache := kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, nil, s.Stopper())
 			addr, err := keys.Addr(key(0))
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -273,6 +273,10 @@ type DistSenderConfig struct {
 	RPCContext      *rpc.Context
 	NodeDialer      *nodedialer.Dialer
 
+	// Gossip, if provided, is used to update range cache entries when a
+	// lease is acquired on a different node.
+	Gossip *gossip.Gossip
+
 	// One of the following two must be provided, but not both.
 	//
 	// If only FirstRangeProvider is supplied, DistSender will use itself as a
@@ -330,7 +334,7 @@ func NewDistSender(cfg DistSenderConfig) *DistSender {
 	getRangeDescCacheSize := func() int64 {
 		return rangeDescriptorCacheSize.Get(&ds.st.SV)
 	}
-	ds.rangeCache = NewRangeDescriptorCache(ds.st, rdb, getRangeDescCacheSize, cfg.RPCContext.Stopper)
+	ds.rangeCache = NewRangeDescriptorCache(ds.st, rdb, getRangeDescCacheSize, cfg.Gossip, cfg.RPCContext.Stopper)
 	if tf := cfg.TestingKnobs.TransportFactory; tf != nil {
 		ds.transportFactory = tf
 	} else {

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -4170,7 +4170,7 @@ func TestSendToReplicasSkipsStaleReplicas(t *testing.T) {
 			getRangeDescCacheSize := func() int64 {
 				return 1 << 20
 			}
-			rc := NewRangeDescriptorCache(st, nil /* db */, getRangeDescCacheSize, stopper)
+			rc := NewRangeDescriptorCache(st, nil /* db */, getRangeDescCacheSize, nil, stopper)
 			rc.Insert(ctx, roachpb.RangeInfo{
 				Desc: desc,
 				Lease: roachpb.Lease{

--- a/pkg/kv/kvclient/kvcoord/range_cache_test.go
+++ b/pkg/kv/kvclient/kvcoord/range_cache_test.go
@@ -256,7 +256,7 @@ func initTestDescriptorDB(t *testing.T) *testDescriptorDB {
 		}
 	}
 	// TODO(andrei): don't leak this Stopper. Someone needs to Stop() it.
-	db.cache = NewRangeDescriptorCache(st, db, staticSize(2<<10), stop.NewStopper())
+	db.cache = NewRangeDescriptorCache(st, db, staticSize(2<<10), nil, stop.NewStopper())
 	return db
 }
 
@@ -973,7 +973,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stopper)
+	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), nil, stopper)
 	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKeyMax)), &rangeCacheEntry{desc: *defDesc})
 
 	// Now, add a new, overlapping set of descriptors.
@@ -1149,7 +1149,7 @@ func TestRangeCacheClearOlderOverlapping(t *testing.T) {
 			st := cluster.MakeTestingClusterSettings()
 			stopper := stop.NewStopper()
 			defer stopper.Stop(ctx)
-			cache := NewRangeDescriptorCache(st, nil /* db */, staticSize(2<<10), stopper)
+			cache := NewRangeDescriptorCache(st, nil /* db */, staticSize(2<<10), nil, stopper)
 			for _, d := range tc.cachedDescs {
 				cache.Insert(ctx, roachpb.RangeInfo{Desc: d})
 			}
@@ -1201,7 +1201,7 @@ func TestRangeCacheClearOverlappingMeta(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stopper)
+	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), nil, stopper)
 	cache.Insert(ctx,
 		roachpb.RangeInfo{Desc: firstDesc},
 		roachpb.RangeInfo{Desc: restDesc})
@@ -1236,7 +1236,7 @@ func TestGetCachedRangeDescriptorInverted(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
-	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stopper)
+	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), nil, stopper)
 	for _, rd := range testData {
 		cache.rangeCache.cache.Add(
 			rangeCacheKey(keys.RangeMetaKey(rd.EndKey)), &rangeCacheEntry{desc: rd})
@@ -1374,7 +1374,7 @@ func TestRangeCacheGeneration(t *testing.T) {
 			st := cluster.MakeTestingClusterSettings()
 			stopper := stop.NewStopper()
 			defer stopper.Stop(ctx)
-			cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stopper)
+			cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), nil, stopper)
 			cache.Insert(ctx, roachpb.RangeInfo{Desc: *descAM2}, roachpb.RangeInfo{Desc: *descMZ4})
 			cache.Insert(ctx, roachpb.RangeInfo{Desc: *tc.insertDesc})
 
@@ -1445,7 +1445,7 @@ func TestRangeCacheUpdateLease(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stopper)
+	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), nil, stopper)
 
 	cache.Insert(ctx, roachpb.RangeInfo{
 		Desc:  desc1,

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -52,6 +52,38 @@ func (r *Replica) gossipFirstRange(ctx context.Context) {
 	}
 }
 
+// gossipLeaseAcquired informs other nodes of the new leaseholder, to
+// invalidate any entries already present in the leaseholder cache of
+// other nodes.
+func (r *Replica) gossipLeaseAcquired(ctx context.Context, newLease *roachpb.Lease) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	// Gossip is not provided for the bootstrap store and for some tests.
+	if r.store.Gossip() == nil {
+		return
+	}
+	// If gossip is not yet ready, don't even try.
+	select {
+	case <-r.store.Gossip().Connected:
+	default:
+		if log.V(1) {
+			log.Infof(ctx, "not gossiping lease acquisition: cluster not yet initialized")
+		}
+		return
+	}
+	if log.V(1) {
+		log.Infof(ctx, "gossiping lease acquisition")
+	}
+
+	if err := r.store.Gossip().AddInfoProto(
+		gossip.MakeRangeIDKey(r.RangeID), /* the range we're gossiping for */
+		newLease,                         /* tell the world about our fresh new lease */
+		0,                                /* gossip forever */
+	); err != nil {
+		log.Warningf(ctx, "failed to gossip lease acquisition: %v", err)
+	}
+}
+
 // shouldGossip returns true if this replica should be gossiping. Gossip is
 // inherently inconsistent and asynchronous, we're using the lease as a way to
 // ensure that only one node gossips at a time.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -374,6 +374,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		AmbientCtx:         cfg.AmbientCtx,
 		Settings:           st,
 		Clock:              clock,
+		Gossip:             g,
 		NodeDescs:          g,
 		RPCContext:         rpcContext,
 		RPCRetryOptions:    &retryOpts,

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -271,7 +271,7 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 
 	size := func() int64 { return 2 << 10 }
 	st := cluster.MakeTestingClusterSettings()
-	rangeCache := kvcoord.NewRangeDescriptorCache(st, nil /* db */, size, stop.NewStopper())
+	rangeCache := kvcoord.NewRangeDescriptorCache(st, nil /* db */, size, nil, stop.NewStopper())
 	r := MakeDistSQLReceiver(
 		context.Background(), nil /* resultWriter */, tree.Rows,
 		rangeCache, nil /* txn */, nil /* updateClock */, &SessionTracing{})

--- a/pkg/sql/rowexec/interleaved_reader_joiner_test.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner_test.go
@@ -405,7 +405,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 				EvalCtx: &evalCtx,
 				Cfg: &execinfra.ServerConfig{
 					Settings:   s.ClusterSettings(),
-					RangeCache: kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, s.Stopper()),
+					RangeCache: kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, nil, s.Stopper()),
 				},
 				// Run in a RootTxn so that there's no txn metadata produced.
 				Txn:    kv.NewTxn(ctx, s.DB(), s.NodeID()),
@@ -597,7 +597,7 @@ func TestInterleavedReaderJoinerTrailingMetadata(t *testing.T) {
 		EvalCtx: &evalCtx,
 		Cfg: &execinfra.ServerConfig{
 			Settings:   s.ClusterSettings(),
-			RangeCache: kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, s.Stopper()),
+			RangeCache: kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, nil, s.Stopper()),
 		},
 		// Run in a LeafTxn so that txn metadata is produced.
 		Txn:    leafTxn,

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -134,7 +134,7 @@ func TestTableReader(t *testing.T) {
 					EvalCtx: &evalCtx,
 					Cfg: &execinfra.ServerConfig{
 						Settings:   s.ClusterSettings(),
-						RangeCache: kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, s.Stopper()),
+						RangeCache: kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, nil, s.Stopper()),
 					},
 					Txn:    kv.NewTxn(ctx, s.DB(), s.NodeID()),
 					NodeID: evalCtx.NodeID,
@@ -330,7 +330,7 @@ func TestLimitScans(t *testing.T) {
 		EvalCtx: &evalCtx,
 		Cfg: &execinfra.ServerConfig{
 			Settings:   s.ClusterSettings(),
-			RangeCache: kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, s.Stopper()),
+			RangeCache: kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, nil, s.Stopper()),
 		},
 		Txn:    kv.NewTxn(ctx, kvDB, s.NodeID()),
 		NodeID: evalCtx.NodeID,
@@ -437,7 +437,7 @@ func BenchmarkTableReader(b *testing.B) {
 			EvalCtx: &evalCtx,
 			Cfg: &execinfra.ServerConfig{
 				Settings:   s.ClusterSettings(),
-				RangeCache: kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, s.Stopper()),
+				RangeCache: kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, nil, s.Stopper()),
 			},
 			Txn:    kv.NewTxn(ctx, s.DB(), s.NodeID()),
 			NodeID: evalCtx.NodeID,


### PR DESCRIPTION
Fixes #50199.

Before this patch, it was possible for a range cache to contain an
outdated lease if the node with the lease was restarted or went
AWOL.

This patch introduces a mechanism by which the new owner of a range
lease announces this ownership to other nodes via gossip.
Any cached lease for that range gets updated from the gossip update
if the gossiped lease is more recent than the one known.

Release note (general change): CockroachDB nodes now learn more
actively of range leadership transfers from other nodes. This makes
query performance generally more resilient to routine node restarts,
as fewer queries now get routed to an outdated or unavailable node.