### PR TITLE
geo/geomfn: implement ST_SetPoint

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1468,6 +1468,8 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 </span></td></tr>
 <tr><td><a name="st_segmentize"></a><code>st_segmentize(geometry: geometry, max_segment_length: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified Geometry having no segment longer than the given max_segment_length. Length units are in units of spatial reference.</p>
 </span></td></tr>
+<tr><td><a name="st_setpoint"></a><code>st_setpoint(line_string: geometry, index: <a href="int.html">int</a>, point: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Sets the Point at the given 0-based index and returns the modified LineString geometry</p>
+</span></td></tr>
 <tr><td><a name="st_setsrid"></a><code>st_setsrid(geography: geography, srid: <a href="int.html">int</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Sets a Geography to a new SRID without transforming the coordinates.</p>
 </span></td></tr>
 <tr><td><a name="st_setsrid"></a><code>st_setsrid(geometry: geometry, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Sets a Geometry to a new SRID without transforming the coordinates.</p>

--- a/pkg/geo/geomfn/set_point.go
+++ b/pkg/geo/geomfn/set_point.go
@@ -1,0 +1,70 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/errors"
+	"github.com/twpayne/go-geom"
+)
+
+// SetPoint sets the point at the given index of lineString; index is 0-based.
+func SetPoint(lineString *geo.Geometry, index int, point *geo.Geometry) (*geo.Geometry, error) {
+	g, err := lineString.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+
+	lineStringG, ok := g.(*geom.LineString)
+	if !ok {
+		e := geom.ErrUnsupportedType{Value: g}
+		return nil, errors.Wrap(e, "geometry to be modified must be a LineString")
+	}
+
+	g, err = point.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+
+	pointG, ok := g.(*geom.Point)
+	if !ok {
+		e := geom.ErrUnsupportedType{Value: g}
+		return nil, errors.Wrapf(e, "invalid geometry used to replace a Point on a LineString")
+	}
+
+	g, err = setPoint(lineStringG, index, pointG)
+	if err != nil {
+		return nil, err
+	}
+
+	return geo.NewGeometryFromGeomT(g)
+}
+
+func setPoint(lineString *geom.LineString, index int, point *geom.Point) (*geom.LineString, error) {
+	if lineString.Layout() != point.Layout() {
+		return nil, geom.ErrLayoutMismatch{Got: point.Layout(), Want: lineString.Layout()}
+	}
+
+	coords := lineString.Coords()
+	hasNegIndex := index < 0
+
+	if index >= len(coords) || (hasNegIndex && index*-1 > len(coords)) {
+		return nil, errors.Newf("index %d out of range of lineString with %d coordinates", index, len(coords))
+	}
+
+	if hasNegIndex {
+		index = len(coords) + index
+	}
+
+	coords[index].Set(point.Coords())
+
+	return lineString.SetCoords(coords)
+}

--- a/pkg/geo/geomfn/set_point_test.go
+++ b/pkg/geo/geomfn/set_point_test.go
@@ -1,0 +1,109 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
+)
+
+func TestSetPoint(t *testing.T) {
+	testCases := []struct {
+		lineString *geom.LineString
+		index      int
+		point      *geom.Point
+		expected   *geom.LineString
+	}{
+		{
+			lineString: geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2}),
+			index:      1,
+			point:      geom.NewPointFlat(geom.XY, []float64{5, 5}),
+			expected:   geom.NewLineStringFlat(geom.XY, []float64{1, 1, 5, 5}),
+		},
+		{
+			lineString: geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3, 4, 4}),
+			index:      -3,
+			point:      geom.NewPointFlat(geom.XY, []float64{0, 0}),
+			expected:   geom.NewLineStringFlat(geom.XY, []float64{1, 1, 0, 0, 3, 3, 4, 4}),
+		},
+		{
+			lineString: geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3, 4, 4}),
+			index:      -4,
+			point:      geom.NewPointFlat(geom.XY, []float64{0, 0}),
+			expected:   geom.NewLineStringFlat(geom.XY, []float64{0, 0, 2, 2, 3, 3, 4, 4}),
+		},
+		{
+			lineString: geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2}),
+			index:      0,
+			point:      geom.NewPointFlat(geom.XY, []float64{0, 0}),
+			expected:   geom.NewLineStringFlat(geom.XY, []float64{0, 0, 2, 2}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ls, err := geo.NewGeometryFromGeomT(tc.lineString)
+			require.NoError(t, err)
+
+			p, err := geo.NewGeometryFromGeomT(tc.point)
+			require.NoError(t, err)
+
+			got, err := SetPoint(ls, tc.index, p)
+			require.NoError(t, err)
+
+			want, err := geo.NewGeometryFromGeomT(tc.expected)
+			require.NoError(t, err)
+
+			require.Equal(t, want, got)
+			require.EqualValues(t, tc.lineString.SRID(), got.SRID())
+		})
+	}
+
+	errTestCases := []struct {
+		lineString *geom.LineString
+		index      int
+		point      *geom.Point
+	}{
+		{
+			lineString: geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2}),
+			index:      3,
+			point:      geom.NewPointFlat(geom.XY, []float64{0, 0}),
+		},
+		{
+			lineString: geom.NewLineStringFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3}),
+			index:      -4,
+			point:      geom.NewPointFlat(geom.XY, []float64{0, 0}),
+		},
+		{
+			lineString: geom.NewLineString(geom.XY),
+			index:      0,
+			point:      geom.NewPointFlat(geom.XY, []float64{0, 0}),
+		},
+	}
+
+	for i, tc := range errTestCases {
+		t.Run(fmt.Sprintf("error-%d", i), func(t *testing.T) {
+			ls, err := geo.NewGeometryFromGeomT(tc.lineString)
+			require.NoError(t, err)
+
+			p, err := geo.NewGeometryFromGeomT(tc.point)
+			require.NoError(t, err)
+
+			wantErr := fmt.Sprintf("index %d out of range of lineString with %d coordinates", tc.index, tc.lineString.NumCoords())
+			_, err = SetPoint(ls, tc.index, p)
+			require.EqualError(t, err, wantErr)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4025,3 +4025,21 @@ SELECT ST_AsEWKT(ST_MakeLine(g::geometry)) FROM ( VALUES
 ) t(g)
 ----
 NULL
+
+subtest set_point_test
+
+query T
+SELECT
+  ST_AsText(ST_SetPoint(ls::geometry, i, p::geometry))
+FROM ( VALUES
+  ('LINESTRING(-1 2,-1 3)', 0, 'POINT(10 10)'),
+  ('LINESTRING(0 0, 1 1, 2 2)', 2, 'POINT(10 10)'),
+  ('LINESTRING(0 0, 1 1, 2 2, 3 3)', -1, 'POINT(10 10)'),
+  ('LINESTRING(0 0, 1 1, 2 2, 3 3)', -4, 'POINT(10 10)')
+  )
+ t(ls, i, p) ;
+----
+LINESTRING (10 10, -1 3)
+LINESTRING (0 0, 1 1, 10 10)
+LINESTRING (0 0, 1 1, 2 2, 10 10)
+LINESTRING (10 10, 1 1, 2 2, 3 3)

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3136,6 +3136,33 @@ For flags=1, validity considers self-intersecting rings forming holes as valid a
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_setpoint": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"line_string", types.Geometry},
+				{"index", types.Int},
+				{"point", types.Geometry},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				lineString := args[0].(*tree.DGeometry)
+				index := int(*args[1].(*tree.DInt))
+				point := args[2].(*tree.DGeometry)
+
+				ret, err := geomfn.SetPoint(lineString.Geometry, index, point.Geometry)
+				if err != nil {
+					return nil, err
+				}
+
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: `Sets the Point at the given 0-based index and returns the modified LineString geometry`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 	"st_segmentize": makeBuiltin(
 		defProps(),
 		tree.Overload{


### PR DESCRIPTION
Implement ST_SetPoint on arguments {geometry, int4, geometry}, which should adopt PostGIS behaviour.

Release note (sql change): Implemented geometry builtin `ST_SetPoint`