### PR TITLE
opt: refactor partial index stats tests

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -9,13 +9,7 @@ CREATE TABLE a (
   k INT PRIMARY KEY,
   i INT,
   s STRING,
-  t STRING,
-  INDEX idx_s_foo (i) WHERE s = 'foo',
-  INDEX idx_i_0_to_100 (s) WHERE i > 0 AND i < 100,
-  INDEX idx_not_tight (i) WHERE i < k AND i % 3 = 0,
-  INDEX idx_equiv (s, t) WHERE s = t,
-  INDEX idx_s_null (i) WHERE s IS NULL,
-  INDEX idx_i_200_to_250 (i) WHERE i > 200 AND i < 250
+  t STRING
 )
 ----
 
@@ -50,7 +44,13 @@ ALTER TABLE a INJECT STATISTICS '[
 ]'
 ----
 
+# Unconstrained partial index scan.
 # Distinct and null counts are updated based on the partial index predicate.
+
+exec-ddl
+CREATE INDEX idx ON a (i) WHERE s = 'foo'
+----
+
 opt
 SELECT * FROM a WHERE s = 'foo'
 ----
@@ -59,13 +59,22 @@ index-join a
  ├── stats: [rows=96.4285714, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4)
- └── scan a@idx_s_foo,partial
+ └── scan a@idx,partial
       ├── columns: k:1(int!null) i:2(int)
       ├── stats: [rows=96.4285714, distinct(3)=1, null(3)=0]
       ├── key: (1)
       └── fd: (1)-->(2)
 
-# Test for Select filter applied after partial index scan.
+exec-ddl
+DROP INDEX idx
+----
+
+# Test for select filter applied after an unconstrained partial index scan.
+
+exec-ddl
+CREATE INDEX idx ON a (s) WHERE i > 0 AND i < 100
+----
+
 opt
 SELECT * FROM a WHERE i > 25 AND i < 50
 ----
@@ -79,7 +88,7 @@ select
  │    ├── stats: [rows=990]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
- │    └── scan a@idx_i_0_to_100,partial
+ │    └── scan a@idx,partial
  │         ├── columns: k:1(int!null) s:3(string)
  │         ├── stats: [rows=990, distinct(2)=99, null(2)=0]
  │         ├── key: (1)
@@ -87,7 +96,16 @@ select
  └── filters
       └── (i:2 > 25) AND (i:2 < 50) [type=bool, outer=(2), constraints=(/2: [/26 - /49]; tight)]
 
+exec-ddl
+DROP INDEX idx
+----
+
 # Test for multiple unapplied conjunctions due to non-tight constraints.
+
+exec-ddl
+CREATE INDEX idx ON a (i) WHERE i < k AND i % 3 = 0
+----
+
 opt
 SELECT * FROM a WHERE i < k AND i % 3 = 0
 ----
@@ -97,15 +115,24 @@ index-join a
  ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0, distinct(2)=500, null(2)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- └── scan a@idx_not_tight,partial
+ └── scan a@idx,partial
       ├── columns: k:1(int!null) i:2(int)
       ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0, distinct(2)=500, null(2)=0]
       ├── key: (1)
       └── fd: (1)-->(2)
 
+exec-ddl
+DROP INDEX idx
+----
+
 # Test for an indexed column that is also constrained by partial index predicate.
+
+exec-ddl
+CREATE INDEX idx ON a (i) WHERE i > 0 AND i < 50
+----
+
 opt
-SELECT * FROM a WHERE i > 215 AND i < 230
+SELECT * FROM a WHERE i > 15 AND i < 30
 ----
 index-join a
  ├── columns: k:1(int!null) i:2(int!null) s:3(string) t:4(string)
@@ -117,15 +144,24 @@ index-join a
       ├── stats: [rows=140, distinct(2)=14, null(2)=0]
       ├── key: (1)
       ├── fd: (1)-->(2)
-      ├── scan a@idx_i_200_to_250,partial
+      ├── scan a@idx,partial
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── stats: [rows=490, distinct(1)=490, null(1)=0, distinct(2)=49, null(2)=0]
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
       └── filters
-           └── (i:2 > 215) AND (i:2 < 230) [type=bool, outer=(2), constraints=(/2: [/216 - /229]; tight)]
+           └── (i:2 > 15) AND (i:2 < 30) [type=bool, outer=(2), constraints=(/2: [/16 - /29]; tight)]
+
+exec-ddl
+DROP INDEX idx
+----
 
 # Test for FuncDep equivalencies.
+
+exec-ddl
+CREATE INDEX idx ON a (s, t) WHERE s = t
+----
+
 opt
 SELECT * FROM a WHERE s = t AND s LIKE '%foo%' AND t LIKE '%bar%'
 ----
@@ -139,7 +175,7 @@ index-join a
       ├── stats: [rows=1.0395, distinct(3)=1.0395, null(3)=0, distinct(4)=1.0395, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4)
-      ├── scan a@idx_equiv,partial
+      ├── scan a@idx,partial
       │    ├── columns: k:1(int!null) s:3(string) t:4(string)
       │    ├── stats: [rows=9.3555, distinct(1)=9.3555, null(1)=0, distinct(3)=9.3555, null(3)=0, distinct(4)=9.3555, null(4)=0]
       │    ├── key: (1)
@@ -148,7 +184,16 @@ index-join a
            ├── s:3 LIKE '%foo%' [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
            └── t:4 LIKE '%bar%' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
 
+exec-ddl
+DROP INDEX idx
+----
+
 # Test for null predicate.
+
+exec-ddl
+CREATE INDEX idx ON a (i) WHERE s IS NULL
+----
+
 opt
 SELECT * FROM a WHERE s IS NULL
 ----
@@ -157,11 +202,15 @@ index-join a
  ├── stats: [rows=275, distinct(3)=1, null(3)=275]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4)
- └── scan a@idx_s_null,partial
+ └── scan a@idx,partial
       ├── columns: k:1(int!null) i:2(int)
       ├── stats: [rows=275, distinct(3)=1, null(3)=275]
       ├── key: (1)
       └── fd: (1)-->(2)
+
+exec-ddl
+DROP INDEX idx
+----
 
 # ---------------------
 # Tests with Histograms


### PR DESCRIPTION
This commit refactors the stats tests for partial indexes. The tests now
use `CREATE INDEX` and `DROP INDEX` (recently added to the test catalog)
so that index definitions are physically close to the queries that use
the index. This makes the tests comprehensible.

Release note: None