### PR TITLE
sql: enable autovacuum_enabled storage param setting

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -90,14 +90,14 @@ unlogged_tbl  CREATE TABLE public.unlogged_tbl (
 statement error invalid storage parameter "foo"
 CREATE TABLE a (b INT) WITH (foo=100);
 
-statement error argument of fillfactor must be type int, not type bool
+statement error parameter "fillfactor" requires an float value
 CREATE TABLE a (b INT) WITH (fillfactor=true);
 
 statement error unimplemented: storage parameter "toast_tuple_target"
 CREATE TABLE a (b INT) WITH (toast_tuple_target=100);
 
 query T noticetrace
-CREATE TABLE a (b INT) WITH (fillfactor=100)
+CREATE TABLE a (b INT) WITH (fillfactor=99.9)
 ----
 NOTICE: storage parameter "fillfactor" is ignored
 
@@ -105,3 +105,15 @@ query T noticetrace
 CREATE INDEX a_idx ON a(b) WITH (fillfactor=50)
 ----
 NOTICE: storage parameter "fillfactor" is ignored
+
+query T noticetrace
+DROP TABLE a CASCADE; CREATE TABLE a (b INT) WITH (autovacuum_enabled=off)
+----
+NOTICE: storage parameter "autovacuum_enabled = 'off'" is ignored
+
+query T noticetrace
+DROP TABLE a CASCADE; CREATE TABLE a (b INT) WITH (autovacuum_enabled=on)
+----
+
+statement error parameter "autovacuum_enabled" requires a Boolean value
+DROP TABLE a CASCADE; CREATE TABLE a (b INT) WITH (autovacuum_enabled='11')

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5258,11 +5258,11 @@ opt_create_table_on_commit:
   }
 
 storage_parameter:
-  name '=' d_expr
+  name '=' var_value
   {
     $$.val = tree.StorageParam{Key: tree.Name($1), Value: $3.expr()}
   }
-|  SCONST '=' d_expr
+|  SCONST '=' var_value
   {
     $$.val = tree.StorageParam{Key: tree.Name($1), Value: $3.expr()}
   }

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
@@ -184,6 +185,28 @@ func getStringVal(evalCtx *tree.EvalContext, name string, values []tree.TypedExp
 		return "", newSingleArgVarError(name)
 	}
 	return datumAsString(evalCtx, name, values[0])
+}
+
+func datumAsFloat(evalCtx *tree.EvalContext, name string, value tree.TypedExpr) (float64, error) {
+	val, err := value.Eval(evalCtx)
+	if err != nil {
+		return 0, err
+	}
+	switch v := tree.UnwrapDatum(evalCtx, val).(type) {
+	case *tree.DString:
+		return strconv.ParseFloat(string(*v), 64)
+	case *tree.DInt:
+		return float64(*v), nil
+	case *tree.DFloat:
+		return float64(*v), nil
+	case *tree.DDecimal:
+		return v.Decimal.Float64()
+	}
+	err = pgerror.Newf(pgcode.InvalidParameterValue,
+		"parameter %q requires an float value", name)
+	err = errors.WithDetailf(err,
+		"%s is a %s", value, errors.Safe(val.ResolvedType()))
+	return 0, err
 }
 
 func datumAsInt(evalCtx *tree.EvalContext, name string, value tree.TypedExpr) (int64, error) {


### PR DESCRIPTION
This change involved a change to the syntax to be more in line with
PostgreSQL's gram.y for storage parameters, allowing most expression
values in the WITH clause. We further parse unresolved names as strings
to allow something like `autovacuum_enabled = off` to work.

Resolves #51818

Release note (sql change): Allow parsing of `CREATE TABLE ... WITH
(autovacuum_enabled = bool)`, which is a no-op operation.