### PR TITLE
sql: support alter type owner

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1141,6 +1141,7 @@ alter_type_stmt ::=
 	| 'ALTER' 'TYPE' type_name 'RENAME' 'VALUE' 'SCONST' 'TO' 'SCONST'
 	| 'ALTER' 'TYPE' type_name 'RENAME' 'TO' name
 	| 'ALTER' 'TYPE' type_name 'SET' 'SCHEMA' schema_name
+	| 'ALTER' 'TYPE' type_name 'OWNER' 'TO' role_spec
 
 role_or_group_or_user ::=
 	'ROLE'

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -69,6 +69,8 @@ func (n *alterTypeNode) startExec(params runParams) error {
 		err = params.p.renameType(params.ctx, n, t.NewName)
 	case *tree.AlterTypeSetSchema:
 		err = params.p.setTypeSchema(params.ctx, n, t.Schema)
+	case *tree.AlterTypeOwner:
+		err = params.p.alterTypeOwner(params.ctx, n, t.Owner)
 	default:
 		err = errors.AssertionFailedf("unknown alter type cmd %s", t)
 	}
@@ -284,6 +286,50 @@ func (p *planner) setTypeSchema(ctx context.Context, n *alterTypeNode, schema st
 
 	return p.performRenameTypeDesc(
 		ctx, arrayDesc, arrayDesc.Name, desiredSchemaID, tree.AsStringWithFQNames(n.n, p.Ann()),
+	)
+}
+
+func (p *planner) alterTypeOwner(ctx context.Context, n *alterTypeNode, newOwner string) error {
+	typeDesc := n.desc
+	privs := typeDesc.GetPrivileges()
+
+	hasOwnership, err := p.HasOwnership(ctx, typeDesc)
+	if err != nil {
+		return err
+	}
+
+	if err := p.checkCanAlterToNewOwner(ctx, typeDesc, privs, newOwner, hasOwnership); err != nil {
+		return err
+	}
+
+	// Ensure the new owner has CREATE privilege on the type's schema.
+	if err := p.canCreateOnSchema(ctx, typeDesc.GetParentSchemaID(), newOwner); err != nil {
+		return err
+	}
+
+	// If the owner we want to set to is the current owner, do a no-op.
+	if newOwner == privs.Owner {
+		return nil
+	}
+
+	privs.SetOwner(newOwner)
+
+	if err := p.writeTypeSchemaChange(
+		ctx, typeDesc, tree.AsStringWithFQNames(n.n, p.Ann()),
+	); err != nil {
+		return err
+	}
+
+	// Also have to change the owner of the implicit array type.
+	arrayDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, n.desc.ArrayTypeID)
+	if err != nil {
+		return err
+	}
+
+	arrayDesc.Privileges.SetOwner(newOwner)
+
+	return p.writeTypeSchemaChange(
+		ctx, arrayDesc, tree.AsStringWithFQNames(n.n, p.Ann()),
 	)
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_type_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type_owner
@@ -1,0 +1,129 @@
+statement ok
+SET experimental_enable_enums = true
+
+statement ok
+CREATE TYPE typ AS ENUM ()
+
+# Ensure user must exist for set owner.
+statement error pq: role/user "fake_user" does not exist
+ALTER TYPE typ OWNER TO fake_user
+
+# Ensure the current user is a member of the role we're setting to.
+statement error pq: must be member of role "testuser"
+ALTER TYPE typ OWNER TO testuser
+
+user testuser
+
+# Ensure the user has to be an owner to alter the owner.
+statement error pq: must be owner of type t
+ALTER TYPE typ OWNER TO testuser
+
+user root
+
+statement ok
+GRANT testuser TO root
+
+# Test set owner for a type in the public schema.
+statement ok
+ALTER TYPE typ OWNER TO testuser
+
+user testuser
+
+statement ok
+SET experimental_enable_user_defined_schemas = true
+
+statement ok
+CREATE SCHEMA s
+
+user root
+
+# testuser2 does not have owner/create privilege on schema s.
+statement ok
+CREATE USER testuser2
+
+statement ok
+CREATE TYPE s.typ AS ENUM ()
+
+statement ok
+GRANT testuser2 TO root
+
+# Ensure the new owner has create privilege on the schema.
+statement error pq: user testuser2 does not have CREATE privilege on schema s
+ALTER TYPE s.typ OWNER TO testuser2
+
+statement ok
+GRANT testuser TO root
+
+# testuser satisfies all the conditions to become the new owner.
+statement ok
+ALTER TYPE s.typ OWNER TO testuser
+
+# setup to allow testuser2 as a member of testuser to alter the owner.
+statement ok
+REVOKE testuser, testuser2 FROM root
+
+statement ok
+GRANT testuser TO testuser2
+
+statement ok
+GRANT root TO testuser
+
+user testuser2
+
+# testuser2 should be able to alter the owner since it is a member of testuser.
+statement ok
+ALTER TYPE s.typ OWNER TO root
+
+# set the owner back to testuser.
+
+user root
+
+statement ok
+REVOKE root FROM testuser
+
+statement ok
+GRANT testuser TO root
+
+statement ok
+ALTER TYPE s.typ OWNER TO testuser
+
+user testuser
+
+# Ensure testuser is owner by dropping the type.
+statement ok
+DROP TYPE s.typ
+
+user root
+
+# Ensure admins who don't have explicit CREATE privilege on a schema can
+# still become the owner.
+
+# Ensure root does not have CREATE privilege on schema by being a member
+# of testuser.
+statement ok
+REVOKE testuser FROM root
+
+user testuser
+
+statement ok
+SET experimental_enable_user_defined_schemas = true
+
+statement ok
+SET experimental_enable_enums = true
+
+statement ok
+CREATE SCHEMA s2
+
+statement ok
+CREATE TYPE s2.typ AS ENUM ()
+
+user root
+
+statement ok
+GRANT root TO testuser
+
+user testuser
+
+# This should succeed despite root not having explicit CREATE privilege on s2.
+statement ok
+ALTER TYPE s2.typ OWNER TO root

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1479,6 +1479,7 @@ func TestParse(t *testing.T) {
 		{`ALTER TYPE t RENAME VALUE 'value1' TO 'value2'`},
 		{`ALTER TYPE t RENAME TO t2`},
 		{`ALTER TYPE t SET SCHEMA newschema`},
+		{`ALTER TYPE t OWNER TO foo`},
 
 		{`COMMENT ON COLUMN a.b IS 'a'`},
 		{`COMMENT ON COLUMN a.b IS NULL`},
@@ -2533,6 +2534,9 @@ SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS,
 		{`SELECT 1::int4.typ array [1]`, `SELECT 1::int4.typ[]`},
 		{`SELECT 1::db.int4.typ array`, `SELECT 1::db.int4.typ[]`},
 		{`CREATE TABLE t (x int4.type array [1])`, `CREATE TABLE t (x int4.type[])`},
+
+		{`ALTER TYPE t OWNER TO CURRENT_USER`, "ALTER TYPE t OWNER TO \"current_user\""},
+		{`ALTER TYPE t OWNER TO SESSION_USER`, "ALTER TYPE t OWNER TO \"session_user\""},
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {
@@ -2966,9 +2970,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`CREATE TYPE a`, 27793, `shell`, ``},
 		{`CREATE DOMAIN a`, 27796, `create`, ``},
 
-		{`ALTER TYPE t OWNER TO hello`, 48700, `ALTER TYPE OWNER TO`, ``},
-		{`ALTER TYPE t OWNER TO CURRENT_USER`, 48700, `ALTER TYPE OWNER TO`, ``},
-		{`ALTER TYPE t OWNER TO SESSION_USER`, 48700, `ALTER TYPE OWNER TO`, ``},
 		{`ALTER TYPE db.t RENAME ATTRIBUTE foo TO bar`, 48701, `ALTER TYPE ATTRIBUTE`, ``},
 		{`ALTER TYPE db.s.t ADD ATTRIBUTE foo bar`, 48701, `ALTER TYPE ATTRIBUTE`, ``},
 		{`ALTER TYPE db.s.t ADD ATTRIBUTE foo bar COLLATE hello`, 48701, `ALTER TYPE ATTRIBUTE`, ``},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2017,7 +2017,12 @@ alter_type_stmt:
   }
 | ALTER TYPE type_name OWNER TO role_spec
   {
-    return unimplementedWithIssueDetail(sqllex, 48700, "ALTER TYPE OWNER TO")
+    $$.val = &tree.AlterType{
+      Type: $3.unresolvedObjectName(),
+      Cmd: &tree.AlterTypeOwner{
+        Owner: $6,
+      },
+    }
   }
 | ALTER TYPE type_name RENAME ATTRIBUTE column_name TO column_name opt_drop_behavior
   {

--- a/pkg/sql/sem/tree/alter_type.go
+++ b/pkg/sql/sem/tree/alter_type.go
@@ -35,11 +35,13 @@ func (*AlterTypeAddValue) alterTypeCmd()    {}
 func (*AlterTypeRenameValue) alterTypeCmd() {}
 func (*AlterTypeRename) alterTypeCmd()      {}
 func (*AlterTypeSetSchema) alterTypeCmd()   {}
+func (*AlterTypeOwner) alterTypeCmd()       {}
 
 var _ AlterTypeCmd = &AlterTypeAddValue{}
 var _ AlterTypeCmd = &AlterTypeRenameValue{}
 var _ AlterTypeCmd = &AlterTypeRename{}
 var _ AlterTypeCmd = &AlterTypeSetSchema{}
+var _ AlterTypeCmd = &AlterTypeOwner{}
 
 // AlterTypeAddValue represents an ALTER TYPE ADD VALUE command.
 type AlterTypeAddValue struct {
@@ -106,4 +108,15 @@ type AlterTypeSetSchema struct {
 func (node *AlterTypeSetSchema) Format(ctx *FmtCtx) {
 	ctx.WriteString(" SET SCHEMA ")
 	ctx.WriteString(node.Schema)
+}
+
+// AlterTypeOwner represents an ALTER TYPE OWNER TO command.
+type AlterTypeOwner struct {
+	Owner string
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterTypeOwner) Format(ctx *FmtCtx) {
+	ctx.WriteString(" OWNER TO ")
+	ctx.FormatNameP(&node.Owner)
 }


### PR DESCRIPTION
Release note (sql change): Support ALTER TYPE <type> OWNER TO <owner>
The command changes the owner of a type.

To use the conditions, the following conditions must be met:
The user executing the command must be the explicit owner of the type.
(Not just have membership of the role who owns the type.)
The user executing the command must be a member of the new owner role.
The new owner role must have CREATE on the schema the type belongs to.

Only the latest commit is relevant, this depends on #51622
Fixes #48700