### PR TITLE
sql: add `schema_name` column for `SHOW ENUMS`

### DIFF
--- a/pkg/sql/delegate/show_enums.go
+++ b/pkg/sql/delegate/show_enums.go
@@ -14,12 +14,14 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 
 func (d *delegator) delegateShowEnums(n *tree.ShowEnums) (tree.Statement, error) {
 	query := `
-  SELECT type.typname AS name,
-         string_agg(enum.enumlabel, '|') AS value
+  SELECT ns.nspname AS schema_name,
+         type.typname AS name,
+         array_agg(enum.enumlabel ORDER BY enum.enumsortorder) AS value
     FROM pg_enum AS enum
     JOIN pg_type AS type ON (type.oid = enum.enumtypid)
-GROUP BY type.typname
-ORDER BY type.typname`
+    JOIN pg_catalog.pg_namespace AS ns ON (ns.oid = type.typnamespace)
+GROUP BY ns.nspname, type.typname
+ORDER BY ns.nspname, type.typname`
 
 	return parse(query)
 }

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1108,13 +1108,13 @@ local
 statement ok
 ROLLBACK
 
-query TT
+query TTT
 SHOW ENUMS
 ----
-as_bytes   bytes
-dbs        postgres|mysql|spanner|cockroach
-farewell   bye|seeya
-greeting   hello|howdy|hi
-greeting2  hello
-int        Z|S of int
-notbad     dup|DUP
+pg_catalog  as_bytes   {bytes}
+pg_catalog  dbs        {postgres,mysql,spanner,cockroach}
+pg_catalog  farewell   {bye,seeya}
+pg_catalog  greeting   {hello,howdy,hi}
+pg_catalog  greeting2  {hello}
+pg_catalog  int        {Z,"S of int"}
+pg_catalog  notbad     {dup,DUP}


### PR DESCRIPTION
Fixes #52636

Added new column `schema_name` by joining old query with
`pg_catalog.pg_namespace`. To have more stable sort in `value` column
used `array_agg` instead of `string_agg`. (`string_agg` cannot be used
like: `string_agg(enum.enumlabel ORDER BY enum.enumsortorder, '|')`)

Release note (sql change): add `schema_name` into result of the `SHOW
ENUMS` statement.