### PR TITLE
sql: allow storage_params with CREATE INDEX syntax

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -34,6 +34,16 @@ type createIndexNode struct {
 	tableDesc *sqlbase.MutableTableDescriptor
 }
 
+var indexStorageParams = map[string]storageParamType{
+	`fillfactor`:                        storageParamInt,
+	`vacuum_cleanup_index_scale_factor`: storageParamUnimplemented,
+	`buffering`:                         storageParamUnimplemented,
+	`fastupdate`:                        storageParamUnimplemented,
+	`gin_pending_list_limit`:            storageParamUnimplemented,
+	`pages_per_range`:                   storageParamUnimplemented,
+	`autosummarize`:                     storageParamUnimplemented,
+}
+
 // CreateIndex creates an index.
 // Privileges: CREATE on table.
 //   notes: postgres requires CREATE on the table.
@@ -134,6 +144,16 @@ func MakeIndexDescriptor(
 		Unique:            n.Unique,
 		StoreColumnNames:  n.Storing.ToStrings(),
 		CreatedExplicitly: true,
+	}
+
+	if err := checkStorageParameters(
+		params.ctx,
+		params.p.SemaCtx(),
+		params.EvalContext(),
+		n.StorageParams,
+		indexStorageParams,
+	); err != nil {
+		return nil, err
 	}
 
 	if n.Inverted {

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -96,5 +96,12 @@ CREATE TABLE a (b INT) WITH (fillfactor=true);
 statement error unimplemented: storage parameter "toast_tuple_target"
 CREATE TABLE a (b INT) WITH (toast_tuple_target=100);
 
-statement ok
-CREATE TABLE a (b INT) WITH (fillfactor=100);
+query T noticetrace
+CREATE TABLE a (b INT) WITH (fillfactor=100)
+----
+NOTICE: storage parameter "fillfactor" is ignored
+
+query T noticetrace
+CREATE INDEX a_idx ON a(b) WITH (fillfactor=50)
+----
+NOTICE: storage parameter "fillfactor" is ignored

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -106,6 +106,7 @@ func TestParse(t *testing.T) {
 		{`CREATE INVERTED INDEX a ON b (c) WHERE d > 3`},
 		{`CREATE INVERTED INDEX a ON b (c) INTERLEAVE IN PARENT d (e)`},
 		{`CREATE INVERTED INDEX IF NOT EXISTS a ON b (c) WHERE d > 3`},
+		{`CREATE INDEX a ON b (c) WITH (fillfactor = 100, y_bounds = 50)`},
 
 		{`CREATE TABLE a ()`},
 		{`CREATE TEMPORARY TABLE a (b INT8)`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -872,7 +872,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 %type <*tree.CopyOptions> opt_with_copy_options copy_options copy_options_list
 %type <str> import_format
 %type <tree.StorageParam> storage_parameter
-%type <[]tree.StorageParam> storage_parameter_list opt_table_with
+%type <[]tree.StorageParam> storage_parameter_list opt_table_with opt_with_storage_parameter_list
 
 %type <*tree.Select> select_no_parens
 %type <tree.SelectStatement> select_clause select_with_parens simple_select values_clause table_clause simple_select_clause
@@ -5143,24 +5143,27 @@ create_table_stmt:
   }
 
 opt_table_with:
-  /* EMPTY */
-  {
-    $$.val = nil
-  }
+  opt_with_storage_parameter_list
 | WITHOUT OIDS
   {
     /* SKIP DOC */
     /* this is also the default in CockroachDB */
     $$.val = nil
   }
+| WITH OIDS error
+  {
+    return unimplemented(sqllex, "create table with oids")
+  }
+
+opt_with_storage_parameter_list:
+  /* EMPTY */
+  {
+    $$.val = nil
+  }
 | WITH '(' storage_parameter_list ')'
   {
     /* SKIP DOC */
     $$.val = $3.storageParams()
-  }
-| WITH OIDS error
-  {
-    return unimplemented(sqllex, "create table with oids")
   }
 
 opt_create_table_on_commit:
@@ -6224,6 +6227,8 @@ enum_val_list:
 // CREATE [UNIQUE | INVERTED] INDEX [CONCURRENTLY] [IF NOT EXISTS] [<idxname>]
 //        ON <tablename> ( <colname> [ASC | DESC] [, ...] )
 //        [USING HASH WITH BUCKET_COUNT = <shard_buckets>] [STORING ( <colnames...> )] [<interleave>]
+//        [PARTITION BY <partition params>]
+//        [WITH <storage_parameter_list] [WHERE <where_conds...>]
 //
 // Interleave clause:
 //    INTERLEAVE IN PARENT <tablename> ( <colnames...> ) [CASCADE | RESTRICT]
@@ -6231,72 +6236,76 @@ enum_val_list:
 // %SeeAlso: CREATE TABLE, SHOW INDEXES, SHOW CREATE,
 // WEBDOCS/create-index.html
 create_index_stmt:
-  CREATE opt_unique INDEX opt_concurrently opt_index_name ON table_name opt_using_gin_btree '(' index_params ')' opt_hash_sharded opt_storing opt_interleave opt_partition_by opt_where_clause
+  CREATE opt_unique INDEX opt_concurrently opt_index_name ON table_name opt_using_gin_btree '(' index_params ')' opt_hash_sharded opt_storing opt_interleave opt_partition_by opt_with_storage_parameter_list opt_where_clause
   {
     table := $7.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateIndex{
-      Name:    tree.Name($5),
-      Table:   table,
-      Unique:  $2.bool(),
-      Columns: $10.idxElems(),
-      Sharded: $12.shardedIndexDef(),
-      Storing: $13.nameList(),
-      Interleave: $14.interleave(),
-      PartitionBy: $15.partitionBy(),
-      Predicate: $16.expr(),
-      Inverted: $8.bool(),
-      Concurrently: $4.bool(),
+      Name:          tree.Name($5),
+      Table:         table,
+      Unique:        $2.bool(),
+      Columns:       $10.idxElems(),
+      Sharded:       $12.shardedIndexDef(),
+      Storing:       $13.nameList(),
+      Interleave:    $14.interleave(),
+      PartitionBy:   $15.partitionBy(),
+      StorageParams: $16.storageParams(),
+      Predicate:     $17.expr(),
+      Inverted:      $8.bool(),
+      Concurrently:  $4.bool(),
     }
   }
-| CREATE opt_unique INDEX opt_concurrently IF NOT EXISTS index_name ON table_name opt_using_gin_btree '(' index_params ')' opt_hash_sharded opt_storing opt_interleave opt_partition_by opt_where_clause
+| CREATE opt_unique INDEX opt_concurrently IF NOT EXISTS index_name ON table_name opt_using_gin_btree '(' index_params ')' opt_hash_sharded opt_storing opt_interleave opt_partition_by opt_with_storage_parameter_list opt_where_clause
   {
     table := $10.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateIndex{
-      Name:        tree.Name($8),
-      Table:       table,
-      Unique:      $2.bool(),
-      IfNotExists: true,
-      Columns:     $13.idxElems(),
-      Sharded:     $15.shardedIndexDef(),
-      Storing:     $16.nameList(),
-      Interleave:  $17.interleave(),
-      PartitionBy: $18.partitionBy(),
-      Inverted:    $11.bool(),
-      Predicate:   $19.expr(),
-      Concurrently: $4.bool(),
+      Name:          tree.Name($8),
+      Table:         table,
+      Unique:        $2.bool(),
+      IfNotExists:   true,
+      Columns:       $13.idxElems(),
+      Sharded:       $15.shardedIndexDef(),
+      Storing:       $16.nameList(),
+      Interleave:    $17.interleave(),
+      PartitionBy:   $18.partitionBy(),
+      Inverted:      $11.bool(),
+      StorageParams: $19.storageParams(),
+      Predicate:     $20.expr(),
+      Concurrently:  $4.bool(),
     }
   }
-| CREATE opt_unique INVERTED INDEX opt_concurrently opt_index_name ON table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_where_clause
+| CREATE opt_unique INVERTED INDEX opt_concurrently opt_index_name ON table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_with_storage_parameter_list opt_where_clause
   {
     table := $8.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateIndex{
-      Name:       tree.Name($6),
-      Table:      table,
-      Unique:     $2.bool(),
-      Inverted:   true,
-      Columns:    $10.idxElems(),
-      Storing:     $12.nameList(),
-      Interleave:  $13.interleave(),
-      PartitionBy: $14.partitionBy(),
-      Predicate:   $15.expr(),
-      Concurrently: $5.bool(),
+      Name:          tree.Name($6),
+      Table:         table,
+      Unique:        $2.bool(),
+      Inverted:      true,
+      Columns:       $10.idxElems(),
+      Storing:       $12.nameList(),
+      Interleave:    $13.interleave(),
+      PartitionBy:   $14.partitionBy(),
+      StorageParams: $15.storageParams(),
+      Predicate:     $16.expr(),
+      Concurrently:  $5.bool(),
     }
   }
-| CREATE opt_unique INVERTED INDEX opt_concurrently IF NOT EXISTS index_name ON table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_where_clause
+| CREATE opt_unique INVERTED INDEX opt_concurrently IF NOT EXISTS index_name ON table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_with_storage_parameter_list opt_where_clause
   {
     table := $11.unresolvedObjectName().ToTableName()
     $$.val = &tree.CreateIndex{
-      Name:        tree.Name($9),
-      Table:       table,
-      Unique:      $2.bool(),
-      Inverted:    true,
-      IfNotExists: true,
-      Columns:     $13.idxElems(),
-      Storing:     $15.nameList(),
-      Interleave:  $16.interleave(),
-      PartitionBy: $17.partitionBy(),
-      Predicate:   $18.expr(),
-      Concurrently: $5.bool(),
+      Name:          tree.Name($9),
+      Table:         table,
+      Unique:        $2.bool(),
+      Inverted:      true,
+      IfNotExists:   true,
+      Columns:       $13.idxElems(),
+      Storing:       $15.nameList(),
+      Interleave:    $16.interleave(),
+      PartitionBy:   $17.partitionBy(),
+      StorageParams: $18.storageParams(),
+      Predicate:     $19.expr(),
+      Concurrently:  $5.bool(),
     }
   }
 | CREATE opt_unique INDEX error // SHOW HELP: CREATE INDEX

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -113,11 +113,12 @@ type CreateIndex struct {
 	Sharded     *ShardedIndexDef
 	// Extra columns to be stored together with the indexed ones as an optimization
 	// for improved reading performance.
-	Storing      NameList
-	Interleave   *InterleaveDef
-	PartitionBy  *PartitionBy
-	Predicate    Expr
-	Concurrently bool
+	Storing       NameList
+	Interleave    *InterleaveDef
+	PartitionBy   *PartitionBy
+	StorageParams StorageParams
+	Predicate     Expr
+	Concurrently  bool
 }
 
 // Format implements the NodeFormatter interface.
@@ -166,6 +167,11 @@ func (node *CreateIndex) Format(ctx *FmtCtx) {
 	}
 	if node.PartitionBy != nil {
 		ctx.FormatNode(node.PartitionBy)
+	}
+	if node.StorageParams != nil {
+		ctx.WriteString(" WITH (")
+		ctx.FormatNode(&node.StorageParams)
+		ctx.WriteString(")")
 	}
 	if node.Predicate != nil {
 		ctx.WriteString(" WHERE ")

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1510,6 +1510,7 @@ func (node *CreateIndex) doc(p *PrettyCfg) pretty.Doc {
 	//    [STORING ( ... )]
 	//    [INTERLEAVE ...]
 	//    [PARTITION BY ...]
+	//    [WITH ...]
 	//    [WHERE ...]
 	//
 	title := make([]pretty.Doc, 0, 6)
@@ -1552,6 +1553,13 @@ func (node *CreateIndex) doc(p *PrettyCfg) pretty.Doc {
 	}
 	if node.PartitionBy != nil {
 		clauses = append(clauses, p.Doc(node.PartitionBy))
+	}
+	if node.StorageParams != nil {
+		clauses = append(clauses, p.bracketKeyword(
+			"WITH", " (",
+			p.Doc(&node.StorageParams),
+			")", "",
+		))
 	}
 	if node.Predicate != nil {
 		clauses = append(clauses, p.nestUnder(pretty.Keyword("WHERE"), p.Doc(node.Predicate)))


### PR DESCRIPTION
Allow storage params to be included parsed by sql.y in the same way
CREATE TABLE is.

Refs: #51818

Release note (sql change): Allow the use of `CREATE INDEX ... WITH ...`
syntax.