### PR TITLE
kv: reject admin KV requests from tenant SQL processes

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/proxy.go
+++ b/pkg/ccl/kvccl/kvtenantccl/proxy.go
@@ -32,6 +32,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func init() {
@@ -315,7 +317,7 @@ func (p *Proxy) RangeLookup(
 
 // FirstRange implements the kvcoord.RangeDescriptorDB interface.
 func (p *Proxy) FirstRange() (*roachpb.RangeDescriptor, error) {
-	return nil, errors.New("kvtenant.Proxy does not have access to FirstRange")
+	return nil, status.Error(codes.Unauthenticated, "kvtenant.Proxy does not have access to FirstRange")
 }
 
 // getClient returns the singleton InternalClient if one is currently active. If

--- a/pkg/ccl/kvccl/kvtenantccl/proxy_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/proxy_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -295,6 +296,7 @@ func TestProxyRangeLookup(t *testing.T) {
 	desc, err := p.FirstRange()
 	require.Nil(t, desc)
 	require.Regexp(t, "does not have access to FirstRange", err)
+	require.True(t, grpcutil.IsAuthenticationError(err))
 }
 
 // TestProxyRetriesUnreachable tests that Proxy iterates over each of its

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
@@ -33,37 +33,37 @@ CREATE TEMP TABLE users (id UUID, city STRING, CONSTRAINT "primary" PRIMARY KEY 
 
 # Missing status server
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 SHOW SESSIONS
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 SHOW QUERIES
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 CANCEL QUERY ''
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 CANCEL SESSION ''
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 SELECT * FROM crdb_internal.node_transactions
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 SELECT * FROM crdb_internal.node_sessions
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 SELECT * FROM crdb_internal.node_queries
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 SELECT * FROM crdb_internal.cluster_sessions
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 SELECT * FROM crdb_internal.cluster_queries
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 SELECT * FROM crdb_internal.kv_store_status
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 SELECT * FROM crdb_internal.kv_node_status
 
 # Cannot manipulate zone configurations
@@ -73,8 +73,31 @@ query IITTTTTTTTTTT
 SELECT * FROM crdb_internal.zones
 ----
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 SHOW ZONE CONFIGURATION FOR TABLE kv
 
-statement error operation is unsupported
+statement error operation is unsupported in multi-tenancy mode
 ALTER TABLE kv CONFIGURE ZONE USING num_replicas = 123
+
+# Cannot perform operations that issue Admin requests.
+
+statement error operation is unsupported in multi-tenancy mode
+ALTER TABLE kv SPLIT AT VALUES ('foo')
+
+statement error operation is unsupported in multi-tenancy mode
+ALTER TABLE kv UNSPLIT AT VALUES ('foo')
+
+statement error operation is unsupported in multi-tenancy mode
+ALTER TABLE kv UNSPLIT ALL
+
+statement error operation is unsupported in multi-tenancy mode
+ALTER TABLE kv SCATTER
+
+statement error operation is unsupported in multi-tenancy mode
+ALTER TABLE kv EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 'k')
+
+statement error operation is unsupported in multi-tenancy mode
+ALTER TABLE kv EXPERIMENTAL_RELOCATE LEASE VALUES (1, 'k')
+
+statement error operation is unsupported in multi-tenancy mode
+SELECT crdb_internal.check_consistency(true, '', '')

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -153,6 +153,11 @@ func TestTenantAuthRequest(t *testing.T) {
 		h := roachpb.RequestHeaderFromSpan(s)
 		return &roachpb.ScanRequest{RequestHeader: h}
 	}
+	makeAdminReq := func(key string) roachpb.Request {
+		s := makeSpan(key)
+		h := roachpb.RequestHeaderFromSpan(s)
+		return &roachpb.AdminSplitRequest{RequestHeader: h, SplitKey: s.Key}
+	}
 	makeReqs := func(reqs ...roachpb.Request) []roachpb.RequestUnion {
 		ru := make([]roachpb.RequestUnion, len(reqs))
 		for i, r := range reqs {
@@ -220,6 +225,47 @@ func TestTenantAuthRequest(t *testing.T) {
 					makeReq(prefix(10, "a"), prefix(20, "b")),
 				)},
 				expErr: `requested key span /Tenant/{10"a"-20"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+			},
+			{
+				req: &roachpb.BatchRequest{Requests: makeReqs(
+					makeAdminReq("a"),
+				)},
+				expErr: `request \[1 AdmSplit\] not permitted`,
+			},
+			{
+				req: &roachpb.BatchRequest{Requests: makeReqs(
+					makeAdminReq(prefix(10, "a")),
+				)},
+				expErr: `request \[1 AdmSplit\] not permitted`,
+			},
+			{
+				req: &roachpb.BatchRequest{Requests: makeReqs(
+					makeAdminReq(prefix(50, "a")),
+				)},
+				expErr: `request \[1 AdmSplit\] not permitted`,
+			},
+			{
+				req: &roachpb.BatchRequest{Requests: makeReqs(
+					makeAdminReq(prefix(10, "a")),
+					makeReq(prefix(10, "a"), prefix(10, "b")),
+				)},
+				expErr: `request \[1 Scan, 1 AdmSplit\] not permitted`,
+			},
+			{
+				req: &roachpb.BatchRequest{Requests: makeReqs(
+					makeReq(prefix(10, "a"), prefix(10, "b")),
+					makeAdminReq(prefix(10, "a")),
+				)},
+				expErr: `request \[1 Scan, 1 AdmSplit\] not permitted`,
+			},
+			{
+				req: &roachpb.BatchRequest{Requests: makeReqs(
+					func() roachpb.Request {
+						h := roachpb.RequestHeaderFromSpan(makeSpan("a"))
+						return &roachpb.SubsumeRequest{RequestHeader: h}
+					}(),
+				)},
+				expErr: `request \[1 Subsume\] not permitted`,
 			},
 		},
 		"/cockroach.roachpb.Internal/RangeLookup": {

--- a/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
@@ -1,3 +1,5 @@
+# LogicTest: !3node-tenant
+
 # This test verifies that we correctly perform an index join when the KV
 # batches span ranges. This is testing that SQL disables batch limits for index
 # join; otherwise it can get out of order results from KV that it can't handle.

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -155,8 +155,12 @@ CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 statement ok
 INSERT INTO abc VALUES (1, 2, 3), (4, 5, 6)
 
-statement ok
-ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
+# TODO(nvanbenschoten): until we have conditional logic in these files, disable
+# this statement so that we can continue to test this file with the 3node-tenant
+# config.
+#
+# statement ok
+# ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
 
 query error unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{int AS a, int AS b, int AS c}}>
 SELECT (1, 2) IN (SELECT * FROM abc)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -1761,6 +1762,10 @@ func (ef *execFactory) ConstructOpaque(metadata opt.OpaqueMetadata) (exec.Node, 
 func (ef *execFactory) ConstructAlterTableSplit(
 	index cat.Index, input exec.Node, expiration tree.TypedExpr,
 ) (exec.Node, error) {
+	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
+		return nil, errorutil.UnsupportedWithMultiTenancy()
+	}
+
 	expirationTime, err := parseExpirationTime(ef.planner.EvalContext(), expiration)
 	if err != nil {
 		return nil, err
@@ -1778,6 +1783,10 @@ func (ef *execFactory) ConstructAlterTableSplit(
 func (ef *execFactory) ConstructAlterTableUnsplit(
 	index cat.Index, input exec.Node,
 ) (exec.Node, error) {
+	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
+		return nil, errorutil.UnsupportedWithMultiTenancy()
+	}
+
 	return &unsplitNode{
 		tableDesc: index.Table().(*optTable).desc,
 		index:     index.(*optIndex).desc,
@@ -1787,6 +1796,10 @@ func (ef *execFactory) ConstructAlterTableUnsplit(
 
 // ConstructAlterTableUnsplitAll is part of the exec.Factory interface.
 func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node, error) {
+	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
+		return nil, errorutil.UnsupportedWithMultiTenancy()
+	}
+
 	return &unsplitAllNode{
 		tableDesc: &index.Table().(*optTable).desc.TableDescriptor,
 		index:     index.(*optIndex).desc,
@@ -1797,6 +1810,10 @@ func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node
 func (ef *execFactory) ConstructAlterTableRelocate(
 	index cat.Index, input exec.Node, relocateLease bool,
 ) (exec.Node, error) {
+	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
+		return nil, errorutil.UnsupportedWithMultiTenancy()
+	}
+
 	return &relocateNode{
 		relocateLease: relocateLease,
 		tableDesc:     index.Table().(*optTable).desc,

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -32,6 +33,10 @@ type scatterNode struct {
 // (`ALTER TABLE/INDEX ... SCATTER ...` statement)
 // Privileges: INSERT on table.
 func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error) {
+	if !p.ExecCfg().Codec.ForSystemTenant() {
+		return nil, errorutil.UnsupportedWithMultiTenancy()
+	}
+
 	tableDesc, index, err := p.getTableAndIndex(ctx, &n.TableOrIndex, privilege.INSERT)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/arith"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
 )
@@ -1127,6 +1128,10 @@ var _ tree.ValueGenerator = &checkConsistencyGenerator{}
 func makeCheckConsistencyGenerator(
 	ctx *tree.EvalContext, args tree.Datums,
 ) (tree.ValueGenerator, error) {
+	if !ctx.Codec.ForSystemTenant() {
+		return nil, errorutil.UnsupportedWithMultiTenancy()
+	}
+
 	keyFrom := roachpb.Key(*args[1].(*tree.DBytes))
 	keyTo := roachpb.Key(*args[2].(*tree.DBytes))
 


### PR DESCRIPTION
Fixes #52360.

This commit adds a new restriction to the tenantAuth policy that it accepts no "Admin" KV requests. This prevents tenants from splitting ranges, merging range, rebalancing ranges, or issuing any other KV requests with the `isAdmin` flag that could dictate KV-level distribution decisions.

This further mitigates the impact that a compromised tenant SQL process could have on the rest of the cluster.