### PR TITLE
execinfra: add retries to outbox DialNoBreaker attempts

### DIFF
--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -642,7 +642,8 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 			roachpb.NodeID(0),
 			execinfrapb.FlowID{UUID: uuid.MakeV4()},
 			outboxStreamID,
-			nil,
+			nil, /* cancelFn */
+			0,   /* connectionTimeout */
 		)
 		outboxDone <- struct{}{}
 	}()

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -586,7 +586,15 @@ func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 		// derive a separate child context for each outbox.
 		var outboxCancelFn context.CancelFunc
 		ctx, outboxCancelFn = context.WithCancel(ctx)
-		outbox.Run(ctx, s.nodeDialer, stream.TargetNodeID, s.flowID, stream.StreamID, outboxCancelFn)
+		outbox.Run(
+			ctx,
+			s.nodeDialer,
+			stream.TargetNodeID,
+			s.flowID,
+			stream.StreamID,
+			outboxCancelFn,
+			flowinfra.SettingFlowStreamTimeout.Get(&flowCtx.Cfg.Settings.SV),
+		)
 		currentOutboxes := atomic.AddInt32(&s.numOutboxes, -1)
 		// When the last Outbox on this node exits, we want to make sure that
 		// everything is shutdown; namely, we need to call cancelFn if:

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -258,7 +258,15 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					require.NoError(t, err)
 					wg.Add(1)
 					go func(id int) {
-						outbox.Run(ctx, dialer, execinfra.StaticNodeID, flowID, execinfrapb.StreamID(id), cancelFn)
+						outbox.Run(
+							ctx,
+							dialer,
+							execinfra.StaticNodeID,
+							flowID,
+							execinfrapb.StreamID(id),
+							cancelFn,
+							0, /* connectionTimeout */
+						)
 						wg.Done()
 					}(id)
 

--- a/pkg/sql/execinfra/outboxbase.go
+++ b/pkg/sql/execinfra/outboxbase.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execinfra
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"google.golang.org/grpc"
+)
+
+// Dialer is used for dialing based on node IDs. It extracts out the single
+// method that outboxes need from nodedialer.Dialer so that we can mock it
+// in tests outside of this package.
+type Dialer interface {
+	DialNoBreaker(context.Context, roachpb.NodeID, rpc.ConnectionClass) (*grpc.ClientConn, error)
+}
+
+// GetConnForOutbox is a shared function between the rowexec and colexec
+// outboxes. It attempts to dial the destination ignoring the breaker, up to the
+// given timeout and returns the connection or an error.
+// This connection attempt is retried since failure results in a query error. In
+// the past, we have seen cases where a gateway node, n1, would send a flow
+// request to n2, but n2 would be unable to connect back to n1 due to this
+// connection attempt failing.
+// Retrying here alleviates these flakes and causes no impact to the end
+// user, since the receiver at the other end will hang for
+// SettingFlowStreamTimeout waiting for a successful connection attempt.
+func GetConnForOutbox(
+	ctx context.Context, dialer Dialer, nodeID roachpb.NodeID, timeout time.Duration,
+) (conn *grpc.ClientConn, err error) {
+	firstConnectionAttempt := timeutil.Now()
+	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+		conn, err = dialer.DialNoBreaker(ctx, nodeID, rpc.DefaultClass)
+		if err == nil || timeutil.Since(firstConnectionAttempt) > timeout {
+			break
+		}
+	}
+	return
+}

--- a/pkg/sql/execinfrapb/testutils.go
+++ b/pkg/sql/execinfrapb/testutils.go
@@ -134,8 +134,8 @@ type MockDialer struct {
 	}
 }
 
-// Dial establishes a grpc connection once.
-func (d *MockDialer) Dial(
+// DialNoBreaker establishes a grpc connection once.
+func (d *MockDialer) DialNoBreaker(
 	context.Context, roachpb.NodeID, rpc.ConnectionClass,
 ) (*grpc.ClientConn, error) {
 	d.mu.Lock()


### PR DESCRIPTION
This connection attempt is retried since failure to connect to an inbox results
in a query error. In the past, we have seen cases where a gateway node, n1,
would send a flow request to n2, but n2 would be unable to connect back to n1.
Retrying these connection attempts alleviates these flakes and causes no impact
to the end user, since the receiver at the other end will hang for
SettingFlowStreamTimeout waiting for a successful connection attempt.

Release note (sql change): "no inbound stream connection" errors should happen
less frequently due to the addition of connection retries

Fixes #50000