### PR TITLE
sql: validate the number of entries in a partial index after a backfill

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -589,31 +589,53 @@ SELECT * FROM j@a_gt_5_idx WHERE a > 5
 ----
 6  6
 
+# Backfill a unique partial index.
+
+statement ok
+CREATE TABLE k (a INT, b INT)
+
+statement ok
+INSERT INTO k VALUES (1, 1), (1, 2)
+
+statement error pgcode 23505 violates unique constraint \"k_a_key\"
+CREATE UNIQUE INDEX ON k (a) WHERE b > 0
+
+statement ok
+UPDATE k SET b = 0 WHERE b = 2
+
+statement ok
+CREATE UNIQUE INDEX ON k (a) WHERE b > 0
+
+query II rowsort
+SELECT * FROM k@k_a_key WHERE b > 0
+----
+1  1
+
 # Truncate "removes" all entries from a partial index (technically a new table
 # is created). The partial index is preserved correctly in the new table.
 
 statement ok
-CREATE TABLE k (
+CREATE TABLE l (
     a INT PRIMARY KEY,
     b INT,
     INDEX a_b_gt_5 (a) WHERE b > 5
 )
 
 statement ok
-INSERT INTO k VALUES (1, 1), (6, 6)
+INSERT INTO l VALUES (1, 1), (6, 6)
 
 statement ok
-TRUNCATE k
+TRUNCATE l
 
 query II rowsort
-SELECT * FROM k@a_b_gt_5 WHERE b > 5
+SELECT * FROM l@a_b_gt_5 WHERE b > 5
 ----
 
 statement ok
-INSERT INTO k VALUES (1, 1), (7, 7)
+INSERT INTO l VALUES (1, 1), (7, 7)
 
 query II rowsort
-SELECT * FROM k@a_b_gt_5 WHERE b > 5
+SELECT * FROM l@a_b_gt_5 WHERE b > 5
 ----
 7  7
 


### PR DESCRIPTION
This commit extends backfilling validation to ensure that the number of
entries in a partial index after backfilling is equal to the number of
rows in the table in which the partial index's predicate evaluates to
true. This provides addition safety to ensure that backfilling occurred
correctly, matching validation that is already performed for non-partial
indexes.

Fixes #50223

Release note: None