### PR TITLE
sql: fix set schema for enum array type

### DIFF
--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -110,6 +110,7 @@ func (p *planner) renameType(ctx context.Context, n *alterTypeNode, newName stri
 		ctx,
 		n.desc,
 		newName,
+		n.desc.ParentSchemaID,
 		tree.AsStringWithFQNames(n.n, p.Ann()),
 	); err != nil {
 		return err
@@ -135,6 +136,7 @@ func (p *planner) renameType(ctx context.Context, n *alterTypeNode, newName stri
 		ctx,
 		arrayDesc,
 		newArrayName,
+		arrayDesc.ParentSchemaID,
 		tree.AsStringWithFQNames(n.n, p.Ann()),
 	); err != nil {
 		return err
@@ -142,8 +144,14 @@ func (p *planner) renameType(ctx context.Context, n *alterTypeNode, newName stri
 	return nil
 }
 
+// performRenameTypeDesc renames and/or sets the schema of a type descriptor.
+// newName and newSchemaID may be the same as the current name and schemaid.
 func (p *planner) performRenameTypeDesc(
-	ctx context.Context, desc *sqlbase.MutableTypeDescriptor, newName string, jobDesc string,
+	ctx context.Context,
+	desc *sqlbase.MutableTypeDescriptor,
+	newName string,
+	newSchemaID descpb.ID,
+	jobDesc string,
 ) error {
 	// Record the rename details in the descriptor for draining.
 	name := descpb.NameInfo{
@@ -155,6 +163,8 @@ func (p *planner) performRenameTypeDesc(
 
 	// Set the descriptor up with the new name.
 	desc.Name = newName
+	// Set the descriptor to the new schema ID.
+	desc.SetParentSchemaID(newSchemaID)
 	if err := p.writeTypeSchemaChange(ctx, desc, jobDesc); err != nil {
 		return err
 	}
@@ -205,7 +215,6 @@ func (p *planner) renameTypeValue(
 func (p *planner) setTypeSchema(ctx context.Context, n *alterTypeNode, schema string) error {
 	typeDesc := n.desc
 	schemaID := typeDesc.GetParentSchemaID()
-	databaseID := typeDesc.GetParentID()
 
 	desiredSchemaID, err := p.prepareSetSchema(ctx, typeDesc, schema)
 	if err != nil {
@@ -218,26 +227,22 @@ func (p *planner) setTypeSchema(ctx context.Context, n *alterTypeNode, schema st
 		return nil
 	}
 
-	name := descpb.NameInfo{
-		ParentID:       databaseID,
-		ParentSchemaID: schemaID,
-		Name:           typeDesc.Name,
-	}
-	typeDesc.AddDrainingName(name)
+	err = p.performRenameTypeDesc(
+		ctx, typeDesc, typeDesc.Name, desiredSchemaID, tree.AsStringWithFQNames(n.n, p.Ann()),
+	)
 
-	// Set the tableDesc's new schema id to the desired schema's id.
-	typeDesc.SetParentSchemaID(desiredSchemaID)
-
-	if err := p.writeTypeSchemaChange(
-		ctx, typeDesc, tree.AsStringWithFQNames(n.n, p.Ann()),
-	); err != nil {
+	if err != nil {
 		return err
 	}
 
-	newKey := catalogkv.MakeObjectNameKey(ctx, p.ExecCfg().Settings,
-		databaseID, desiredSchemaID, typeDesc.Name)
+	arrayDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, n.desc.ArrayTypeID)
+	if err != nil {
+		return err
+	}
 
-	return p.writeNameKey(ctx, newKey, typeDesc.ID)
+	return p.performRenameTypeDesc(
+		ctx, arrayDesc, arrayDesc.Name, desiredSchemaID, tree.AsStringWithFQNames(n.n, p.Ann()),
+	)
 }
 
 func (n *alterTypeNode) Next(params runParams) (bool, error) { return false, nil }

--- a/pkg/sql/logictest/testdata/logic_test/set_schema
+++ b/pkg/sql/logictest/testdata/logic_test/set_schema
@@ -317,12 +317,23 @@ ALTER TYPE typ SET SCHEMA s1
 statement ok
 SELECT 'hello'::s1.typ
 
+# Ensure the array type is set to the new schema as well.
+statement ok
+SELECT ARRAY['hello']::s1._typ
+
 # Ensure the type does not exist in the public schema.
 statement error pq: type "public.typ" does not exist
 SELECT 'hello'::public.typ
 
 statement error pq: type "typ" does not exist
 SELECT 'hello'::typ
+
+# Ensure the array type is removed from the old schema.
+statement error pq: type "public._typ" does not exist
+SELECT ARRAY['hello']::public._typ
+
+statement error pq: type "_typ" does not exist
+SELECT ARRAY['hello']::_typ
 
 # Testing setting a type to the public schema.
 
@@ -333,9 +344,17 @@ ALTER TYPE s1.typ SET SCHEMA public
 statement ok
 SELECT 'hello'::public.typ
 
+# Ensure the array type is set to the new schema as well.
+statement ok
+SELECT ARRAY['hello']::public._typ
+
 # Ensure the type does not exist in the s1 schema.
 statement error pq: type "s1.typ" does not exist
 SELECT 'hello'::s1.typ
+
+# Ensure the array type is removed from the old schema.
+statement error pq: type "s1._typ" does not exist
+SELECT ARRAY['hello']::s1._typ
 
 # Test moving from one user defined schema to another.
 statement ok
@@ -347,9 +366,17 @@ ALTER TYPE s1.typ2 SET SCHEMA s2
 statement ok
 SELECT 'hello'::s2.typ2
 
+# Ensure the array type is set to the new schema as well.
+statement ok
+SELECT ARRAY['hello']::s2._typ2
+
 # Ensure the type does not exist in the s1 schema.
 statement error pq: type "s1.typ2" does not exist
 SELECT 'hello'::s1.typ2
+
+# Ensure the array type is removed from the old schema.
+statement error pq: type "s1._typ2" does not exist
+SELECT ARRAY['hello']::s1._typ2
 
 statement ok
 CREATE TYPE s1.typ3 AS ENUM ('hello')
@@ -427,4 +454,3 @@ user testuser
 
 statement error pq: user testuser does not have CREATE privilege on schema s1
 ALTER TYPE typ5 SET SCHEMA s1
-


### PR DESCRIPTION
Update set schema to set schema the array enum type.
Enum array types have an implicit name, ie for type "typ1", there is
an implicit name for the the array type typ1[] (_typ1).

Set schema also sets the schema for the implicit array type.

Release note: None