### PR TITLE
release-20.1: build: print git tag at end of Make and Publish so it's easy to find

### DIFF
--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -76,3 +76,13 @@ if [[ -n "${release_branch}" ]] ; then
   gcloud container images add-tag "${gcr_repository}:${build_name}" "${gcr_repository}:latest-${release_branch}-build"
 fi
 tc_end_block "Tag docker image as latest-build"
+
+
+# Make finding the tag name easy.
+cat << EOF
+
+
+Git Tag: ${build_name}
+
+
+EOF


### PR DESCRIPTION
Backport 1/1 commits from #52608.

/cc @cockroachdb/release

---

Before: It was a pain to find the git tag for a build.

Why: So it's easier to find the tag.

Now: The tag is printed as the last statement in the build run.

Release note: None

An [example of what the output looks like in the logs](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Release_MakeAndPublishBuild/2167940?showLog=2167940_15576_544.15576).
