### PR TITLE
backupccl: fix flake in backup stats tests

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -4507,7 +4507,7 @@ func TestBackupRestoreShowJob(t *testing.T) {
 	)
 }
 
-func TestBackupCreatedStats(t *testing.T) {
+func TestBackupCreatedStatsWithUniqueName(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -4518,27 +4518,18 @@ func TestBackupCreatedStats(t *testing.T) {
 	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false`)
 
 	sqlDB.Exec(t, `CREATE TABLE data.foo (a INT PRIMARY KEY)`)
-	sqlDB.Exec(t, `CREATE STATISTICS foo_stats FROM data.foo`)
-	sqlDB.Exec(t, `CREATE STATISTICS bank_stats FROM data.bank`)
+	injectStats(t, sqlDB, "data.bank", "id")
+	injectStats(t, sqlDB, "data.foo", "a")
+
 	sqlDB.Exec(t, `BACKUP data.bank, data.foo TO $1 WITH revision_history`, LocalFoo)
 	sqlDB.Exec(t, `CREATE DATABASE "data 2"`)
 	sqlDB.Exec(t, `RESTORE data.bank, data.foo FROM $1 WITH skip_missing_foreign_keys, into_db = $2`,
 		LocalFoo, "data 2")
 
-	sqlDB.CheckQueryResults(t,
-		`SELECT statistics_name, column_names, row_count, distinct_count, null_count
-	FROM [SHOW STATISTICS FOR TABLE "data 2".bank] WHERE statistics_name='bank_stats'`,
-		[][]string{
-			{"bank_stats", "{id}", "1", "1", "0"},
-			{"bank_stats", "{balance}", "1", "1", "0"},
-			{"bank_stats", "{payload}", "1", "1", "0"},
-		})
-	sqlDB.CheckQueryResults(t,
-		`SELECT statistics_name, column_names, row_count, distinct_count, null_count
-	FROM [SHOW STATISTICS FOR TABLE "data 2".foo] WHERE statistics_name='foo_stats'`,
-		[][]string{
-			{"foo_stats", "{a}", "0", "0", "0"},
-		})
+	sqlDB.CheckQueryResults(t, getStatsQuery(`"data 2".bank`),
+		sqlDB.QueryStr(t, getStatsQuery("data.bank")))
+	sqlDB.CheckQueryResults(t, getStatsQuery(`"data 2".foo`),
+		sqlDB.QueryStr(t, getStatsQuery("data.foo")))
 }
 
 // Ensure that backing up and restoring an empty database succeeds.
@@ -4568,23 +4559,20 @@ func TestBackupRestoreSubsetCreatedStats(t *testing.T) {
 	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false`)
 
 	sqlDB.Exec(t, `CREATE TABLE data.foo (a INT)`)
-	sqlDB.Exec(t, `CREATE STATISTICS foo_stats FROM data.foo`)
-	sqlDB.Exec(t, `CREATE STATISTICS bank_stats FROM data.bank`)
+	bankStats := injectStats(t, sqlDB, "data.bank", "id")
+	injectStats(t, sqlDB, "data.foo", "a")
 
 	sqlDB.Exec(t, `BACKUP data.bank, data.foo TO $1 WITH revision_history`, LocalFoo)
-	sqlDB.Exec(t, `DELETE FROM system.table_statistics WHERE name = 'foo_stats' OR name = 'bank_stats'`)
+	// Clear the stats.
+	sqlDB.Exec(t, `DELETE FROM system.table_statistics WHERE true`)
 	sqlDB.Exec(t, `CREATE DATABASE "data 2"`)
+	sqlDB.Exec(t, `CREATE TABLE "data 2".foo (a INT)`)
 	sqlDB.Exec(t, `RESTORE data.bank FROM $1 WITH skip_missing_foreign_keys, into_db = $2`,
 		LocalFoo, "data 2")
 
-	// Ensure that the bank_stats have been restored, but foo_stats have not.
-	sqlDB.CheckQueryResults(t,
-		`SELECT name, "columnIDs", "rowCount", "distinctCount", "nullCount" FROM system.table_statistics`,
-		[][]string{
-			{"bank_stats", "{1}", "1", "1", "0"}, // id column
-			{"bank_stats", "{2}", "1", "1", "0"}, // balance column
-			{"bank_stats", "{3}", "1", "1", "0"}, // payload column
-		})
+	// Ensure that bank's stats have been restored, but foo's have not.
+	sqlDB.CheckQueryResults(t, getStatsQuery(`"data 2".bank`), bankStats)
+	sqlDB.CheckQueryResults(t, getStatsQuery(`"data 2".foo`), [][]string{})
 }
 
 // Ensure that statistics are restored from correct backup.
@@ -4601,19 +4589,18 @@ func TestBackupCreatedStatsFromIncrementalBackup(t *testing.T) {
 
 	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false`)
 
-	// Create the 1st backup, where data.bank has 1 account.
-	sqlDB.Exec(t, `CREATE STATISTICS bank_stats FROM data.bank`)
+	// Create the 1st backup, with stats estimating 50 rows.
+	injectStatsWithRowCount(t, sqlDB, "data.bank", "id", 50 /* rowCount */)
 	sqlDB.Exec(t, `BACKUP data.bank TO $1 WITH revision_history`, LocalFoo)
 
-	// Create the 2nd backup, where data.bank has 3 accounts.
-	sqlDB.Exec(t, `INSERT INTO data.bank VALUES (2, 2), (4, 4)`)
-	sqlDB.Exec(t, `CREATE STATISTICS bank_stats FROM data.bank`)
+	// Create the 2nd backup, with stats estimating 100 rows.
+	injectStatsWithRowCount(t, sqlDB, "data.bank", "id", 100 /* rowCount */)
+	statsBackup2 := sqlDB.QueryStr(t, getStatsQuery("data.bank"))
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&beforeTs) // Save time to restore to this point.
 	sqlDB.Exec(t, `BACKUP data.bank TO $1 INCREMENTAL FROM $2 WITH revision_history`, incremental1Foo, LocalFoo)
 
-	// Create the 3rd backup, where data.bank has 5 accounts.
-	sqlDB.Exec(t, `INSERT INTO data.bank VALUES (3, 3), (5, 2)`)
-	sqlDB.Exec(t, `CREATE STATISTICS bank_stats FROM data.bank`)
+	// Create the 3rd backup, with stats estimating 500 rows.
+	injectStatsWithRowCount(t, sqlDB, "data.bank", "id", 500 /* rowCount */)
 	sqlDB.Exec(t, `BACKUP data.bank TO $1 INCREMENTAL FROM $2, $3 WITH revision_history`, incremental2Foo, LocalFoo, incremental1Foo)
 
 	// Restore the 2nd backup.
@@ -4621,17 +4608,8 @@ func TestBackupCreatedStatsFromIncrementalBackup(t *testing.T) {
 	sqlDB.Exec(t, fmt.Sprintf(`RESTORE data.bank FROM "%s", "%s", "%s" AS OF SYSTEM TIME %s WITH skip_missing_foreign_keys, into_db = "%s"`,
 		LocalFoo, incremental1Foo, incremental2Foo, beforeTs, "data 2"))
 
-	// Expect the values in row_count and distinct_count to be 3. The values
-	// would be 1 if the stats from the full backup were restored and 5 if
-	// the stats from the latest incremental backup were restored.
-	sqlDB.CheckQueryResults(t,
-		`SELECT statistics_name, column_names, row_count, distinct_count, null_count
-	FROM [SHOW STATISTICS FOR TABLE "data 2".bank] WHERE statistics_name='bank_stats'`,
-		[][]string{
-			{"bank_stats", "{id}", "3", "3", "0"},
-			{"bank_stats", "{balance}", "3", "3", "0"},
-			{"bank_stats", "{payload}", "3", "2", "2"},
-		})
+	// Expect the stats look as they did in the second backup.
+	sqlDB.CheckQueryResults(t, getStatsQuery(`"data 2".bank`), statsBackup2)
 }
 
 // TestProtectedTimestampsDuringBackup ensures that the timestamp at which a

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -81,7 +81,7 @@ func TestFullClusterBackup(t *testing.T) {
 	sqlDB.Exec(t, `GRANT CREATE, SELECT ON DATABASE data TO system_ops;`)
 	sqlDB.Exec(t, `GRANT system_ops TO maxroach1;`)
 
-	sqlDB.Exec(t, `CREATE STATISTICS my_stats FROM data.bank`)
+	injectStats(t, sqlDB, "data.bank", "id")
 	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
 
 	// Create a bunch of user tables on the restoring cluster that we're going

--- a/pkg/ccl/backupccl/helpers_test.go
+++ b/pkg/ccl/backupccl/helpers_test.go
@@ -11,6 +11,7 @@ package backupccl
 import (
 	"context"
 	gosql "database/sql"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -248,4 +249,44 @@ func createEmptyCluster(
 	}
 
 	return sqlDB, dir, cleanupFn
+}
+
+// getStatsQuery returns a SQL query that will return the properties of the
+// statistics on a table that are expected to remain the same after being
+// restored on a new cluster.
+func getStatsQuery(tableName string) string {
+	return fmt.Sprintf(`SELECT
+	  statistics_name,
+	  column_names,
+	  row_count,
+	  distinct_count,
+	  null_count
+	FROM [SHOW STATISTICS FOR TABLE %s]`, tableName)
+}
+
+// injectStats directly injects some arbitrary statistic into a given table for
+// a specified column.
+// See injectStatsWithRowCount.
+func injectStats(
+	t *testing.T, sqlDB *sqlutils.SQLRunner, tableName string, columnName string,
+) [][]string {
+	return injectStatsWithRowCount(t, sqlDB, tableName, columnName, 100 /* rowCount */)
+}
+
+// injectStatsWithRowCount directly injects some statistics specifying some row
+// count for a column in the given table.
+// N.B. This should be used in backup testing over CREATE STATISTICS since it
+// ensures that the stats cache will be up to date during a subsequent BACKUP.
+func injectStatsWithRowCount(
+	t *testing.T, sqlDB *sqlutils.SQLRunner, tableName string, columnName string, rowCount int,
+) [][]string {
+	sqlDB.Exec(t, fmt.Sprintf(`ALTER TABLE %s INJECT STATISTICS '[
+	{
+		"columns": ["%s"],
+		"created_at": "2018-01-01 1:00:00.00000+00:00",
+		"row_count": %d,
+		"distinct_count": %d
+	}
+	]'`, tableName, columnName, rowCount, rowCount))
+	return sqlDB.QueryStr(t, getStatsQuery(tableName))
 }


### PR DESCRIPTION
This commit updates the way we generate table stats in tests to ensure
that the stats cache always sees the values we insert. This change takes
advantage of the fact that inject stats directly to a table will
invalidate the stats cache, so when BACKUP queries the stats it will
find the latest information.

Release note: None