### PR TITLE
importccl,jobs: move super-user checks to privileged IO paths for IMPORT

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -243,10 +243,6 @@ func importPlanHook(
 
 		walltime := p.ExecCfg().Clock.Now().WallTime
 
-		if err := p.RequireAdminRole(ctx, "IMPORT"); err != nil {
-			return err
-		}
-
 		if !p.ExtendedEvalContext().TxnImplicit {
 			return errors.Errorf("IMPORT cannot be used inside a transaction")
 		}
@@ -260,6 +256,23 @@ func importPlanHook(
 		if err != nil {
 			return err
 		}
+
+		// Certain ExternalStorage URIs require super-user access. Check all the
+		// URIs passed to the IMPORT command.
+		for _, file := range filenamePatterns {
+			requiresAdmin, uriScheme, err := cloudimpl.URIRequiresAdminRole(file)
+			if err != nil {
+				return err
+			}
+			if requiresAdmin {
+				err := p.RequireAdminRole(ctx,
+					fmt.Sprintf("IMPORT from the specified %s URI", uriScheme))
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		var files []string
 		if _, ok := opts[importOptionDisableGlobMatch]; ok {
 			files = filenamePatterns
@@ -949,7 +962,7 @@ func prepareNewTableDescsForIngestion(
 		return nil, err
 	}
 
-	// tableDescs constains the same slice as newMutableTableDescriptors but
+	// tableDescs contains the same slice as newMutableTableDescriptors but
 	// as sqlbase.TableDescriptor.
 	tableDescs := make([]sqlbase.TableDescriptor, len(newMutableTableDescriptors))
 	for i := range tableDescs {
@@ -1318,7 +1331,6 @@ func (r *importResumer) publishTables(ctx context.Context, execCfg *sql.Executor
 		if err != nil {
 			return errors.Wrap(err, "updating job details after publishing tables")
 		}
-
 		return nil
 	})
 

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -149,6 +149,10 @@ var mysqlDumpAllowedOptions = makeStringSet(importOptionSkipFKs)
 var pgCopyAllowedOptions = makeStringSet(pgCopyDelimiter, pgCopyNull, optMaxRowSize)
 var pgDumpAllowedOptions = makeStringSet(optMaxRowSize, importOptionSkipFKs)
 
+// DROP is required because the target table needs to be take offline during
+// IMPORT INTO.
+var importIntoRequiredPrivileges = []privilege.Kind{privilege.INSERT, privilege.DROP}
+
 // File formats supported for IMPORT INTO
 var allowedIntoFormats = map[string]struct{}{
 	"CSV":       {},
@@ -202,6 +206,22 @@ func importJobDescription(
 	sort.Slice(stmt.Options, func(i, j int) bool { return stmt.Options[i].Key < stmt.Options[j].Key })
 	ann := p.ExtendedEvalContext().Annotations
 	return tree.AsStringWithFQNames(&stmt, ann), nil
+}
+
+func ensureRequiredPrivileges(
+	ctx context.Context,
+	requiredPrivileges []privilege.Kind,
+	p sql.PlanHookState,
+	desc *sqlbase.MutableTableDescriptor,
+) error {
+	for _, priv := range requiredPrivileges {
+		err := p.CheckPrivilege(ctx, desc, priv)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // importPlanHook implements sql.PlanHookFn.
@@ -608,8 +628,8 @@ func importPlanHook(
 				return err
 			}
 
-			// TODO(dt): checking *CREATE* on an *existing table* is weird.
-			if err := p.CheckPrivilege(ctx, found, privilege.CREATE); err != nil {
+			err = ensureRequiredPrivileges(ctx, importIntoRequiredPrivileges, p, found)
+			if err != nil {
 				return err
 			}
 

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -280,11 +280,11 @@ func importPlanHook(
 		// Certain ExternalStorage URIs require super-user access. Check all the
 		// URIs passed to the IMPORT command.
 		for _, file := range filenamePatterns {
-			requiresAdmin, uriScheme, err := cloudimpl.URIRequiresAdminRole(file)
+			hasExplicitAuth, uriScheme, err := cloudimpl.AccessIsWithExplicitAuth(file)
 			if err != nil {
 				return err
 			}
-			if requiresAdmin {
+			if !hasExplicitAuth {
 				err := p.RequireAdminRole(ctx,
 					fmt.Sprintf("IMPORT from the specified %s URI", uriScheme))
 				if err != nil {

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1769,11 +1769,12 @@ func TestImportCSVStmt(t *testing.T) {
 
 	// Test basic role based access control. Users who have the admin role should
 	// be able to IMPORT.
-	t.Run("RBAC", func(t *testing.T) {
+	t.Run("RBAC-SuperUser", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE USER testuser`)
 		sqlDB.Exec(t, `GRANT admin TO testuser`)
 		pgURL, cleanupFunc := sqlutils.PGUrl(
-			t, tc.Server(0).ServingSQLAddr(), "TestImportPrivileges-testuser", url.User("testuser"),
+			t, tc.Server(0).ServingSQLAddr(), "TestImportPrivileges-testuser",
+			url.User("testuser"),
 		)
 		defer cleanupFunc()
 		testuser, err := gosql.Open("postgres", pgURL.String())
@@ -1783,16 +1784,18 @@ func TestImportCSVStmt(t *testing.T) {
 		defer testuser.Close()
 
 		t.Run("IMPORT TABLE", func(t *testing.T) {
-			if _, err := testuser.Exec(fmt.Sprintf(`IMPORT TABLE rbac_table_t (a INT8 PRIMARY KEY, b STRING) CSV DATA (%s)`, testFiles.files[0])); err != nil {
+			if _, err := testuser.Exec(fmt.Sprintf(`IMPORT TABLE rbac_superuser (a INT8 PRIMARY KEY, 
+b STRING) CSV DATA (%s)`, testFiles.files[0])); err != nil {
 				t.Fatal(err)
 			}
 		})
 
 		t.Run("IMPORT INTO", func(t *testing.T) {
-			if _, err := testuser.Exec("CREATE TABLE rbac_into_t (a INT8 PRIMARY KEY, b STRING)"); err != nil {
+			if _, err := testuser.Exec("CREATE TABLE rbac_into_superuser (a INT8 PRIMARY KEY, " +
+				"b STRING)"); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := testuser.Exec(fmt.Sprintf(`IMPORT INTO rbac_into_t (a, b) CSV DATA (%s)`, testFiles.files[0])); err != nil {
+			if _, err := testuser.Exec(fmt.Sprintf(`IMPORT INTO rbac_into_superuser (a, b) CSV DATA (%s)`, testFiles.files[0])); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -1813,14 +1816,14 @@ func TestImportCSVStmt(t *testing.T) {
 
 		const (
 			query = `IMPORT TABLE t (
-			a SERIAL8,
-			b INT8 DEFAULT unique_rowid(),
-			c STRING DEFAULT 's',
-			d SERIAL8,
-			e INT8 DEFAULT unique_rowid(),
-			f STRING DEFAULT 's',
-			PRIMARY KEY (a, b, c)
-		) CSV DATA ($1)`
+				a SERIAL8,
+				b INT8 DEFAULT unique_rowid(),
+				c STRING DEFAULT 's',
+				d SERIAL8,
+				e INT8 DEFAULT unique_rowid(),
+				f STRING DEFAULT 's',
+				PRIMARY KEY (a, b, c)
+			) CSV DATA ($1)`
 			nullif = ` WITH nullif=''`
 		)
 
@@ -1891,7 +1894,7 @@ func TestImportCSVStmt(t *testing.T) {
 		sqlDB.Exec(t, `GRANT ALL ON DATABASE defaultdb TO foo`)
 
 		sqlDB.Exec(t, fmt.Sprintf(`
-IMPORT TABLE import_with_db_privs (a INT8 PRIMARY KEY, b STRING) CSV DATA (%s)`,
+	IMPORT TABLE import_with_db_privs (a INT8 PRIMARY KEY, b STRING) CSV DATA (%s)`,
 			testFiles.files[0]))
 
 		// Verify correct number of rows via COUNT.
@@ -1913,6 +1916,111 @@ IMPORT TABLE import_with_db_privs (a INT8 PRIMARY KEY, b STRING) CSV DATA (%s)`,
 		var result int
 		sqlDB.QueryRow(t, `SELECT count(*) FROM uds.sc.t`).Scan(&result)
 		require.Equal(t, rowsPerFile, result)
+	})
+}
+
+func TestImportObjectLevelRBAC(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const nodes = 3
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
+		SQLMemoryPoolSize: 256 << 20,
+	}})
+	defer tc.Stopper().Stop(ctx)
+	conn := tc.Conns[0]
+	rootDB := sqlutils.MakeSQLRunner(conn)
+
+	rootDB.Exec(t, `CREATE USER testuser`)
+	pgURL, cleanupFunc := sqlutils.PGUrl(
+		t, tc.Server(0).ServingSQLAddr(), "TestImportPrivileges-testuser",
+		url.User("testuser"),
+	)
+	defer cleanupFunc()
+
+	startTestUser := func() *gosql.DB {
+		testuser, err := gosql.Open("postgres", pgURL.String())
+		require.NoError(t, err)
+		return testuser
+	}
+
+	qualifiedTableName := "defaultdb.public.user_file_table_test"
+	filename := "path/to/file"
+	dest := cloudimpl.MakeUserFileStorageURI(qualifiedTableName, filename)
+
+	writeToUserfile := func(filename string) {
+		// Write to userfile storage now that testuser has CREATE privileges.
+		ie := tc.Server(0).InternalExecutor().(*sql.InternalExecutor)
+		fileTableSystem1, err := cloudimpl.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
+			cluster.NoSettings, blobs.TestEmptyBlobClientFactory, "testuser", ie, tc.Server(0).DB())
+		require.NoError(t, err)
+		require.NoError(t, fileTableSystem1.WriteFile(ctx, filename, bytes.NewReader([]byte("1,aaa"))))
+	}
+
+	t.Run("import-RBAC", func(t *testing.T) {
+		userfileDest := dest + "/" + t.Name()
+		testuser := startTestUser()
+
+		// User has no privileges at this point. Check that an IMPORT requires
+		// CREATE privileges on the database.
+		_, err := testuser.Exec(fmt.Sprintf(`IMPORT TABLE rbac_import_priv (a INT8 PRIMARY KEY, 
+b STRING) CSV DATA ('%s')`, userfileDest))
+		require.True(t, testutils.IsError(err, "testuser does not have CREATE privilege on database"))
+
+		// Grant user CREATE privilege on the database.
+		rootDB.Exec(t, `GRANT create ON DATABASE defaultdb TO testuser`)
+		// Reopen testuser sql connection.
+		// TODO(adityamaru): The above GRANT does not reflect unless we restart
+		// the testuser SQL connection, understand why.
+		require.NoError(t, testuser.Close())
+
+		testuser = startTestUser()
+		defer testuser.Close()
+
+		// Write to userfile now that the user has CREATE privileges.
+		writeToUserfile(t.Name())
+
+		// Import should now have the required privileges to start the job.
+		_, err = testuser.Exec(fmt.Sprintf(`IMPORT TABLE rbac_import_priv (a INT8 PRIMARY KEY, 
+b STRING) CSV DATA ('%s')`, userfileDest))
+		require.NoError(t, err)
+	})
+
+	t.Run("import-into-RBAC", func(t *testing.T) {
+		// Create table to IMPORT INTO.
+		rootDB.Exec(t, `CREATE TABLE rbac_import_into_priv (a INT8 PRIMARY KEY, b STRING)`)
+		userFileDest := dest + "/" + t.Name()
+		testuser := startTestUser()
+
+		// User has no privileges at this point. Check that an IMPORT INTO requires
+		// INSERT and DROP privileges.
+		for _, privilege := range []string{"INSERT", "DROP"} {
+			_, err := testuser.Exec(fmt.Sprintf(`IMPORT INTO rbac_import_into_priv (a, 
+b) CSV DATA ('%s')`, userFileDest))
+			require.True(t, testutils.IsError(err,
+				fmt.Sprintf("user testuser does not have %s privilege on relation rbac_import_into_priv",
+					privilege)))
+
+			rootDB.Exec(t, fmt.Sprintf(`GRANT %s ON TABLE rbac_import_into_priv TO testuser`, privilege))
+		}
+
+		// Grant user CREATE privilege on the database.
+		rootDB.Exec(t, `GRANT create ON DATABASE defaultdb TO testuser`)
+		// Reopen testuser sql connection.
+		// TODO(adityamaru): The above GRANT does not reflect unless we restart
+		// the testuser SQL connection, understand why.
+		require.NoError(t, testuser.Close())
+		testuser = startTestUser()
+		defer testuser.Close()
+
+		// Write to userfile now that the user has CREATE privileges.
+		writeToUserfile(t.Name())
+
+		// Import should now have the required privileges to start the job.
+		_, err := testuser.Exec(fmt.Sprintf(`IMPORT INTO rbac_import_into_priv (a,b) CSV DATA ('%s')`,
+			userFileDest))
+		require.NoError(t, err)
 	})
 }
 

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -23,11 +23,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -47,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -1912,6 +1914,103 @@ IMPORT TABLE import_with_db_privs (a INT8 PRIMARY KEY, b STRING) CSV DATA (%s)`,
 		sqlDB.QueryRow(t, `SELECT count(*) FROM uds.sc.t`).Scan(&result)
 		require.Equal(t, rowsPerFile, result)
 	})
+}
+
+// TestURIRequiresAdminRole tests the IMPORT logic which guards certain
+// privileged ExternalStorage IO paths with an admin only check.
+func TestURIRequiresAdminRole(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const nodes = 3
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
+		SQLMemoryPoolSize: 256 << 20,
+	}})
+	defer tc.Stopper().Stop(ctx)
+	conn := tc.Conns[0]
+	rootDB := sqlutils.MakeSQLRunner(conn)
+
+	rootDB.Exec(t, `CREATE USER testuser`)
+	pgURL, cleanupFunc := sqlutils.PGUrl(
+		t, tc.Server(0).ServingSQLAddr(), "TestImportPrivileges-testuser",
+		url.User("testuser"),
+	)
+	defer cleanupFunc()
+	testuser, err := gosql.Open("postgres", pgURL.String())
+	require.NoError(t, err)
+	defer testuser.Close()
+
+	for _, tc := range []struct {
+		name          string
+		uri           string
+		requiresAdmin bool
+	}{
+		{
+			name:          "s3-implicit",
+			uri:           "s3://foo/bar?AUTH=implicit",
+			requiresAdmin: true,
+		},
+		{
+			name:          "s3-specified",
+			uri:           "s3://foo/bar?AUTH=specified",
+			requiresAdmin: false,
+		},
+		{
+			name:          "s3-custom",
+			uri:           "s3://foo/bar?AUTH=specified&AWS_ENDPOINT=baz",
+			requiresAdmin: true,
+		},
+		{
+			name:          "gs-implicit",
+			uri:           "gs://foo/bar?AUTH=implicit",
+			requiresAdmin: true,
+		},
+		{
+			name:          "gs-specified",
+			uri:           "gs://foo/bar?AUTH=specified",
+			requiresAdmin: false,
+		},
+		{
+			name:          "userfile",
+			uri:           "userfile:///foo",
+			requiresAdmin: false,
+		},
+		{
+			name:          "nodelocal",
+			uri:           "nodelocal://self/foo",
+			requiresAdmin: true,
+		},
+		{
+			name:          "http",
+			uri:           "http://foo/bar",
+			requiresAdmin: true,
+		},
+		{
+			name:          "https",
+			uri:           "https://foo/bar",
+			requiresAdmin: true,
+		},
+	} {
+		t.Run(tc.name+"-via-import", func(t *testing.T) {
+			_, err := testuser.Exec(fmt.Sprintf(`IMPORT TABLE foo (id INT) CSV DATA ('%s')`, tc.uri))
+			if tc.requiresAdmin {
+				require.True(t, testutils.IsError(err, "only users with the admin role are allowed to IMPORT"))
+			} else {
+				require.False(t, testutils.IsError(err, "only users with the admin role are allowed to IMPORT"))
+			}
+		})
+
+		t.Run(tc.name+"-direct", func(t *testing.T) {
+			requires, scheme, err := cloudimpl.URIRequiresAdminRole(tc.uri)
+			require.NoError(t, err)
+			require.Equal(t, requires, tc.requiresAdmin)
+
+			url, err := url.Parse(tc.uri)
+			require.NoError(t, err)
+			require.Equal(t, scheme, url.Scheme)
+		})
+	}
 }
 
 func TestExportImportRoundTrip(t *testing.T) {

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -2110,9 +2110,9 @@ func TestURIRequiresAdminRole(t *testing.T) {
 		})
 
 		t.Run(tc.name+"-direct", func(t *testing.T) {
-			requires, scheme, err := cloudimpl.URIRequiresAdminRole(tc.uri)
+			requires, scheme, err := cloudimpl.AccessIsWithExplicitAuth(tc.uri)
 			require.NoError(t, err)
-			require.Equal(t, requires, tc.requiresAdmin)
+			require.Equal(t, requires, !tc.requiresAdmin)
 
 			url, err := url.Parse(tc.uri)
 			require.NoError(t, err)
@@ -4113,6 +4113,144 @@ func TestImportControlJob(t *testing.T) {
 			sqlDB.QueryStr(t, `SELECT * FROM generate_series(0, $1)`, count-1),
 		)
 	})
+}
+
+// FakeResumer calls optional callbacks during the job lifecycle.
+type fakeResumer struct {
+	OnResume     func(context.Context, chan<- tree.Datums) error
+	FailOrCancel func(context.Context) error
+}
+
+var _ jobs.Resumer = fakeResumer{}
+
+func (d fakeResumer) Resume(
+	ctx context.Context, _ interface{}, resultsCh chan<- tree.Datums,
+) error {
+	if d.OnResume != nil {
+		if err := d.OnResume(ctx, resultsCh); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d fakeResumer) OnFailOrCancel(ctx context.Context, _ interface{}) error {
+	if d.FailOrCancel != nil {
+		return d.FailOrCancel(ctx)
+	}
+	return nil
+}
+
+// TestImportControlJobRBAC tests that a root user can control any job, but
+// a non-admin user can only control jobs which are created by them.
+// TODO(adityamaru): Verifying the state of the job after the control command
+// has been issued would also be nice, but it makes the test flaky.
+func TestImportControlJobRBAC(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer jobs.ResetConstructors()()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	rootDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+
+	registry := tc.Server(0).JobRegistry().(*jobs.Registry)
+
+	// Create non-root user.
+	rootDB.Exec(t, `CREATE USER testuser`)
+	rootDB.Exec(t, `ALTER ROLE testuser CONTROLJOB`)
+	pgURL, cleanupFunc := sqlutils.PGUrl(
+		t, tc.Server(0).ServingSQLAddr(), "TestImportPrivileges-testuser",
+		url.User("testuser"),
+	)
+	defer cleanupFunc()
+	testuser, err := gosql.Open("postgres", pgURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testuser.Close()
+
+	done := make(chan struct{})
+	defer close(done)
+
+	jobs.RegisterConstructor(jobspb.TypeImport, func(_ *jobs.Job, _ *cluster.Settings) jobs.Resumer {
+		return fakeResumer{
+			OnResume: func(ctx context.Context, _ chan<- tree.Datums) error {
+				<-done
+				return nil
+			},
+			FailOrCancel: func(ctx context.Context) error {
+				<-done
+				return nil
+			},
+		}
+	})
+
+	startLeasedJob := func(t *testing.T, record jobs.Record) *jobs.Job {
+		job, _, err := registry.CreateAndStartJob(ctx, nil, record)
+		require.NoError(t, err)
+		return job
+	}
+
+	defaultRecord := jobs.Record{
+		// Job does not accept an empty Details field, so arbitrarily provide
+		// ImportDetails.
+		Details:  jobspb.ImportDetails{},
+		Progress: jobspb.ImportProgress{},
+	}
+
+	for _, tc := range []struct {
+		name         string
+		controlQuery string
+	}{
+		{
+			"pause",
+			`PAUSE JOB $1`,
+		},
+		{
+			"cancel",
+			`CANCEL JOB $1`,
+		},
+		{
+			"resume",
+			`RESUME JOB $1`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Start import job as root.
+			rootJobRecord := defaultRecord
+			rootJobRecord.Username = "root"
+			rootJob := startLeasedJob(t, rootJobRecord)
+
+			// Test root can control root job.
+			rootDB.Exec(t, tc.controlQuery, *rootJob.ID())
+			require.NoError(t, err)
+
+			// Start import job as non-admin user.
+			nonAdminJobRecord := defaultRecord
+			nonAdminJobRecord.Username = "testuser"
+			userJob := startLeasedJob(t, nonAdminJobRecord)
+
+			// Test testuser can control testuser job.
+			_, err := testuser.Exec(tc.controlQuery, *userJob.ID())
+			require.NoError(t, err)
+
+			// Start second import job as root.
+			rootJob2 := startLeasedJob(t, rootJobRecord)
+
+			// Start second import job as non-admin user.
+			userJob2 := startLeasedJob(t, nonAdminJobRecord)
+
+			// Test root can control testuser job.
+			rootDB.Exec(t, tc.controlQuery, *userJob2.ID())
+			require.NoError(t, err)
+
+			// Test testuser CANNOT control root job.
+			_, err = testuser.Exec(tc.controlQuery, *rootJob2.ID())
+			require.True(t, testutils.IsError(err, "only admins can control jobs owned by other admins"))
+		})
+	}
 }
 
 // TestImportWorkerFailure tests that IMPORT can restart after the failure

--- a/pkg/jobs/helpers.go
+++ b/pkg/jobs/helpers.go
@@ -12,6 +12,7 @@ package jobs
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -106,4 +107,13 @@ func (nl *FakeNodeLiveness) FakeSetExpiration(id roachpb.NodeID, ts hlc.Timestam
 	nl.mu.Lock()
 	defer nl.mu.Unlock()
 	nl.mu.livenessMap[id].Expiration = hlc.LegacyTimestamp(ts)
+}
+
+// ResetConstructors resets the registered Resumer constructors.
+func ResetConstructors() func() {
+	old := make(map[jobspb.Type]Constructor)
+	for k, v := range constructors {
+		old[k] = v
+	}
+	return func() { constructors = old }
 }

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -18,14 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-func ResetConstructors() func() {
-	old := make(map[jobspb.Type]Constructor)
-	for k, v := range constructors {
-		old[k] = v
-	}
-	return func() { constructors = old }
-}
-
 // FakeResumer calls optional callbacks during the job lifecycle.
 type FakeResumer struct {
 	OnResume     func(context.Context, chan<- tree.Datums) error


### PR DESCRIPTION
Commit 1 - audit privileged ExternalStorage paths for IMPORT
Commit 2 - audit object-level permissions for IMPORT
Commit 3 - audit job control for IMPORT jobs

~~A follow-up PR will remove the umbrella admin-only check we enforce during IMPORT planning.~~

Informs: #52004

EDIT: I had to remove the  admin-only check we enforce during IMPORT planning in the first commit to allow unit tests to work as expected.