### PR TITLE
kv: mask system config gossip info in tenant GossipSubscription stream

### DIFF
--- a/pkg/config/system_mask.go
+++ b/pkg/config/system_mask.go
@@ -1,0 +1,47 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package config
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// SystemConfigMask is a mask that can be applied to a set of system config
+// entries to filter out unwanted entries.
+type SystemConfigMask struct {
+	allowed []roachpb.Key
+}
+
+// MakeSystemConfigMask constructs a new SystemConfigMask that passes through
+// only the specified keys when applied.
+func MakeSystemConfigMask(allowed ...roachpb.Key) SystemConfigMask {
+	sort.Slice(allowed, func(i, j int) bool {
+		return allowed[i].Compare(allowed[j]) < 0
+	})
+	return SystemConfigMask{allowed: allowed}
+}
+
+// Apply applies the mask to the provided set of system config entries,
+// returning a filtered down set of entries.
+func (m SystemConfigMask) Apply(entries SystemConfigEntries) SystemConfigEntries {
+	var res SystemConfigEntries
+	for _, key := range m.allowed {
+		i := sort.Search(len(entries.Values), func(i int) bool {
+			return entries.Values[i].Key.Compare(key) >= 0
+		})
+		if i < len(entries.Values) && entries.Values[i].Key.Equal(key) {
+			res.Values = append(res.Values, entries.Values[i])
+		}
+	}
+	return res
+}

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -94,3 +95,13 @@ func AddressResolver(c Connector) nodedialer.AddressResolver {
 		return nd.CheckedTenantAddress(), nil
 	}
 }
+
+// GossipSubscriptionSystemConfigMask filters a system config down to just the
+// keys that a tenant SQL process needs access to. All system tenant objects are
+// filtered out (e.g. system tenant descriptors and users).
+var GossipSubscriptionSystemConfigMask = config.MakeSystemConfigMask(
+	// Tenant SQL processes need just enough of the zone hierarchy to understand
+	// which zone configurations apply to their keyspace.
+	config.MakeZoneKey(keys.RootNamespaceID),
+	config.MakeZoneKey(keys.TenantsRangesID),
+)


### PR DESCRIPTION
Fixes #52361.

This commit creates a new GossipSubscriptionSystemConfigMask object that the
KV server uses to filter out most system config keys within the "system-db"
gossip key. The keys remaining after the filter are only those that a tenant
SQL process needs access to, namely just enough of the zone hierarchy to
understand which zone configurations apply to their keyspace.