### PR TITLE
opt: move "final" autocommit decision to the execbuilder

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -56,7 +56,7 @@ const (
 	// per chunk during an index truncation. This value is larger than the
 	// other chunk constants because the operation involves only running a
 	// DeleteRange().
-	indexTruncateChunkSize = 600
+	indexTruncateChunkSize = row.TableTruncateChunkSize
 
 	// indexTxnBackfillChunkSize is the maximum number index entries backfilled
 	// per chunk during an index backfill done in a txn. The index backfill

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -131,7 +131,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		for len(spans) != 0 {
 			b := params.p.txn.NewBatch()
 			d.deleteSpans(params, b, spans)
-			b.Header.MaxSpanRequestKeys = TableTruncateChunkSize
+			b.Header.MaxSpanRequestKeys = row.TableTruncateChunkSize
 			if err := params.p.txn.Run(ctx, b); err != nil {
 				return err
 			}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1044,11 +1044,13 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 		execFactory := newExecFactory(planner)
 		// The cascading query is allowed to autocommit only if it is the last
 		// cascade and there are no check queries to run.
+		allowAutoCommit := planner.autoCommit
 		if len(plan.checkPlans) > 0 || i < len(plan.cascades)-1 {
-			execFactory.disableAutoCommit()
+			allowAutoCommit = false
 		}
 		cascadePlan, err := plan.cascades[i].PlanFn(
-			ctx, &planner.semaCtx, &evalCtx.EvalContext, execFactory, buf, buf.bufferedRows.Len(),
+			ctx, &planner.semaCtx, &evalCtx.EvalContext, execFactory,
+			buf, buf.bufferedRows.Len(), allowAutoCommit,
 		)
 		if err != nil {
 			recv.SetError(err)

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -789,7 +789,7 @@ func (e *distSQLSpecExecFactory) ConstructInsert(
 	insertCols exec.TableColumnOrdinalSet,
 	returnCols exec.TableColumnOrdinalSet,
 	checkCols exec.CheckOrdinalSet,
-	allowAutoCommit bool,
+	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: insert")
 }
@@ -801,6 +801,7 @@ func (e *distSQLSpecExecFactory) ConstructInsertFastPath(
 	returnCols exec.TableColumnOrdinalSet,
 	checkCols exec.CheckOrdinalSet,
 	fkChecks []exec.InsertFastPathFKCheck,
+	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: insert fast path")
 }
@@ -813,7 +814,7 @@ func (e *distSQLSpecExecFactory) ConstructUpdate(
 	returnCols exec.TableColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	passthrough sqlbase.ResultColumns,
-	allowAutoCommit bool,
+	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: update")
 }
@@ -827,7 +828,7 @@ func (e *distSQLSpecExecFactory) ConstructUpsert(
 	updateCols exec.TableColumnOrdinalSet,
 	returnCols exec.TableColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
-	allowAutoCommit bool,
+	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: upsert")
 }
@@ -837,7 +838,7 @@ func (e *distSQLSpecExecFactory) ConstructDelete(
 	table cat.Table,
 	fetchCols exec.TableColumnOrdinalSet,
 	returnCols exec.TableColumnOrdinalSet,
-	allowAutoCommit bool,
+	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: delete")
 }
@@ -847,8 +848,7 @@ func (e *distSQLSpecExecFactory) ConstructDeleteRange(
 	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
 	interleavedTables []cat.Table,
-	maxReturnedKeys int,
-	allowAutoCommit bool,
+	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: delete range")
 }

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -655,7 +656,7 @@ func TestDropTable(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 	ctx := context.Background()
 
-	numRows := 2*sql.TableTruncateChunkSize + 1
+	numRows := 2*row.TableTruncateChunkSize + 1
 	if err := tests.CreateKVTable(sqlDB, "kv", numRows); err != nil {
 		t.Fatal(err)
 	}
@@ -749,7 +750,7 @@ func TestDropTableDeleteData(t *testing.T) {
 	// TTL into the system with AddImmediateGCZoneConfig.
 	defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
 
-	const numRows = 2*sql.TableTruncateChunkSize + 1
+	const numRows = 2*row.TableTruncateChunkSize + 1
 	const numKeys = 3 * numRows
 	const numTables = 5
 	var descs []*sqlbase.ImmutableTableDescriptor
@@ -973,7 +974,7 @@ func TestDropTableInterleavedDeleteData(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 
-	numRows := 2*sql.TableTruncateChunkSize + 1
+	numRows := 2*row.TableTruncateChunkSize + 1
 	tests.CreateKVInterleavedTable(t, sqlDB, numRows)
 
 	tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -573,7 +573,9 @@ func (h *harness) runUsingAPI(tb testing.TB, bmType BenchmarkType, usePrepared b
 	}
 
 	root := execMemo.RootExpr()
-	eb := execbuilder.New(exec.StubFactory{}, execMemo, nil /* catalog */, root, &h.evalCtx)
+	eb := execbuilder.New(
+		exec.StubFactory{}, execMemo, nil /* catalog */, root, &h.evalCtx, true, /* allowAutoCommit */
+	)
 	if _, err = eb.Build(); err != nil {
 		tb.Fatalf("%v", err)
 	}

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -159,8 +159,11 @@ func (cb *cascadeBuilder) setupCascade(cascade *memo.FKCascade) exec.Cascade {
 			execFactory exec.Factory,
 			bufferRef exec.Node,
 			numBufferedRows int,
+			allowAutoCommit bool,
 		) (exec.Plan, error) {
-			return cb.planCascade(ctx, semaCtx, evalCtx, execFactory, cascade, bufferRef, numBufferedRows)
+			return cb.planCascade(
+				ctx, semaCtx, evalCtx, execFactory, cascade, bufferRef, numBufferedRows, allowAutoCommit,
+			)
 		},
 	}
 }
@@ -179,6 +182,7 @@ func (cb *cascadeBuilder) planCascade(
 	cascade *memo.FKCascade,
 	bufferRef exec.Node,
 	numBufferedRows int,
+	allowAutoCommit bool,
 ) (exec.Plan, error) {
 	// 1. Set up a brand new memo in which to plan the cascading query.
 	var o xform.Optimizer
@@ -253,7 +257,7 @@ func (cb *cascadeBuilder) planCascade(
 	}
 
 	// 4. Execbuild the optimized expression.
-	eb := New(execFactory, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx)
+	eb := New(execFactory, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx, allowAutoCommit)
 	// Set up the With binding.
 	eb.addBuiltWithExpr(cascadeInputWithID, bufferColMap, bufferRef)
 	plan, err := eb.Build()

--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -35,7 +35,7 @@ func fmtInterceptor(f *memo.ExprFmtCtx, scalar opt.ScalarExpr) string {
 	}
 
 	// Build the scalar expression and format it as a single string.
-	bld := New(nil /* factory */, f.Memo, nil /* catalog */, scalar, nil /* evalCtx */)
+	bld := New(nil /* factory */, f.Memo, nil /* catalog */, scalar, nil /* evalCtx */, false /* allowAutoCommit */)
 	md := f.Memo.Metadata()
 	ivh := tree.MakeIndexedVarHelper(nil /* container */, md.NumColumns())
 	expr, err := bld.BuildScalar(&ivh)

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -117,7 +117,7 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 	}
 
 	// Create a separate builder for the explain query.
-	explainBld := New(b.factory, b.mem, b.catalog, explain.Input, b.evalCtx)
+	explainBld := New(b.factory, b.mem, b.catalog, explain.Input, b.evalCtx, b.initialAllowAutoCommit)
 	explainBld.disableTelemetry = true
 	plan, err := explainBld.Build()
 	if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -205,7 +205,7 @@ count           ·             ·           ()      ·
 statement ok
 CREATE TABLE a (a INT PRIMARY KEY)
 
-# Delete range operates in chunks of 600 (defined by sql.TableTruncateChunkSize).
+# Delete range operates in chunks of 600 (defined by row.TableTruncateChunkSize).
 statement ok
 INSERT INTO a SELECT * FROM generate_series(1,1000)
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -234,6 +234,7 @@ type Cascade struct {
 		execFactory Factory,
 		bufferRef Node,
 		numBufferedRows int,
+		allowAutoCommit bool,
 	) (Plan, error)
 }
 

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -362,18 +362,18 @@ define ShowTrace {
 # of columns in the table into which values are inserted. All columns are
 # expected to be present except delete-only mutation columns, since those do not
 # need to participate in an insert operation.
-#
-# If allowAutoCommit is set, the operator is allowed to commit the
-# transaction (if appropriate, i.e. if it is in an implicit transaction).
-# This is false if there are multiple mutations in a statement, or the output
-# of the mutation is processed through side-effecting expressions.
 define Insert {
     Input exec.Node
     Table cat.Table
     InsertCols exec.TableColumnOrdinalSet
     ReturnCols exec.TableColumnOrdinalSet
     CheckCols exec.CheckOrdinalSet
-    AllowAutoCommit bool
+
+    # If set, the operator will commit the transaction as part of its execution.
+    # This is false when executing inside an explicit transaction, or there are
+    # multiple mutations in a statement, or the output of the mutation is
+    # processed through side-effecting expressions.
+    AutoCommit bool
 }
 
 # InsertFastPath implements a special (but very common) case of insert,
@@ -381,8 +381,7 @@ define Insert {
 #  - the input is Values with at most InsertFastPathMaxRows, and there are no
 #    subqueries;
 #  - there are no other mutations in the statement, and the output of the
-#    insert is not processed through side-effecting expressions (see
-#    allowAutoCommit flag for ConstructInsert);
+#    insert is not processed through side-effecting expressions.
 #  - there are no self-referencing foreign keys;
 #  - all FK checks can be performed using direct lookups into unique indexes.
 #
@@ -396,6 +395,10 @@ define InsertFastPath {
     ReturnCols exec.TableColumnOrdinalSet
     CheckCols exec.CheckOrdinalSet
     FkChecks []exec.InsertFastPathFKCheck
+
+    # If set, the operator will commit the transaction as part of its execution.
+    # This is false when executing inside an explicit transaction.
+    AutoCommit bool
 }
 
 # Update implements an UPDATE statement. The input contains columns that were
@@ -427,7 +430,9 @@ define Update {
     ReturnCols exec.TableColumnOrdinalSet
     Checks exec.CheckOrdinalSet
     Passthrough sqlbase.ResultColumns
-    AllowAutoCommit bool
+
+    # If set, the operator will commit the transaction as part of its execution.
+    AutoCommit bool
 }
 
 # Upsert implements an INSERT..ON CONFLICT DO UPDATE or UPSERT statement.
@@ -454,11 +459,6 @@ define Update {
 # columns {0, 1, 2} of the table. The next 3 columns contain the existing
 # values of columns {0, 1, 2} of the table. The last column contains the
 # new value for column {1} of the table.
-#
-# If allowAutoCommit is set, the operator is allowed to commit the
-# transaction (if appropriate, i.e. if it is in an implicit transaction).
-# This is false if there are multiple mutations in a statement, or the output
-# of the mutation is processed through side-effecting expressions.
 define Upsert {
     Input exec.Node
     Table cat.Table
@@ -468,7 +468,12 @@ define Upsert {
     UpdateCols exec.TableColumnOrdinalSet
     ReturnCols exec.TableColumnOrdinalSet
     Checks exec.CheckOrdinalSet
-    AllowAutoCommit bool
+
+    # If set, the operator will commit the transaction as part of its execution.
+    # This is false when executing inside an explicit transaction, or there are
+    # multiple mutations in a statement, or the output of the mutation is
+    # processed through side-effecting expressions.
+    AutoCommit bool
 }
 
 # Delete implements a DELETE statement. The input contains columns that were
@@ -477,17 +482,17 @@ define Upsert {
 # The fetchCols set contains the ordinal positions of the fetch columns in
 # the target table. The input must contain those columns in the same order
 # as they appear in the table schema.
-#
-# If allowAutoCommit is set, the operator is allowed to commit the
-# transaction (if appropriate, i.e. if it is in an implicit transaction).
-# This is false if there are multiple mutations in a statement, or the output
-# of the mutation is processed through side-effecting expressions.
 define Delete {
     Input exec.Node
     Table cat.Table
     FetchCols exec.TableColumnOrdinalSet
     ReturnCols exec.TableColumnOrdinalSet
-    AllowAutoCommit bool
+
+    # If set, the operator will commit the transaction as part of its execution.
+    # This is false when executing inside an explicit transaction, or there are
+    # multiple mutations in a statement, or the output of the mutation is
+    # processed through side-effecting expressions.
+    AutoCommit bool
 }
 
 # DeleteRange efficiently deletes contiguous rows stored in the given table's
@@ -512,8 +517,13 @@ define DeleteRange {
     Needed exec.TableColumnOrdinalSet
     IndexConstraint *constraint.Constraint
     InterleavedTables []cat.Table
-    MaxReturnedKeys int
-    AllowAutoCommit bool
+
+    # If set, the operator will commit the transaction as part of its execution.
+    # This is false when executing inside an explicit transaction, or there are
+    # multiple mutations in a statement, or the output of the mutation is
+    # processed through side-effecting expressions, or the operation might
+    # process too many rows.
+    AutoCommit bool
 }
 
 # CreateTable implements a CREATE TABLE statement.

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -142,7 +142,10 @@ func TestIndexConstraints(t *testing.T) {
 				}
 				remainingFilter := ic.RemainingFilters()
 				if !remainingFilter.IsTrue() {
-					execBld := execbuilder.New(nil /* execFactory */, f.Memo(), nil /* catalog */, &remainingFilter, &evalCtx)
+					execBld := execbuilder.New(
+						nil /* execFactory */, f.Memo(), nil /* catalog */, &remainingFilter,
+						&evalCtx, false, /* allowAutoCommit */
+					)
 					expr, err := execBld.BuildScalar(&iVarHelper)
 					if err != nil {
 						return fmt.Sprintf("error: %v\n", err)

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1722,8 +1722,8 @@ func (b *logicalPropsBuilder) updateCardinalityFromConstraint(
 		return
 	}
 
-	count := c.CalculateMaxResults(b.evalCtx, cols, rel.NotNullCols)
-	if count != 0 && count < math.MaxUint32 {
+	count, ok := c.CalculateMaxResults(b.evalCtx, cols, rel.NotNullCols)
+	if ok && count < math.MaxUint32 {
 		rel.Cardinality = rel.Cardinality.Limit(uint32(count))
 	}
 }

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -118,7 +118,10 @@ func TestImplicator(t *testing.T) {
 			if remainingFilters.IsTrue() {
 				buf.WriteString("none")
 			} else {
-				execBld := execbuilder.New(nil /* factory */, f.Memo(), nil /* catalog */, &remainingFilters, &evalCtx)
+				execBld := execbuilder.New(
+					nil /* factory */, f.Memo(), nil /* catalog */, &remainingFilters,
+					&evalCtx, false, /* allowAutoCommit */
+				)
 				expr, err := execBld.BuildScalar(&iVarHelper)
 				if err != nil {
 					d.Fatalf(t, "unexpected error: %v\n", err)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -37,21 +37,15 @@ import (
 )
 
 type execFactory struct {
-	planner         *planner
-	allowAutoCommit bool
+	planner *planner
 }
 
 var _ exec.Factory = &execFactory{}
 
 func newExecFactory(p *planner) *execFactory {
 	return &execFactory{
-		planner:         p,
-		allowAutoCommit: p.autoCommit,
+		planner: p,
 	}
-}
-
-func (ef *execFactory) disableAutoCommit() {
-	ef.allowAutoCommit = false
 }
 
 // ConstructValues is part of the exec.Factory interface.
@@ -1182,7 +1176,7 @@ func (ef *execFactory) ConstructInsert(
 	insertColOrdSet exec.TableColumnOrdinalSet,
 	returnColOrdSet exec.TableColumnOrdinalSet,
 	checkOrdSet exec.CheckOrdinalSet,
-	allowAutoCommit bool,
+	autoCommit bool,
 ) (exec.Node, error) {
 	ctx := ef.planner.extendedEvalCtx.Context
 
@@ -1225,7 +1219,7 @@ func (ef *execFactory) ConstructInsert(
 		ins.run.rowsNeeded = true
 	}
 
-	if allowAutoCommit && ef.allowAutoCommit {
+	if autoCommit {
 		ins.enableAutoCommit()
 	}
 
@@ -1248,6 +1242,7 @@ func (ef *execFactory) ConstructInsertFastPath(
 	returnColOrdSet exec.TableColumnOrdinalSet,
 	checkOrdSet exec.CheckOrdinalSet,
 	fkChecks []exec.InsertFastPathFKCheck,
+	autoCommit bool,
 ) (exec.Node, error) {
 	ctx := ef.planner.extendedEvalCtx.Context
 
@@ -1303,7 +1298,7 @@ func (ef *execFactory) ConstructInsertFastPath(
 		return &zeroNode{columns: ins.columns}, nil
 	}
 
-	if ef.allowAutoCommit {
+	if autoCommit {
 		ins.enableAutoCommit()
 	}
 
@@ -1327,7 +1322,7 @@ func (ef *execFactory) ConstructUpdate(
 	returnColOrdSet exec.TableColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	passthrough sqlbase.ResultColumns,
-	allowAutoCommit bool,
+	autoCommit bool,
 ) (exec.Node, error) {
 	ctx := ef.planner.extendedEvalCtx.Context
 
@@ -1413,7 +1408,7 @@ func (ef *execFactory) ConstructUpdate(
 		upd.run.rowsNeeded = true
 	}
 
-	if allowAutoCommit && ef.allowAutoCommit {
+	if autoCommit {
 		upd.enableAutoCommit()
 	}
 
@@ -1438,7 +1433,7 @@ func (ef *execFactory) ConstructUpsert(
 	updateColOrdSet exec.TableColumnOrdinalSet,
 	returnColOrdSet exec.TableColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
-	allowAutoCommit bool,
+	autoCommit bool,
 ) (exec.Node, error) {
 	ctx := ef.planner.extendedEvalCtx.Context
 
@@ -1523,7 +1518,7 @@ func (ef *execFactory) ConstructUpsert(
 		ups.run.tw.collectRows = true
 	}
 
-	if allowAutoCommit && ef.allowAutoCommit {
+	if autoCommit {
 		ups.enableAutoCommit()
 	}
 
@@ -1544,7 +1539,7 @@ func (ef *execFactory) ConstructDelete(
 	table cat.Table,
 	fetchColOrdSet exec.TableColumnOrdinalSet,
 	returnColOrdSet exec.TableColumnOrdinalSet,
-	allowAutoCommit bool,
+	autoCommit bool,
 ) (exec.Node, error) {
 	ctx := ef.planner.extendedEvalCtx.Context
 
@@ -1598,7 +1593,7 @@ func (ef *execFactory) ConstructDelete(
 		del.run.rowsNeeded = true
 	}
 
-	if allowAutoCommit && ef.allowAutoCommit {
+	if autoCommit {
 		del.enableAutoCommit()
 	}
 
@@ -1619,8 +1614,7 @@ func (ef *execFactory) ConstructDeleteRange(
 	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
 	interleavedTables []cat.Table,
-	maxReturnedKeys int,
-	allowAutoCommit bool,
+	autoCommit bool,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
 	indexDesc := &tabDesc.PrimaryIndex
@@ -1637,29 +1631,11 @@ func (ef *execFactory) ConstructDeleteRange(
 		return nil, err
 	}
 
-	// Permitting autocommit in DeleteRange is very important, because DeleteRange
-	// is used for simple deletes from primary indexes like
-	// DELETE FROM t WHERE key = 1000
-	// When possible, we need to make this a 1pc transaction for performance
-	// reasons. At the same time, we have to be careful, because DeleteRange
-	// returns all of the keys that it deleted - so we have to set a limit on the
-	// DeleteRange request. But, trying to set autocommit and a limit on the
-	// request doesn't work properly if the limit is hit. So, we permit autocommit
-	// here if we can guarantee that the number of returned keys is finite and
-	// relatively small.
-	autoCommitEnabled := allowAutoCommit && ef.allowAutoCommit
-	// If maxReturnedKeys is 0, it indicates that we weren't able to determine
-	// the maximum number of returned keys, so we'll give up and not permit
-	// autocommit.
-	if maxReturnedKeys == 0 || maxReturnedKeys > TableTruncateChunkSize {
-		autoCommitEnabled = false
-	}
-
 	dr := &deleteRangeNode{
 		interleavedFastPath: false,
 		spans:               spans,
 		desc:                tabDesc,
-		autoCommitEnabled:   autoCommitEnabled,
+		autoCommitEnabled:   autoCommit,
 	}
 
 	if len(interleavedTables) > 0 {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -211,7 +211,10 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 		if p.Descriptors().HasUncommittedTypes() {
 			planningMode = distSQLLocalOnlyPlanning
 		}
-		bld = execbuilder.New(newDistSQLSpecExecFactory(p, planningMode), execMemo, &opc.catalog, root, p.EvalContext())
+		bld = execbuilder.New(
+			newDistSQLSpecExecFactory(p, planningMode), execMemo, &opc.catalog, root,
+			p.EvalContext(), p.autoCommit,
+		)
 		plan, err = bld.Build()
 		if err != nil {
 			if mode == sessiondata.ExperimentalDistSQLPlanningAlways &&
@@ -240,7 +243,10 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 				// that forces local planning.
 				// TODO(yuzefovich): remove this logic when deleting old
 				// execFactory.
-				bld = execbuilder.New(newDistSQLSpecExecFactory(p, distSQLLocalOnlyPlanning), execMemo, &opc.catalog, root, p.EvalContext())
+				bld = execbuilder.New(
+					newDistSQLSpecExecFactory(p, distSQLLocalOnlyPlanning), execMemo, &opc.catalog, root,
+					p.EvalContext(), p.autoCommit,
+				)
 				plan, err = bld.Build()
 			}
 		}
@@ -255,7 +261,9 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 	if bld == nil {
 		// If bld is non-nil, then experimental planning has succeeded and has
 		// already created a plan.
-		bld = execbuilder.New(newExecFactory(p), execMemo, &opc.catalog, root, p.EvalContext())
+		bld = execbuilder.New(
+			newExecFactory(p), execMemo, &opc.catalog, root, p.EvalContext(), p.autoCommit,
+		)
 		plan, err = bld.Build()
 		if err != nil {
 			return err

--- a/pkg/sql/row/truncate.go
+++ b/pkg/sql/row/truncate.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package row
+
+// TableTruncateChunkSize is the maximum number of keys deleted per chunk
+// during a table or index truncation.
+const TableTruncateChunkSize = 600

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -102,7 +102,10 @@ func optBuildScalar(evalCtx *tree.EvalContext, e tree.Expr) (tree.TypedExpr, err
 		return nil, err
 	}
 
-	bld := execbuilder.New(nil /* factory */, o.Memo(), nil /* catalog */, o.Memo().RootExpr(), evalCtx)
+	bld := execbuilder.New(
+		nil /* factory */, o.Memo(), nil /* catalog */, o.Memo().RootExpr(),
+		evalCtx, false, /* allowAutoCommit */
+	)
 	ivh := tree.MakeIndexedVarHelper(nil /* container */, 0)
 
 	expr, err := bld.BuildScalar(&ivh)

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -30,10 +30,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// TableTruncateChunkSize is the maximum number of keys deleted per chunk
-// during a table truncation.
-const TableTruncateChunkSize = indexTruncateChunkSize
-
 type truncateNode struct {
 	n *tree.Truncate
 }
@@ -413,7 +409,7 @@ func ClearTableDataInChunks(
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	traceKV bool,
 ) error {
-	const chunkSize = TableTruncateChunkSize
+	const chunkSize = row.TableTruncateChunkSize
 	var resume roachpb.Span
 	alloc := &sqlbase.DatumAlloc{}
 	for rowIdx, done := 0, false; !done; rowIdx += chunkSize {


### PR DESCRIPTION
Currently, the exec factory has a flag indicating whether auto commit is acceptable
(i.e. we're not inside an explicit transaction) and it combines this information
with `enableAutoCommit` flags passed to mutation primitives.

We now instead plumb all information through execbuilder, which makes the final
decision for autocommit. This will be necessary with the new EXPLAIN, which
is not aware of any shenanigans that happen inside the factory.

Release note: None