### PR TITLE
release: add script to mark to promote build tags

### DIFF
--- a/build/release/teamcity-mark-build-internal-rc.sh
+++ b/build/release/teamcity-mark-build-internal-rc.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+source "$(dirname "${0}")/teamcity-mark-build.sh"
+
+mark_build "internal-rc"

--- a/build/release/teamcity-mark-build-internal-test.sh
+++ b/build/release/teamcity-mark-build-internal-test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+source "$(dirname "${0}")/teamcity-mark-build.sh"
+
+mark_build "internal-test"


### PR DESCRIPTION
This change adds 2 scripts which mark a build as the internal-test
candidate and the internal-rc candidate for a specific release.

Release note: None