### PR TITLE
sql: don't show schema in constraint defs if in search_path

### DIFF
--- a/pkg/cmd/roachtest/sqlalchemy_blocklist.go
+++ b/pkg/cmd/roachtest/sqlalchemy_blocklist.go
@@ -18,9 +18,7 @@ var sqlAlchemyBlocklists = blocklistsForVersion{
 	{"v20.2", "sqlAlchemyBlocklist20_2", sqlAlchemyBlocklist20_2, "sqlAlchemyIgnoreList20_2", sqlAlchemyIgnoreList20_2},
 }
 
-var sqlAlchemyBlocklist20_2 = blocklist{
-	"test/dialect/test_suite.py::ComponentReflectionTest_cockroachdb+psycopg2_9_5_0::test_get_foreign_keys": "52356",
-}
+var sqlAlchemyBlocklist20_2 = blocklist{}
 
 var sqlAlchemyBlocklist20_1 = blocklist{
 	"test/dialect/test_suite.py::ExpandingBoundInTest_cockroachdb+psycopg2_9_5_0::test_null_in_empty_set_is_false": "41596",

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1610,7 +1610,17 @@ func showAlterStatementWithInterleave(
 		f.WriteString(" ADD CONSTRAINT ")
 		f.FormatNameP(&fk.Name)
 		f.WriteByte(' ')
-		if err := showForeignKeyConstraint(&f.Buffer, contextName, table, fk, lCtx); err != nil {
+		// Passing in EmptySearchPath causes the schema name to show up in the
+		// constraint definition, which we need for `cockroach dump` output to be
+		// usable.
+		if err := showForeignKeyConstraint(
+			&f.Buffer,
+			contextName,
+			table,
+			fk,
+			lCtx,
+			sessiondata.EmptySearchPath,
+		); err != nil {
 			return err
 		}
 		if err := alterStmts.Append(tree.NewDString(f.CloseAndGetString())); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -89,11 +89,11 @@ a f b    c
 query TTTTB colnames
 SHOW CONSTRAINTS FROM t
 ----
-table_name  constraint_name  constraint_type  details                                     validated
-t           check_a          CHECK            CHECK ((a > 0:::INT8))                      true
-t           fk_f_ref_other   FOREIGN KEY      FOREIGN KEY (f) REFERENCES public.other(b)  true
-t           foo              UNIQUE           UNIQUE (b ASC)                              true
-t           primary          PRIMARY KEY      PRIMARY KEY (a ASC)                         true
+table_name  constraint_name  constraint_type  details                              validated
+t           check_a          CHECK            CHECK ((a > 0:::INT8))               true
+t           fk_f_ref_other   FOREIGN KEY      FOREIGN KEY (f) REFERENCES other(b)  true
+t           foo              UNIQUE           UNIQUE (b ASC)                       true
+t           primary          PRIMARY KEY      PRIMARY KEY (a ASC)                  true
 
 statement error CHECK
 INSERT INTO t (a, f) VALUES (-2, 9)
@@ -119,10 +119,10 @@ INSERT INTO t (a) VALUES (-3)
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK        CHECK ((a > 0:::INT8))                      true
-t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES public.other(b)  true
-t  foo             UNIQUE       UNIQUE (b ASC)                              true
-t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                         true
+t  check_a         CHECK        CHECK ((a > 0:::INT8))               true
+t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
+t  foo             UNIQUE       UNIQUE (b ASC)                       true
+t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                  true
 
 statement error duplicate constraint name
 ALTER TABLE t ADD CONSTRAINT check_a CHECK (a > 0)
@@ -137,11 +137,11 @@ ALTER TABLE t ADD CHECK (a > 0)
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK        CHECK ((a > 0:::INT8))                      true
-t  check_a1        CHECK        CHECK ((a > 0:::INT8))                      true
-t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES public.other(b)  true
-t  foo             UNIQUE       UNIQUE (b ASC)                              true
-t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                         true
+t  check_a         CHECK        CHECK ((a > 0:::INT8))               true
+t  check_a1        CHECK        CHECK ((a > 0:::INT8))               true
+t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
+t  foo             UNIQUE       UNIQUE (b ASC)                       true
+t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                  true
 
 statement error constraint "typo" does not exist
 ALTER TABLE t VALIDATE CONSTRAINT typo
@@ -159,11 +159,11 @@ ALTER TABLE t VALIDATE CONSTRAINT check_a
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK        CHECK ((a > 0:::INT8))                      true
-t  check_a1        CHECK        CHECK ((a > 0:::INT8))                      true
-t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES public.other(b)  true
-t  foo             UNIQUE       UNIQUE (b ASC)                              true
-t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                         true
+t  check_a         CHECK        CHECK ((a > 0:::INT8))               true
+t  check_a1        CHECK        CHECK ((a > 0:::INT8))               true
+t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
+t  foo             UNIQUE       UNIQUE (b ASC)                       true
+t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                  true
 
 statement ok
 ALTER TABLE t DROP CONSTRAINT check_a, DROP CONSTRAINT check_a1

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2164,7 +2164,7 @@ FROM pg_catalog.pg_constraint
 WHERE conrelid='pg_constraintdef_test'::regclass
 ----
 UNIQUE (b ASC)
-FOREIGN KEY (a) REFERENCES public.pg_indexdef_test(a) ON DELETE CASCADE
+FOREIGN KEY (a) REFERENCES pg_indexdef_test(a) ON DELETE CASCADE
 CHECK ((c > a))
 
 # These functions always return NULL since we don't support comments on vtable columns and databases.

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -429,8 +429,8 @@ CREATE TABLE "user content".review_stats (
 query TTTTB
 SHOW CONSTRAINTS FROM "user content".review_stats
 ----
-review_stats  primary   PRIMARY KEY  PRIMARY KEY (id ASC)                                       true
-review_stats  reviewfk  FOREIGN KEY  FOREIGN KEY (id) REFERENCES public."customer reviews"(id)  true
+review_stats  primary   PRIMARY KEY  PRIMARY KEY (id ASC)                                true
+review_stats  reviewfk  FOREIGN KEY  FOREIGN KEY (id) REFERENCES "customer reviews"(id)  true
 
 statement error pgcode 23503 insert on table "review_stats" violates foreign key constraint "reviewfk"\nDETAIL: Key \(id\)=\(5\) is not present in table "customer reviews"
 INSERT INTO "user content".review_stats (id, upvotes) VALUES (5, 1)
@@ -553,7 +553,7 @@ ALTER TABLE delivery ADD FOREIGN KEY (item) REFERENCES products (upc)
 query TTTTB
 SHOW CONSTRAINTS FROM delivery
 ----
-delivery  fk_order_ref_orders  FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES public.orders(id, shipment)  true
+delivery  fk_order_ref_orders  FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders(id, shipment)  true
 
 statement ok
 UPDATE products SET upc = '885155001450' WHERE sku = '780'
@@ -564,8 +564,8 @@ ALTER TABLE delivery ADD FOREIGN KEY (item) REFERENCES products (upc)
 query TTTTB
 SHOW CONSTRAINTS FROM delivery
 ----
-delivery  fk_item_ref_products  FOREIGN KEY  FOREIGN KEY (item) REFERENCES public.products(upc)                      true
-delivery  fk_order_ref_orders   FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES public.orders(id, shipment)  true
+delivery  fk_item_ref_products  FOREIGN KEY  FOREIGN KEY (item) REFERENCES products(upc)                      true
+delivery  fk_order_ref_orders   FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders(id, shipment)  true
 
 statement ok
 ALTER TABLE "user content"."customer reviews"
@@ -632,10 +632,10 @@ TRUNCATE delivery, products, orders, "user content"."customer reviews"
 query TTTTB colnames
 SHOW CONSTRAINTS FROM orders
 ----
-table_name  constraint_name          constraint_type  details                                                                                      validated
-orders      fk_product_ref_products  FOREIGN KEY      FOREIGN KEY (product) REFERENCES public.products(sku) ON DELETE RESTRICT ON UPDATE RESTRICT  true
-orders      primary                  PRIMARY KEY      PRIMARY KEY (id ASC, shipment ASC)                                                           true
-orders      valid_customer           FOREIGN KEY      FOREIGN KEY (customer) REFERENCES public.customers(id)                                       true
+table_name  constraint_name          constraint_type  details                                                                               validated
+orders      fk_product_ref_products  FOREIGN KEY      FOREIGN KEY (product) REFERENCES products(sku) ON DELETE RESTRICT ON UPDATE RESTRICT  true
+orders      primary                  PRIMARY KEY      PRIMARY KEY (id ASC, shipment ASC)                                                    true
+orders      valid_customer           FOREIGN KEY      FOREIGN KEY (customer) REFERENCES customers(id)                                       true
 
 statement error pq: index "products_upc_key" is in use as unique constraint
 DROP INDEX products@products_upc_key
@@ -898,10 +898,10 @@ CREATE TABLE domain_modules (
 query TTTTB
 SHOW CONSTRAINTS FROM domain_modules
 ----
-domain_modules  domain_modules_domain_id_fk  FOREIGN KEY  FOREIGN KEY (domain_id) REFERENCES public.domains(id)  true
-domain_modules  domain_modules_module_id_fk  FOREIGN KEY  FOREIGN KEY (module_id) REFERENCES public.modules(id)  true
-domain_modules  domain_modules_uq            UNIQUE       UNIQUE (domain_id ASC, module_id ASC)                  true
-domain_modules  primary                      PRIMARY KEY  PRIMARY KEY (id ASC)                                   true
+domain_modules  domain_modules_domain_id_fk  FOREIGN KEY  FOREIGN KEY (domain_id) REFERENCES domains(id)  true
+domain_modules  domain_modules_module_id_fk  FOREIGN KEY  FOREIGN KEY (module_id) REFERENCES modules(id)  true
+domain_modules  domain_modules_uq            UNIQUE       UNIQUE (domain_id ASC, module_id ASC)           true
+domain_modules  primary                      PRIMARY KEY  PRIMARY KEY (id ASC)                            true
 
 statement ok
 INSERT INTO modules VALUES(3)
@@ -2754,8 +2754,8 @@ ALTER TABLE pet ADD CONSTRAINT fk_constraint FOREIGN KEY (id) REFERENCES person 
 query TTTTB
 SHOW CONSTRAINTS FROM pet
 ----
-pet  fk_constraint  FOREIGN KEY  FOREIGN KEY (id) REFERENCES public.person(id)  false
-pet  primary        PRIMARY KEY  PRIMARY KEY (id ASC)                           true
+pet  fk_constraint  FOREIGN KEY  FOREIGN KEY (id) REFERENCES person(id)  false
+pet  primary        PRIMARY KEY  PRIMARY KEY (id ASC)                    true
 
 statement error pq: foreign key violation: "pet" row id=0 has no match in "person"
 ALTER TABLE pet VALIDATE CONSTRAINT fk_constraint
@@ -2769,8 +2769,8 @@ ALTER TABLE pet VALIDATE CONSTRAINT fk_constraint
 query TTTTB
 SHOW CONSTRAINTS FROM pet
 ----
-pet  fk_constraint  FOREIGN KEY  FOREIGN KEY (id) REFERENCES public.person(id)  true
-pet  primary        PRIMARY KEY  PRIMARY KEY (id ASC)                           true
+pet  fk_constraint  FOREIGN KEY  FOREIGN KEY (id) REFERENCES person(id)  true
+pet  primary        PRIMARY KEY  PRIMARY KEY (id ASC)                    true
 
 statement ok
 DROP TABLE person, pet

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -793,20 +793,20 @@ user root
 ## These order of this virtual table is non-deterministic, so all queries must
 ## explicitly add an ORDER BY clause.
 
-query OTOT colnames
-SELECT con.oid, conname, connamespace, contype
+query OTOTT colnames
+SELECT con.oid, conname, connamespace, contype, condef
 FROM pg_catalog.pg_constraint con
 JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
-oid         conname    connamespace  contype
-2143281868  fk         2332901747    f
-2792001267  check_b    2332901747    c
-3572320190  primary    2332901747    p
-4089604113  fk         2332901747    f
-4243354484  t1_a_key   2332901747    u
-4243354485  index_key  2332901747    u
+oid         conname    connamespace  contype  condef
+2143281868  fk         2332901747    f        FOREIGN KEY (a, b) REFERENCES t1(b, c)
+2792001267  check_b    2332901747    c        CHECK ((b > 11:::INT8))
+3572320190  primary    2332901747    p        PRIMARY KEY (p ASC)
+4089604113  fk         2332901747    f        FOREIGN KEY (t1_id) REFERENCES t1(a)
+4243354484  t1_a_key   2332901747    u        UNIQUE (a ASC)
+4243354485  index_key  2332901747    u        UNIQUE (b ASC, c ASC)
 
 query TTBBBOOO colnames
 SELECT conname, contype, condeferrable, condeferred, convalidated, conrelid, contypid, conindid

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -32,8 +32,8 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM test.child
 ----
-child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES public.parent(id)  false
-child  primary             PRIMARY KEY  PRIMARY KEY (id ASC)                                  true
+child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES parent(id)  false
+child  primary             PRIMARY KEY  PRIMARY KEY (id ASC)                           true
 
 statement ok
 ALTER TABLE test.child VALIDATE CONSTRAINT fk_child_parent_id
@@ -41,8 +41,8 @@ ALTER TABLE test.child VALIDATE CONSTRAINT fk_child_parent_id
 query TTTTB
 SHOW CONSTRAINTS FROM test.child
 ----
-child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES public.parent(id)  true
-child  primary             PRIMARY KEY  PRIMARY KEY (id ASC)                                  true
+child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES parent(id)  true
+child  primary             PRIMARY KEY  PRIMARY KEY (id ASC)                           true
 
 statement ok
 DROP TABLE test.child, test.parent
@@ -74,8 +74,8 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM test.child
 ----
-child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES public.parent(id)  true
-child  primary             PRIMARY KEY  PRIMARY KEY (id ASC)                                  true
+child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES parent(id)  true
+child  primary             PRIMARY KEY  PRIMARY KEY (id ASC)                           true
 
 statement ok
 DROP TABLE test.child, test.parent
@@ -1520,8 +1520,8 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM y
 ----
-y  fk_b_ref_x  FOREIGN KEY  FOREIGN KEY (b) REFERENCES public.x(b)  true
-y  primary     PRIMARY KEY  PRIMARY KEY (a ASC)                     true
+y  fk_b_ref_x  FOREIGN KEY  FOREIGN KEY (b) REFERENCES x(b)  true
+y  primary     PRIMARY KEY  PRIMARY KEY (a ASC)              true
 
 # Also test dropping the index on the referenced side
 statement ok

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -928,7 +928,12 @@ func populateTableConstraints(
 				return err
 			}
 			var buf bytes.Buffer
-			if err := showForeignKeyConstraint(&buf, db.GetName(), table, con.FK, tableLookup); err != nil {
+			if err := showForeignKeyConstraint(
+				&buf, db.GetName(),
+				table, con.FK,
+				tableLookup,
+				p.extendedEvalCtx.SessionData.SearchPath,
+			); err != nil {
 				return err
 			}
 			condef = tree.NewDString(buf.String())

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -656,7 +656,8 @@ func getParentAsTableName(
 	return parentName, nil
 }
 
-// getTableNameFromTableDescriptor returns a TableName object for a given TableDescriptor.
+// getTableNameFromTableDescriptor returns a TableName object for a given
+// TableDescriptor.
 func getTableNameFromTableDescriptor(
 	l simpleSchemaResolver, table sqlbase.TableDescriptor, dbPrefix string,
 ) (tree.TableName, error) {

--- a/pkg/sql/sessiondata/search_path.go
+++ b/pkg/sql/sessiondata/search_path.go
@@ -50,6 +50,9 @@ type SearchPath struct {
 	tempSchemaName       string
 }
 
+// EmptySearchPath is a SearchPath with no schema names in it.
+var EmptySearchPath = SearchPath{}
+
 // MakeSearchPath returns a new immutable SearchPath struct. The paths slice
 // must not be modified after hand-off to MakeSearchPath.
 func MakeSearchPath(paths []string) SearchPath {
@@ -152,6 +155,16 @@ func (s SearchPath) IterWithoutImplicitPGSchemas() SearchPathIter {
 // resultant slice is not to be modified.
 func (s SearchPath) GetPathArray() []string {
 	return s.paths
+}
+
+// Contains returns true iff the SearchPath contains the given string.
+func (s SearchPath) Contains(target string) bool {
+	for _, candidate := range s.GetPathArray() {
+		if candidate == target {
+			return true
+		}
+	}
+	return false
 }
 
 // GetTemporarySchemaName returns the temporary schema specific to the current


### PR DESCRIPTION
If the schema name is in search_path, then do not include the schema
name in the foreign key definition in the pg_constraint table. This
matches the behavior of the pg_get_constraintdef function from Postgres.

The create_statements logic test ensures that the schema name still is
included when displaying create statements. The pg_catalog and
builtin_function tests were updated to check for the desired display
behavior when showing constraint definitions alone.

There is no release note because this changes behavior that was
introduced in an alpha.

fixes: #52356

Release note: None