### PR TITLE
flowinfra: replace ConcurrentExecution with ConcurrentTxnUse

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -274,9 +274,14 @@ func (f *vectorizedFlow) IsVectorized() bool {
 	return true
 }
 
-// ConcurrentExecution is part of the flowinfra.Flow interface.
-func (f *vectorizedFlow) ConcurrentExecution() bool {
-	return f.operatorConcurrency || f.FlowBase.ConcurrentExecution()
+// ConcurrentTxnUse is part of the flowinfra.Flow interface. It is conservative
+// in that it returns that there is concurrent txn use as soon as any operator
+// concurrency is detected. This should be inconsequential for local flows that
+// use the RootTxn (which are the cases in which we care about this return
+// value), because only unordered synchronizers introduce operator concurrency
+// at the time of writing.
+func (f *vectorizedFlow) ConcurrentTxnUse() bool {
+	return f.operatorConcurrency || f.FlowBase.ConcurrentTxnUse()
 }
 
 // Release releases this vectorizedFlow back to the pool.

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -381,7 +381,7 @@ func (ds *ServerImpl) setupFlow(
 	// localState.Txn. Otherwise, we create a txn based on the request's
 	// LeafTxnInputState.
 	var txn *kv.Txn
-	if localState.IsLocal && !f.ConcurrentExecution() {
+	if localState.IsLocal && !f.ConcurrentTxnUse() {
 		txn = localState.Txn
 	} else {
 		// If I haven't created the leaf already, do it now.

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -411,7 +411,7 @@ func (dsp *DistSQLPlanner) Run(
 	// This is important, since these flows are forced to use the RootTxn (since
 	// they might have mutations), and the RootTxn does not permit concurrency.
 	// For such flows, we were supposed to have fused everything.
-	if txn != nil && planCtx.isLocal && flow.ConcurrentExecution() {
+	if txn != nil && planCtx.isLocal && flow.ConcurrentTxnUse() {
 		recv.SetError(errors.AssertionFailedf(
 			"unexpected concurrency for a flow that was forced to be planned locally"))
 		return func() {}

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -512,3 +512,8 @@ func (rc *RowChannel) ConsumerClosed() {
 func (rc *RowChannel) Types() []*types.T {
 	return rc.types
 }
+
+// DoesNotUseTxn implements the DoesNotUseTxn interface. Since the RowChannel's
+// input is run in a different goroutine, the flow will check the RowChannel's
+// input separately.
+func (rc *RowChannel) DoesNotUseTxn() bool { return true }

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -38,6 +38,17 @@ type Processor interface {
 	Run(context.Context)
 }
 
+// DoesNotUseTxn is an interface implemented by some processors to mark that
+// they do not use a txn. The DistSQLPlanner forbids multiple processors in a
+// local flow from running in parallel if this is unknown since concurrent use
+// of the RootTxn is forbidden (in a distributed flow these are leaf txns, so
+// it doesn't matter).
+// Implementing this interface lets the DistSQLPlanner know that it is ok to
+// run this processor in an additional goroutine.
+type DoesNotUseTxn interface {
+	DoesNotUseTxn() bool
+}
+
 // ProcOutputHelper is a helper type that performs filtering and projection on
 // the output of a processor.
 type ProcOutputHelper struct {

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -114,10 +114,11 @@ type Flow interface {
 	// mailboxes exited).
 	Cleanup(context.Context)
 
-	// ConcurrentExecution returns true if multiple processors/operators in the
-	// flow will execute concurrently (i.e. if not all of them have been fused).
+	// ConcurrentTxnUse returns true if multiple processors/operators in the flow
+	// will execute concurrently (i.e. if not all of them have been fused) and
+	// more than one goroutine will be using a txn.
 	// Can only be called after Setup().
-	ConcurrentExecution() bool
+	ConcurrentTxnUse() bool
 }
 
 // FlowBase is the shared logic between row based and vectorized flows. It
@@ -186,9 +187,18 @@ func (f *FlowBase) SetTxn(txn *kv.Txn) {
 	f.EvalCtx.Txn = txn
 }
 
-// ConcurrentExecution is part of the Flow interface.
-func (f *FlowBase) ConcurrentExecution() bool {
-	return len(f.processors) > 1
+// ConcurrentTxnUse is part of the Flow interface.
+func (f *FlowBase) ConcurrentTxnUse() bool {
+	numProcessorsThatMightUseTxn := 0
+	for _, proc := range f.processors {
+		if txnUser, ok := proc.(execinfra.DoesNotUseTxn); !ok || !txnUser.DoesNotUseTxn() {
+			numProcessorsThatMightUseTxn++
+			if numProcessorsThatMightUseTxn > 1 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 var _ Flow = &FlowBase{}

--- a/pkg/sql/flowinfra/flow_scheduler_test.go
+++ b/pkg/sql/flowinfra/flow_scheduler_test.go
@@ -96,8 +96,8 @@ func (m *mockFlow) GetID() execinfrapb.FlowID {
 
 func (m *mockFlow) Cleanup(_ context.Context) {}
 
-func (m *mockFlow) ConcurrentExecution() bool {
-	panic("not implemented")
+func (m *mockFlow) ConcurrentTxnUse() bool {
+	return false
 }
 
 func TestFlowScheduler(t *testing.T) {

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(50049)
+# LogicTest: !3node-tenant(49854)
 
 statement ok
 SET experimental_enable_enums=true;

--- a/pkg/sql/logictest/testdata/logic_test/owner
+++ b/pkg/sql/logictest/testdata/logic_test/owner
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant(50049)
+# LogicTest: !3node-tenant(52567)
 
 statement ok
 GRANT CREATE ON DATABASE test TO testuser

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -1,5 +1,3 @@
-# LogicTest: !3node-tenant(50049)
-
 statement ok
 SET DATABASE = ""
 

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -540,3 +540,11 @@ func (s *sampleAggregator) generateHistogram(
 	}
 	return stats.EquiDepthHistogram(evalCtx, values, numRows, distinctCount, maxBuckets)
 }
+
+var _ execinfra.DoesNotUseTxn = &sampleAggregator{}
+
+// DoesNotUseTxn implements the DoesNotUseTxn interface.
+func (s *sampleAggregator) DoesNotUseTxn() bool {
+	txnUser, ok := s.input.(execinfra.DoesNotUseTxn)
+	return ok && txnUser.DoesNotUseTxn()
+}

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -483,6 +483,14 @@ func (s *samplerProcessor) close() {
 	}
 }
 
+var _ execinfra.DoesNotUseTxn = &samplerProcessor{}
+
+// DoesNotUseTxn implements the DoesNotUseTxn interface.
+func (s *samplerProcessor) DoesNotUseTxn() bool {
+	txnUser, ok := s.input.(execinfra.DoesNotUseTxn)
+	return ok && txnUser.DoesNotUseTxn()
+}
+
 // addRow adds a row to the sketch and updates row counts.
 func (s *sketchInfo) addRow(
 	row sqlbase.EncDatumRow, typs []*types.T, buf *[]byte, da *sqlbase.DatumAlloc,


### PR DESCRIPTION
Previously, the DistSQLPlanner would reject any local flows with any
concurrency due to possible concurrent use of a RootTxn. This policy was overly
prohibitive as it would reject stats flows that contain processors that cannot
be fused even though there would be no concurrent txn usage.

This commit makes this policy a bit more lenient, introducing a way for
processors to indicate that they and their input will not be using a txn. This
is exposed through the new ConcurrentTxnUse method in the flow interface, which
returns whether more than one processor will be using a txn.

This commit also removes ConcurrentExecution since all usages have been
replaced with ConcurrentTxnUse.

Release note: None (internal refactor to fix an error message received only in
a multitenant environment)

Fixes #50049 