### PR TITLE
sql: add schema to the `SHOW ENUMS` command

### DIFF
--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -463,6 +463,22 @@ func MustGetDatabaseDescByID(
 	return desc.(*sqlbase.ImmutableDatabaseDescriptor), nil
 }
 
+// MustGetSchemaDescByID looks up the schema descriptor given its ID,
+// returning an error if the descriptor is not found.
+func MustGetSchemaDescByID(
+	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, id descpb.ID,
+) (*sqlbase.ImmutableSchemaDescriptor, error) {
+	desc, err := GetAnyDescriptorByID(ctx, txn, codec, id, Immutable)
+	if err != nil || desc == nil {
+		return nil, err
+	}
+	sc, ok := desc.(*sqlbase.ImmutableSchemaDescriptor)
+	if !ok {
+		return nil, errors.Newf("descriptor with id %d was not a schema", id)
+	}
+	return sc, nil
+}
+
 // GetDatabaseDescriptorsFromIDs returns the database descriptors from an input
 // set of database IDs. It will return an error if any one of the IDs is not a
 // database. It attempts to perform this operation in a single request,

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -44,7 +44,7 @@ func TryDelegate(
 		return d.delegateShowDatabases(t)
 
 	case *tree.ShowEnums:
-		return d.delegateShowEnums(t)
+		return d.delegateShowEnums()
 
 	case *tree.ShowCreate:
 		return d.delegateShowCreate(t)

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1108,13 +1108,30 @@ local
 statement ok
 ROLLBACK
 
-query TT
+query TTT
 SHOW ENUMS
 ----
-as_bytes   bytes
-dbs        postgres|mysql|spanner|cockroach
-farewell   bye|seeya
-greeting   hello|howdy|hi
-greeting2  hello
-int        Z|S of int
-notbad     dup|DUP
+public as_bytes   bytes
+public dbs        postgres|mysql|spanner|cockroach
+public farewell   bye|seeya
+public greeting   hello|howdy|hi
+public greeting2  hello
+public int        Z|S of int
+public notbad     dup|DUP
+
+statement ok
+SET experimental_enable_user_defined_schemas = true;
+CREATE SCHEMA uds;
+CREATE TYPE uds.typ AS ENUM ('schema')
+
+query TTT
+SHOW ENUMS
+----
+public as_bytes   bytes
+public dbs        postgres|mysql|spanner|cockroach
+public farewell   bye|seeya
+public greeting   hello|howdy|hi
+public greeting2  hello
+public int        Z|S of int
+public notbad     dup|DUP
+uds    typ        schema

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1038,10 +1038,10 @@ oid     typname        typnamespace  typowner  typlen  typbyval  typtype
 90001   _geometry      1307062959    NULL      -1      false     b
 90002   geography      1307062959    NULL      -1      false     b
 90003   _geography     1307062959    NULL      -1      false     b
-100063  newtype1       1307062959    NULL      -1      false     e
-100064  _newtype1      1307062959    NULL      -1      false     b
-100065  newtype2       1307062959    NULL      -1      false     e
-100066  _newtype2      1307062959    NULL      -1      false     b
+100063  newtype1       2332901747    NULL      -1      false     e
+100064  _newtype1      2332901747    NULL      -1      false     b
+100065  newtype2       2332901747    NULL      -1      false     e
+100066  _newtype2      2332901747    NULL      -1      false     b
 
 query OTTBBTOOO colnames
 SELECT oid, typname, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray
@@ -1405,8 +1405,8 @@ SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype
 FROM pg_catalog.pg_type
 WHERE oid = 100063
 ----
-oid     typname        typnamespace  typowner  typlen  typbyval  typtype
-100063  newtype1       1307062959    NULL      -1      false     e
+oid     typname   typnamespace  typowner  typlen  typbyval  typtype
+100063  newtype1  2332901747    NULL      -1      false     e
 
 query OTOOIBT colnames
 SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2796,6 +2796,11 @@ CREATE TABLE pg_catalog.pg_type (
 
 				// Now generate rows for user defined types in this database.
 				return forEachTypeDesc(ctx, p, dbContext, func(_ *sqlbase.ImmutableDatabaseDescriptor, _ string, typDesc *sqlbase.ImmutableTypeDescriptor) error {
+					schema, err := p.getSchemaNameFromID(ctx, typDesc.ParentSchemaID)
+					if err != nil {
+						return err
+					}
+					nspOid := h.NamespaceOid(db, schema)
 					typ, err := typDesc.MakeTypesT(ctx, tree.NewUnqualifiedTypeName(tree.Name(typDesc.GetName())), p)
 					if err != nil {
 						return err
@@ -2836,6 +2841,11 @@ CREATE TABLE pg_catalog.pg_type (
 					}
 					return false, err
 				}
+				schema, err := p.getSchemaNameFromID(ctx, typDesc.ParentSchemaID)
+				if err != nil {
+					return false, err
+				}
+				nspOid = h.NamespaceOid(db, schema)
 				typ, err = typDesc.MakeTypesT(ctx, tree.NewUnqualifiedTypeName(tree.Name(typDesc.GetName())), p)
 				if err != nil {
 					return false, err

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -147,6 +147,21 @@ func (p *planner) CommonLookupFlags(required bool) tree.CommonLookupFlags {
 	}
 }
 
+// TODO (lucy-zhang): This API should be removed and moved into the descs.Collection.
+// TODO (rohany): This API doesn't yet support the temporary schema. Checking
+//  against the session's temporary schema information should be implemented
+//  when this is moved into the descs.Collection.
+func (p *planner) getSchemaNameFromID(ctx context.Context, id descpb.ID) (string, error) {
+	if id == keys.PublicSchemaID {
+		return tree.PublicSchema, nil
+	}
+	sc, err := catalogkv.MustGetSchemaDescByID(ctx, p.txn, p.ExecCfg().Codec, id)
+	if err != nil {
+		return "", err
+	}
+	return sc.GetName(), nil
+}
+
 // GetTypeDescriptor implements the descpb.TypeDescriptorResolver interface.
 func (p *planner) GetTypeDescriptor(
 	ctx context.Context, id descpb.ID,


### PR DESCRIPTION
Fixes #52636.

This commits adds the schema of the type to the output of the `SHOW
ENUMS` command.

Release note: None