### PR TITLE
security: tenant client certificates have OU=Tenants

### DIFF
--- a/pkg/cli/mt_cert.go
+++ b/pkg/cli/mt_cert.go
@@ -11,6 +11,8 @@
 package cli
 
 import (
+	"strconv"
+
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
@@ -60,12 +62,16 @@ Creation fails if the CA expiration time is before the desired certificate expir
 	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(
 		func(cmd *cobra.Command, args []string) error {
+			tenantID, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				return errors.Wrapf(err, "%s is invalid uint64", args[0])
+			}
 			cp, err := security.CreateTenantClientPair(
 				baseCfg.SSLCertsDir,
 				baseCfg.SSLCAKey,
 				keySize,
 				certificateLifetime,
-				args[0],
+				tenantID,
 			)
 			if err != nil {
 				return errors.Wrap(

--- a/pkg/rpc/tls.go
+++ b/pkg/rpc/tls.go
@@ -83,7 +83,7 @@ func (ctx *SecurityContext) GetCertificateManager() (*security.CertificateManage
 	ctx.lazy.certificateManager.Do(func() {
 		var opts []security.Option
 		if ctx.tenID != roachpb.SystemTenantID {
-			opts = append(opts, security.ForTenant(ctx.tenID.String()))
+			opts = append(opts, security.ForTenant(ctx.tenID.ToUint64()))
 		}
 		ctx.lazy.certificateManager.cm, ctx.lazy.certificateManager.err =
 			security.NewCertificateManager(ctx.config.SSLCertsDir, opts...)

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -140,6 +140,17 @@ func UserAuthCertHook(insecureMode bool, tlsState *tls.ConnectionState) (UserAut
 			return nil, nil
 		}
 
+		// The client certificate should not be a tenant client type. For now just
+		// check that it doesn't have OU=Tenants. It would make sense to add
+		// explicit OU=Users to all client certificates and to check for match.
+		ous := tlsState.PeerCertificates[0].Subject.OrganizationalUnit
+		for _, ou := range ous {
+			if ou == tenantsOU {
+				return nil,
+					errors.Errorf("using tenant client certificate as user certificate is not allowed")
+			}
+		}
+
 		// The client certificate user must match the requested user,
 		// except if the certificate user is NodeUser, which is allowed to
 		// act on behalf of all other users.

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -457,7 +457,7 @@ type TenantClientPair struct {
 //
 // To write the returned TenantClientPair to disk, use WriteTenantClientPair.
 func CreateTenantClientPair(
-	certsDir, caKeyPath string, keySize int, lifetime time.Duration, tenantIdentifier string,
+	certsDir, caKeyPath string, keySize int, lifetime time.Duration, tenantIdentifier uint64,
 ) (*TenantClientPair, error) {
 	if len(caKeyPath) == 0 {
 		return nil, errors.New("the path to the CA key is required")
@@ -490,7 +490,7 @@ func CreateTenantClientPair(
 		return nil, errors.Errorf("could not generate new tenant key: %v", err)
 	}
 
-	clientCert, err := GenerateClientCert(
+	clientCert, err := GenerateTenantClientCert(
 		caCert, caPrivateKey, clientKey.Public(), lifetime, tenantIdentifier,
 	)
 	if err != nil {

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -141,7 +141,7 @@ func TestGenerateTenantCerts(t *testing.T) {
 		caKeyFile,
 		testKeySize,
 		time.Hour,
-		"999",
+		999,
 	)
 	require.NoError(t, err)
 	require.NoError(t, security.WriteTenantClientPair(certsDir, cp, false))
@@ -253,7 +253,7 @@ func generateBaseCerts(certsDir string) error {
 		}
 
 		tcp, err := security.CreateTenantClientPair(certsDir, caKey,
-			testKeySize, time.Hour*48, "10")
+			testKeySize, time.Hour*48, 10)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Before this PR it was possible to use a tenant client certificate
as user certificate. I.e. the tenant client certificate for tenant 33
was an exact substitute for the user certificate for user 33 (a valid user name).
This PR changes the tenant client certficate generation, adding
OU=Tenants to the Subject fields. It also adds a check that
prevents certificate user authentication using a tenant client certficate.
Preventing use of user certificates for authenticating tenants is not
currently done but it will be once tenant split port is dropped.

Release note: None