### PR TITLE
kvserver: make TransferLeaseRequests check for pending merge

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -29,7 +29,7 @@ func registerAcceptance(r *testRegistry) {
 		{
 			name: "bank/zerosum-splits", fn: runBankNodeZeroSum,
 			skip: "https://github.com/cockroachdb/cockroach/issues/33683 (runs into " +
-				" various errors during its rebalances, see isExpectedRelocateError)",
+				" various errors during its rebalances, see IsExpectedRelocateError)",
 		},
 		// {"bank/zerosum-restart", runBankZeroSumRestart},
 		{name: "build-info", fn: runBuildInfo},

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -644,7 +645,7 @@ func registerKVRangeLookups(r *testRegistry) {
 							EXPERIMENTAL_RELOCATE
 								SELECT ARRAY[$1, $2, $3], CAST(floor(random() * 9223372036854775808) AS INT)
 						`, newReplicas[0]+1, newReplicas[1]+1, newReplicas[2]+1)
-						if err != nil && !pgerror.IsSQLRetryableError(err) && !isExpectedRelocateError(err) {
+						if err != nil && !pgerror.IsSQLRetryableError(err) && !kv.IsExpectedRelocateError(err) {
 							return err
 						}
 					default:

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -1559,6 +1559,15 @@ func pushTxnArgs(
 	}
 }
 
+func adminTransferLeaseArgs(key roachpb.Key, target roachpb.StoreID) roachpb.Request {
+	return &roachpb.AdminTransferLeaseRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: key,
+		},
+		Target: target,
+	}
+}
+
 func TestSortRangeDescByAge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -157,7 +157,8 @@ func (r *Replica) executeWriteBatch(
 			// a serializability violation.
 			//
 			// See comment block in Subsume() in cmd_subsume.go for details.
-			log.Fatalf(ctx, "lease applied index bumped while the range was subsumed")
+			log.Fatalf(ctx,
+				"lease applied index bumped by %v while the range was subsumed", ba)
 		}
 		untrack(ctx, ctpb.Epoch(st.Lease.Epoch), r.RangeID, ctpb.LAI(maxLeaseIndex))
 	}


### PR DESCRIPTION
Currently, in `checkExecutionCanProceed`, we predicate the check for an
ongoing merge on whether we hold a `VALID` `LeaseStatus` object
(indicating that the lease is currently held by the evaluating replica).
However, a `TransferLeaseRequest` is special in that before we start
executing such a request, we invalidate the current (soon-to-be-old)
leaseholder's lease (locally on the leaseholder replica), because we'd
like it to reject all future requests with a `NotLeaseHolderError`. But
we still want the `TransferLeaseRequest` itself to execute on the
current leaseholder, so such requests carry a `skipLeaseCheck` flag.

This lets `TransferLeaseRequests` go through without checking for an
ongoing merge, which is incorrect because these requests bump the lease
applied index of the range and must not be allowed to execute when a
merge is in progress. This PR fixes this issue by broadeningthe
aforementioned predicate such that it no longer cares about the lease
status of the evaluating replica. This means that
`TransferLeaseRequest`s and follower read requests will now check for a
pending merge before proceeding.

Fixes #52517 and #52524

Release note: None
