### PR TITLE
opt: improve system column handling in optbuilder

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mvcc
+++ b/pkg/sql/logictest/testdata/logic_test/mvcc
@@ -90,6 +90,17 @@ SELECT z = ($update_ts + 1.0)::INT FROM t WHERE x = 1
 ----
 true
 
+let $update_ts
+SELECT crdb_internal_mvcc_timestamp FROM t WHERE x = 1
+
+statement ok
+INSERT INTO t VALUES (1, 2, 3) ON CONFLICT (x) DO UPDATE SET z = (crdb_internal_mvcc_timestamp + 1.0)::INT
+
+query B
+SELECT z = ($update_ts + 1.0)::INT FROM t WHERE x = 1
+----
+true
+
 query IIB
 SELECT x, y, crdb_internal_mvcc_timestamp IS NOT NULL AS foo FROM t ORDER BY foo
 ----

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -241,20 +241,20 @@ project
            │    ├── fd: (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11)
            │    ├── prune: (6,7,10,11)
            │    └── select
-           │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:22(int) b:23(int) c:24(int) rowid:25(int) abc.crdb_internal_mvcc_timestamp:26(decimal)
+           │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:22(int) b:23(int) c:24(int) rowid:25(int)
            │         ├── volatile
            │         ├── key: (6)
-           │         ├── fd: ()-->(22-26), (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11)
-           │         ├── prune: (22,26)
+           │         ├── fd: ()-->(22-25), (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11)
+           │         ├── prune: (22)
            │         ├── interesting orderings: (+25) (+22) (+23,+24,+25)
            │         ├── left-join (hash)
-           │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:22(int) b:23(int) c:24(int) rowid:25(int) abc.crdb_internal_mvcc_timestamp:26(decimal)
+           │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:22(int) b:23(int) c:24(int) rowid:25(int)
            │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
            │         │    ├── volatile
            │         │    ├── key: (6,25)
-           │         │    ├── fd: (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11), (25)-->(22-24,26), (22)-->(23-26), (23,24)~~>(22,25,26)
-           │         │    ├── prune: (22,25,26)
-           │         │    ├── reject-nulls: (22-26)
+           │         │    ├── fd: (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11), (25)-->(22-24), (22)-->(23-25), (23,24)~~>(22,25)
+           │         │    ├── prune: (22,25)
+           │         │    ├── reject-nulls: (22-25)
            │         │    ├── interesting orderings: (+25) (+22) (+23,+24,+25)
            │         │    ├── upsert-distinct-on
            │         │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
@@ -269,20 +269,20 @@ project
            │         │    │    │    ├── fd: (6)-->(7,10), (7)-->(11), (10)~~>(6,7,11)
            │         │    │    │    ├── prune: (6,7,10,11)
            │         │    │    │    └── select
-           │         │    │    │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:17(int) b:18(int) c:19(int) rowid:20(int) abc.crdb_internal_mvcc_timestamp:21(decimal)
+           │         │    │    │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:17(int) b:18(int) c:19(int) rowid:20(int)
            │         │    │    │         ├── volatile
            │         │    │    │         ├── key: (6)
-           │         │    │    │         ├── fd: ()-->(17-21), (6)-->(7,10), (7)-->(11), (10)~~>(6,7,11)
-           │         │    │    │         ├── prune: (18-21)
+           │         │    │    │         ├── fd: ()-->(17-20), (6)-->(7,10), (7)-->(11), (10)~~>(6,7,11)
+           │         │    │    │         ├── prune: (18-20)
            │         │    │    │         ├── interesting orderings: (+20) (+17) (+18,+19,+20)
            │         │    │    │         ├── left-join (hash)
-           │         │    │    │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:17(int) b:18(int) c:19(int) rowid:20(int) abc.crdb_internal_mvcc_timestamp:21(decimal)
+           │         │    │    │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:17(int) b:18(int) c:19(int) rowid:20(int)
            │         │    │    │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
            │         │    │    │         │    ├── volatile
            │         │    │    │         │    ├── key: (6)
-           │         │    │    │         │    ├── fd: (6)-->(7,10,17-21), (7)-->(11), (10)~~>(6,7,11), (20)-->(17-19,21), (17)-->(18-21), (18,19)~~>(17,20,21)
-           │         │    │    │         │    ├── prune: (18-21)
-           │         │    │    │         │    ├── reject-nulls: (17-21)
+           │         │    │    │         │    ├── fd: (6)-->(7,10,17-20), (7)-->(11), (10)~~>(6,7,11), (20)-->(17-19), (17)-->(18-20), (18,19)~~>(17,20)
+           │         │    │    │         │    ├── prune: (18-20)
+           │         │    │    │         │    ├── reject-nulls: (17-20)
            │         │    │    │         │    ├── interesting orderings: (+20) (+17) (+18,+19,+20)
            │         │    │    │         │    ├── upsert-distinct-on
            │         │    │    │         │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
@@ -298,20 +298,20 @@ project
            │         │    │    │         │    │    │    ├── prune: (6,7,10,11)
            │         │    │    │         │    │    │    ├── interesting orderings: (+6) (+7)
            │         │    │    │         │    │    │    └── select
-           │         │    │    │         │    │    │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:12(int) b:13(int) c:14(int) rowid:15(int) abc.crdb_internal_mvcc_timestamp:16(decimal)
+           │         │    │    │         │    │    │         ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:12(int) b:13(int) c:14(int) rowid:15(int)
            │         │    │    │         │    │    │         ├── volatile
            │         │    │    │         │    │    │         ├── key: (6)
-           │         │    │    │         │    │    │         ├── fd: ()-->(12-16), (6)-->(7,10), (7)-->(11)
-           │         │    │    │         │    │    │         ├── prune: (6,7,11-14,16)
+           │         │    │    │         │    │    │         ├── fd: ()-->(12-15), (6)-->(7,10), (7)-->(11)
+           │         │    │    │         │    │    │         ├── prune: (6,7,11-14)
            │         │    │    │         │    │    │         ├── interesting orderings: (+6) (+7) (+15) (+12) (+13,+14,+15)
            │         │    │    │         │    │    │         ├── left-join (hash)
-           │         │    │    │         │    │    │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:12(int) b:13(int) c:14(int) rowid:15(int) abc.crdb_internal_mvcc_timestamp:16(decimal)
+           │         │    │    │         │    │    │         │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int) a:12(int) b:13(int) c:14(int) rowid:15(int)
            │         │    │    │         │    │    │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
            │         │    │    │         │    │    │         │    ├── volatile
            │         │    │    │         │    │    │         │    ├── key: (6)
-           │         │    │    │         │    │    │         │    ├── fd: (6)-->(7,10,12-16), (7)-->(11), (15)-->(12-14,16), (12)-->(13-16), (13,14)~~>(12,15,16)
-           │         │    │    │         │    │    │         │    ├── prune: (6,7,11-14,16)
-           │         │    │    │         │    │    │         │    ├── reject-nulls: (12-16)
+           │         │    │    │         │    │    │         │    ├── fd: (6)-->(7,10,12-15), (7)-->(11), (15)-->(12-14), (12)-->(13-15), (13,14)~~>(12,15)
+           │         │    │    │         │    │    │         │    ├── prune: (6,7,11-14)
+           │         │    │    │         │    │    │         │    ├── reject-nulls: (12-15)
            │         │    │    │         │    │    │         │    ├── interesting orderings: (+6) (+7) (+15) (+12) (+13,+14,+15)
            │         │    │    │         │    │    │         │    ├── project
            │         │    │    │         │    │    │         │    │    ├── columns: column11:11(int) x:6(int!null) y:7(int) column10:10(int)
@@ -350,15 +350,15 @@ project
            │         │    │    │         │    │    │         │    │              ├── variable: y:7 [type=int]
            │         │    │    │         │    │    │         │    │              └── const: 1 [type=int]
            │         │    │    │         │    │    │         │    ├── scan abc
-           │         │    │    │         │    │    │         │    │    ├── columns: a:12(int!null) b:13(int) c:14(int) rowid:15(int!null) abc.crdb_internal_mvcc_timestamp:16(decimal)
+           │         │    │    │         │    │    │         │    │    ├── columns: a:12(int!null) b:13(int) c:14(int) rowid:15(int!null)
            │         │    │    │         │    │    │         │    │    ├── computed column expressions
            │         │    │    │         │    │    │         │    │    │    └── c:14
            │         │    │    │         │    │    │         │    │    │         └── plus [type=int]
            │         │    │    │         │    │    │         │    │    │              ├── variable: b:13 [type=int]
            │         │    │    │         │    │    │         │    │    │              └── const: 1 [type=int]
            │         │    │    │         │    │    │         │    │    ├── key: (15)
