### PR TITLE
opt: add support for CREATE/DROP INDEX in test catalog

### DIFF
--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -227,6 +227,10 @@ func formatCatalogIndex(tab Table, ord int, tp treeprinter.Node) {
 			c.Childf("table=%d index=%d", table, index)
 		}
 	}
+	if pred, isPartial := idx.Predicate(); isPartial {
+		c := child.Child("WHERE")
+		c.Childf(pred)
+	}
 }
 
 // formatColPrefix returns a string representation of a list of columns. The

--- a/pkg/sql/opt/testutils/testcat/create_index.go
+++ b/pkg/sql/opt/testutils/testcat/create_index.go
@@ -1,0 +1,51 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package testcat
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// CreateIndex is a partial implementation of the CREATE INDEX statement.
+func (tc *Catalog) CreateIndex(stmt *tree.CreateIndex) {
+	tn := stmt.Table
+	// Update the table name to include catalog and schema if not provided.
+	tc.qualifyTableName(&tn)
+	tab := tc.Table(&tn)
+
+	for _, idx := range tab.Indexes {
+		in := stmt.Name.String()
+		if idx.IdxName == in {
+			panic(errors.Newf(`relation "%s" already exists`, in))
+		}
+	}
+
+	// Convert stmt to a tree.IndexTableDef so that Table.addIndex can be used
+	// to add the index to the table.
+	indexTableDef := &tree.IndexTableDef{
+		Name:        stmt.Name,
+		Columns:     stmt.Columns,
+		Sharded:     stmt.Sharded,
+		Storing:     stmt.Storing,
+		Interleave:  stmt.Interleave,
+		Inverted:    stmt.Inverted,
+		PartitionBy: stmt.PartitionBy,
+		Predicate:   stmt.Predicate,
+	}
+
+	idxType := nonUniqueIndex
+	if stmt.Unique {
+		idxType = uniqueIndex
+
+	}
+	tab.addIndex(indexTableDef, idxType)
+}

--- a/pkg/sql/opt/testutils/testcat/drop_index.go
+++ b/pkg/sql/opt/testutils/testcat/drop_index.go
@@ -1,0 +1,65 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package testcat
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// DropIndex is a partial implementation of the DROP INDEX statement.
+//
+// It only supports dropping a secondary index with an unqualified name.
+func (tc *Catalog) DropIndex(stmt *tree.DropIndex) {
+	for _, tableIndexName := range stmt.IndexList {
+		indexName := tableIndexName.Index.String()
+
+		var foundTab *Table
+		var idxOrd int
+		for _, tab := range tc.Tables() {
+			if idx, ok := findIndex(tab, indexName); ok {
+				if foundTab != nil {
+					panic(errors.Newf(
+						`index name "%s" is ambiguous; dropping ambiguous indexes is not supported in the test catalog`,
+						indexName,
+					))
+				}
+				foundTab = tab
+				idxOrd = idx.ordinal
+			}
+		}
+
+		if foundTab == nil {
+			panic(errors.Newf(`index "%s" does not exist`, indexName))
+		}
+
+		if idxOrd == 0 {
+			panic(errors.Newf("dropping primary indexes is not supported in the test catalog"))
+		}
+
+		// Delete the index from the table.
+		idxLen := len(foundTab.Indexes)
+		foundTab.Indexes[idxOrd] = foundTab.Indexes[idxLen-1]
+		foundTab.Indexes = foundTab.Indexes[:idxLen-1]
+	}
+}
+
+// findIndex returns the first index within tab that has an IdxName equal to
+// name. If an index is found it returns the index and true, and nil and false
+// otherwise.
+func findIndex(tab *Table, name string) (*Index, bool) {
+	for _, idx := range tab.Indexes {
+		if idx.IdxName == name {
+			return idx, true
+		}
+	}
+	return nil, false
+}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -266,6 +266,17 @@ func (tc *Catalog) Table(name *tree.TableName) *Table {
 		"\"%q\" is not a table", tree.ErrString(name)))
 }
 
+// Tables returns a list of all tables added to the test catalog.
+func (tc *Catalog) Tables() []*Table {
+	tables := make([]*Table, 0, len(tc.testSchema.dataSources))
+	for _, ds := range tc.testSchema.dataSources {
+		if tab, ok := ds.(*Table); ok {
+			tables = append(tables, tab)
+		}
+	}
+	return tables
+}
+
 // AddTable adds the given test table to the catalog.
 func (tc *Catalog) AddTable(tab *Table) {
 	fq := tab.TabName.FQString()
@@ -340,6 +351,10 @@ func (tc *Catalog) ExecuteDDL(sql string) (string, error) {
 		tc.CreateTable(stmt)
 		return "", nil
 
+	case *tree.CreateIndex:
+		tc.CreateIndex(stmt)
+		return "", nil
+
 	case *tree.CreateView:
 		tc.CreateView(stmt)
 		return "", nil
@@ -350,6 +365,10 @@ func (tc *Catalog) ExecuteDDL(sql string) (string, error) {
 
 	case *tree.DropTable:
 		tc.DropTable(stmt)
+		return "", nil
+
+	case *tree.DropIndex:
+		tc.DropIndex(stmt)
 		return "", nil
 
 	case *tree.CreateSequence:

--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -1,0 +1,54 @@
+exec-ddl
+CREATE TABLE kv (
+    k INT PRIMARY KEY,
+    v INT
+)
+----
+
+exec-ddl
+CREATE INDEX idx ON kv (v)
+----
+
+exec-ddl
+SHOW CREATE kv
+----
+TABLE kv
+ ├── k int not null
+ ├── v int
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── INDEX primary
+ │    └── k int not null
+ └── INDEX idx
+      ├── v int
+      └── k int not null
+
+exec-ddl
+DROP INDEX idx
+----
+
+exec-ddl
+CREATE TABLE ab (
+    a INT PRIMARY KEY,
+    b INT,
+    INDEX idx (b)
+)
+----
+
+exec-ddl
+CREATE INDEX idx ON kv (v) STORING (k) WHERE v > 1
+----
+
+exec-ddl
+SHOW CREATE kv
+----
+TABLE kv
+ ├── k int not null
+ ├── v int
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── INDEX primary
+ │    └── k int not null
+ └── INDEX idx
+      ├── v int
+      ├── k int not null
+      └── WHERE
+           └── v > 1


### PR DESCRIPTION
This commit adds support `CREATE INDEX` and `DROP INDEX` in `exec-ddl`
commands. This change should allow me to clean up the partial index
stats tests and more easily add cases for constrained partial index
scans.

These statements will allow me to reuse the same table and stats for
multiple test cases by adding and dropping partial indexes. In order to
reuse the same table and stats previously, I would have to define many
partial indexes in `CREATE TABLE` and take care to write query filters
that only invoked a specific partial index scan. Fully understanding
each test case required repeatedly scrolling back and forth from the
case to the top of the file in order to view the index predicate
expression.

Release note: None