### PR TITLE
[WIP] kv: merge latch spans and lock spans

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -64,10 +64,10 @@ func declareKeysEndTxn(
 ) {
 	et := req.(*roachpb.EndTxnRequest)
 	declareKeysWriteTransaction(desc, header, req, latchSpans)
-	var minTxnTS hlc.Timestamp
+	// var minTxnTS hlc.Timestamp
 	if header.Txn != nil {
 		header.Txn.AssertInitialized(context.TODO())
-		minTxnTS = header.Txn.MinTimestamp
+		// minTxnTS = header.Txn.MinTimestamp
 		abortSpanAccess := spanset.SpanReadOnly
 		if !et.Commit {
 			// Rollback EndTxn requests may write to the abort span, either if
@@ -94,7 +94,8 @@ func declareKeysEndTxn(
 		// purpose of acquiring latches. The parts in our Range will
 		// be resolved eagerly.
 		for _, span := range et.LockSpans {
-			latchSpans.AddMVCC(spanset.SpanReadWrite, span, minTxnTS)
+			latchSpans.AddNonMVCC(spanset.SpanReadWrite, span)
+			// latchSpans.AddMVCC(spanset.SpanReadWrite, span, minTxnTS)
 		}
 
 		if et.InternalCommitTrigger != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_gc.go
+++ b/pkg/kv/kvserver/batcheval/cmd_gc.go
@@ -35,11 +35,11 @@ func declareKeysGC(
 	// is usually the whole range (pending resolution of #7880).
 	gcr := req.(*roachpb.GCRequest)
 	for _, key := range gcr.Keys {
-		if keys.IsLocal(key.Key) {
-			latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: key.Key})
-		} else {
-			latchSpans.AddMVCC(spanset.SpanReadWrite, roachpb.Span{Key: key.Key}, header.Timestamp)
-		}
+		latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: key.Key})
+		// if keys.IsLocal(key.Key) {
+		// } else {
+		// 	latchSpans.AddMVCC(spanset.SpanReadWrite, roachpb.Span{Key: key.Key}, header.Timestamp)
+		// }
 	}
 	// Be smart here about blocking on the threshold keys. The GC queue can send an empty
 	// request first to bump the thresholds, and then another one that actually does work

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -31,18 +30,18 @@ func declareKeysResolveIntentCombined(
 ) {
 	var status roachpb.TransactionStatus
 	var txnID uuid.UUID
-	var minTxnTS hlc.Timestamp
+	// var minTxnTS hlc.Timestamp
 	switch t := req.(type) {
 	case *roachpb.ResolveIntentRequest:
 		status = t.Status
 		txnID = t.IntentTxn.ID
-		minTxnTS = t.IntentTxn.MinTimestamp
+		// minTxnTS = t.IntentTxn.MinTimestamp
 	case *roachpb.ResolveIntentRangeRequest:
 		status = t.Status
 		txnID = t.IntentTxn.ID
-		minTxnTS = t.IntentTxn.MinTimestamp
+		// minTxnTS = t.IntentTxn.MinTimestamp
 	}
-	latchSpans.AddMVCC(spanset.SpanReadWrite, req.Header().Span(), minTxnTS)
+	latchSpans.AddNonMVCC(spanset.SpanReadWrite, req.Header().Span()) //, minTxnTS)
 	if status == roachpb.ABORTED {
 		// We don't always write to the abort span when resolving an ABORTED
 		// intent, but we can't tell whether we will or not ahead of time.

--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -30,7 +30,7 @@ func DefaultDeclareKeys(
 	if roachpb.IsReadOnly(req) && !roachpb.IsLocking(req) {
 		access = spanset.SpanReadOnly
 	}
-	latchSpans.AddMVCC(access, req.Header().Span(), header.Timestamp)
+	latchSpans.AddNonMVCC(access, req.Header().Span()) //, header.Timestamp)
 }
 
 // DefaultDeclareIsolatedKeys is similar to DefaultDeclareKeys, but it declares
@@ -87,7 +87,7 @@ func DefaultDeclareIsolatedKeys(
 		}
 	}
 	latchSpans.AddMVCC(access, req.Header().Span(), timestamp)
-	lockSpans.AddNonMVCC(access, req.Header().Span())
+	// lockSpans.AddNonMVCC(access, req.Header().Span())
 }
 
 // DeclareKeysForBatch adds all keys that the batch with the provided header

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -336,21 +336,21 @@ type Request struct {
 
 	// The maximal set of spans that the request will access. Latches
 	// will be acquired for these spans.
-	// TODO(nvanbenschoten): don't allocate these SpanSet objects.
+	// TODO rename to spans.
 	LatchSpans *spanset.SpanSet
 
-	// The maximal set of spans within which the request expects to have
-	// isolation from conflicting transactions. Conflicting locks within
-	// these spans will be queued on and conditionally pushed.
-	//
-	// Note that unlike LatchSpans, the timestamps that these spans are
-	// declared at are NOT consulted. All read spans are considered to take
-	// place at the transaction's read timestamp (Txn.ReadTimestamp) and all
-	// write spans are considered to take place the transaction's write
-	// timestamp (Txn.WriteTimestamp). If the request is non-transactional
-	// (Txn == nil), all reads and writes are considered to take place at
-	// Timestamp.
-	LockSpans *spanset.SpanSet
+	// // The maximal set of spans within which the request expects to have
+	// // isolation from conflicting transactions. Conflicting locks within
+	// // these spans will be queued on and conditionally pushed.
+	// //
+	// // Note that unlike LatchSpans, the timestamps that these spans are
+	// // declared at are NOT consulted. All read spans are considered to take
+	// // place at the transaction's read timestamp (Txn.ReadTimestamp) and all
+	// // write spans are considered to take place the transaction's write
+	// // timestamp (Txn.WriteTimestamp). If the request is non-transactional
+	// // (Txn == nil), all reads and writes are considered to take place at
+	// // Timestamp.
+	// LockSpans *spanset.SpanSet
 }
 
 // Guard is returned from Manager.SequenceReq. The guard is passed back in to

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -156,7 +156,7 @@ func (m *managerImpl) sequenceReqWithGuard(
 		}
 
 		// Some requests don't want the wait on locks.
-		if req.LockSpans.Empty() {
+		if req.LatchSpans.EmptyTransactional() {
 			return nil, nil
 		}
 

--- a/pkg/kv/kvserver/concurrency/latch_manager.go
+++ b/pkg/kv/kvserver/concurrency/latch_manager.go
@@ -24,7 +24,7 @@ type latchManagerImpl struct {
 }
 
 func (m *latchManagerImpl) Acquire(ctx context.Context, req Request) (latchGuard, *Error) {
-	lg, err := m.m.Acquire(ctx, req.LatchSpans)
+	lg, err := m.m.Acquire(ctx, req.LatchSpans, req.readConflictTimestamp(), req.writeConflictTimestamp())
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -202,7 +202,7 @@ func TestLockTableBasic(t *testing.T) {
 				req := Request{
 					Timestamp:  ts,
 					LatchSpans: spans,
-					LockSpans:  spans,
+					// LockSpans:  spans,
 				}
 				if txnMeta != nil {
 					// Update the transaction's timestamp, if necessary. The transaction
@@ -527,7 +527,7 @@ func doWork(ctx context.Context, item *workItem, e *workloadExecutor) error {
 			// cancellation, the code makes sure to release latches when returning
 			// early due to error. Otherwise other requests will get stuck and
 			// group.Wait() will not return until the test times out.
-			lg, err = e.lm.Acquire(context.Background(), item.request.LatchSpans)
+			lg, err = e.lm.Acquire(context.Background(), item.request.LatchSpans, item.request.Timestamp, item.request.Timestamp)
 			if err != nil {
 				return err
 			}
@@ -919,7 +919,7 @@ func TestLockTableConcurrentSingleRequests(t *testing.T) {
 			Txn:        txn,
 			Timestamp:  ts,
 			LatchSpans: spans,
-			LockSpans:  spans,
+			// LockSpans:  spans,
 		}
 		items = append(items, workloadItem{request: request})
 		if txn != nil {
@@ -998,7 +998,7 @@ func TestLockTableConcurrentRequests(t *testing.T) {
 		request := &Request{
 			Timestamp:  ts,
 			LatchSpans: spans,
-			LockSpans:  spans,
+			// LockSpans:  spans,
 		}
 		if txnMeta != nil {
 			request.Txn = &roachpb.Transaction{
@@ -1071,7 +1071,7 @@ func doBenchWork(item *benchWorkItem, env benchEnv, doneCh chan<- error) {
 	var err error
 	firstIter := true
 	for {
-		if lg, err = env.lm.Acquire(context.Background(), item.LatchSpans); err != nil {
+		if lg, err = env.lm.Acquire(context.Background(), item.LatchSpans, item.Timestamp, item.Timestamp); err != nil {
 			doneCh <- err
 			return
 		}
@@ -1106,7 +1106,7 @@ func doBenchWork(item *benchWorkItem, env benchEnv, doneCh chan<- error) {
 		return
 	}
 	// Release locks.
-	if lg, err = env.lm.Acquire(context.Background(), item.LatchSpans); err != nil {
+	if lg, err = env.lm.Acquire(context.Background(), item.LatchSpans, item.Timestamp, item.Timestamp); err != nil {
 		doneCh <- err
 		return
 	}
@@ -1137,7 +1137,7 @@ func createRequests(index int, numOutstanding int, numKeys int, numReadKeys int)
 		Request: Request{
 			Timestamp:  ts,
 			LatchSpans: spans,
-			LockSpans:  spans,
+			// LockSpans:  spans,
 		},
 	}
 	for i := 0; i < numKeys; i++ {

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -402,7 +402,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 func (w *lockTableWaiterImpl) WaitOnLock(
 	ctx context.Context, req Request, intent *roachpb.Intent,
 ) *Error {
-	sa, _, err := findAccessInSpans(intent.Key, req.LockSpans)
+	sa, _, err := findAccessInSpans(intent.Key, req.LatchSpans)
 	if err != nil {
 		return roachpb.NewError(err)
 	}

--- a/pkg/kv/kvserver/replica_batch_updates.go
+++ b/pkg/kv/kvserver/replica_batch_updates.go
@@ -204,18 +204,19 @@ func maybeBumpReadTimestampToWriteTimestamp(
 func tryBumpBatchTimestamp(
 	ctx context.Context, ba *roachpb.BatchRequest, ts hlc.Timestamp, latchSpans *spanset.SpanSet,
 ) bool {
-	if latchSpans.MaxProtectedTimestamp().Less(ts) {
-		// If the batch acquired any read latches with bounded (MVCC) timestamps
-		// below this new timestamp then we can not trivially bump the batch's
-		// timestamp without dropping and re-acquiring those latches. Doing so
-		// could allow the request to read at an unprotected timestamp.
-		//
-		// NOTE: we could consider adding a retry-loop above the latch
-		// acquisition to allow this to be retried, but given that we try not to
-		// mix read-only and read-write requests, doing so doesn't seem worth
-		// it.
-		return false
-	}
+	// TODO: fix.
+	// if latchSpans.MaxProtectedTimestamp().Less(ts) {
+	// 	// If the batch acquired any read latches with bounded (MVCC) timestamps
+	// 	// below this new timestamp then we can not trivially bump the batch's
+	// 	// timestamp without dropping and re-acquiring those latches. Doing so
+	// 	// could allow the request to read at an unprotected timestamp.
+	// 	//
+	// 	// NOTE: we could consider adding a retry-loop above the latch
+	// 	// acquisition to allow this to be retried, but given that we try not to
+	// 	// mix read-only and read-write requests, doing so doesn't seem worth
+	// 	// it.
+	// 	return false
+	// }
 	if ts.Less(ba.Timestamp) {
 		log.Fatalf(ctx, "trying to bump to %s <= ba.Timestamp: %s", ts, ba.Timestamp)
 	}

--- a/pkg/kv/kvserver/spanset/merge.go
+++ b/pkg/kv/kvserver/spanset/merge.go
@@ -10,114 +10,114 @@
 
 package spanset
 
-import "sort"
+// import "sort"
 
-type sortedSpans []Span
+// type sortedSpans []Span
 
-func (s sortedSpans) Less(i, j int) bool {
-	// Sort first on the start key and second on the end key. Note that we're
-	// relying on EndKey = nil (and len(EndKey) == 0) sorting before other
-	// EndKeys.
-	c := s[i].Key.Compare(s[j].Key)
-	if c != 0 {
-		return c < 0
-	}
-	return s[i].EndKey.Compare(s[j].EndKey) < 0
-}
+// func (s sortedSpans) Less(i, j int) bool {
+// 	// Sort first on the start key and second on the end key. Note that we're
+// 	// relying on EndKey = nil (and len(EndKey) == 0) sorting before other
+// 	// EndKeys.
+// 	c := s[i].Key.Compare(s[j].Key)
+// 	if c != 0 {
+// 		return c < 0
+// 	}
+// 	return s[i].EndKey.Compare(s[j].EndKey) < 0
+// }
 
-func (s sortedSpans) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
+// func (s sortedSpans) Swap(i, j int) {
+// 	s[i], s[j] = s[j], s[i]
+// }
 
-func (s sortedSpans) Len() int {
-	return len(s)
-}
+// func (s sortedSpans) Len() int {
+// 	return len(s)
+// }
 
-// mergeSpans sorts the given spans and merges ones with overlapping
-// spans and equal access timestamps. The implementation is a copy of
-// roachpb.MergeSpans.
-//
-// Returns true iff all of the spans are distinct.
-// The input spans are not safe for re-use.
-func mergeSpans(latches []Span) ([]Span, bool) {
-	if len(latches) == 0 {
-		return latches, true
-	}
+// // mergeSpans sorts the given spans and merges ones with overlapping
+// // spans and equal access timestamps. The implementation is a copy of
+// // roachpb.MergeSpans.
+// //
+// // Returns true iff all of the spans are distinct.
+// // The input spans are not safe for re-use.
+// func mergeSpans(latches []Span) ([]Span, bool) {
+// 	if len(latches) == 0 {
+// 		return latches, true
+// 	}
 
-	sort.Sort(sortedSpans(latches))
+// 	sort.Sort(sortedSpans(latches))
 
-	// We build up the resulting slice of merged spans in place. This is safe
-	// because "r" grows by at most 1 element on each iteration, staying abreast
-	// or behind the iteration over "latches".
-	r := latches[:1]
-	distinct := true
+// 	// We build up the resulting slice of merged spans in place. This is safe
+// 	// because "r" grows by at most 1 element on each iteration, staying abreast
+// 	// or behind the iteration over "latches".
+// 	r := latches[:1]
+// 	distinct := true
 
-	for _, cur := range latches[1:] {
-		prev := &r[len(r)-1]
-		if len(cur.EndKey) == 0 && len(prev.EndKey) == 0 {
-			if cur.Key.Compare(prev.Key) != 0 {
-				// [a, nil] merge [b, nil]
-				r = append(r, cur)
-			} else {
-				// [a, nil] merge [a, nil]
-				if cur.Timestamp != prev.Timestamp {
-					r = append(r, cur)
-				}
-				distinct = false
-			}
-			continue
-		}
-		if len(prev.EndKey) == 0 {
-			if cur.Key.Compare(prev.Key) == 0 {
-				// [a, nil] merge [a, b]
-				if cur.Timestamp != prev.Timestamp {
-					r = append(r, cur)
-				} else {
-					prev.EndKey = cur.EndKey
-				}
-				distinct = false
-			} else {
-				// [a, nil] merge [b, c]
-				r = append(r, cur)
-			}
-			continue
-		}
+// 	for _, cur := range latches[1:] {
+// 		prev := &r[len(r)-1]
+// 		if len(cur.EndKey) == 0 && len(prev.EndKey) == 0 {
+// 			if cur.Key.Compare(prev.Key) != 0 {
+// 				// [a, nil] merge [b, nil]
+// 				r = append(r, cur)
+// 			} else {
+// 				// [a, nil] merge [a, nil]
+// 				if cur.Timestamp != prev.Timestamp {
+// 					r = append(r, cur)
+// 				}
+// 				distinct = false
+// 			}
+// 			continue
+// 		}
+// 		if len(prev.EndKey) == 0 {
+// 			if cur.Key.Compare(prev.Key) == 0 {
+// 				// [a, nil] merge [a, b]
+// 				if cur.Timestamp != prev.Timestamp {
+// 					r = append(r, cur)
+// 				} else {
+// 					prev.EndKey = cur.EndKey
+// 				}
+// 				distinct = false
+// 			} else {
+// 				// [a, nil] merge [b, c]
+// 				r = append(r, cur)
+// 			}
+// 			continue
+// 		}
 
-		if c := prev.EndKey.Compare(cur.Key); c >= 0 {
-			if cur.EndKey != nil {
-				if prev.EndKey.Compare(cur.EndKey) < 0 {
-					// [a, c] merge [b, d]
-					if cur.Timestamp != prev.Timestamp {
-						r = append(r, cur)
-					} else {
-						prev.EndKey = cur.EndKey
-					}
-					if c > 0 {
-						distinct = false
-					}
-				} else {
-					// [a, c] merge [b, c]
-					if cur.Timestamp != prev.Timestamp {
-						r = append(r, cur)
-					}
-					distinct = false
-				}
-			} else if c == 0 {
-				// [a, b] merge [b, nil]
-				if cur.Timestamp != prev.Timestamp {
-					r = append(r, cur)
-				}
-				prev.EndKey = cur.Key.Next()
-			} else {
-				// [a, c] merge [b, nil]
-				if cur.Timestamp != prev.Timestamp {
-					r = append(r, cur)
-				}
-				distinct = false
-			}
-			continue
-		}
-		r = append(r, cur)
-	}
-	return r, distinct
-}
+// 		if c := prev.EndKey.Compare(cur.Key); c >= 0 {
+// 			if cur.EndKey != nil {
+// 				if prev.EndKey.Compare(cur.EndKey) < 0 {
+// 					// [a, c] merge [b, d]
+// 					if cur.Timestamp != prev.Timestamp {
+// 						r = append(r, cur)
+// 					} else {
+// 						prev.EndKey = cur.EndKey
+// 					}
+// 					if c > 0 {
+// 						distinct = false
+// 					}
+// 				} else {
+// 					// [a, c] merge [b, c]
+// 					if cur.Timestamp != prev.Timestamp {
+// 						r = append(r, cur)
+// 					}
+// 					distinct = false
+// 				}
+// 			} else if c == 0 {
+// 				// [a, b] merge [b, nil]
+// 				if cur.Timestamp != prev.Timestamp {
+// 					r = append(r, cur)
+// 				}
+// 				prev.EndKey = cur.Key.Next()
+// 			} else {
+// 				// [a, c] merge [b, nil]
+// 				if cur.Timestamp != prev.Timestamp {
+// 					r = append(r, cur)
+// 				}
+// 				distinct = false
+// 			}
+// 			continue
+// 		}
+// 		r = append(r, cur)
+// 	}
+// 	return r, distinct
+// }

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -23,10 +23,35 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// SpanIsolation records the intended isolation level of access in a SpanSet.
+type SpanIsolation int16
+
+// Constants for SpanIsolation. Higher-valued accesses imply lower-level ones.
+const (
+	RequestIsolation SpanIsolation = iota
+	TransactionIsolation
+	NumSpanIsolation
+)
+
+// String returns a string representation of the SpanIsolation.
+func (a SpanIsolation) String() string {
+	switch a {
+	case RequestIsolation:
+		return "request"
+	case TransactionIsolation:
+		return "transaction"
+	default:
+		panic("unreachable")
+	}
+}
+
 // SpanAccess records the intended mode of access in a SpanSet.
-type SpanAccess int
+type SpanAccess int16
 
 // Constants for SpanAccess. Higher-valued accesses imply lower-level ones.
+// TODO(nvanbenschoten):
+//   s/SpanReadOnly/ReadOnlyAccess/g
+//   s/SpanReadWrite/ReadWriteAccess/g
 const (
 	SpanReadOnly SpanAccess = iota
 	SpanReadWrite
@@ -46,9 +71,12 @@ func (a SpanAccess) String() string {
 }
 
 // SpanScope divides access types into local and global keys.
-type SpanScope int
+type SpanScope int16
 
 // Constants for span scopes.
+// TODO(nvanbenschoten):
+//   s/SpanGlobal/GlobalScope/g
+//   s/SpanLocal/LocalScope/g
 const (
 	SpanGlobal SpanScope = iota
 	SpanLocal
@@ -67,159 +95,146 @@ func (a SpanScope) String() string {
 	}
 }
 
-// Span is used to represent a keyspan accessed by a request at a given
-// timestamp. A zero timestamp indicates it's a non-MVCC access.
-type Span struct {
-	roachpb.Span
-	Timestamp hlc.Timestamp
+// SpanSet ...
+type SpanSet [NumSpanIsolation][NumSpanAccess][NumSpanScope][]roachpb.Span
+
+// Get returns a slice of spans with the given parameters.
+func (s *SpanSet) Get(si SpanIsolation, sa SpanAccess, ss SpanScope) []roachpb.Span {
+	return (*s)[si][sa][ss]
 }
 
-// SpanSet tracks the set of key spans touched by a command, broken into MVCC
-// and non-MVCC accesses. The set is divided into subsets for access type
-// (read-only or read/write) and key scope (local or global; used to facilitate
-// use by the separate local and global latches).
-// The Span slice for a particular access and scope contains non-overlapping
-// spans in increasing key order after calls to SortAndDedup.
-type SpanSet struct {
-	spans [NumSpanAccess][NumSpanScope][]Span
+// GetRef returns a reference to a slice of spans with the given parameters.
+func (s *SpanSet) GetRef(si SpanIsolation, sa SpanAccess, ss SpanScope) *[]roachpb.Span {
+	return &(*s)[si][sa][ss]
+}
+
+// ForEach calls the provided function with each span.
+func (s *SpanSet) ForEach(fn func(SpanIsolation, SpanAccess, SpanScope, roachpb.Span)) {
+	for si := SpanIsolation(0); si < NumSpanIsolation; si++ {
+		for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
+			for ss := SpanScope(0); ss < NumSpanScope; ss++ {
+				for _, span := range s.Get(si, sa, ss) {
+					fn(si, sa, ss, span)
+				}
+			}
+		}
+	}
+}
+
+// Map applies a mapping function to each slice of spans sharing identical
+// isolation, access, and scope levels.
+func (s *SpanSet) Map(
+	fn func(SpanIsolation, SpanAccess, SpanScope, []roachpb.Span) []roachpb.Span,
+) {
+	for si := SpanIsolation(0); si < NumSpanIsolation; si++ {
+		for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
+			for ss := SpanScope(0); ss < NumSpanScope; ss++ {
+				*s.GetRef(si, sa, ss) = fn(si, sa, ss, s.Get(si, sa, ss))
+			}
+		}
+	}
 }
 
 // String prints a string representation of the SpanSet.
 func (s *SpanSet) String() string {
 	var buf strings.Builder
-	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
-		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
-			for _, cur := range s.GetSpans(sa, ss) {
-				fmt.Fprintf(&buf, "%s %s: %s at %s\n",
-					sa, ss, cur.Span.String(), cur.Timestamp.String())
-			}
-		}
-	}
+	s.ForEach(func(si SpanIsolation, sa SpanAccess, ss SpanScope, span roachpb.Span) {
+		fmt.Fprintf(&buf, "%s %s %s: %s\n", si, sa, ss, span)
+	})
 	return buf.String()
 }
 
 // Len returns the total number of spans tracked across all accesses and scopes.
 func (s *SpanSet) Len() int {
 	var count int
-	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
-		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
-			count += len(s.GetSpans(sa, ss))
-		}
-	}
+	s.ForEach(func(_ SpanIsolation, _ SpanAccess, _ SpanScope, _ roachpb.Span) {
+		count++
+	})
 	return count
 }
 
-// Empty returns whether the set contains any spans across all accesses and scopes.
+// Empty returns whether the set contains any spans across all isolation,
+// access, and scope levels.
 func (s *SpanSet) Empty() bool {
 	return s.Len() == 0
 }
 
-// Reserve space for N additional spans.
-func (s *SpanSet) Reserve(access SpanAccess, scope SpanScope, n int) {
-	existing := s.spans[access][scope]
-	s.spans[access][scope] = make([]Span, len(existing), n+cap(existing))
-	copy(s.spans[access][scope], existing)
-}
-
-// AddNonMVCC adds a non-MVCC span to the span set. This should typically
-// local keys.
-func (s *SpanSet) AddNonMVCC(access SpanAccess, span roachpb.Span) {
-	s.AddMVCC(access, span, hlc.Timestamp{})
-}
-
-// AddMVCC adds an MVCC span to the span set to be accessed at the given
-// timestamp. This should typically be used for MVCC keys, user keys for e.g.
-func (s *SpanSet) AddMVCC(access SpanAccess, span roachpb.Span, timestamp hlc.Timestamp) {
-	scope := SpanGlobal
-	if keys.IsLocal(span.Key) {
-		scope = SpanLocal
-		timestamp = hlc.Timestamp{}
-	}
-
-	s.spans[access][scope] = append(s.spans[access][scope], Span{Span: span, Timestamp: timestamp})
-}
-
-// Merge merges all spans in s2 into s. s2 is not modified.
-func (s *SpanSet) Merge(s2 *SpanSet) {
-	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
-		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
-			s.spans[sa][ss] = append(s.spans[sa][ss], s2.spans[sa][ss]...)
+// EmptyTransactional returns whether the set contains any spans across all
+// access and scope levels with the transaction isolation.
+func (s *SpanSet) EmptyTransactional() bool {
+	var count int
+	s.ForEach(func(si SpanIsolation, _ SpanAccess, _ SpanScope, _ roachpb.Span) {
+		if si == TransactionIsolation {
+			count++
 		}
-	}
-	s.SortAndDedup()
-}
-
-// SortAndDedup sorts the spans in the SpanSet and removes any duplicates.
-func (s *SpanSet) SortAndDedup() {
-	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
-		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
-			s.spans[sa][ss], _ /* distinct */ = mergeSpans(s.spans[sa][ss])
-		}
-	}
-}
-
-// GetSpans returns a slice of spans with the given parameters.
-func (s *SpanSet) GetSpans(access SpanAccess, scope SpanScope) []Span {
-	return s.spans[access][scope]
+	})
+	return count == 0
 }
 
 // BoundarySpan returns a span containing all the spans with the given params.
 func (s *SpanSet) BoundarySpan(scope SpanScope) roachpb.Span {
 	var boundary roachpb.Span
-	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
-		for _, cur := range s.GetSpans(sa, scope) {
-			if !boundary.Valid() {
-				boundary = cur.Span
-				continue
-			}
-			boundary = boundary.Combine(cur.Span)
+	s.ForEach(func(_ SpanIsolation, _ SpanAccess, _ SpanScope, span roachpb.Span) {
+		if !boundary.Valid() {
+			boundary = span
+		} else {
+			boundary = boundary.Combine(span)
 		}
-	}
+	})
 	return boundary
 }
 
-// MaxProtectedTimestamp returns the maximum timestamp that is protected across
-// all MVCC spans in the SpanSet. ReadWrite spans are protected from their
-// declared timestamp forward, so they have no maximum protect timestamp.
-// However, ReadOnly are protected only up to their declared timestamp and
-// are not protected at later timestamps.
-func (s *SpanSet) MaxProtectedTimestamp() hlc.Timestamp {
-	maxTS := hlc.MaxTimestamp
-	for ss := SpanScope(0); ss < NumSpanScope; ss++ {
-		for _, cur := range s.GetSpans(SpanReadOnly, ss) {
-			curTS := cur.Timestamp
-			if !curTS.IsEmpty() {
-				maxTS.Backward(curTS)
-			}
+// Validate returns an error if any spans that have been added to the set
+// are invalid.
+func (s *SpanSet) Validate() error {
+	var err error
+	s.ForEach(func(_ SpanIsolation, _ SpanAccess, _ SpanScope, span roachpb.Span) {
+		if !span.Valid() && err == nil {
+			err = errors.Errorf("invalid span %s", span)
 		}
-	}
-	return maxTS
+	})
+	return err
 }
 
-// Intersects returns true iff the span set denoted by `other` has any
-// overlapping spans with `s`, and that those spans overlap in access type. Note
-// that timestamps associated with the spans in the spanset are not considered,
-// only the span boundaries are checked.
-func (s *SpanSet) Intersects(other *SpanSet) bool {
-	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
-		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
-			otherSpans := other.GetSpans(sa, ss)
-			for _, span := range otherSpans {
-				// If access is allowed, we must have an overlap.
-				if err := s.CheckAllowed(sa, span.Span); err == nil {
-					return true
-				}
-			}
-		}
+// Reserve space for N additional spans.
+func (s *SpanSet) Reserve(si SpanIsolation, sa SpanAccess, ss SpanScope, n int) {
+	existing := s.Get(si, sa, ss)
+	updated := make([]roachpb.Span, len(existing), n+cap(existing))
+	copy(updated, existing)
+	*s.GetRef(si, sa, ss) = updated
+}
+
+// Add adds a span to the span set with the specified isolation, and access
+// levels.
+func (s *SpanSet) Add(si SpanIsolation, sa SpanAccess, span roachpb.Span) {
+	ss := SpanGlobal
+	if keys.IsLocal(span.Key) {
+		ss = SpanLocal
 	}
-	return false
+	*s.GetRef(si, sa, ss) = append(s.Get(si, sa, ss), span)
+}
+
+// SortAndDedup sorts the spans in the SpanSet and removes any duplicates.
+func (s *SpanSet) SortAndDedup() {
+	s.Map(func(_ SpanIsolation, _ SpanAccess, _ SpanScope, spans []roachpb.Span) []roachpb.Span {
+		spans, _ /* distinct */ = roachpb.MergeSpans(spans)
+		return spans
+	})
+}
+
+// Merge merges all spans in s2 into s. s2 is not modified.
+func (s *SpanSet) Merge(s2 *SpanSet) {
+	s.Map(func(si SpanIsolation, sa SpanAccess, ss SpanScope, spans []roachpb.Span) []roachpb.Span {
+		return append(spans, s2.Get(si, sa, ss)...)
+	})
+	s.SortAndDedup()
 }
 
 // AssertAllowed calls CheckAllowed and fatals if the access is not allowed.
 // Timestamps associated with the spans in the spanset are not considered,
 // only the span boundaries are checked.
-func (s *SpanSet) AssertAllowed(access SpanAccess, span roachpb.Span) {
-	if err := s.CheckAllowed(access, span); err != nil {
+func (s *SpanSet) AssertAllowed(sa SpanAccess, span roachpb.Span) {
+	if err := s.CheckAllowed(sa, span); err != nil {
 		log.Fatalf(context.TODO(), "%v", err)
 	}
 }
@@ -239,78 +254,354 @@ func (s *SpanSet) AssertAllowed(access SpanAccess, span roachpb.Span) {
 // fail at checking if read only access over the span [a-d) was requested. This
 // is also a problem if the added spans were read only and the spanset wasn't
 // already SortAndDedup-ed.
-func (s *SpanSet) CheckAllowed(access SpanAccess, span roachpb.Span) error {
-	return s.checkAllowed(access, span, func(_ SpanAccess, _ Span) bool {
-		return true
-	})
-}
-
-// CheckAllowedAt is like CheckAllowed, except it returns an error if the access
-// is not allowed over the given keyspan at the given timestamp.
-func (s *SpanSet) CheckAllowedAt(
-	access SpanAccess, span roachpb.Span, timestamp hlc.Timestamp,
-) error {
-	mvcc := !timestamp.IsEmpty()
-	return s.checkAllowed(access, span, func(declAccess SpanAccess, declSpan Span) bool {
-		declTimestamp := declSpan.Timestamp
-		if declTimestamp.IsEmpty() {
-			// When the span is declared as non-MVCC (i.e. with an empty
-			// timestamp), it's equivalent to a read/write mutex where we
-			// don't consider access timestamps.
-			return true
-		}
-
-		switch declAccess {
-		case SpanReadOnly:
-			switch access {
-			case SpanReadOnly:
-				// Read spans acquired at a specific timestamp only allow reads
-				// at that timestamp and below. Non-MVCC access is not allowed.
-				return mvcc && timestamp.LessEq(declTimestamp)
-			case SpanReadWrite:
-				// NB: should not get here, see checkAllowed.
-				panic("unexpected SpanReadWrite access")
-			default:
-				panic("unexpected span access")
-			}
-		case SpanReadWrite:
-			switch access {
-			case SpanReadOnly:
-				// Write spans acquired at a specific timestamp allow reads at
-				// any timestamp. Non-MVCC access is not allowed.
-				return mvcc
-			case SpanReadWrite:
-				// Write spans acquired at a specific timestamp allow writes at
-				// that timestamp of above. Non-MVCC access is not allowed.
-				return mvcc && declTimestamp.LessEq(timestamp)
-			default:
-				panic("unexpected span access")
-			}
-		default:
-			panic("unexpected span access")
-		}
-	})
-}
-
-func (s *SpanSet) checkAllowed(
-	access SpanAccess, span roachpb.Span, check func(SpanAccess, Span) bool,
-) error {
-	scope := SpanGlobal
-	if (span.Key != nil && keys.IsLocal(span.Key)) ||
-		(span.EndKey != nil && keys.IsLocal(span.EndKey)) {
-		scope = SpanLocal
+func (s *SpanSet) CheckAllowed(saCheck SpanAccess, spanCheck roachpb.Span) error {
+	ssCheck := SpanGlobal
+	if (spanCheck.Key != nil && keys.IsLocal(spanCheck.Key)) ||
+		(spanCheck.EndKey != nil && keys.IsLocal(spanCheck.EndKey)) {
+		ssCheck = SpanLocal
 	}
 
-	for ac := access; ac < NumSpanAccess; ac++ {
-		for _, cur := range s.spans[ac][scope] {
-			if contains(cur.Span, span) && check(ac, cur) {
-				return nil
-			}
+	allowed := false
+	s.ForEach(func(_ SpanIsolation, sa SpanAccess, ss SpanScope, span roachpb.Span) {
+		if sa < saCheck {
+			// Incompatible access (e.g. read access does not allow writes).
+			return
+		} else if ss != ssCheck {
+			// Incompatible scope (e.g. local scope cannot contain global keys).
+			return
 		}
+		if contains(span, spanCheck) {
+			allowed = true
+		}
+	})
+	if !allowed {
+		return errors.Errorf("cannot %s undeclared span %s\ndeclared:\n%s\nstack:\n%s",
+			saCheck, spanCheck, s, debug.Stack())
 	}
-
-	return errors.Errorf("cannot %s undeclared span %s\ndeclared:\n%s\nstack:\n%s", access, span, s, debug.Stack())
+	return nil
 }
+
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
+// TO DELETE.
+
+// AddNonMVCC adds a non-MVCC span to the span set. This should typically
+// local keys.
+func (s *SpanSet) AddNonMVCC(sa SpanAccess, span roachpb.Span) {
+	s.Add(RequestIsolation, sa, span)
+}
+
+// AddMVCC adds an MVCC span to the span set to be accessed at the given
+// timestamp. This should typically be used for MVCC keys, user keys for e.g.
+func (s *SpanSet) AddMVCC(sa SpanAccess, span roachpb.Span, _ hlc.Timestamp) {
+	s.Add(TransactionIsolation, sa, span)
+}
+
+// CheckAllowedAt ...
+func (s *SpanSet) CheckAllowedAt(saCheck SpanAccess, spanCheck roachpb.Span, _ hlc.Timestamp) error {
+	return s.CheckAllowed(saCheck, spanCheck)
+}
+
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
+// // Span is used to represent a keyspan accessed by a request at a given
+// // timestamp. A zero timestamp indicates it's a non-MVCC access.
+// type Span struct {
+// 	roachpb.Span
+// 	Timestamp hlc.Timestamp
+// }
+
+// // SpanSet tracks the set of key spans touched by a command, broken into MVCC
+// // and non-MVCC accesses. The set is divided into subsets for access type
+// // (read-only or read/write) and key scope (local or global; used to facilitate
+// // use by the separate local and global latches).
+// // The Span slice for a particular access and scope contains non-overlapping
+// // spans in increasing key order after calls to SortAndDedup.
+// type SpanSetOld struct {
+// 	spans [NumSpanAccess][NumSpanScope][]Span
+// }
+
+// // String prints a string representation of the SpanSet.
+// func (s *SpanSetOld) String() string {
+// 	var buf strings.Builder
+// 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
+// 		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
+// 			for _, cur := range s.GetSpans(sa, ss) {
+// 				fmt.Fprintf(&buf, "%s %s: %s at %s\n",
+// 					sa, ss, cur.Span.String(), cur.Timestamp.String())
+// 			}
+// 		}
+// 	}
+// 	return buf.String()
+// }
+
+// // Len returns the total number of spans tracked across all accesses and scopes.
+// func (s *SpanSetOld) Len() int {
+// 	var count int
+// 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
+// 		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
+// 			count += len(s.GetSpans(sa, ss))
+// 		}
+// 	}
+// 	return count
+// }
+
+// // Empty returns whether the set contains any spans across all accesses and scopes.
+// func (s *SpanSetOld) Empty() bool {
+// 	return s.Len() == 0
+// }
+
+// // Reserve space for N additional spans.
+// func (s *SpanSetOld) Reserve(access SpanAccess, scope SpanScope, n int) {
+// 	existing := s.spans[access][scope]
+// 	s.spans[access][scope] = make([]Span, len(existing), n+cap(existing))
+// 	copy(s.spans[access][scope], existing)
+// }
+
+// // AddNonMVCC adds a non-MVCC span to the span set. This should typically
+// // local keys.
+// func (s *SpanSetOld) AddNonMVCC(access SpanAccess, span roachpb.Span) {
+// 	s.AddMVCC(access, span, hlc.Timestamp{})
+// }
+
+// // AddMVCC adds an MVCC span to the span set to be accessed at the given
+// // timestamp. This should typically be used for MVCC keys, user keys for e.g.
+// func (s *SpanSetOld) AddMVCC(access SpanAccess, span roachpb.Span, timestamp hlc.Timestamp) {
+// 	scope := SpanGlobal
+// 	if keys.IsLocal(span.Key) {
+// 		scope = SpanLocal
+// 		timestamp = hlc.Timestamp{}
+// 	}
+
+// 	s.spans[access][scope] = append(s.spans[access][scope], Span{Span: span, Timestamp: timestamp})
+// }
+
+// // Merge merges all spans in s2 into s. s2 is not modified.
+// func (s *SpanSetOld) Merge(s2 *SpanSet) {
+// 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
+// 		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
+// 			s.spans[sa][ss] = append(s.spans[sa][ss], s2.spans[sa][ss]...)
+// 		}
+// 	}
+// 	s.SortAndDedup()
+// }
+
+// // SortAndDedup sorts the spans in the SpanSet and removes any duplicates.
+// func (s *SpanSetOld) SortAndDedup() {
+// 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
+// 		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
+// 			s.spans[sa][ss], _ /* distinct */ = mergeSpans(s.spans[sa][ss])
+// 		}
+// 	}
+// }
+
+// // GetSpans returns a slice of spans with the given parameters.
+// func (s *SpanSetOld) GetSpans(access SpanAccess, scope SpanScope) []Span {
+// 	return s.spans[access][scope]
+// }
+
+// // BoundarySpan returns a span containing all the spans with the given params.
+// func (s *SpanSetOld) BoundarySpan(scope SpanScope) roachpb.Span {
+// 	var boundary roachpb.Span
+// 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
+// 		for _, cur := range s.GetSpans(sa, scope) {
+// 			if !boundary.Valid() {
+// 				boundary = cur.Span
+// 				continue
+// 			}
+// 			boundary = boundary.Combine(cur.Span)
+// 		}
+// 	}
+// 	return boundary
+// }
+
+// // MaxProtectedTimestamp returns the maximum timestamp that is protected across
+// // all MVCC spans in the SpanSet. ReadWrite spans are protected from their
+// // declared timestamp forward, so they have no maximum protect timestamp.
+// // However, ReadOnly are protected only up to their declared timestamp and
+// // are not protected at later timestamps.
+// func (s *SpanSetOld) MaxProtectedTimestamp() hlc.Timestamp {
+// 	maxTS := hlc.MaxTimestamp
+// 	for ss := SpanScope(0); ss < NumSpanScope; ss++ {
+// 		for _, cur := range s.GetSpans(SpanReadOnly, ss) {
+// 			curTS := cur.Timestamp
+// 			if !curTS.IsEmpty() {
+// 				maxTS.Backward(curTS)
+// 			}
+// 		}
+// 	}
+// 	return maxTS
+// }
+
+// // Intersects returns true iff the span set denoted by `other` has any
+// // overlapping spans with `s`, and that those spans overlap in access type. Note
+// // that timestamps associated with the spans in the spanset are not considered,
+// // only the span boundaries are checked.
+// func (s *SpanSetOld) Intersects(other *SpanSet) bool {
+// 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
+// 		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
+// 			otherSpans := other.GetSpans(sa, ss)
+// 			for _, span := range otherSpans {
+// 				// If access is allowed, we must have an overlap.
+// 				if err := s.CheckAllowed(sa, span.Span); err == nil {
+// 					return true
+// 				}
+// 			}
+// 		}
+// 	}
+// 	return false
+// }
+
+// // AssertAllowed calls CheckAllowed and fatals if the access is not allowed.
+// // Timestamps associated with the spans in the spanset are not considered,
+// // only the span boundaries are checked.
+// func (s *SpanSetOld) AssertAllowed(access SpanAccess, span roachpb.Span) {
+// 	if err := s.CheckAllowed(access, span); err != nil {
+// 		log.Fatalf(context.TODO(), "%v", err)
+// 	}
+// }
+
+// // CheckAllowed returns an error if the access is not allowed over the given
+// // keyspan based on the collection of spans in the spanset. Timestamps
+// // associated with the spans in the spanset are not considered, only the span
+// // boundaries are checked.
+// //
+// // If the provided span contains only an (exclusive) EndKey and has a nil
+// // (inclusive) Key then Key is considered to be the key previous to EndKey,
+// // i.e. [,b) will be considered [b.Prev(),b).
+// //
+// // TODO(irfansharif): This does not currently work for spans that straddle
+// // across multiple added spans. Specifically a spanset with spans [a-c) and
+// // [b-d) added under read only and read write access modes respectively would
+// // fail at checking if read only access over the span [a-d) was requested. This
+// // is also a problem if the added spans were read only and the spanset wasn't
+// // already SortAndDedup-ed.
+// func (s *SpanSetOld) CheckAllowed(access SpanAccess, span roachpb.Span) error {
+// 	return s.checkAllowed(access, span, func(_ SpanAccess, _ Span) bool {
+// 		return true
+// 	})
+// }
+
+// // CheckAllowedAt is like CheckAllowed, except it returns an error if the access
+// // is not allowed over the given keyspan at the given timestamp.
+// func (s *SpanSetOld) CheckAllowedAt(
+// 	access SpanAccess, span roachpb.Span, timestamp hlc.Timestamp,
+// ) error {
+// 	mvcc := !timestamp.IsEmpty()
+// 	return s.checkAllowed(access, span, func(declAccess SpanAccess, declSpan Span) bool {
+// 		declTimestamp := declSpan.Timestamp
+// 		if declTimestamp.IsEmpty() {
+// 			// When the span is declared as non-MVCC (i.e. with an empty
+// 			// timestamp), it's equivalent to a read/write mutex where we
+// 			// don't consider access timestamps.
+// 			return true
+// 		}
+
+// 		switch declAccess {
+// 		case SpanReadOnly:
+// 			switch access {
+// 			case SpanReadOnly:
+// 				// Read spans acquired at a specific timestamp only allow reads
+// 				// at that timestamp and below. Non-MVCC access is not allowed.
+// 				return mvcc && timestamp.LessEq(declTimestamp)
+// 			case SpanReadWrite:
+// 				// NB: should not get here, see checkAllowed.
+// 				panic("unexpected SpanReadWrite access")
+// 			default:
+// 				panic("unexpected span access")
+// 			}
+// 		case SpanReadWrite:
+// 			switch access {
+// 			case SpanReadOnly:
+// 				// Write spans acquired at a specific timestamp allow reads at
+// 				// any timestamp. Non-MVCC access is not allowed.
+// 				return mvcc
+// 			case SpanReadWrite:
+// 				// Write spans acquired at a specific timestamp allow writes at
+// 				// that timestamp of above. Non-MVCC access is not allowed.
+// 				return mvcc && declTimestamp.LessEq(timestamp)
+// 			default:
+// 				panic("unexpected span access")
+// 			}
+// 		default:
+// 			panic("unexpected span access")
+// 		}
+// 	})
+// }
+
+// func (s *SpanSetOld) checkAllowed(
+// 	access SpanAccess, span roachpb.Span, check func(SpanAccess, Span) bool,
+// ) error {
+// 	scope := SpanGlobal
+// 	if (span.Key != nil && keys.IsLocal(span.Key)) ||
+// 		(span.EndKey != nil && keys.IsLocal(span.EndKey)) {
+// 		scope = SpanLocal
+// 	}
+
+// 	for ac := access; ac < NumSpanAccess; ac++ {
+// 		for _, cur := range s.spans[ac][scope] {
+// 			if contains(cur.Span, span) && check(ac, cur) {
+// 				return nil
+// 			}
+// 		}
+// 	}
+
+// 	return errors.Errorf("cannot %s undeclared span %s\ndeclared:\n%s\nstack:\n%s", access, span, s, debug.Stack())
+// }
+
+// // Validate returns an error if any spans that have been added to the set
+// // are invalid.
+// func (s *SpanSetOld) Validate() error {
+// 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
+// 		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
+// 			for _, cur := range s.GetSpans(sa, ss) {
+// 				if len(cur.EndKey) > 0 && cur.Key.Compare(cur.EndKey) >= 0 {
+// 					return errors.Errorf("inverted span %s %s", cur.Key, cur.EndKey)
+// 				}
+// 			}
+// 		}
+// 	}
+
+// 	return nil
+// }
 
 // contains returns whether s1 contains s2. Unlike Span.Contains, this function
 // supports spans with a nil start key and a non-nil end key (e.g. "[nil, c)").
@@ -330,20 +621,4 @@ func contains(s1, s2 roachpb.Span) bool {
 	}
 
 	return s1.Key.Compare(s2.EndKey) < 0 && s1.EndKey.Compare(s2.EndKey) >= 0
-}
-
-// Validate returns an error if any spans that have been added to the set
-// are invalid.
-func (s *SpanSet) Validate() error {
-	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
-		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
-			for _, cur := range s.GetSpans(sa, ss) {
-				if len(cur.EndKey) > 0 && cur.Key.Compare(cur.EndKey) >= 0 {
-					return errors.Errorf("inverted span %s %s", cur.Key, cur.EndKey)
-				}
-			}
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
```
name                          old time/op    new time/op    delta
KV/Scan/Native/rows=10000-16    49.9ms ± 4%    46.8ms ± 6%   -6.21%  (p=0.000 n=10+10)
KV/Scan/Native/rows=1000-16     4.04ms ± 3%    3.82ms ± 3%   -5.48%  (p=0.000 n=10+9)
KV/Scan/Native/rows=100-16       412µs ± 5%     397µs ± 3%   -3.65%  (p=0.013 n=10+8)
KV/Scan/Native/rows=10-16       64.1µs ± 4%    61.4µs ± 2%   -4.33%  (p=0.000 n=10+9)
KV/Scan/Native/rows=1-16        28.8µs ± 4%    28.5µs ± 3%     ~     (p=0.133 n=10+9)

name                          old alloc/op   new alloc/op   delta
KV/Scan/Native/rows=10000-16    19.8MB ± 2%    16.5MB ± 3%  -16.64%  (p=0.000 n=10+10)
KV/Scan/Native/rows=1000-16     1.37MB ± 0%    1.23MB ± 1%  -10.40%  (p=0.000 n=8+10)
KV/Scan/Native/rows=100-16       150kB ± 1%     135kB ± 2%   -9.70%  (p=0.000 n=10+10)
KV/Scan/Native/rows=10-16       21.3kB ± 0%    19.0kB ± 0%  -10.49%  (p=0.000 n=10+9)
KV/Scan/Native/rows=1-16        8.19kB ± 0%    8.06kB ± 0%   -1.59%  (p=0.000 n=8+9)

name                          old allocs/op  new allocs/op  delta
KV/Scan/Native/rows=1-16          72.0 ± 0%      69.0 ± 0%   -4.17%  (p=0.000 n=9+10)
KV/Scan/Native/rows=10-16          236 ± 0%       229 ± 0%   -2.97%  (p=0.001 n=8+9)
KV/Scan/Native/rows=100-16       1.78k ± 0%     1.77k ± 0%   -0.62%  (p=0.000 n=8+8)
KV/Scan/Native/rows=1000-16      17.1k ± 0%     17.1k ± 0%   -0.10%  (p=0.000 n=10+8)
KV/Scan/Native/rows=10000-16      171k ± 0%      171k ± 0%   -0.03%  (p=0.031 n=9+9)
```