-           │         │    │    │         │    │    │         │    │    ├── fd: (15)-->(12-14,16), (12)-->(13-16), (13,14)~~>(12,15,16)
-           │         │    │    │         │    │    │         │    │    ├── prune: (12-16)
+           │         │    │    │         │    │    │         │    │    ├── fd: (15)-->(12-14), (12)-->(13-15), (13,14)~~>(12,15)
+           │         │    │    │         │    │    │         │    │    ├── prune: (12-15)
            │         │    │    │         │    │    │         │    │    ├── interesting orderings: (+15) (+12) (+13,+14,+15)
            │         │    │    │         │    │    │         │    │    └── unfiltered-cols: (12-16)
            │         │    │    │         │    │    │         │    └── filters
@@ -377,15 +377,15 @@ project
            │         │    │    │         │    │         └── first-agg [as=column11:11, type=int, outer=(11)]
            │         │    │    │         │    │              └── variable: column11:11 [type=int]
            │         │    │    │         │    ├── scan abc
-           │         │    │    │         │    │    ├── columns: a:17(int!null) b:18(int) c:19(int) rowid:20(int!null) abc.crdb_internal_mvcc_timestamp:21(decimal)
+           │         │    │    │         │    │    ├── columns: a:17(int!null) b:18(int) c:19(int) rowid:20(int!null)
            │         │    │    │         │    │    ├── computed column expressions
            │         │    │    │         │    │    │    └── c:19
            │         │    │    │         │    │    │         └── plus [type=int]
            │         │    │    │         │    │    │              ├── variable: b:18 [type=int]
            │         │    │    │         │    │    │              └── const: 1 [type=int]
            │         │    │    │         │    │    ├── key: (20)
-           │         │    │    │         │    │    ├── fd: (20)-->(17-19,21), (17)-->(18-21), (18,19)~~>(17,20,21)
-           │         │    │    │         │    │    ├── prune: (17-21)
+           │         │    │    │         │    │    ├── fd: (20)-->(17-19), (17)-->(18-20), (18,19)~~>(17,20)
+           │         │    │    │         │    │    ├── prune: (17-20)
            │         │    │    │         │    │    ├── interesting orderings: (+20) (+17) (+18,+19,+20)
            │         │    │    │         │    │    └── unfiltered-cols: (17-21)
            │         │    │    │         │    └── filters
@@ -404,15 +404,15 @@ project
            │         │    │         └── first-agg [as=column11:11, type=int, outer=(11)]
            │         │    │              └── variable: column11:11 [type=int]
            │         │    ├── scan abc
-           │         │    │    ├── columns: a:22(int!null) b:23(int) c:24(int) rowid:25(int!null) abc.crdb_internal_mvcc_timestamp:26(decimal)
+           │         │    │    ├── columns: a:22(int!null) b:23(int) c:24(int) rowid:25(int!null)
            │         │    │    ├── computed column expressions
            │         │    │    │    └── c:24
            │         │    │    │         └── plus [type=int]
            │         │    │    │              ├── variable: b:23 [type=int]
            │         │    │    │              └── const: 1 [type=int]
            │         │    │    ├── key: (25)
-           │         │    │    ├── fd: (25)-->(22-24,26), (22)-->(23-26), (23,24)~~>(22,25,26)
-           │         │    │    ├── prune: (22-26)
+           │         │    │    ├── fd: (25)-->(22-24), (22)-->(23-25), (23,24)~~>(22,25)
+           │         │    │    ├── prune: (22-25)
            │         │    │    ├── interesting orderings: (+25) (+22) (+23,+24,+25)
            │         │    │    └── unfiltered-cols: (22-26)
            │         │    └── filters

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -112,12 +112,7 @@ func (cb *onDeleteCascadeBuilder) Build(
 	)
 
 	// Set list of columns that will be fetched by the input expression.
-	for i := range mb.outScope.cols {
-		// Ensure that we don't add system columns to the fetch columns.
-		if !mb.outScope.cols[i].system {
-			mb.fetchColIDs[i] = mb.outScope.cols[i].id
-		}
-	}
+	mb.setFetchColIDs(mb.outScope.cols)
 	mb.buildDelete(nil /* returning */)
 	return mb.outScope.expr, nil
 }
@@ -225,12 +220,7 @@ func (cb *onDeleteSetBuilder) Build(
 	)
 
 	// Set list of columns that will be fetched by the input expression.
