### PR TITLE
roachtest: Add --local-ssd, --create-args

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -224,6 +224,10 @@ the test tags.
 			"The number of cloud CPUs roachtest is allowed to use at any one time.")
 		cmd.Flags().IntVar(
 			&httpPort, "port", 8080, "the port on which to serve the HTTP interface")
+		cmd.Flags().BoolVar(
+			&localSSD, "local-ssd", true, "Use a local SSD instead of an EBS volume (only for use with AWS) (defaults to true if instance type supports local SSDs)")
+		cmd.Flags().StringSliceVar(
+			&createArgs, "create-args", []string{}, "extra args to pass onto the roachprod create command")
 	}
 
 	rootCmd.AddCommand(listCmd)


### PR DESCRIPTION
For storage-level testing, it's useful to be able to force the use
of an EBS volume and to manually restrict its IOPS / storage size.
This change adds a --local-ssd flag which defaults to true to mimic
existing behaviour. But when --local-ssd=false is specified, it allows
for an EBS volume to be used regardless of instance type. Any additional
flags governing IOPS, etc can be passed in using --create-args.

Release note: None.