### PR TITLE
release-19.1: build: add dryrun option to make and publish build script

### DIFF
--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -11,14 +11,24 @@ build/builder.sh make .buildinfo/tag
 build_name="${TAG_NAME:-$(cat .buildinfo/tag)}"
 release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+")"
 
-bucket="${BUCKET-cockroach-builds}"
+if [[ -z "${DRY_RUN}" ]] ; then
+  bucket="${BUCKET-cockroach-builds}"
+  google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_CREDENTIALS
+  gcr_repository="us.gcr.io/cockroach-cloud-images/cockroach"
+else
+  bucket="${BUCKET:-cockroach-release-test}"
+  google_credentials="$GOOGLE_COCKROACH_RELEASE_CREDENTIALS"
+  gcr_repository="us.gcr.io/cockroach-release/cockroach-test"
+  build_name="${build_name}.dryrun"
+fi
 
-google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_CREDENTIALS
+# Used for docker login for gcloud
+gcr_hostname="us.gcr.io"
 tc_end_block "Variable Setup"
 
 
 tc_start_block "Tag the release"
-git tag "$build_name"
+git tag "${build_name}"
 tc_end_block "Tag the release"
 
 
@@ -38,11 +48,7 @@ tc_end_block "Compile and publish S3 artifacts"
 
 tc_start_block "Make and push docker image"
 configure_docker_creds
-
-gcr_hostname="us.gcr.io"
 docker_login_with_google
-
-gcr_repository="us.gcr.io/cockroach-cloud-images/cockroach"
 
 # TODO: update publish-provisional-artifacts with option to leave one or more cockroach binaries in the local filesystem
 # NB: tar usually stops reading as soon as it sees an empty block but that makes
@@ -58,7 +64,7 @@ tc_end_block "Make and push docker image"
 tc_start_block "Push release tag to github.com/cockroachdb/cockroach"
 github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY}"
 configure_git_ssh_key
-push_to_git ssh://git@github.com/cockroachlabs/release-staging.git "$build_name"
+push_to_git ssh://git@github.com/cockroachlabs/release-staging.git "${build_name}"
 tc_end_block "Push release tag to github.com/cockroachdb/cockroach"
 
 


### PR DESCRIPTION
Backport 1/1 commits from #52587.

/cc @cockroachdb/release

---

Before: The Make and Publish Build TeamCity script always pushed to
final locations.

Why change:

- So we can inspect all the artifacts created during the build process
- So the "Mark Build As X" steps can tag docker images during dryrun

Now:

A DRY_RUN option allows the script to deposit build artifacts in test
locations instead of the normal locations.

- S3: `cockroach-release-test`
- GCR: `us.gcr.io/cockroach-release/cockroach-test`
- Git Tag: `dryrun-${build_name}`
- Git Repo: `cockroachlabs/release-staging`

Release note: None