-	for i := range mb.outScope.cols {
-		// Ensure that we don't add system columns to the fetch columns.
-		if !mb.outScope.cols[i].system {
-			mb.fetchColIDs[i] = mb.outScope.cols[i].id
-		}
-	}
+	mb.setFetchColIDs(mb.outScope.cols)
 	// Add target columns.
 	numFKCols := fk.ColumnCount()
 	for i := 0; i < numFKCols; i++ {
@@ -294,10 +284,12 @@ func (b *Builder) buildDeleteCascadeMutationInput(
 ) (outScope *scope) {
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
-		nil, /* ordinals */
+		tableOrdinals(childTable, columnKinds{
+			includeMutations: false,
+			includeSystem:    false,
+		}),
 		nil, /* indexFlags */
 		noRowLocking,
-		excludeMutations,
 		b.allocScope(),
 	)
 
@@ -453,12 +445,7 @@ func (cb *onUpdateCascadeBuilder) Build(
 	newValScopeCols := mb.outScope.cols[len(mb.outScope.cols)-numFKCols:]
 
 	// Set list of columns that will be fetched by the input expression.
-	for i := range tableScopeCols {
-		// Ensure that we don't add system columns to the fetch columns.
-		if !tableScopeCols[i].system {
-			mb.fetchColIDs[i] = tableScopeCols[i].id
-		}
-	}
+	mb.setFetchColIDs(tableScopeCols)
 	// Add target columns.
 	for i := 0; i < numFKCols; i++ {
 		tabOrd := fk.OriginColumnOrdinal(cb.childTable, i)
@@ -541,10 +528,12 @@ func (b *Builder) buildUpdateCascadeMutationInput(
 ) (outScope *scope) {
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
-		nil, /* ordinals */
+		tableOrdinals(childTable, columnKinds{
+			includeMutations: false,
+			includeSystem:    false,
+		}),
 		nil, /* indexFlags */
 		noRowLocking,
-		excludeMutations,
 		b.allocScope(),
 	)
 

--- a/pkg/sql/opt/optbuilder/mutation_builder_fk.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_fk.go
@@ -653,7 +653,6 @@ func (h *fkCheckHelper) buildOtherTableScan() (outScope *scope, tabMeta *opt.Tab
 		h.otherTabOrdinals,
 		&tree.IndexFlags{IgnoreForeignKeys: true},
 		noRowLocking,
-		excludeMutations,
 		h.mb.b.allocScope(),
 	), otherTabMeta
 }

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
@@ -39,13 +40,16 @@ type scopeColumn struct {
 	// included.
 	hidden bool
 
+	// tableOrdinal is set to the table ordinal corresponding to this column, if
+	// this is a column from a scan.
+	tableOrdinal int
+
 	// mutation is true if the column is in the process of being dropped or added
 	// to the table. It should not be visible to variable references.
 	mutation bool
 
-	// system is true if the column is an implicit system column. It should not
-	// be included in mutations.
-	system bool
+	// kind of the table column, if this is a column from a scan.
+	kind cat.ColumnKind
 
 	// descending indicates whether this column is sorted in descending order.
 	// This field is only used for ordering columns.

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -47,15 +47,15 @@ insert child
  │    ├── project
  │    │    ├── columns: column1:4!null column2:5!null
  │    │    └── select
- │    │         ├── columns: column1:4!null column2:5!null c:6 child.p:7 child.crdb_internal_mvcc_timestamp:8
+ │    │         ├── columns: column1:4!null column2:5!null c:6 child.p:7
  │    │         ├── left-join (hash)
- │    │         │    ├── columns: column1:4!null column2:5!null c:6 child.p:7 child.crdb_internal_mvcc_timestamp:8
+ │    │         │    ├── columns: column1:4!null column2:5!null c:6 child.p:7
  │    │         │    ├── values
  │    │         │    │    ├── columns: column1:4!null column2:5!null
  │    │         │    │    ├── (100, 1)
  │    │         │    │    └── (200, 1)
  │    │         │    ├── scan child
- │    │         │    │    └── columns: c:6!null child.p:7!null child.crdb_internal_mvcc_timestamp:8
+ │    │         │    │    └── columns: c:6!null child.p:7!null
  │    │         │    └── filters
  │    │         │         └── column1:4 = c:6
  │    │         └── filters

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
@@ -28,9 +28,9 @@ root
            ├── columns: <none>
            ├── fetch columns: c:8 child.p:9
            └── semi-join (hash)
-                ├── columns: c:8!null child.p:9!null child.crdb_internal_mvcc_timestamp:10
+                ├── columns: c:8!null child.p:9!null
                 ├── scan child
-                │    └── columns: c:8!null child.p:9!null child.crdb_internal_mvcc_timestamp:10
+                │    └── columns: c:8!null child.p:9!null
                 ├── with-scan &1
                 │    ├── columns: p:11!null
                 │    └── mapping:
@@ -67,9 +67,9 @@ root
       │    ├── cascades
       │    │    └── fk_c_ref_child
       │    └── semi-join (hash)
-      │         ├── columns: c:8!null child.p:9!null child.crdb_internal_mvcc_timestamp:10
+      │         ├── columns: c:8!null child.p:9!null
       │         ├── scan child
-      │         │    └── columns: c:8!null child.p:9!null child.crdb_internal_mvcc_timestamp:10
+      │         │    └── columns: c:8!null child.p:9!null
       │         ├── with-scan &1
       │         │    ├── columns: p:11!null
       │         │    └── mapping:
@@ -81,9 +81,9 @@ root
                 ├── columns: <none>
                 ├── fetch columns: g:15 grandchild.c:16
                 └── semi-join (hash)
-                     ├── columns: g:15!null grandchild.c:16 grandchild.crdb_internal_mvcc_timestamp:17
+                     ├── columns: g:15!null grandchild.c:16
                      ├── scan grandchild
-                     │    └── columns: g:15!null grandchild.c:16 grandchild.crdb_internal_mvcc_timestamp:17
+                     │    └── columns: g:15!null grandchild.c:16
                      ├── with-scan &2
                      │    ├── columns: c:18!null
                      │    └── mapping:
@@ -122,9 +122,9 @@ root
            ├── fetch columns: child.c:8 child.p:9
            ├── input binding: &2
            ├── semi-join (hash)
-           │    ├── columns: child.c:8!null child.p:9!null child.crdb_internal_mvcc_timestamp:10
+           │    ├── columns: child.c:8!null child.p:9!null
            │    ├── scan child
-           │    │    └── columns: child.c:8!null child.p:9!null child.crdb_internal_mvcc_timestamp:10
+           │    │    └── columns: child.c:8!null child.p:9!null
            │    ├── with-scan &1
            │    │    ├── columns: p:11!null
            │    │    └── mapping:
@@ -173,9 +173,9 @@ root
       │    ├── cascades
       │    │    └── fk_b_ref_self
       │    └── semi-join (hash)
-      │         ├── columns: self.a:10!null b:11 crdb_internal_mvcc_timestamp:12
+      │         ├── columns: self.a:10!null b:11
       │         ├── scan self
-      │         │    └── columns: self.a:10!null b:11 crdb_internal_mvcc_timestamp:12
+      │         │    └── columns: self.a:10!null b:11
       │         ├── with-scan &1
       │         │    ├── columns: a:13!null
       │         │    └── mapping:
@@ -190,9 +190,9 @@ root
            │    ├── cascades
            │    │    └── fk_b_ref_self
            │    └── semi-join (hash)
-           │         ├── columns: self.a:17!null b:18 crdb_internal_mvcc_timestamp:19
+           │         ├── columns: self.a:17!null b:18
            │         ├── scan self
-           │         │    └── columns: self.a:17!null b:18 crdb_internal_mvcc_timestamp:19
+           │         │    └── columns: self.a:17!null b:18
            │         ├── with-scan &2
            │         │    ├── columns: a:20!null
            │         │    └── mapping:
@@ -207,9 +207,9 @@ root
                      ├── cascades
                      │    └── fk_b_ref_self
                      └── semi-join (hash)
-                          ├── columns: self.a:24!null b:25 crdb_internal_mvcc_timestamp:26
+                          ├── columns: self.a:24!null b:25
                           ├── scan self
-                          │    └── columns: self.a:24!null b:25 crdb_internal_mvcc_timestamp:26
+                          │    └── columns: self.a:24!null b:25
                           ├── with-scan &3
                           │    ├── columns: a:27!null
                           │    └── mapping:
@@ -266,9 +266,9 @@ root
       │    ├── cascades
       │    │    └── cd_ef
       │    └── semi-join (hash)
-      │         ├── columns: e:10!null f:11 ef.crdb_internal_mvcc_timestamp:12
+      │         ├── columns: e:10!null f:11
       │         ├── scan ef
-      │         │    └── columns: e:10!null f:11 ef.crdb_internal_mvcc_timestamp:12
+      │         │    └── columns: e:10!null f:11
       │         ├── with-scan &1
       │         │    ├── columns: a:13!null
       │         │    └── mapping:
@@ -283,9 +283,9 @@ root
            │    ├── cascades
            │    │    └── ab_cd
            │    └── semi-join (hash)
-           │         ├── columns: c:17!null d:18 cd.crdb_internal_mvcc_timestamp:19
+           │         ├── columns: c:17!null d:18
            │         ├── scan cd
-           │         │    └── columns: c:17!null d:18 cd.crdb_internal_mvcc_timestamp:19
+           │         │    └── columns: c:17!null d:18
            │         ├── with-scan &2
            │         │    ├── columns: e:20!null
            │         │    └── mapping:
@@ -300,9 +300,9 @@ root
                      ├── cascades
                      │    └── ef_ab
                      └── semi-join (hash)
-                          ├── columns: ab.a:24!null b:25 ab.crdb_internal_mvcc_timestamp:26
+                          ├── columns: ab.a:24!null b:25
                           ├── scan ab
-                          │    └── columns: ab.a:24!null b:25 ab.crdb_internal_mvcc_timestamp:26
+                          │    └── columns: ab.a:24!null b:25
                           ├── with-scan &3
                           │    ├── columns: c:27!null
                           │    └── mapping:

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
@@ -30,11 +30,11 @@ root
            │    └── p_new:12 => child.p:6
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:12!null c:8!null child.p:9 child.crdb_internal_mvcc_timestamp:10
+           │    ├── columns: p_new:12!null c:8!null child.p:9
            │    ├── semi-join (hash)
-           │    │    ├── columns: c:8!null child.p:9 child.crdb_internal_mvcc_timestamp:10
+           │    │    ├── columns: c:8!null child.p:9
            │    │    ├── scan child
-           │    │    │    └── columns: c:8!null child.p:9 child.crdb_internal_mvcc_timestamp:10
+           │    │    │    └── columns: c:8!null child.p:9
            │    │    ├── with-scan &1
            │    │    │    ├── columns: p:11!null
            │    │    │    └── mapping:
@@ -89,11 +89,11 @@ root
            ├── update-mapping:
            │    └── p_new:12 => child_null.p:6
            └── project
-                ├── columns: p_new:12 c:8!null child_null.p:9 child_null.crdb_internal_mvcc_timestamp:10
+                ├── columns: p_new:12 c:8!null child_null.p:9
                 ├── semi-join (hash)
-                │    ├── columns: c:8!null child_null.p:9 child_null.crdb_internal_mvcc_timestamp:10
+                │    ├── columns: c:8!null child_null.p:9
                 │    ├── scan child_null
-                │    │    └── columns: c:8!null child_null.p:9 child_null.crdb_internal_mvcc_timestamp:10
+                │    │    └── columns: c:8!null child_null.p:9
                 │    ├── with-scan &1
                 │    │    ├── columns: p:11!null
                 │    │    └── mapping:
@@ -150,15 +150,15 @@ root
            ├── check columns: check1:27
            ├── input binding: &2
            ├── project
-           │    ├── columns: check1:27!null child_multicol.c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 child_multicol.crdb_internal_mvcc_timestamp:20 q_new:24 r_new:25 column26:26
+           │    ├── columns: check1:27!null child_multicol.c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 q_new:24 r_new:25 column26:26
            │    ├── project
-           │    │    ├── columns: column26:26 child_multicol.c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 child_multicol.crdb_internal_mvcc_timestamp:20 q_new:24 r_new:25
+           │    │    ├── columns: column26:26 child_multicol.c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 q_new:24 r_new:25
            │    │    ├── project
-           │    │    │    ├── columns: q_new:24 r_new:25 child_multicol.c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 child_multicol.crdb_internal_mvcc_timestamp:20
+           │    │    │    ├── columns: q_new:24 r_new:25 child_multicol.c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19
            │    │    │    ├── semi-join (hash)
-           │    │    │    │    ├── columns: child_multicol.c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 child_multicol.crdb_internal_mvcc_timestamp:20
+           │    │    │    │    ├── columns: child_multicol.c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19
            │    │    │    │    ├── scan child_multicol
-           │    │    │    │    │    ├── columns: child_multicol.c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 child_multicol.crdb_internal_mvcc_timestamp:20
+           │    │    │    │    │    ├── columns: child_multicol.c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19
            │    │    │    │    │    └── computed column expressions
            │    │    │    │    │         └── x:19
            │    │    │    │    │              └── (child_multicol.p:16 + child_multicol.q:17) + child_multicol.r:18

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
@@ -29,11 +29,11 @@ root
            ├── update-mapping:
            │    └── p_new:12 => child.p:6
            └── project
-                ├── columns: p_new:12 c:8!null child.p:9 child.crdb_internal_mvcc_timestamp:10
+                ├── columns: p_new:12 c:8!null child.p:9
                 ├── semi-join (hash)
-                │    ├── columns: c:8!null child.p:9 child.crdb_internal_mvcc_timestamp:10
+                │    ├── columns: c:8!null child.p:9
                 │    ├── scan child
-                │    │    └── columns: c:8!null child.p:9 child.crdb_internal_mvcc_timestamp:10
+                │    │    └── columns: c:8!null child.p:9
                 │    ├── with-scan &1
                 │    │    ├── columns: p:11!null
                 │    │    └── mapping:
@@ -88,15 +88,15 @@ root
            │    └── column25:25 => x:13
            ├── check columns: check1:26
            └── project
-                ├── columns: check1:26!null c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 child_multicol.crdb_internal_mvcc_timestamp:20 p_new:24 column25:25
+                ├── columns: check1:26!null c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 p_new:24 column25:25
                 ├── project
-                │    ├── columns: column25:25 c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 child_multicol.crdb_internal_mvcc_timestamp:20 p_new:24
+                │    ├── columns: column25:25 c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 p_new:24
                 │    ├── project
-                │    │    ├── columns: p_new:24 c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 child_multicol.crdb_internal_mvcc_timestamp:20
+                │    │    ├── columns: p_new:24 c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19
                 │    │    ├── semi-join (hash)
-                │    │    │    ├── columns: c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 child_multicol.crdb_internal_mvcc_timestamp:20
+                │    │    │    ├── columns: c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19
                 │    │    │    ├── scan child_multicol
-                │    │    │    │    ├── columns: c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 child_multicol.crdb_internal_mvcc_timestamp:20
+                │    │    │    │    ├── columns: c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19
                 │    │    │    │    ├── check constraint expressions
                 │    │    │    │    │    └── (c:15 > 100) OR (child_multicol.p:16 IS NOT NULL)
                 │    │    │    │    └── computed column expressions

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -36,9 +36,9 @@ root
            │    └── p_new:13 => child.p:7
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:9!null child.p:10!null child.crdb_internal_mvcc_timestamp:11 p:12!null p_new:13!null
+           │    ├── columns: c:9!null child.p:10!null p:12!null p_new:13!null
            │    ├── scan child
-           │    │    └── columns: c:9!null child.p:10!null child.crdb_internal_mvcc_timestamp:11
+           │    │    └── columns: c:9!null child.p:10!null
            │    ├── select
            │    │    ├── columns: p:12!null p_new:13!null
            │    │    ├── with-scan &1
@@ -116,9 +116,9 @@ root
            │    └── q_new:22 => child_multi.q:13
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:15!null child_multi.p:16!null child_multi.q:17!null child_multi.crdb_internal_mvcc_timestamp:18 p:19!null q:20!null p_new:21 q_new:22
+           │    ├── columns: c:15!null child_multi.p:16!null child_multi.q:17!null p:19!null q:20!null p_new:21 q_new:22
            │    ├── scan child_multi
-           │    │    └── columns: c:15!null child_multi.p:16 child_multi.q:17 child_multi.crdb_internal_mvcc_timestamp:18
+           │    │    └── columns: c:15!null child_multi.p:16 child_multi.q:17
            │    ├── select
            │    │    ├── columns: p:19 q:20 p_new:21 q_new:22
            │    │    ├── with-scan &1
@@ -186,9 +186,9 @@ root
            │    └── q:21 => child_multi.q:12
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null child_multi.crdb_internal_mvcc_timestamp:17 p:18!null q:19!null p_new:20!null q:21
+           │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null p:18!null q:19!null p_new:20!null q:21
            │    ├── scan child_multi
-           │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16 child_multi.crdb_internal_mvcc_timestamp:17
+           │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16
            │    ├── select
            │    │    ├── columns: p:18!null q:19 p_new:20!null q:21
            │    │    ├── with-scan &1
@@ -271,9 +271,9 @@ root
            │    └── column3:24 => child_multi.q:15
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null child_multi.crdb_internal_mvcc_timestamp:20 p:21!null q:22!null column2:23!null column3:24!null
+           │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:21!null q:22!null column2:23!null column3:24!null
            │    ├── scan child_multi
-           │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19 child_multi.crdb_internal_mvcc_timestamp:20
+           │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
            │    ├── select
            │    │    ├── columns: p:21 q:22 column2:23!null column3:24!null
            │    │    ├── with-scan &1
@@ -357,9 +357,9 @@ root
            │    └── q:25 => child_multi.q:16
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null child_multi.crdb_internal_mvcc_timestamp:21 p:22!null q:23!null column2:24!null q:25
+           │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p:22!null q:23!null column2:24!null q:25
            │    ├── scan child_multi
-           │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20 child_multi.crdb_internal_mvcc_timestamp:21
+           │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20
            │    ├── select
            │    │    ├── columns: p:22 q:23 column2:24!null q:25
            │    │    ├── with-scan &1
@@ -446,9 +446,9 @@ root
            │    └── q:27 => child_multi.q:18
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null child_multi.crdb_internal_mvcc_timestamp:23 p:24!null q:25!null upsert_p:26!null q:27
+           │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p:24!null q:25!null upsert_p:26!null q:27
            │    ├── scan child_multi
-           │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22 child_multi.crdb_internal_mvcc_timestamp:23
+           │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22
            │    ├── select
            │    │    ├── columns: p:24 q:25 upsert_p:26!null q:27
            │    │    ├── with-scan &1
@@ -524,9 +524,9 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── inner-join (hash)
-      │    │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null child_multi.crdb_internal_mvcc_timestamp:17 p:18!null q:19!null p:20!null q_new:21
+      │    │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null p:18!null q:19!null p:20!null q_new:21
       │    │    ├── scan child_multi
-      │    │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16 child_multi.crdb_internal_mvcc_timestamp:17
+      │    │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16
       │    │    ├── select
       │    │    │    ├── columns: p:18!null q:19 p:20!null q_new:21
       │    │    │    ├── with-scan &1
@@ -568,9 +568,9 @@ root
                 │    └── q_new:39 => grandchild.q:30
                 ├── input binding: &3
                 ├── inner-join (hash)
-                │    ├── columns: g:32!null grandchild.c:33!null grandchild.q:34!null grandchild.crdb_internal_mvcc_timestamp:35 c:36!null q:37!null c:38!null q_new:39
+                │    ├── columns: g:32!null grandchild.c:33!null grandchild.q:34!null c:36!null q:37!null c:38!null q_new:39
                 │    ├── scan grandchild
-                │    │    └── columns: g:32!null grandchild.c:33 grandchild.q:34 grandchild.crdb_internal_mvcc_timestamp:35
+                │    │    └── columns: g:32!null grandchild.c:33 grandchild.q:34
                 │    ├── select
                 │    │    ├── columns: c:36!null q:37!null c:38!null q_new:39
                 │    │    ├── with-scan &2
@@ -655,9 +655,9 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── inner-join (hash)
-      │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null child_multi.crdb_internal_mvcc_timestamp:20 p:21!null q:22!null column2:23!null column3:24!null
+      │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:21!null q:22!null column2:23!null column3:24!null
       │    │    ├── scan child_multi
-      │    │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19 child_multi.crdb_internal_mvcc_timestamp:20
+      │    │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
       │    │    ├── select
       │    │    │    ├── columns: p:21 q:22 column2:23!null column3:24!null
       │    │    │    ├── with-scan &1
@@ -695,9 +695,9 @@ root
                 │    └── column3:42 => grandchild.q:33
                 ├── input binding: &3
                 ├── inner-join (hash)
-                │    ├── columns: g:35!null grandchild.c:36!null grandchild.q:37!null grandchild.crdb_internal_mvcc_timestamp:38 c:39!null q:40!null c:41!null column3:42!null
+                │    ├── columns: g:35!null grandchild.c:36!null grandchild.q:37!null c:39!null q:40!null c:41!null column3:42!null
                 │    ├── scan grandchild
-                │    │    └── columns: g:35!null grandchild.c:36 grandchild.q:37 grandchild.crdb_internal_mvcc_timestamp:38
+                │    │    └── columns: g:35!null grandchild.c:36 grandchild.q:37
                 │    ├── select
                 │    │    ├── columns: c:39!null q:40!null c:41!null column3:42!null
                 │    │    ├── with-scan &2

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
@@ -36,11 +36,11 @@ root
            │    └── p_new:14 => child.p:7
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:14!null c:9!null child.p:10!null child.crdb_internal_mvcc_timestamp:11 p:12!null p_new:13!null
+           │    ├── columns: p_new:14!null c:9!null child.p:10!null p:12!null p_new:13!null
            │    ├── inner-join (hash)
-           │    │    ├── columns: c:9!null child.p:10!null child.crdb_internal_mvcc_timestamp:11 p:12!null p_new:13!null
+           │    │    ├── columns: c:9!null child.p:10!null p:12!null p_new:13!null
            │    │    ├── scan child
-           │    │    │    └── columns: c:9!null child.p:10!null child.crdb_internal_mvcc_timestamp:11
+           │    │    │    └── columns: c:9!null child.p:10!null
            │    │    ├── select
            │    │    │    ├── columns: p:12!null p_new:13!null
            │    │    │    ├── with-scan &1
@@ -121,11 +121,11 @@ root
            │    └── q_new:24 => child_multi.q:13
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:23!null q_new:24!null c:15!null child_multi.p:16!null child_multi.q:17!null child_multi.crdb_internal_mvcc_timestamp:18 p:19!null q:20!null p_new:21 q_new:22
+           │    ├── columns: p_new:23!null q_new:24!null c:15!null child_multi.p:16!null child_multi.q:17!null p:19!null q:20!null p_new:21 q_new:22
            │    ├── inner-join (hash)
-           │    │    ├── columns: c:15!null child_multi.p:16!null child_multi.q:17!null child_multi.crdb_internal_mvcc_timestamp:18 p:19!null q:20!null p_new:21 q_new:22
+           │    │    ├── columns: c:15!null child_multi.p:16!null child_multi.q:17!null p:19!null q:20!null p_new:21 q_new:22
            │    │    ├── scan child_multi
-           │    │    │    └── columns: c:15!null child_multi.p:16 child_multi.q:17 child_multi.crdb_internal_mvcc_timestamp:18
+           │    │    │    └── columns: c:15!null child_multi.p:16 child_multi.q:17
            │    │    ├── select
            │    │    │    ├── columns: p:19 q:20 p_new:21 q_new:22
            │    │    │    ├── with-scan &1
@@ -191,11 +191,11 @@ root
            │    └── q_new:23 => child_multi.q:12
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:22!null q_new:23!null c:14!null child_multi.p:15!null child_multi.q:16!null child_multi.crdb_internal_mvcc_timestamp:17 p:18!null q:19!null p_new:20!null q:21
+           │    ├── columns: p_new:22!null q_new:23!null c:14!null child_multi.p:15!null child_multi.q:16!null p:18!null q:19!null p_new:20!null q:21
            │    ├── inner-join (hash)
-           │    │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null child_multi.crdb_internal_mvcc_timestamp:17 p:18!null q:19!null p_new:20!null q:21
+           │    │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null p:18!null q:19!null p_new:20!null q:21
            │    │    ├── scan child_multi
-           │    │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16 child_multi.crdb_internal_mvcc_timestamp:17
+           │    │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16
            │    │    ├── select
            │    │    │    ├── columns: p:18!null q:19 p_new:20!null q:21
            │    │    │    ├── with-scan &1
@@ -270,11 +270,11 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:22!null q_new:23!null c:14!null child_multi.p:15!null child_multi.q:16!null child_multi.crdb_internal_mvcc_timestamp:17 p:18!null q:19!null p:20!null q_new:21
+      │    │    ├── columns: p_new:22!null q_new:23!null c:14!null child_multi.p:15!null child_multi.q:16!null p:18!null q:19!null p:20!null q_new:21
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null child_multi.crdb_internal_mvcc_timestamp:17 p:18!null q:19!null p:20!null q_new:21
+      │    │    │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null p:18!null q:19!null p:20!null q_new:21
       │    │    │    ├── scan child_multi
-      │    │    │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16 child_multi.crdb_internal_mvcc_timestamp:17
+      │    │    │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16
       │    │    │    ├── select
       │    │    │    │    ├── columns: p:18!null q:19 p:20!null q_new:21
       │    │    │    │    ├── with-scan &1
@@ -315,11 +315,11 @@ root
                 │    └── q_new:43 => grandchild.q:32
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:42!null q_new:43!null g:34!null grandchild.c:35!null grandchild.q:36!null grandchild.crdb_internal_mvcc_timestamp:37 c:38!null q:39!null c:40!null q_new:41!null
+                │    ├── columns: c_new:42!null q_new:43!null g:34!null grandchild.c:35!null grandchild.q:36!null c:38!null q:39!null c:40!null q_new:41!null
                 │    ├── inner-join (hash)
-                │    │    ├── columns: g:34!null grandchild.c:35!null grandchild.q:36!null grandchild.crdb_internal_mvcc_timestamp:37 c:38!null q:39!null c:40!null q_new:41!null
+                │    │    ├── columns: g:34!null grandchild.c:35!null grandchild.q:36!null c:38!null q:39!null c:40!null q_new:41!null
                 │    │    ├── scan grandchild
-                │    │    │    └── columns: g:34!null grandchild.c:35 grandchild.q:36 grandchild.crdb_internal_mvcc_timestamp:37
+                │    │    │    └── columns: g:34!null grandchild.c:35 grandchild.q:36
                 │    │    ├── select
                 │    │    │    ├── columns: c:38!null q:39!null c:40!null q_new:41!null
                 │    │    │    ├── with-scan &2
@@ -403,11 +403,11 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:25!null q_new:26!null c:17!null child_multi.p:18!null child_multi.q:19!null child_multi.crdb_internal_mvcc_timestamp:20 p:21!null q:22!null column2:23!null column3:24!null
+      │    │    ├── columns: p_new:25!null q_new:26!null c:17!null child_multi.p:18!null child_multi.q:19!null p:21!null q:22!null column2:23!null column3:24!null
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null child_multi.crdb_internal_mvcc_timestamp:20 p:21!null q:22!null column2:23!null column3:24!null
+      │    │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:21!null q:22!null column2:23!null column3:24!null
       │    │    │    ├── scan child_multi
-      │    │    │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19 child_multi.crdb_internal_mvcc_timestamp:20
+      │    │    │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
       │    │    │    ├── select
       │    │    │    │    ├── columns: p:21 q:22 column2:23!null column3:24!null
       │    │    │    │    ├── with-scan &1
@@ -448,11 +448,11 @@ root
                 │    └── q_new:46 => grandchild.q:35
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:45!null q_new:46!null g:37!null grandchild.c:38!null grandchild.q:39!null grandchild.crdb_internal_mvcc_timestamp:40 c:41!null q:42!null c:43!null q_new:44!null
+                │    ├── columns: c_new:45!null q_new:46!null g:37!null grandchild.c:38!null grandchild.q:39!null c:41!null q:42!null c:43!null q_new:44!null
                 │    ├── inner-join (hash)
-                │    │    ├── columns: g:37!null grandchild.c:38!null grandchild.q:39!null grandchild.crdb_internal_mvcc_timestamp:40 c:41!null q:42!null c:43!null q_new:44!null
+                │    │    ├── columns: g:37!null grandchild.c:38!null grandchild.q:39!null c:41!null q:42!null c:43!null q_new:44!null
                 │    │    ├── scan grandchild
-                │    │    │    └── columns: g:37!null grandchild.c:38 grandchild.q:39 grandchild.crdb_internal_mvcc_timestamp:40
+                │    │    │    └── columns: g:37!null grandchild.c:38 grandchild.q:39
                 │    │    ├── select
                 │    │    │    ├── columns: c:41!null q:42!null c:43!null q_new:44!null
                 │    │    │    ├── with-scan &2
@@ -541,11 +541,11 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:26!null q_new:27!null c:18!null child_multi.p:19!null child_multi.q:20!null child_multi.crdb_internal_mvcc_timestamp:21 p:22!null q:23!null column2:24!null q:25
+      │    │    ├── columns: p_new:26!null q_new:27!null c:18!null child_multi.p:19!null child_multi.q:20!null p:22!null q:23!null column2:24!null q:25
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null child_multi.crdb_internal_mvcc_timestamp:21 p:22!null q:23!null column2:24!null q:25
+      │    │    │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p:22!null q:23!null column2:24!null q:25
       │    │    │    ├── scan child_multi
-      │    │    │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20 child_multi.crdb_internal_mvcc_timestamp:21
+      │    │    │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20
       │    │    │    ├── select
       │    │    │    │    ├── columns: p:22 q:23 column2:24!null q:25
       │    │    │    │    ├── with-scan &1
@@ -586,11 +586,11 @@ root
                 │    └── q_new:47 => grandchild.q:36
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:46!null q_new:47!null g:38!null grandchild.c:39!null grandchild.q:40!null grandchild.crdb_internal_mvcc_timestamp:41 c:42!null q:43!null c:44!null q_new:45!null
+                │    ├── columns: c_new:46!null q_new:47!null g:38!null grandchild.c:39!null grandchild.q:40!null c:42!null q:43!null c:44!null q_new:45!null
                 │    ├── inner-join (hash)
-                │    │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null grandchild.crdb_internal_mvcc_timestamp:41 c:42!null q:43!null c:44!null q_new:45!null
+                │    │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c:42!null q:43!null c:44!null q_new:45!null
                 │    │    ├── scan grandchild
-                │    │    │    └── columns: g:38!null grandchild.c:39 grandchild.q:40 grandchild.crdb_internal_mvcc_timestamp:41
+                │    │    │    └── columns: g:38!null grandchild.c:39 grandchild.q:40
                 │    │    ├── select
                 │    │    │    ├── columns: c:42!null q:43!null c:44!null q_new:45!null
                 │    │    │    ├── with-scan &2
@@ -678,11 +678,11 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:28!null q_new:29!null c:20!null child_multi.p:21!null child_multi.q:22!null child_multi.crdb_internal_mvcc_timestamp:23 p:24!null q:25!null upsert_p:26!null q:27
+      │    │    ├── columns: p_new:28!null q_new:29!null c:20!null child_multi.p:21!null child_multi.q:22!null p:24!null q:25!null upsert_p:26!null q:27
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null child_multi.crdb_internal_mvcc_timestamp:23 p:24!null q:25!null upsert_p:26!null q:27
+      │    │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p:24!null q:25!null upsert_p:26!null q:27
       │    │    │    ├── scan child_multi
-      │    │    │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22 child_multi.crdb_internal_mvcc_timestamp:23
+      │    │    │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22
       │    │    │    ├── select
       │    │    │    │    ├── columns: p:24 q:25 upsert_p:26!null q:27
       │    │    │    │    ├── with-scan &1
@@ -723,11 +723,11 @@ root
                 │    └── q_new:49 => grandchild.q:38
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:48!null q_new:49!null g:40!null grandchild.c:41!null grandchild.q:42!null grandchild.crdb_internal_mvcc_timestamp:43 c:44!null q:45!null c:46!null q_new:47!null
+                │    ├── columns: c_new:48!null q_new:49!null g:40!null grandchild.c:41!null grandchild.q:42!null c:44!null q:45!null c:46!null q_new:47!null
                 │    ├── inner-join (hash)
-                │    │    ├── columns: g:40!null grandchild.c:41!null grandchild.q:42!null grandchild.crdb_internal_mvcc_timestamp:43 c:44!null q:45!null c:46!null q_new:47!null
+                │    │    ├── columns: g:40!null grandchild.c:41!null grandchild.q:42!null c:44!null q:45!null c:46!null q_new:47!null
                 │    │    ├── scan grandchild
-                │    │    │    └── columns: g:40!null grandchild.c:41 grandchild.q:42 grandchild.crdb_internal_mvcc_timestamp:43
+                │    │    │    └── columns: g:40!null grandchild.c:41 grandchild.q:42
                 │    │    ├── select
                 │    │    │    ├── columns: c:44!null q:45!null c:46!null q_new:47!null
                 │    │    │    ├── with-scan &2

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
@@ -35,11 +35,11 @@ root
            ├── update-mapping:
            │    └── p_new:14 => child.p:7
            └── project
-                ├── columns: p_new:14 c:9!null child.p:10!null child.crdb_internal_mvcc_timestamp:11 p:12!null p_new:13!null
+                ├── columns: p_new:14 c:9!null child.p:10!null p:12!null p_new:13!null
                 ├── inner-join (hash)
-                │    ├── columns: c:9!null child.p:10!null child.crdb_internal_mvcc_timestamp:11 p:12!null p_new:13!null
+                │    ├── columns: c:9!null child.p:10!null p:12!null p_new:13!null
                 │    ├── scan child
-                │    │    └── columns: c:9!null child.p:10!null child.crdb_internal_mvcc_timestamp:11
+                │    │    └── columns: c:9!null child.p:10!null
                 │    ├── select
                 │    │    ├── columns: p:12!null p_new:13!null
                 │    │    ├── with-scan &1
@@ -106,11 +106,11 @@ root
            │    ├── p_new:23 => child_multi.p:12
            │    └── p_new:23 => child_multi.q:13
            └── project
-                ├── columns: p_new:23 c:15!null child_multi.p:16!null child_multi.q:17!null child_multi.crdb_internal_mvcc_timestamp:18 p:19!null q:20!null p_new:21 q_new:22
+                ├── columns: p_new:23 c:15!null child_multi.p:16!null child_multi.q:17!null p:19!null q:20!null p_new:21 q_new:22
                 ├── inner-join (hash)
-                │    ├── columns: c:15!null child_multi.p:16!null child_multi.q:17!null child_multi.crdb_internal_mvcc_timestamp:18 p:19!null q:20!null p_new:21 q_new:22
+                │    ├── columns: c:15!null child_multi.p:16!null child_multi.q:17!null p:19!null q:20!null p_new:21 q_new:22
                 │    ├── scan child_multi
-                │    │    └── columns: c:15!null child_multi.p:16 child_multi.q:17 child_multi.crdb_internal_mvcc_timestamp:18
+                │    │    └── columns: c:15!null child_multi.p:16 child_multi.q:17
                 │    ├── select
                 │    │    ├── columns: p:19 q:20 p_new:21 q_new:22
                 │    │    ├── with-scan &1
@@ -159,11 +159,11 @@ root
            │    ├── p_new:22 => child_multi.p:11
            │    └── p_new:22 => child_multi.q:12
            └── project
-                ├── columns: p_new:22 c:14!null child_multi.p:15!null child_multi.q:16!null child_multi.crdb_internal_mvcc_timestamp:17 p:18!null q:19!null p_new:20!null q:21
+                ├── columns: p_new:22 c:14!null child_multi.p:15!null child_multi.q:16!null p:18!null q:19!null p_new:20!null q:21
                 ├── inner-join (hash)
-                │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null child_multi.crdb_internal_mvcc_timestamp:17 p:18!null q:19!null p_new:20!null q:21
+                │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null p:18!null q:19!null p_new:20!null q:21
                 │    ├── scan child_multi
-                │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16 child_multi.crdb_internal_mvcc_timestamp:17
+                │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16
                 │    ├── select
                 │    │    ├── columns: p:18!null q:19 p_new:20!null q:21
                 │    │    ├── with-scan &1
@@ -223,11 +223,11 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:22 c:14!null child_multi.p:15!null child_multi.q:16!null child_multi.crdb_internal_mvcc_timestamp:17 p:18!null q:19!null p:20!null q_new:21
+      │         ├── columns: p_new:22 c:14!null child_multi.p:15!null child_multi.q:16!null p:18!null q:19!null p:20!null q_new:21
       │         ├── inner-join (hash)
-      │         │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null child_multi.crdb_internal_mvcc_timestamp:17 p:18!null q:19!null p:20!null q_new:21
+      │         │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null p:18!null q:19!null p:20!null q_new:21
       │         │    ├── scan child_multi
-      │         │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16 child_multi.crdb_internal_mvcc_timestamp:17
+      │         │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16
       │         │    ├── select
       │         │    │    ├── columns: p:18!null q:19 p:20!null q_new:21
       │         │    │    ├── with-scan &1
@@ -252,11 +252,11 @@ root
                 │    ├── c_new:35 => grandchild.c:24
                 │    └── c_new:35 => grandchild.q:25
                 └── project
-                     ├── columns: c_new:35 g:27!null grandchild.c:28!null grandchild.q:29!null grandchild.crdb_internal_mvcc_timestamp:30 c:31!null q:32!null c:33!null p_new:34
+                     ├── columns: c_new:35 g:27!null grandchild.c:28!null grandchild.q:29!null c:31!null q:32!null c:33!null p_new:34
                      ├── inner-join (hash)
-                     │    ├── columns: g:27!null grandchild.c:28!null grandchild.q:29!null grandchild.crdb_internal_mvcc_timestamp:30 c:31!null q:32!null c:33!null p_new:34
+                     │    ├── columns: g:27!null grandchild.c:28!null grandchild.q:29!null c:31!null q:32!null c:33!null p_new:34
                      │    ├── scan grandchild
-                     │    │    └── columns: g:27!null grandchild.c:28 grandchild.q:29 grandchild.crdb_internal_mvcc_timestamp:30
+                     │    │    └── columns: g:27!null grandchild.c:28 grandchild.q:29
                      │    ├── select
                      │    │    ├── columns: c:31!null q:32!null c:33!null p_new:34
                      │    │    ├── with-scan &2
@@ -325,11 +325,11 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:25 c:17!null child_multi.p:18!null child_multi.q:19!null child_multi.crdb_internal_mvcc_timestamp:20 p:21!null q:22!null column2:23!null column3:24!null
+      │         ├── columns: p_new:25 c:17!null child_multi.p:18!null child_multi.q:19!null p:21!null q:22!null column2:23!null column3:24!null
       │         ├── inner-join (hash)
-      │         │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null child_multi.crdb_internal_mvcc_timestamp:20 p:21!null q:22!null column2:23!null column3:24!null
+      │         │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:21!null q:22!null column2:23!null column3:24!null
       │         │    ├── scan child_multi
-      │         │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19 child_multi.crdb_internal_mvcc_timestamp:20
+      │         │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
       │         │    ├── select
       │         │    │    ├── columns: p:21 q:22 column2:23!null column3:24!null
       │         │    │    ├── with-scan &1
@@ -354,11 +354,11 @@ root
                 │    ├── c_new:38 => grandchild.c:27
                 │    └── c_new:38 => grandchild.q:28
                 └── project
-                     ├── columns: c_new:38 g:30!null grandchild.c:31!null grandchild.q:32!null grandchild.crdb_internal_mvcc_timestamp:33 c:34!null q:35!null c:36!null p_new:37
+                     ├── columns: c_new:38 g:30!null grandchild.c:31!null grandchild.q:32!null c:34!null q:35!null c:36!null p_new:37
                      ├── inner-join (hash)
-                     │    ├── columns: g:30!null grandchild.c:31!null grandchild.q:32!null grandchild.crdb_internal_mvcc_timestamp:33 c:34!null q:35!null c:36!null p_new:37
+                     │    ├── columns: g:30!null grandchild.c:31!null grandchild.q:32!null c:34!null q:35!null c:36!null p_new:37
                      │    ├── scan grandchild
-                     │    │    └── columns: g:30!null grandchild.c:31 grandchild.q:32 grandchild.crdb_internal_mvcc_timestamp:33
+                     │    │    └── columns: g:30!null grandchild.c:31 grandchild.q:32
                      │    ├── select
                      │    │    ├── columns: c:34!null q:35!null c:36!null p_new:37
                      │    │    ├── with-scan &2
@@ -432,11 +432,11 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:26 c:18!null child_multi.p:19!null child_multi.q:20!null child_multi.crdb_internal_mvcc_timestamp:21 p:22!null q:23!null column2:24!null q:25
+      │         ├── columns: p_new:26 c:18!null child_multi.p:19!null child_multi.q:20!null p:22!null q:23!null column2:24!null q:25
       │         ├── inner-join (hash)
-      │         │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null child_multi.crdb_internal_mvcc_timestamp:21 p:22!null q:23!null column2:24!null q:25
+      │         │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p:22!null q:23!null column2:24!null q:25
       │         │    ├── scan child_multi
-      │         │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20 child_multi.crdb_internal_mvcc_timestamp:21
+      │         │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20
       │         │    ├── select
       │         │    │    ├── columns: p:22 q:23 column2:24!null q:25
       │         │    │    ├── with-scan &1
@@ -461,11 +461,11 @@ root
                 │    ├── c_new:39 => grandchild.c:28
                 │    └── c_new:39 => grandchild.q:29
                 └── project
-                     ├── columns: c_new:39 g:31!null grandchild.c:32!null grandchild.q:33!null grandchild.crdb_internal_mvcc_timestamp:34 c:35!null q:36!null c:37!null p_new:38
+                     ├── columns: c_new:39 g:31!null grandchild.c:32!null grandchild.q:33!null c:35!null q:36!null c:37!null p_new:38
                      ├── inner-join (hash)
-                     │    ├── columns: g:31!null grandchild.c:32!null grandchild.q:33!null grandchild.crdb_internal_mvcc_timestamp:34 c:35!null q:36!null c:37!null p_new:38
+                     │    ├── columns: g:31!null grandchild.c:32!null grandchild.q:33!null c:35!null q:36!null c:37!null p_new:38
                      │    ├── scan grandchild
-                     │    │    └── columns: g:31!null grandchild.c:32 grandchild.q:33 grandchild.crdb_internal_mvcc_timestamp:34
+                     │    │    └── columns: g:31!null grandchild.c:32 grandchild.q:33
                      │    ├── select
                      │    │    ├── columns: c:35!null q:36!null c:37!null p_new:38
                      │    │    ├── with-scan &2
@@ -538,11 +538,11 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:28 c:20!null child_multi.p:21!null child_multi.q:22!null child_multi.crdb_internal_mvcc_timestamp:23 p:24!null q:25!null upsert_p:26!null q:27
+      │         ├── columns: p_new:28 c:20!null child_multi.p:21!null child_multi.q:22!null p:24!null q:25!null upsert_p:26!null q:27
       │         ├── inner-join (hash)
-      │         │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null child_multi.crdb_internal_mvcc_timestamp:23 p:24!null q:25!null upsert_p:26!null q:27
+      │         │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p:24!null q:25!null upsert_p:26!null q:27
       │         │    ├── scan child_multi
-      │         │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22 child_multi.crdb_internal_mvcc_timestamp:23
+      │         │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22
       │         │    ├── select
       │         │    │    ├── columns: p:24 q:25 upsert_p:26!null q:27
       │         │    │    ├── with-scan &1
@@ -567,11 +567,11 @@ root
                 │    ├── c_new:41 => grandchild.c:30
                 │    └── c_new:41 => grandchild.q:31
                 └── project
-                     ├── columns: c_new:41 g:33!null grandchild.c:34!null grandchild.q:35!null grandchild.crdb_internal_mvcc_timestamp:36 c:37!null q:38!null c:39!null p_new:40
+                     ├── columns: c_new:41 g:33!null grandchild.c:34!null grandchild.q:35!null c:37!null q:38!null c:39!null p_new:40
                      ├── inner-join (hash)
-                     │    ├── columns: g:33!null grandchild.c:34!null grandchild.q:35!null grandchild.crdb_internal_mvcc_timestamp:36 c:37!null q:38!null c:39!null p_new:40
+                     │    ├── columns: g:33!null grandchild.c:34!null grandchild.q:35!null c:37!null q:38!null c:39!null p_new:40
                      │    ├── scan grandchild
-                     │    │    └── columns: g:33!null grandchild.c:34 grandchild.q:35 grandchild.crdb_internal_mvcc_timestamp:36
+                     │    │    └── columns: g:33!null grandchild.c:34 grandchild.q:35
                      │    ├── select
                      │    │    ├── columns: c:37!null q:38!null c:39!null p_new:40
                      │    │    ├── with-scan &2

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -540,33 +540,33 @@ insert xyz
       ├── project
       │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    └── select
-      │         ├── columns: column1:5!null column2:6!null column3:7!null x:16 y:17 z:18 crdb_internal_mvcc_timestamp:19
+      │         ├── columns: column1:5!null column2:6!null column3:7!null x:16 y:17 z:18
       │         ├── left-join (hash)
-      │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:16 y:17 z:18 crdb_internal_mvcc_timestamp:19
+      │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:16 y:17 z:18
       │         │    ├── upsert-distinct-on
       │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │         │    │    ├── grouping columns: column2:6!null column3:7!null
       │         │    │    ├── project
       │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │         │    │    │    └── select
-      │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:12 y:13 z:14 crdb_internal_mvcc_timestamp:15
+      │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:12 y:13 z:14
       │         │    │    │         ├── left-join (hash)
-      │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:12 y:13 z:14 crdb_internal_mvcc_timestamp:15
+      │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:12 y:13 z:14
       │         │    │    │         │    ├── upsert-distinct-on
       │         │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │         │    │    │         │    │    ├── grouping columns: column1:5!null
       │         │    │    │         │    │    ├── project
       │         │    │    │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │         │    │    │         │    │    │    └── select
-      │         │    │    │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10 crdb_internal_mvcc_timestamp:11
+      │         │    │    │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10
       │         │    │    │         │    │    │         ├── left-join (hash)
-      │         │    │    │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10 crdb_internal_mvcc_timestamp:11
+      │         │    │    │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10
       │         │    │    │         │    │    │         │    ├── values
       │         │    │    │         │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │         │    │    │         │    │    │         │    │    ├── (1, 2, 3)
       │         │    │    │         │    │    │         │    │    └── (4, 5, 6)
       │         │    │    │         │    │    │         │    ├── scan xyz
-      │         │    │    │         │    │    │         │    │    └── columns: x:8!null y:9 z:10 crdb_internal_mvcc_timestamp:11
+      │         │    │    │         │    │    │         │    │    └── columns: x:8!null y:9 z:10
       │         │    │    │         │    │    │         │    └── filters
       │         │    │    │         │    │    │         │         └── column1:5 = x:8
       │         │    │    │         │    │    │         └── filters
@@ -577,7 +577,7 @@ insert xyz
       │         │    │    │         │    │         └── first-agg [as=column3:7]
       │         │    │    │         │    │              └── column3:7
       │         │    │    │         │    ├── scan xyz
-      │         │    │    │         │    │    └── columns: x:12!null y:13 z:14 crdb_internal_mvcc_timestamp:15
+      │         │    │    │         │    │    └── columns: x:12!null y:13 z:14
       │         │    │    │         │    └── filters
       │         │    │    │         │         ├── column2:6 = y:13
       │         │    │    │         │         └── column3:7 = z:14
@@ -587,7 +587,7 @@ insert xyz
       │         │    │         └── first-agg [as=column1:5]
       │         │    │              └── column1:5
       │         │    ├── scan xyz
-      │         │    │    └── columns: x:16!null y:17 z:18 crdb_internal_mvcc_timestamp:19
+      │         │    │    └── columns: x:16!null y:17 z:18
       │         │    └── filters
       │         │         ├── column3:7 = z:18
       │         │         └── column2:6 = y:17
@@ -615,15 +615,15 @@ insert xyz
       ├── project
       │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    └── select
-      │         ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10 crdb_internal_mvcc_timestamp:11
+      │         ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10
       │         ├── left-join (hash)
-      │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10 crdb_internal_mvcc_timestamp:11
+      │         │    ├── columns: column1:5!null column2:6!null column3:7!null x:8 y:9 z:10
       │         │    ├── values
       │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │         │    │    ├── (1, 2, 3)
       │         │    │    └── (4, 5, 6)
       │         │    ├── scan xyz
-      │         │    │    └── columns: x:8!null y:9 z:10 crdb_internal_mvcc_timestamp:11
+      │         │    │    └── columns: x:8!null y:9 z:10
       │         │    └── filters
       │         │         ├── column2:6 = y:9
       │         │         └── column3:7 = z:10
@@ -1389,9 +1389,9 @@ insert checks
       │    ├── project
       │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
       │    │    └── select
-      │    │         ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+      │    │         ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13
       │    │         ├── left-join (hash)
-      │    │         │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+      │    │         │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13
       │    │         │    ├── project
       │    │         │    │    ├── columns: column9:9 column1:6!null column2:7!null column8:8
       │    │         │    │    ├── project
@@ -1404,7 +1404,7 @@ insert checks
       │    │         │    │    └── projections
       │    │         │    │         └── column8:8 + 1 [as=column9:9]
       │    │         │    ├── scan checks
-      │    │         │    │    ├── columns: a:10!null b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+      │    │         │    │    ├── columns: a:10!null b:11 c:12 d:13
       │    │         │    │    ├── check constraint expressions
       │    │         │    │    │    └── a:10 > 0
       │    │         │    │    └── computed column expressions
@@ -1906,23 +1906,23 @@ insert partial_indexes
       │    ├── project
       │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    │    └── select
-      │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14 crdb_internal_mvcc_timestamp:15
+      │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
       │    │         ├── left-join (hash)
-      │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14 crdb_internal_mvcc_timestamp:15
+      │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
       │    │         │    ├── upsert-distinct-on
       │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    │         │    │    ├── grouping columns: column1:5!null
       │    │         │    │    ├── project
       │    │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    │         │    │    │    └── select
-      │    │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
       │    │         │    │    │         ├── left-join (hash)
-      │    │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
       │    │         │    │    │         │    ├── values
       │    │         │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    │         │    │    │         │    │    └── (2, 1, 'bar')
       │    │         │    │    │         │    ├── scan partial_indexes
-      │    │         │    │    │         │    │    ├── columns: a:8!null b:9 c:10 crdb_internal_mvcc_timestamp:11
+      │    │         │    │    │         │    │    ├── columns: a:8!null b:9 c:10
       │    │         │    │    │         │    │    └── partial index predicates
       │    │         │    │    │         │    │         ├── secondary: filters
       │    │         │    │    │         │    │         │    └── c:10 = 'foo'
@@ -1939,7 +1939,7 @@ insert partial_indexes
       │    │         │    │         └── first-agg [as=column3:7]
       │    │         │    │              └── column3:7
       │    │         │    ├── scan partial_indexes
-      │    │         │    │    ├── columns: a:12!null b:13 c:14 crdb_internal_mvcc_timestamp:15
+      │    │         │    │    ├── columns: a:12!null b:13 c:14
       │    │         │    │    └── partial index predicates
       │    │         │    │         ├── secondary: filters
       │    │         │    │         │    └── c:14 = 'foo'


### PR DESCRIPTION
Various places in the mutation code assume a 1:1 correspondence between a scope
created by `buildScan` and the table ordinals. To ensure this, the current code
always builds the system column in the scan (even if it is not necessary).
Normalization rules later prune the column from the `Scan`.

The addition of virtual columns would make this situation much worse.

This commit cleans this up; we add a `tableOrdinal` field in scope column. This
field allows us to relax the requirement of having a perfect correspondence
between scope and table columns. We also centralize the code that sets
`fetchColIDs`.

This change allows us to stop building system columns for FK checks/cascades and
INSERT ON CONFLICT DO NOTHING, where they are never needed.

Release note: None