### PR TITLE
roachtest: fix regex for django test suite

### DIFF
--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -16,7 +16,7 @@ import (
 	"regexp"
 )
 
-var djangoReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
+var djangoReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<point>\d+))?$`)
 var djangoCockroachDBReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)$`)
 
 var djangoSupportedTag = "3.0.6"

--- a/pkg/cmd/roachtest/sqlalchemy_blocklist.go
+++ b/pkg/cmd/roachtest/sqlalchemy_blocklist.go
@@ -18,7 +18,9 @@ var sqlAlchemyBlocklists = blocklistsForVersion{
 	{"v20.2", "sqlAlchemyBlocklist20_2", sqlAlchemyBlocklist20_2, "sqlAlchemyIgnoreList20_2", sqlAlchemyIgnoreList20_2},
 }
 
-var sqlAlchemyBlocklist20_2 = blocklist{}
+var sqlAlchemyBlocklist20_2 = blocklist{
+	"test/dialect/test_suite.py::ComponentReflectionTest_cockroachdb+psycopg2_9_5_0::test_get_foreign_keys": "52356",
+}
 
 var sqlAlchemyBlocklist20_1 = blocklist{
 	"test/dialect/test_suite.py::ExpandingBoundInTest_cockroachdb+psycopg2_9_5_0::test_null_in_empty_set_is_false": "41596",


### PR DESCRIPTION
- The release tag regex was too restrictive.
- Update SQLAlchemy failure list with new expected fail.

fixes https://github.com/cockroachdb/cockroach/issues/52225
fixes https://github.com/cockroachdb/cockroach/issues/52222
fixes https://github.com/cockroachdb/cockroach/issues/46800

Release note: None