### PR TITLE
opt: streamline stats test rewrite process

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -15,8 +15,9 @@ import file=tpcc_stats_w10
 # reflect on-line database activity as typically found in production
 # environments.
 # --------------------------------------------------
-save-tables format=hide-qual database=tpcc save-tables-prefix=new_order_01
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=new_order_01 ignore-tables=1
 SELECT w_tax FROM warehouse WHERE w_id = 1
+----
 ----
 project
  ├── save-table-name: new_order_01_project_1
@@ -34,8 +35,7 @@ project
       ├── key: ()
       └── fd: ()-->(1,8)
 
-stats table=new_order_01_scan_2
-----
+----Stats for new_order_01_scan_2----
 column_names  row_count  distinct_count  null_count
 {w_id}        1          1               0
 {w_tax}       1          1               0
@@ -43,11 +43,14 @@ column_names  row_count  distinct_count  null_count
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {w_id}        1.00           1.00           1.00                1.00                0.00            1.00
 {w_tax}       1.00           1.00           1.00                1.00                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=new_order_02
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=new_order_02 ignore-tables=1
 SELECT c_discount, c_last, c_credit
 FROM customer
 WHERE c_w_id = 1 AND c_d_id = 1 AND c_id = 50
+----
 ----
 project
  ├── save-table-name: new_order_02_project_1
@@ -65,8 +68,7 @@ project
       ├── key: ()
       └── fd: ()-->(1-3,6,14,16)
 
-stats table=new_order_02_scan_2
-----
+----Stats for new_order_02_scan_2----
 column_names  row_count  distinct_count  null_count
 {c_credit}    1          1               0
 {c_d_id}      1          1               0
@@ -82,12 +84,15 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {c_id}        1.00           1.00           1.00                1.00                0.00            1.00
 {c_last}      1.00           1.00           1.00                1.00                0.00            1.00
 {c_w_id}      1.00           1.00           1.00                1.00                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=new_order_03
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=new_order_03
 SELECT i_price, i_name, i_data
 FROM item
 WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
 ORDER BY i_id
+----
 ----
 scan item
  ├── save-table-name: new_order_03_scan_1
@@ -111,8 +116,7 @@ scan item
  ├── fd: (1)-->(3-5)
  └── ordering: +1
 
-stats table=new_order_03_scan_1
-----
+----Stats for new_order_03_scan_1----
 column_names  row_count  distinct_count  null_count
 {i_data}      12         12              0
 {i_id}        12         12              0
@@ -124,12 +128,15 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {i_id}        12.00          1.00           12.00               1.00                0.00            1.00
 {i_name}      12.00          1.00           12.00               1.00                0.00            1.00
 {i_price}     12.00          1.00           12.00               1.00                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=new_order_04
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=new_order_04 ignore-tables=1
 SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
 FROM stock
 WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
 ORDER BY s_i_id
+----
 ----
 project
  ├── save-table-name: new_order_04_project_1
@@ -154,8 +161,7 @@ project
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
       └── ordering: +1 opt(2) [actual: +1]
 
-stats table=new_order_04_scan_2
-----
+----Stats for new_order_04_scan_2----
 column_names    row_count  distinct_count  null_count
 {s_data}        5          5               0
 {s_dist_05}     5          5               0
@@ -175,6 +181,8 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {s_remote_cnt}  5.00           1.00           1.00                1.00                0.00            1.00
 {s_w_id}        5.00           1.00           1.00                1.00                0.00            1.00
 {s_ytd}         5.00           1.00           1.00                1.00                0.00            1.00
+----
+----
 
 # --------------------------------------------------
 # 2.5 The Payment Transaction
@@ -185,11 +193,12 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 # stringent response time requirements to satisfy on-line users. In addition,
 # this transaction includes non-primary key access to the CUSTOMER table.
 # --------------------------------------------------
-save-tables format=hide-qual database=tpcc save-tables-prefix=payment_01
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=payment_01 ignore-tables=1
 SELECT c_id
 FROM customer
 WHERE c_w_id = 1 AND c_d_id = 1 AND c_last = 'ANTIABLEABLE'
 ORDER BY c_first ASC
+----
 ----
 project
  ├── save-table-name: payment_01_project_1
@@ -209,8 +218,7 @@ project
       ├── fd: ()-->(2,3,6), (1)-->(4)
       └── ordering: +4 opt(2,3,6) [actual: +4]
 
-stats table=payment_01_scan_2
-----
+----Stats for payment_01_scan_2----
 column_names  row_count  distinct_count  null_count
 {c_d_id}      2          1               0
 {c_first}     2          2               0
@@ -224,6 +232,8 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {c_id}        3.00           1.50           3.00                1.50                0.00            1.00
 {c_last}      3.00           1.50           1.00                1.00                0.00            1.00
 {c_w_id}      3.00           1.50           1.00                1.00                0.00            1.00
+----
+----
 
 # --------------------------------------------------
 # 2.6 The Order Status Transaction
@@ -234,10 +244,11 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 # users. In addition, this table includes non-primary key access to the
 # CUSTOMER table.
 # --------------------------------------------------
-save-tables format=hide-qual database=tpcc save-tables-prefix=order_status_01
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=order_status_01 ignore-tables=1
 SELECT c_balance, c_first, c_middle, c_last
 FROM customer
 WHERE c_w_id = 1 AND c_d_id = 1 AND c_id = 50
+----
 ----
 project
  ├── save-table-name: order_status_01_project_1
@@ -255,8 +266,7 @@ project
       ├── key: ()
       └── fd: ()-->(1-6,17)
 
-stats table=order_status_01_scan_2
-----
+----Stats for order_status_01_scan_2----
 column_names  row_count  distinct_count  null_count
 {c_balance}   1          1               0
 {c_d_id}      1          1               0
@@ -274,12 +284,15 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {c_last}      1.00           1.00           1.00                1.00                0.00            1.00
 {c_middle}    1.00           1.00           1.00                1.00                0.00            1.00
 {c_w_id}      1.00           1.00           1.00                1.00                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=order_status_02
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=order_status_02 ignore-tables=(1,3)
 SELECT c_id, c_balance, c_first, c_middle
 FROM customer
 WHERE c_w_id = 2 AND c_d_id = 2 AND c_last = 'ANTIBARESE'
 ORDER BY c_first ASC
+----
 ----
 project
  ├── save-table-name: order_status_02_project_1
@@ -308,8 +321,7 @@ project
            ├── fd: ()-->(2,3,6), (1)-->(4)
            └── ordering: +4 opt(2,3,6) [actual: +4]
 
-stats table=order_status_02_index_join_2
-----
+----Stats for order_status_02_index_join_2----
 column_names  row_count  distinct_count  null_count
 {c_balance}   3          1               0
 {c_d_id}      3          1               0
@@ -327,13 +339,16 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {c_last}      3.00           1.00           1.00                1.00                0.00            1.00
 {c_middle}    3.00           1.00           1.00                1.00                0.00            1.00
 {c_w_id}      3.00           1.00           1.00                1.00                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=order_status_03
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=order_status_03 ignore-tables=1
 SELECT o_id, o_entry_d, o_carrier_id
 FROM "order"
 WHERE o_w_id = 4 AND o_d_id = 3 AND o_c_id = 10
 ORDER BY o_id DESC
 LIMIT 1
+----
 ----
 project
  ├── save-table-name: order_status_03_project_1
@@ -351,10 +366,30 @@ project
       ├── key: ()
       └── fd: ()-->(1-6)
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=order_status_04
+----Stats for order_status_03_scan_2----
+column_names    row_count  distinct_count  null_count
+{o_c_id}        1          1               0
+{o_carrier_id}  1          1               0
+{o_d_id}        1          1               0
+{o_entry_d}     1          1               0
+{o_id}          1          1               0
+{o_w_id}        1          1               0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_c_id}        1.00           1.00           1.00                1.00                0.00            1.00
+{o_carrier_id}  1.00           1.00           1.00                1.00                0.00            1.00
+{o_d_id}        1.00           1.00           1.00                1.00                0.00            1.00
+{o_entry_d}     1.00           1.00           1.00                1.00                0.00            1.00
+{o_id}          1.00           1.00           1.00                1.00                0.00            1.00
+{o_w_id}        1.00           1.00           1.00                1.00                0.00            1.00
+----
+----
+
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=order_status_04 ignore-tables=1
 SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
 FROM order_line
 WHERE ol_w_id = 1 AND ol_d_id = 1 AND ol_o_id = 1000
+----
 ----
 project
  ├── save-table-name: order_status_04_project_1
@@ -369,8 +404,7 @@ project
       │                <---- 1 --
       └── fd: ()-->(1-3)
 
-stats table=order_status_04_scan_2
-----
+----Stats for order_status_04_scan_2----
 column_names      row_count  distinct_count  null_count
 {ol_amount}       12         1               0
 {ol_d_id}         12         1               0
@@ -390,6 +424,8 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 {ol_quantity}     9.00           1.33           1.00                1.00                0.00            1.00
 {ol_supply_w_id}  9.00           1.33           6.00                6.00 <==            0.00            1.00
 {ol_w_id}         9.00           1.33           1.00                1.00                0.00            1.00
+----
+----
 
 # --------------------------------------------------
 # 2.7 The Delivery Transaction
@@ -407,12 +443,13 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 # indicating transaction completion. The result of the deferred execution is
 # recorded into a result file.
 # --------------------------------------------------
-save-tables format=hide-qual database=tpcc save-tables-prefix=delivery_01
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=delivery_01 ignore-tables=1
 SELECT no_o_id
 FROM new_order
 WHERE no_w_id = 7 AND no_d_id = 6
 ORDER BY no_o_id ASC
 LIMIT 1
+----
 ----
 project
  ├── save-table-name: delivery_01_project_1
@@ -430,8 +467,7 @@ project
       ├── key: ()
       └── fd: ()-->(1-3)
 
-stats table=delivery_01_scan_2
-----
+----Stats for delivery_01_scan_2----
 column_names  row_count  distinct_count  null_count
 {no_d_id}     1          1               0
 {no_o_id}     1          1               0
@@ -441,11 +477,14 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {no_d_id}     1.00           1.00           1.00                1.00                0.00            1.00
 {no_o_id}     1.00           1.00           1.00                1.00                0.00            1.00
 {no_w_id}     1.00           1.00           1.00                1.00                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=delivery_02
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=delivery_02
 SELECT sum(ol_amount)
 FROM order_line
 WHERE ol_w_id = 8 AND ol_d_id = 6 AND ol_o_id = 1000
+----
 ----
 scalar-group-by
  ├── save-table-name: delivery_02_scalar_group_by_1
@@ -466,8 +505,14 @@ scalar-group-by
       └── sum [as=sum:12, type=decimal, outer=(9)]
            └── ol_amount:9 [type=decimal]
 
-stats table=delivery_02_scan_2
-----
+----Stats for delivery_02_scalar_group_by_1----
+column_names  row_count  distinct_count  null_count
+{sum}         1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{sum}         1.00           1.00           1.00                1.00                0.00            1.00
+
+----Stats for delivery_02_scan_2----
 column_names  row_count  distinct_count  null_count
 {ol_amount}   7          1               0
 {ol_d_id}     7          1               0
@@ -479,14 +524,8 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {ol_d_id}     10.00          1.43           1.00                1.00                0.00            1.00
 {ol_o_id}     10.00          1.43           1.00                1.00                0.00            1.00
 {ol_w_id}     10.00          1.43           1.00                1.00                0.00            1.00
-
-stats table=delivery_02_scalar_group_by_1
 ----
-column_names  row_count  distinct_count  null_count
-{sum}         1          1               0
-~~~~
-column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{sum}         1.00           1.00           1.00                1.00                0.00            1.00
+----
 
 # --------------------------------------------------
 # 2.8 The Stock-Level Transaction
@@ -496,10 +535,11 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 # heavy read-only database transaction with a low frequency of execution, a
 # relaxed response time requirement, and relaxed consistency requirements.
 # --------------------------------------------------
-save-tables format=hide-qual database=tpcc save-tables-prefix=stock_level_01
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=stock_level_01 ignore-tables=1
 SELECT d_next_o_id
 FROM district
 WHERE d_w_id = 4 AND d_id = 9
+----
 ----
 project
  ├── save-table-name: stock_level_01_project_1
@@ -517,8 +557,7 @@ project
       ├── key: ()
       └── fd: ()-->(1,2,11)
 
-stats table=stock_level_01_scan_2
-----
+----Stats for stock_level_01_scan_2----
 column_names   row_count  distinct_count  null_count
 {d_id}         1          1               0
 {d_next_o_id}  1          1               0
@@ -528,8 +567,10 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {d_id}         1.00           1.00           1.00                1.00                0.00            1.00
 {d_next_o_id}  1.00           1.00           1.00                1.00                0.00            1.00
 {d_w_id}       1.00           1.00           1.00                1.00                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=stock_level_02
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=stock_level_02
 SELECT count(DISTINCT s_i_id)
 FROM order_line
 JOIN stock
@@ -538,6 +579,7 @@ WHERE ol_w_id = 1
     AND ol_d_id = 1
     AND ol_o_id BETWEEN 1000 - 20 AND 1000 - 1
     AND s_quantity < 15
+----
 ----
 scalar-group-by
  ├── save-table-name: stock_level_02_scalar_group_by_1
@@ -573,22 +615,21 @@ scalar-group-by
  └── aggregations
       └── count-rows [as=count:30, type=int]
 
-stats table=stock_level_02_scan_4
-----
+----Stats for stock_level_02_scalar_group_by_1----
 column_names  row_count  distinct_count  null_count
-{ol_d_id}     193        1               0
-{ol_i_id}     193        193             0
-{ol_o_id}     193        20              0
-{ol_w_id}     193        1               0
+{count}       1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{ol_d_id}     188.00         1.03           1.00                1.00                0.00            1.00
-{ol_i_id}     188.00         1.03           188.00              1.03                0.00            1.00
-{ol_o_id}     188.00         1.03           20.00               1.00                0.00            1.00
-{ol_w_id}     188.00         1.03           1.00                1.00                0.00            1.00
+{count}       1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=stock_level_02_lookup_join_3
-----
+----Stats for stock_level_02_distinct_on_2----
+column_names  row_count  distinct_count  null_count
+{s_i_id}      15         15              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_i_id}      188.00         12.53 <==      188.00              12.53 <==           0.00            1.00
+
+----Stats for stock_level_02_lookup_join_3----
 column_names  row_count  distinct_count  null_count
 {ol_d_id}     15         1               0
 {ol_i_id}     15         15              0
@@ -607,15 +648,20 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {s_quantity}  219.00         14.60 <==      30.00               6.00 <==            0.00            1.00
 {s_w_id}      219.00         14.60 <==      1.00                1.00                0.00            1.00
 
-# TODO(radu): add stock_level_02_distinct_on_2.
-
-stats table=stock_level_02_scalar_group_by_1
-----
+----Stats for stock_level_02_scan_4----
 column_names  row_count  distinct_count  null_count
-{count}       1          1               0
+{ol_d_id}     193        1               0
+{ol_i_id}     193        193             0
+{ol_o_id}     193        20              0
+{ol_w_id}     193        1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{count}       1.00           1.00           1.00                1.00                0.00            1.00
+{ol_d_id}     188.00         1.03           1.00                1.00                0.00            1.00
+{ol_i_id}     188.00         1.03           188.00              1.03                0.00            1.00
+{ol_o_id}     188.00         1.03           20.00               1.00                0.00            1.00
+{ol_w_id}     188.00         1.03           1.00                1.00                0.00            1.00
+----
+----
 
 # --------------------------------------------------
 # Consistency Queries
@@ -623,7 +669,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 # These queries run after TPCC in order to check database consistency.
 # They are not part of the benchmark itself.
 # --------------------------------------------------
-save-tables format=hide-qual database=tpcc save-tables-prefix=consistency_01
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=consistency_01 ignore-tables=(3,5)
 SELECT count(*)
 FROM warehouse
 FULL OUTER JOIN
@@ -634,6 +680,7 @@ FULL OUTER JOIN
 )
 ON (w_id = d_w_id)
 WHERE w_ytd != sum_d_ytd
+----
 ----
 scalar-group-by
  ├── save-table-name: consistency_01_scalar_group_by_1
@@ -684,18 +731,14 @@ scalar-group-by
  └── aggregations
       └── count-rows [as=count_rows:24, type=int]
 
-stats table=consistency_01_group_by_4
-----
+----Stats for consistency_01_scalar_group_by_1----
 column_names  row_count  distinct_count  null_count
-{d_w_id}      10         10              0
-{sum}         10         1               0
+{count}       1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{d_w_id}      10.00          1.00           10.00               1.00                0.00            1.00
-{sum}         10.00          1.00           10.00               10.00 <==           0.00            1.00
+{count}       1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=consistency_01_merge_join_2
-----
+----Stats for consistency_01_merge_join_2----
 column_names  row_count  distinct_count  null_count
 {d_w_id}      0          0               0
 {sum}         0          0               0
@@ -708,18 +751,22 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {w_id}        3.00           +Inf <==       3.00                +Inf <==            0.00            1.00
 {w_ytd}       3.00           +Inf <==       1.00                +Inf <==            0.00            1.00
 
-stats table=consistency_01_scalar_group_by_1
-----
+----Stats for consistency_01_group_by_4----
 column_names  row_count  distinct_count  null_count
-{count}       1          1               0
+{d_w_id}      10         10              0
+{sum}         10         1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{count}       1.00           1.00           1.00                1.00                0.00            1.00
+{d_w_id}      10.00          1.00           10.00               1.00                0.00            1.00
+{sum}         10.00          1.00           10.00               10.00 <==           0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=consistency_02
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=consistency_02
 SELECT d_next_o_id
 FROM district
 ORDER BY d_w_id, d_id
+----
 ----
 scan district
  ├── save-table-name: consistency_02_scan_1
@@ -731,11 +778,25 @@ scan district
  ├── fd: (1,2)-->(11)
  └── ordering: +2,+1
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=consistency_03
+----Stats for consistency_02_scan_1----
+column_names   row_count  distinct_count  null_count
+{d_id}         100        10              0
+{d_next_o_id}  100        1               0
+{d_w_id}       100        10              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{d_id}         100.00         1.00           10.00               1.00                0.00            1.00
+{d_next_o_id}  100.00         1.00           1.00                1.00                0.00            1.00
+{d_w_id}       100.00         1.00           10.00               1.00                0.00            1.00
+----
+----
+
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=consistency_03 ignore-tables=2
 SELECT max(no_o_id)
 FROM new_order
 GROUP BY no_d_id, no_w_id
 ORDER BY no_w_id, no_d_id
+----
 ----
 group-by
  ├── save-table-name: consistency_03_group_by_1
@@ -757,8 +818,7 @@ group-by
       └── max [as=max:5, type=int, outer=(1)]
            └── no_o_id:1 [type=int]
 
-stats table=consistency_03_group_by_1
-----
+----Stats for consistency_03_group_by_1----
 column_names  row_count  distinct_count  null_count
 {max}         100        1               0
 {no_d_id}     100        10              0
@@ -768,12 +828,15 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {max}         100.00         1.00           100.00              100.00 <==          0.00            1.00
 {no_d_id}     100.00         1.00           10.00               1.00                0.00            1.00
 {no_w_id}     100.00         1.00           10.00               1.00                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=consistency_04
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=consistency_04 ignore-tables=2
 SELECT max(o_id)
 FROM "order"
 GROUP BY o_d_id, o_w_id
 ORDER BY o_w_id, o_d_id
+----
 ----
 group-by
  ├── save-table-name: consistency_04_group_by_1
@@ -795,8 +858,7 @@ group-by
       └── max [as=max:10, type=int, outer=(1)]
            └── o_id:1 [type=int]
 
-stats table=consistency_04_group_by_1
-----
+----Stats for consistency_04_group_by_1----
 column_names  row_count  distinct_count  null_count
 {max}         100        1               0
 {o_d_id}      100        10              0
@@ -806,8 +868,10 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {max}         100.00         1.00           100.00              100.00 <==          0.00            1.00
 {o_d_id}      100.00         1.00           10.00               1.00                0.00            1.00
 {o_w_id}      100.00         1.00           10.00               1.00                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=consistency_05
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=consistency_05 ignore-tables=4
 SELECT count(*)
 FROM
 (
@@ -816,6 +880,7 @@ FROM
     GROUP BY no_w_id, no_d_id
 )
 WHERE nod != -1
+----
 ----
 scalar-group-by
  ├── save-table-name: consistency_05_scalar_group_by_1
@@ -859,24 +924,14 @@ scalar-group-by
  └── aggregations
       └── count-rows [as=count_rows:9, type=int]
 
-stats table=consistency_05_group_by_3
-----
+----Stats for consistency_05_scalar_group_by_1----
 column_names  row_count  distinct_count  null_count
-{count_rows}  100        1               0
-{max}         100        1               0
-{min}         100        1               0
-{no_d_id}     100        10              0
-{no_w_id}     100        10              0
+{count}       1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{count_rows}  100.00         1.00           100.00              100.00 <==          0.00            1.00
-{max}         100.00         1.00           100.00              100.00 <==          0.00            1.00
-{min}         100.00         1.00           100.00              100.00 <==          0.00            1.00
-{no_d_id}     100.00         1.00           10.00               1.00                0.00            1.00
-{no_w_id}     100.00         1.00           10.00               1.00                0.00            1.00
+{count}       1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=consistency_05_select_2
-----
+----Stats for consistency_05_select_2----
 column_names  row_count  distinct_count  null_count
 {count_rows}  0          0               0
 {max}         0          0               0
@@ -891,19 +946,29 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {no_d_id}     33.00          +Inf <==       10.00               +Inf <==            0.00            1.00
 {no_w_id}     33.00          +Inf <==       10.00               +Inf <==            0.00            1.00
 
-stats table=consistency_05_scalar_group_by_1
-----
+----Stats for consistency_05_group_by_3----
 column_names  row_count  distinct_count  null_count
-{count}       1          1               0
+{count_rows}  100        1               0
+{max}         100        1               0
+{min}         100        1               0
+{no_d_id}     100        10              0
+{no_w_id}     100        10              0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{count}       1.00           1.00           1.00                1.00                0.00            1.00
+{count_rows}  100.00         1.00           100.00              100.00 <==          0.00            1.00
+{max}         100.00         1.00           100.00              100.00 <==          0.00            1.00
+{min}         100.00         1.00           100.00              100.00 <==          0.00            1.00
+{no_d_id}     100.00         1.00           10.00               1.00                0.00            1.00
+{no_w_id}     100.00         1.00           10.00               1.00                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=consistency_06
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=consistency_06 ignore-tables=2
 SELECT sum(o_ol_cnt)
 FROM "order"
 GROUP BY o_w_id, o_d_id
 ORDER BY o_w_id, o_d_id
+----
 ----
 group-by
  ├── save-table-name: consistency_06_group_by_1
@@ -924,8 +989,7 @@ group-by
       └── sum [as=sum:10, type=decimal, outer=(7)]
            └── o_ol_cnt:7 [type=int]
 
-stats table=consistency_06_group_by_1
-----
+----Stats for consistency_06_group_by_1----
 column_names  row_count  distinct_count  null_count
 {o_d_id}      100        10              0
 {o_w_id}      100        10              0
@@ -935,12 +999,15 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {o_d_id}      100.00         1.00           10.00               1.00                0.00            1.00
 {o_w_id}      100.00         1.00           10.00               1.00                0.00            1.00
 {sum}         100.00         1.00           100.00              1.08                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=consistency_07
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=consistency_07 ignore-tables=2
 SELECT count(*)
 FROM order_line
 GROUP BY ol_w_id, ol_d_id
 ORDER BY ol_w_id, ol_d_id
+----
 ----
 group-by
  ├── save-table-name: consistency_07_group_by_1
@@ -960,8 +1027,7 @@ group-by
  └── aggregations
       └── count-rows [as=count_rows:12, type=int]
 
-stats table=consistency_07_group_by_1
-----
+----Stats for consistency_07_group_by_1----
 column_names  row_count  distinct_count  null_count
 {count}       100        93              0
 {ol_d_id}     100        10              0
@@ -971,11 +1037,14 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {count}       100.00         1.00           100.00              1.08                0.00            1.00
 {ol_d_id}     100.00         1.00           10.00               1.00                0.00            1.00
 {ol_w_id}     100.00         1.00           10.00               1.00                0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=consistency_08
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=consistency_08 ignore-tables=(2,3,5)
 (SELECT no_w_id, no_d_id, no_o_id FROM new_order)
 EXCEPT ALL
 (SELECT o_w_id, o_d_id, o_id FROM "order" WHERE o_carrier_id IS NULL)
+----
 ----
 except-all
  ├── save-table-name: consistency_08_except_all_1
@@ -1012,8 +1081,18 @@ except-all
            └── filters
                 └── o_carrier_id:10 IS NULL [type=bool, outer=(10), constraints=(/10: [/NULL - /NULL]; tight), fd=()-->(10)]
 
-stats table=consistency_08_select_4
-----
+----Stats for consistency_08_except_all_1----
+column_names  row_count  distinct_count  null_count
+{no_d_id}     0          0               0
+{no_o_id}     0          0               0
+{no_w_id}     0          0               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{no_d_id}     90000.00       +Inf <==       10.00               +Inf <==            0.00            1.00
+{no_o_id}     90000.00       +Inf <==       900.00              +Inf <==            0.00            1.00
+{no_w_id}     90000.00       +Inf <==       10.00               +Inf <==            0.00            1.00
+
+----Stats for consistency_08_select_4----
 column_names    row_count  distinct_count  null_count
 {o_carrier_id}  90000      1               90000
 {o_d_id}        90000      10              0
@@ -1025,23 +1104,14 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {o_d_id}        90000.00       1.00           10.00               1.00                0.00            1.00
 {o_id}          90000.00       1.00           2999.00             3.33 <==            0.00            1.00
 {o_w_id}        90000.00       1.00           10.00               1.00                0.00            1.00
-
-stats table=consistency_08_except_all_1
 ----
-column_names  row_count  distinct_count  null_count
-{no_d_id}     0          0               0
-{no_o_id}     0          0               0
-{no_w_id}     0          0               0
-~~~~
-column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{no_d_id}     90000.00       +Inf <==       10.00               +Inf <==            0.00            1.00
-{no_o_id}     90000.00       +Inf <==       900.00              +Inf <==            0.00            1.00
-{no_w_id}     90000.00       +Inf <==       10.00               +Inf <==            0.00            1.00
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=consistency_09
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=consistency_09 ignore-tables=(2-5)
 (SELECT o_w_id, o_d_id, o_id FROM "order" WHERE o_carrier_id IS NULL)
 EXCEPT ALL
 (SELECT no_w_id, no_d_id, no_o_id FROM new_order)
+----
 ----
 except-all
  ├── save-table-name: consistency_09_except_all_1
@@ -1078,8 +1148,7 @@ except-all
       │                 <--- 0 ---- 1 ---- 2 ---- 3 ---- 4 ---- 5 ---- 6 ---- 7 ---- 8 ---- 9 -
       └── key: (10-12)
 
-stats table=consistency_09_except_all_1
-----
+----Stats for consistency_09_except_all_1----
 column_names  row_count  distinct_count  null_count
 {o_d_id}      0          0               0
 {o_id}        0          0               0
@@ -1089,8 +1158,10 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {o_d_id}      90000.00       +Inf <==       10.00               +Inf <==            0.00            1.00
 {o_id}        90000.00       +Inf <==       2999.00             +Inf <==            0.00            1.00
 {o_w_id}      90000.00       +Inf <==       10.00               +Inf <==            0.00            1.00
+----
+----
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=consistency_10
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=consistency_10 ignore-tables=(2,4)
 (
     SELECT o_w_id, o_d_id, o_id, o_ol_cnt
     FROM "order"
@@ -1103,6 +1174,7 @@ EXCEPT ALL
     GROUP BY (ol_w_id, ol_d_id, ol_o_id)
     ORDER BY ol_w_id, ol_d_id, ol_o_id DESC
 )
+----
 ----
 except-all
  ├── save-table-name: consistency_10_except_all_1
@@ -1136,22 +1208,7 @@ except-all
       └── aggregations
            └── count-rows [as=count_rows:21, type=int]
 
-stats table=consistency_10_group_by_3
-----
-column_names  row_count  distinct_count  null_count
-{count_rows}  300000     11              0
-{ol_d_id}     300000     10              0
-{ol_o_id}     300000     2999            0
-{ol_w_id}     300000     10              0
-~~~~
-column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{count_rows}  295745.00      1.01           295745.00           26885.91 <==        0.00            1.00
-{ol_d_id}     295745.00      1.01           10.00               1.00                0.00            1.00
-{ol_o_id}     295745.00      1.01           2999.00             1.00                0.00            1.00
-{ol_w_id}     295745.00      1.01           10.00               1.00                0.00            1.00
-
-stats table=consistency_10_except_all_1
-----
+----Stats for consistency_10_except_all_1----
 column_names  row_count  distinct_count  null_count
 {o_d_id}      0          0               0
 {o_id}        0          0               0
@@ -1164,7 +1221,22 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {o_ol_cnt}    300000.00      +Inf <==       11.00               +Inf <==            0.00            1.00
 {o_w_id}      300000.00      +Inf <==       10.00               +Inf <==            0.00            1.00
 
-save-tables format=hide-qual database=tpcc save-tables-prefix=consistency_11
+----Stats for consistency_10_group_by_3----
+column_names  row_count  distinct_count  null_count
+{count_rows}  300000     11              0
+{ol_d_id}     300000     10              0
+{ol_o_id}     300000     2999            0
+{ol_w_id}     300000     10              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{count_rows}  295745.00      1.01           295745.00           26885.91 <==        0.00            1.00
+{ol_d_id}     295745.00      1.01           10.00               1.00                0.00            1.00
+{ol_o_id}     295745.00      1.01           2999.00             1.00                0.00            1.00
+{ol_w_id}     295745.00      1.01           10.00               1.00                0.00            1.00
+----
+----
+
+stats-quality format=hide-qual database=tpcc stats-quality-prefix=consistency_11 ignore-tables=(2-4)
 (
     SELECT ol_w_id, ol_d_id, ol_o_id, count(*)
     FROM order_line
@@ -1177,6 +1249,7 @@ EXCEPT ALL
     FROM "order"
     ORDER BY o_w_id, o_d_id, o_id DESC
 )
+----
 ----
 except-all
  ├── save-table-name: consistency_11_except_all_1
@@ -1210,8 +1283,7 @@ except-all
       ├── key: (13-15)
       └── fd: (13-15)-->(19)
 
-stats table=consistency_11_except_all_1
-----
+----Stats for consistency_11_except_all_1----
 column_names  row_count  distinct_count  null_count
 {count}       0          0               0
 {ol_d_id}     0          0               0
@@ -1223,8 +1295,10 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {ol_d_id}     295745.00      +Inf <==       10.00               +Inf <==            0.00            1.00
 {ol_o_id}     295745.00      +Inf <==       2999.00             +Inf <==            0.00            1.00
 {ol_w_id}     295745.00      +Inf <==       10.00               +Inf <==            0.00            1.00
+----
+----
 
-save-tables database=tpcc save-tables-prefix=consistency_12
+stats-quality database=tpcc stats-quality-prefix=consistency_12 ignore-tables=(4,6,7,9)
 SELECT count(*)
 FROM
 (
@@ -1240,6 +1314,7 @@ FULL OUTER JOIN
 )
 ON (ol_w_id = o_w_id AND ol_d_id = o_d_id AND ol_o_id = o_id)
 WHERE ol_o_id IS NULL OR o_id IS NULL
+----
 ----
 scalar-group-by
  ├── save-table-name: consistency_12_scalar_group_by_1
@@ -1304,54 +1379,14 @@ scalar-group-by
  └── aggregations
       └── count-rows [as=count_rows:21, type=int]
 
-stats table=consistency_12_select_5
-----
-column_names     row_count  distinct_count  null_count
-{ol_d_id}        899134     10              0
-{ol_delivery_d}  899134     1               899134
-{ol_o_id}        899134     900             0
-{ol_w_id}        899134     10              0
-~~~~
-column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{ol_d_id}        899134.00      1.00           10.00               1.00                0.00            1.00
-{ol_delivery_d}  899134.00      1.00           1.00                1.00                899134.00       1.00
-{ol_o_id}        899134.00      1.00           2999.00             3.33 <==            0.00            1.00
-{ol_w_id}        899134.00      1.00           10.00               1.00                0.00            1.00
-
-stats table=consistency_12_select_8
-----
-column_names    row_count  distinct_count  null_count
-{o_carrier_id}  90000      1               90000
-{o_d_id}        90000      10              0
-{o_id}          90000      900             0
-{o_w_id}        90000      10              0
-~~~~
-column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_carrier_id}  90000.00       1.00           1.00                1.00                90000.00        1.00
-{o_d_id}        90000.00       1.00           10.00               1.00                0.00            1.00
-{o_id}          90000.00       1.00           2999.00             3.33 <==            0.00            1.00
-{o_w_id}        90000.00       1.00           10.00               1.00                0.00            1.00
-
-stats table=consistency_12_full_join_3
-----
+----Stats for consistency_12_scalar_group_by_1----
 column_names  row_count  distinct_count  null_count
-{o_d_id}      899134     10              0
-{o_id}        899134     900             0
-{o_w_id}      899134     10              0
-{ol_d_id}     899134     10              0
-{ol_o_id}     899134     900             0
-{ol_w_id}     899134     10              0
+{count}       1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_d_id}      899134.00      1.00           10.00               1.00                629304.00       +Inf <==
-{o_id}        899134.00      1.00           2999.00             3.33 <==            629304.00       +Inf <==
-{o_w_id}      899134.00      1.00           10.00               1.00                629304.00       +Inf <==
-{ol_d_id}     899134.00      1.00           10.00               1.00                0.00            1.00
-{ol_o_id}     899134.00      1.00           2999.00             3.33 <==            0.00            1.00
-{ol_w_id}     899134.00      1.00           10.00               1.00                0.00            1.00
+{count}       1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=consistency_12_select_2
-----
+----Stats for consistency_12_select_2----
 column_names  row_count  distinct_count  null_count
 {o_d_id}      0          0               0
 {o_id}        0          0               0
@@ -1368,10 +1403,47 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {ol_o_id}     299711.00      +Inf <==       2999.00             +Inf <==            0.00            1.00
 {ol_w_id}     299711.00      +Inf <==       10.00               +Inf <==            0.00            1.00
 
-stats table=consistency_12_scalar_group_by_1
-----
+----Stats for consistency_12_full_join_3----
 column_names  row_count  distinct_count  null_count
-{count}       1          1               0
+{o_d_id}      899134     10              0
+{o_id}        899134     900             0
+{o_w_id}      899134     10              0
+{ol_d_id}     899134     10              0
+{ol_o_id}     899134     900             0
+{ol_w_id}     899134     10              0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{count}       1.00           1.00           1.00                1.00                0.00            1.00
+{o_d_id}      899134.00      1.00           10.00               1.00                629304.00       +Inf <==
+{o_id}        899134.00      1.00           2999.00             3.33 <==            629304.00       +Inf <==
+{o_w_id}      899134.00      1.00           10.00               1.00                629304.00       +Inf <==
+{ol_d_id}     899134.00      1.00           10.00               1.00                0.00            1.00
+{ol_o_id}     899134.00      1.00           2999.00             3.33 <==            0.00            1.00
+{ol_w_id}     899134.00      1.00           10.00               1.00                0.00            1.00
+
+----Stats for consistency_12_select_5----
+column_names     row_count  distinct_count  null_count
+{ol_d_id}        899134     10              0
+{ol_delivery_d}  899134     1               899134
+{ol_o_id}        899134     900             0
+{ol_w_id}        899134     10              0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ol_d_id}        899134.00      1.00           10.00               1.00                0.00            1.00
+{ol_delivery_d}  899134.00      1.00           1.00                1.00                899134.00       1.00
+{ol_o_id}        899134.00      1.00           2999.00             3.33 <==            0.00            1.00
+{ol_w_id}        899134.00      1.00           10.00               1.00                0.00            1.00
+
+----Stats for consistency_12_select_8----
+column_names    row_count  distinct_count  null_count
+{o_carrier_id}  90000      1               90000
+{o_d_id}        90000      10              0
+{o_id}          90000      900             0
+{o_w_id}        90000      10              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_carrier_id}  90000.00       1.00           1.00                1.00                90000.00        1.00
+{o_d_id}        90000.00       1.00           10.00               1.00                0.00            1.00
+{o_id}          90000.00       1.00           2999.00             3.33 <==            0.00            1.00
+{o_w_id}        90000.00       1.00           10.00               1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q01
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q01
@@ -17,7 +17,7 @@ import file=tpch_stats
 # LINESTATUS, and listed in ascending order of RETURNFLAG and LINESTATUS. A
 # count of the number of lineitems in each group is included.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q1
+stats-quality database=tpch stats-quality-prefix=q1
 SELECT
     l_returnflag,
     l_linestatus,
@@ -39,6 +39,7 @@ GROUP BY
 ORDER BY
     l_returnflag,
     l_linestatus;
+----
 ----
 sort
  ├── save-table-name: q1_sort_1
@@ -95,8 +96,7 @@ sort
            │    └── l_discount:7 [type=float]
            └── count-rows [as=count_rows:27, type=int]
 
-stats table=q1_sort_1
-----
+----Stats for q1_sort_1----
 column_names      row_count  distinct_count  null_count
 {avg_disc}        4          4               0
 {avg_price}       4          4               0
@@ -121,8 +121,7 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 {sum_disc_price}  6.00           1.50           6.00                1.50                0.00            1.00
 {sum_qty}         6.00           1.50           6.00                1.50                0.00            1.00
 
-stats table=q1_group_by_2
-----
+----Stats for q1_group_by_2----
 column_names    row_count  distinct_count  null_count
 {avg_1}         4          4               0
 {avg_2}         4          4               0
@@ -147,8 +146,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {sum_2}         6.00           1.50           6.00                1.50                0.00            1.00
 {sum_3}         6.00           1.50           6.00                1.50                0.00            1.00
 
-stats table=q1_project_3
-----
+----Stats for q1_project_3----
 column_names       row_count  distinct_count  null_count
 {column20}         5916591    4150364         0
 {column22}         5916591    5661182         0
@@ -167,8 +165,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_quantity}       5925056.00     1.00           50.00               1.00                0.00            1.00
 {l_returnflag}     5925056.00     1.00           3.00                1.00                0.00            1.00
 
-stats table=q1_select_4
-----
+----Stats for q1_select_4----
 column_names       row_count  distinct_count  null_count
 {l_discount}       5916591    11              0
 {l_extendedprice}  5916591    925955          0
@@ -187,8 +184,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_shipdate}       5925056.00     1.00           2435.00             1.00                0.00            1.00
 {l_tax}            5925056.00     1.00           9.00                1.00                0.00            1.00
 
-stats table=q1_scan_5
-----
+----Stats for q1_scan_5----
 column_names       row_count  distinct_count  null_count
 {l_discount}       6001215    11              0
 {l_extendedprice}  6001215    925955          0
@@ -206,3 +202,5 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_returnflag}     6001215.00     1.00           3.00                1.00                0.00            1.00
 {l_shipdate}       6001215.00     1.00           2526.00             1.00                0.00            1.00
 {l_tax}            6001215.00     1.00           9.00                1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q02
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q02
@@ -22,7 +22,7 @@ import file=tpch_stats
 #   1. Allow Select to be pushed below Ordinality used to add key column
 #   2. Add decorrelation rule for Ordinality/RowKey
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q2
+stats-quality database=tpch stats-quality-prefix=q2
 SELECT
     s_acctbal,
     s_name,
@@ -67,6 +67,7 @@ ORDER BY
     s_name,
     p_partkey
 LIMIT 100;
+----
 ----
 project
  ├── save-table-name: q2_project_1
@@ -281,8 +282,7 @@ project
       │              └── ps_supplycost:22 = min:57 [type=bool, outer=(22,57), constraints=(/22: (/NULL - ]; /57: (/NULL - ]), fd=(22)==(57), (57)==(22)]
       └── 100 [type=int]
 
-stats table=q2_project_1
-----
+----Stats for q2_project_1----
 column_names  row_count  distinct_count  null_count
 {n_name}      100        5               0
 {p_mfgr}      100        5               0
@@ -303,8 +303,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {s_name}      1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
 {s_phone}     1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
 
-stats table=q2_limit_2
-----
+----Stats for q2_limit_2----
 column_names     row_count  distinct_count  null_count
 {min}            100        100             0
 {n_name}         100        5               0
@@ -333,8 +332,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_name}         1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
 {s_phone}        1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
 
-stats table=q2_sort_3
-----
+----Stats for q2_sort_3----
 column_names     row_count  distinct_count  null_count
 {min}            100        100             0
 {n_name}         100        5               0
@@ -363,8 +361,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_name}         1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
 {s_phone}        1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
 
-stats table=q2_select_4
-----
+----Stats for q2_select_4----
 column_names     row_count  distinct_count  null_count
 {min}            460        458             0
 {n_name}         460        5               0
@@ -393,8 +390,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_name}         1.00           460.00 <==     1.00                406.00 <==          0.00            1.00
 {s_phone}        1.00           460.00 <==     1.00                406.00 <==          0.00            1.00
 
-stats table=q2_group_by_5
-----
+----Stats for q2_group_by_5----
 column_names     row_count  distinct_count  null_count
 {min}            642        458             0
 {n_name}         642        5               0
@@ -423,8 +419,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_name}         1477.00        2.30 <==       1477.00             2.70 <==            0.00            1.00
 {s_phone}        1477.00        2.30 <==       1477.00             2.70 <==            0.00            1.00
 
-stats table=q2_inner_join_6
-----
+----Stats for q2_inner_join_6----
 column_names       row_count  distinct_count  null_count
 {n_name}           1070       5               0
 {n_nationkey_1}    1070       5               0
@@ -485,8 +480,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {s_suppkey}        2818.00        2.63 <==       1403.00             2.56 <==            0.00            1.00
 {s_suppkey_1}      2818.00        2.63 <==       1444.00             2.64 <==            0.00            1.00
 
-stats table=q2_lookup_join_7
-----
+----Stats for q2_lookup_join_7----
 column_names       row_count  distinct_count  null_count
 {n_name}           2568       5               0
 {n_nationkey}      2568       5               0
@@ -535,8 +529,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {s_phone}          4452.00        1.73           3593.00             6.56 <==            0.00            1.00
 {s_suppkey}        4452.00        1.73           3587.00             6.55 <==            0.00            1.00
 
-stats table=q2_inner_join_8
-----
+----Stats for q2_inner_join_8----
 column_names     row_count  distinct_count  null_count
 {n_name}         642        5               0
 {n_nationkey}    642        5               0
@@ -579,8 +572,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_phone}        1932.00        3.01 <==       1757.00             3.21 <==            0.00            1.00
 {s_suppkey}      1932.00        3.01 <==       1755.00             3.20 <==            0.00            1.00
 
-stats table=q2_lookup_join_9
-----
+----Stats for q2_lookup_join_9----
 column_names     row_count  distinct_count  null_count
 {p_mfgr}         2988       5               0
 {p_partkey}      2988       747             0
@@ -599,8 +591,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {ps_suppkey}     5354.00        1.79           4137.00             1.61                0.00            1.00
 {ps_supplycost}  5354.00        1.79           5213.00             1.77                0.00            1.00
 
-stats table=q2_select_10
-----
+----Stats for q2_select_10----
 column_names  row_count  distinct_count  null_count
 {p_mfgr}      747        5               0
 {p_partkey}   747        747             0
@@ -613,8 +604,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {p_size}      1333.00        1.78           1.00                1.00                0.00            1.00
 {p_type}      1333.00        1.78           150.00              5.00 <==            0.00            1.00
 
-stats table=q2_scan_11
-----
+----Stats for q2_scan_11----
 column_names  row_count  distinct_count  null_count
 {p_mfgr}      200000     5               0
 {p_partkey}   200000     199241          0
@@ -627,8 +617,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {p_size}      200000.00      1.00           50.00               1.00                0.00            1.00
 {p_type}      200000.00      1.00           150.00              1.00                0.00            1.00
 
-stats table=q2_inner_join_12
-----
+----Stats for q2_inner_join_12----
 column_names   row_count  distinct_count  null_count
 {n_name}       1987       5               0
 {n_nationkey}  1987       5               0
@@ -657,8 +646,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_phone}      2000.00        1.01           1846.00             1.08                0.00            1.00
 {s_suppkey}    2000.00        1.01           1845.00             1.08                0.00            1.00
 
-stats table=q2_scan_13
-----
+----Stats for q2_scan_13----
 column_names   row_count  distinct_count  null_count
 {s_acctbal}    10000      9967            0
 {s_address}    10000      10027           0
@@ -677,8 +665,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_phone}      10000.00       1.00           10000.00            1.00                0.00            1.00
 {s_suppkey}    10000.00       1.00           9920.00             1.00                0.00            1.00
 
-stats table=q2_inner_join_14
-----
+----Stats for q2_inner_join_14----
 column_names   row_count  distinct_count  null_count
 {n_name}       5          5               0
 {n_nationkey}  5          5               0
@@ -693,8 +680,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       5.00           1.00           1.00                1.00                0.00            1.00
 {r_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q2_scan_15
-----
+----Stats for q2_scan_15----
 column_names   row_count  distinct_count  null_count
 {n_name}       25         25              0
 {n_nationkey}  25         25              0
@@ -705,8 +691,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
 {n_regionkey}  25.00          1.00           5.00                1.00                0.00            1.00
 
-stats table=q2_select_16
-----
+----Stats for q2_select_16----
 column_names   row_count  distinct_count  null_count
 {r_name}       1          1               0
 {r_regionkey}  1          1               0
@@ -715,8 +700,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       1.00           1.00           1.00                1.00                0.00            1.00
 {r_regionkey}  1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q2_scan_17
-----
+----Stats for q2_scan_17----
 column_names   row_count  distinct_count  null_count
 {r_name}       5          5               0
 {r_regionkey}  5          5               0
@@ -725,8 +709,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       5.00           1.00           5.00                1.00                0.00            1.00
 {r_regionkey}  5.00           1.00           5.00                1.00                0.00            1.00
 
-stats table=q2_lookup_join_18
-----
+----Stats for q2_lookup_join_18----
 column_names   row_count  distinct_count  null_count
 {n_nationkey}  1987       5               0
 {n_regionkey}  1987       1               0
@@ -743,8 +726,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  2000.00        1.01           5.00                1.00                0.00            1.00
 {s_suppkey}    2000.00        1.01           1845.00             1.08                0.00            1.00
 
-stats table=q2_merge_join_19
-----
+----Stats for q2_merge_join_19----
 column_names   row_count  distinct_count  null_count
 {n_nationkey}  5          5               0
 {n_regionkey}  5          1               0
@@ -757,8 +739,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       5.00           1.00           1.00                1.00                0.00            1.00
 {r_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q2_scan_20
-----
+----Stats for q2_scan_20----
 column_names   row_count  distinct_count  null_count
 {n_nationkey}  25         25              0
 {n_regionkey}  25         5               0
@@ -767,8 +748,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
 {n_regionkey}  25.00          1.00           5.00                1.00                0.00            1.00
 
-stats table=q2_select_21
-----
+----Stats for q2_select_21----
 column_names   row_count  distinct_count  null_count
 {r_name}       1          1               0
 {r_regionkey}  1          1               0
@@ -777,8 +757,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       1.00           1.00           1.00                1.00                0.00            1.00
 {r_regionkey}  1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q2_scan_22
-----
+----Stats for q2_scan_22----
 column_names   row_count  distinct_count  null_count
 {r_name}       5          5               0
 {r_regionkey}  5          5               0
@@ -786,3 +765,5 @@ column_names   row_count  distinct_count  null_count
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {r_name}       5.00           1.00           5.00                1.00                0.00            1.00
 {r_regionkey}  5.00           1.00           5.00                1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q03
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q03
@@ -15,7 +15,7 @@ import file=tpch_stats
 # decreasing order of revenue. If more than 10 unshipped orders exist, only the
 # 10 orders with the largest revenue are listed.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q3
+stats-quality database=tpch stats-quality-prefix=q3
 SELECT
     l_orderkey,
     sum(l_extendedprice * (1 - l_discount)) AS revenue,
@@ -39,6 +39,7 @@ ORDER BY
     revenue DESC,
     o_orderdate
 LIMIT 10;
+----
 ----
 limit
  ├── save-table-name: q3_limit_1
@@ -139,8 +140,7 @@ limit
  │                   └── o_shippriority:17 [type=int]
  └── 10 [type=int]
 
-stats table=q3_limit_1
-----
+----Stats for q3_limit_1----
 column_names      row_count  distinct_count  null_count
 {l_orderkey}      10         10              0
 {o_orderdate}     10         8               0
@@ -153,8 +153,7 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 {o_shippriority}  10.00          1.00           10.00               10.00 <==           0.00            1.00
 {revenue}         10.00          1.00           10.00               1.00                0.00            1.00
 
-stats table=q3_sort_2
-----
+----Stats for q3_sort_2----
 column_names      row_count  distinct_count  null_count
 {l_orderkey}      0          0               0
 {o_orderdate}     0          0               0
@@ -167,8 +166,7 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 {o_shippriority}  359560.00      +Inf <==       359560.00           +Inf <==            0.00            1.00
 {sum}             359560.00      +Inf <==       359560.00           +Inf <==            0.00            1.00
 
-stats table=q3_group_by_3
-----
+----Stats for q3_group_by_3----
 column_names      row_count  distinct_count  null_count
 {l_orderkey}      11620      11611           0
 {o_orderdate}     11620      120             0
@@ -181,8 +179,7 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 {o_shippriority}  359560.00      30.94 <==      359560.00           359560.00 <==       0.00            1.00
 {sum}             359560.00      30.94 <==      359560.00           30.99 <==           0.00            1.00
 
-stats table=q3_project_4
-----
+----Stats for q3_project_4----
 column_names      row_count  distinct_count  null_count
 {column37}        30519      30424           0
 {l_orderkey}      30519      11611           0
@@ -195,8 +192,7 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 {o_orderdate}     493779.00      16.18 <==      1169.00             9.74 <==            0.00            1.00
 {o_shippriority}  493779.00      16.18 <==      1.00                1.00                0.00            1.00
 
-stats table=q3_lookup_join_5
-----
+----Stats for q3_lookup_join_5----
 column_names       row_count  distinct_count  null_count
 {c_custkey}        30519      8643            0
 {c_mktsegment}     30519      1               0
@@ -221,8 +217,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {o_orderkey}       493779.00      16.18 <==      359560.00           30.97 <==           0.00            1.00
 {o_shippriority}   493779.00      16.18 <==      1.00                1.00                0.00            1.00
 
-stats table=q3_inner_join_6
-----
+----Stats for q3_inner_join_6----
 column_names      row_count  distinct_count  null_count
 {c_custkey}       147126     20129           0
 {c_mktsegment}    147126     1               0
@@ -239,8 +234,7 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 {o_orderkey}      220819.00      1.50           190732.00           1.31                0.00            1.00
 {o_shippriority}  220819.00      1.50           1.00                1.00                0.00            1.00
 
-stats table=q3_select_7
-----
+----Stats for q3_select_7----
 column_names      row_count  distinct_count  null_count
 {o_custkey}       727305     99492           0
 {o_orderdate}     727305     1169            0
@@ -253,8 +247,7 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 {o_orderkey}      734900.00      1.01           734900.00           1.01                0.00            1.00
 {o_shippriority}  734900.00      1.01           1.00                1.00                0.00            1.00
 
-stats table=q3_scan_8
-----
+----Stats for q3_scan_8----
 column_names      row_count  distinct_count  null_count
 {o_custkey}       1500000    99846           0
 {o_orderdate}     1500000    2406            0
@@ -267,8 +260,7 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 {o_orderkey}      1500000.00     1.00           1500000.00          1.02                0.00            1.00
 {o_shippriority}  1500000.00     1.00           1.00                1.00                0.00            1.00
 
-stats table=q3_select_9
-----
+----Stats for q3_select_9----
 column_names    row_count  distinct_count  null_count
 {c_custkey}     30142      30101           0
 {c_mktsegment}  30142      1               0
@@ -277,8 +269,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {c_custkey}     30000.00       1.00           29974.00            1.00                0.00            1.00
 {c_mktsegment}  30000.00       1.00           1.00                1.00                0.00            1.00
 
-stats table=q3_scan_10
-----
+----Stats for q3_scan_10----
 column_names    row_count  distinct_count  null_count
 {c_custkey}     150000     148813          0
 {c_mktsegment}  150000     5               0
@@ -286,3 +277,5 @@ column_names    row_count  distinct_count  null_count
 column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {c_custkey}     150000.00      1.00           148813.00           1.00                0.00            1.00
 {c_mktsegment}  150000.00      1.00           5.00                1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q04
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q04
@@ -15,7 +15,7 @@ import file=tpch_stats
 # committed date. The query lists the count of such orders for each order
 # priority sorted in ascending priority order.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q4
+stats-quality database=tpch stats-quality-prefix=q4
 SELECT
     o_orderpriority,
     count(*) AS order_count
@@ -37,6 +37,7 @@ GROUP BY
     o_orderpriority
 ORDER BY
     o_orderpriority;
+----
 ----
 sort
  ├── save-table-name: q4_sort_1
@@ -83,8 +84,7 @@ sort
       └── aggregations
            └── count-rows [as=count_rows:28, type=int]
 
-stats table=q4_sort_1
-----
+----Stats for q4_sort_1----
 column_names       row_count  distinct_count  null_count
 {o_orderpriority}  5          5               0
 {order_count}      5          5               0
@@ -93,8 +93,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {o_orderpriority}  5.00           1.00           5.00                1.00                0.00            1.00
 {order_count}      5.00           1.00           5.00                1.00                0.00            1.00
 
-stats table=q4_group_by_2
-----
+----Stats for q4_group_by_2----
 column_names       row_count  distinct_count  null_count
 {count_rows}       5          5               0
 {o_orderpriority}  5          5               0
@@ -103,8 +102,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {count_rows}       5.00           1.00           5.00                1.00                0.00            1.00
 {o_orderpriority}  5.00           1.00           5.00                1.00                0.00            1.00
 
-stats table=q4_lookup_join_3
-----
+----Stats for q4_lookup_join_3----
 column_names       row_count  distinct_count  null_count
 {o_orderdate}      52523      92              0
 {o_orderkey}       52523      52442           0
@@ -115,8 +113,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {o_orderkey}       61200.00       1.17           61200.00            1.17                0.00            1.00
 {o_orderpriority}  61200.00       1.17           5.00                1.00                0.00            1.00
 
-stats table=q4_index_join_4
-----
+----Stats for q4_index_join_4----
 column_names       row_count  distinct_count  null_count
 {o_orderdate}      57218      92              0
 {o_orderkey}       57218      57392           0
@@ -127,8 +124,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {o_orderkey}       61200.00       1.07           61200.00            1.07                0.00            1.00
 {o_orderpriority}  61200.00       1.07           5.00                1.00                0.00            1.00
 
-stats table=q4_scan_5
-----
+----Stats for q4_scan_5----
 column_names   row_count  distinct_count  null_count
 {o_orderdate}  57218      92              0
 {o_orderkey}   57218      57392           0
@@ -136,3 +132,5 @@ column_names   row_count  distinct_count  null_count
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {o_orderdate}  61200.00       1.07           92.00               1.00                0.00            1.00
 {o_orderkey}   61200.00       1.07           61200.00            1.07                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q05
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q05
@@ -18,7 +18,7 @@ import file=tpch_stats
 # all qualifying lineitems in a particular nation is defined as
 # sum(l_extendedprice * (1 - l_discount)).
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q5
+stats-quality database=tpch stats-quality-prefix=q5
 SELECT
     n_name,
     sum(l_extendedprice * (1 - l_discount)) AS revenue
@@ -43,6 +43,7 @@ GROUP BY
     n_name
 ORDER BY
     revenue DESC;
+----
 ----
 sort
  ├── save-table-name: q5_sort_1
@@ -168,8 +169,7 @@ sort
            └── sum [as=sum:55, type=float, outer=(54)]
                 └── column54:54 [type=float]
 
-stats table=q5_sort_1
-----
+----Stats for q5_sort_1----
 column_names  row_count  distinct_count  null_count
 {n_name}      5          5               0
 {revenue}     5          5               0
@@ -178,8 +178,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {n_name}      5.00           1.00           5.00                1.00                0.00            1.00
 {revenue}     5.00           1.00           5.00                1.00                0.00            1.00
 
-stats table=q5_group_by_2
-----
+----Stats for q5_group_by_2----
 column_names  row_count  distinct_count  null_count
 {n_name}      5          5               0
 {sum}         5          5               0
@@ -188,8 +187,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {n_name}      5.00           1.00           5.00                1.00                0.00            1.00
 {sum}         5.00           1.00           5.00                1.00                0.00            1.00
 
-stats table=q5_project_3
-----
+----Stats for q5_project_3----
 column_names  row_count  distinct_count  null_count
 {column54}    7243       7245            0
 {n_name}      7243       5               0
@@ -198,8 +196,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {column54}    13445.00       1.86           13136.00            1.81                0.00            1.00
 {n_name}      13445.00       1.86           5.00                1.00                0.00            1.00
 
-stats table=q5_inner_join_4
-----
+----Stats for q5_inner_join_4----
 column_names       row_count  distinct_count  null_count
 {c_custkey}        7243       5557            0
 {c_nationkey}      7243       5               0
@@ -236,8 +233,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {s_nationkey}      13445.00       1.86           5.00                1.00                0.00            1.00
 {s_suppkey}        13445.00       1.86           1844.00             1.05                0.00            1.00
 
-stats table=q5_lookup_join_5
-----
+----Stats for q5_lookup_join_5----
 column_names       row_count  distinct_count  null_count
 {c_custkey}        184082     17300           0
 {c_nationkey}      184082     5               0
@@ -270,8 +266,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {r_name}           296135.00      1.61           1.00                1.00                0.00            1.00
 {r_regionkey}      296135.00      1.61           1.00                1.00                0.00            1.00
 
-stats table=q5_inner_join_6
-----
+----Stats for q5_inner_join_6----
 column_names   row_count  distinct_count  null_count
 {c_custkey}    46008      17300           0
 {c_nationkey}  46008      5               0
@@ -296,8 +291,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       75364.00       1.64           1.00                1.00                0.00            1.00
 {r_regionkey}  75364.00       1.64           1.00                1.00                0.00            1.00
 
-stats table=q5_index_join_7
-----
+----Stats for q5_index_join_7----
 column_names   row_count  distinct_count  null_count
 {o_custkey}    227597     86427           0
 {o_orderdate}  227597     365             0
@@ -308,8 +302,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {o_orderdate}  230331.00      1.01           365.00              1.00                0.00            1.00
 {o_orderkey}   230331.00      1.01           230331.00           1.01                0.00            1.00
 
-stats table=q5_scan_8
-----
+----Stats for q5_scan_8----
 column_names   row_count  distinct_count  null_count
 {o_orderdate}  227597     365             0
 {o_orderkey}   227597     229152          0
@@ -318,8 +311,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {o_orderdate}  230331.00      1.01           365.00              1.00                0.00            1.00
 {o_orderkey}   230331.00      1.01           230331.00           1.01                0.00            1.00
 
-stats table=q5_lookup_join_9
-----
+----Stats for q5_lookup_join_9----
 column_names   row_count  distinct_count  null_count
 {c_custkey}    30183      29993           0
 {c_nationkey}  30183      5               0
@@ -338,8 +330,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       30000.00       1.01           1.00                1.00                0.00            1.00
 {r_regionkey}  30000.00       1.01           1.00                1.00                0.00            1.00
 
-stats table=q5_inner_join_10
-----
+----Stats for q5_inner_join_10----
 column_names   row_count  distinct_count  null_count
 {n_name}       5          5               0
 {n_nationkey}  5          5               0
@@ -354,8 +345,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       5.00           1.00           1.00                1.00                0.00            1.00
 {r_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q5_scan_11
-----
+----Stats for q5_scan_11----
 column_names   row_count  distinct_count  null_count
 {n_name}       25         25              0
 {n_nationkey}  25         25              0
@@ -366,8 +356,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
 {n_regionkey}  25.00          1.00           5.00                1.00                0.00            1.00
 
-stats table=q5_select_12
-----
+----Stats for q5_select_12----
 column_names   row_count  distinct_count  null_count
 {r_name}       1          1               0
 {r_regionkey}  1          1               0
@@ -376,8 +365,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       1.00           1.00           1.00                1.00                0.00            1.00
 {r_regionkey}  1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q5_scan_13
-----
+----Stats for q5_scan_13----
 column_names   row_count  distinct_count  null_count
 {r_name}       5          5               0
 {r_regionkey}  5          5               0
@@ -386,8 +374,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       5.00           1.00           5.00                1.00                0.00            1.00
 {r_regionkey}  5.00           1.00           5.00                1.00                0.00            1.00
 
-stats table=q5_scan_14
-----
+----Stats for q5_scan_14----
 column_names   row_count  distinct_count  null_count
 {s_nationkey}  10000      25              0
 {s_suppkey}    10000      9920            0
@@ -395,3 +382,5 @@ column_names   row_count  distinct_count  null_count
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {s_nationkey}  10000.00       1.00           25.00               1.00                0.00            1.00
 {s_suppkey}    10000.00       1.00           9920.00             1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q06
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q06
@@ -19,7 +19,7 @@ import file=tpch_stats
 # increase is equal to the sum of [l_extendedprice * l_discount] for all
 # lineitems with discounts and quantities in the qualifying range.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q6
+stats-quality database=tpch stats-quality-prefix=q6
 SELECT
     sum(l_extendedprice * l_discount) AS revenue
 FROM
@@ -29,6 +29,7 @@ WHERE
     AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR
     AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
     AND l_quantity < 24;
+----
 ----
 scalar-group-by
  ├── save-table-name: q6_scalar_group_by_1
@@ -73,24 +74,21 @@ scalar-group-by
       └── sum [as=sum:19, type=float, outer=(18)]
            └── column18:18 [type=float]
 
-stats table=q6_scalar_group_by_1
-----
+----Stats for q6_scalar_group_by_1----
 column_names  row_count  distinct_count  null_count
 {revenue}     1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {revenue}     1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q6_project_2
-----
+----Stats for q6_project_2----
 column_names  row_count  distinct_count  null_count
 {column18}    114160     108866          0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {column18}    34746.00       3.29 <==       34746.00            3.13 <==            0.00            1.00
 
-stats table=q6_select_3
-----
+----Stats for q6_select_3----
 column_names       row_count  distinct_count  null_count
 {l_discount}       114160     3               0
 {l_extendedprice}  114160     98751           0
@@ -103,8 +101,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_quantity}       34746.00       3.29 <==       17.00               1.35                0.00            1.00
 {l_shipdate}       34746.00       3.29 <==       365.00              1.00                0.00            1.00
 
-stats table=q6_index_join_4
-----
+----Stats for q6_index_join_4----
 column_names       row_count  distinct_count  null_count
 {l_discount}       909455     11              0
 {l_extendedprice}  909455     565291          0
@@ -116,3 +113,16 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_extendedprice}  938138.00      1.03           618257.00           1.09                0.00            1.00
 {l_quantity}       938138.00      1.03           50.00               1.00                0.00            1.00
 {l_shipdate}       938138.00      1.03           365.00              1.00                0.00            1.00
+
+----Stats for q6_scan_5----
+column_names    row_count  distinct_count  null_count
+{l_linenumber}  909455     7               0
+{l_orderkey}    909455     266035          0
+{l_shipdate}    909455     365             0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_linenumber}  938138.00      1.03           7.00                1.00                0.00            1.00
+{l_orderkey}    938138.00      1.03           744145.00           2.80 <==            0.00            1.00
+{l_shipdate}    938138.00      1.03           365.00              1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q07
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q07
@@ -17,7 +17,7 @@ import file=tpch_stats
 # that took place in that year. The query orders the answer by Supplier nation,
 # Customer nation, and year (all ascending).
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q7
+stats-quality database=tpch stats-quality-prefix=q7
 SELECT
     supp_nation,
     cust_nation,
@@ -55,6 +55,7 @@ ORDER BY
     supp_nation,
     cust_nation,
     l_year;
+----
 ----
 sort
  ├── save-table-name: q7_sort_1
@@ -160,8 +161,7 @@ sort
            └── sum [as=sum:57, type=float, outer=(56)]
                 └── volume:56 [type=float]
 
-stats table=q7_sort_1
-----
+----Stats for q7_sort_1----
 column_names   row_count  distinct_count  null_count
 {cust_nation}  4          2               0
 {l_year}       4          2               0
@@ -174,8 +174,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {revenue}      974.00         243.50 <==     974.00              243.50 <==          0.00            1.00
 {supp_nation}  974.00         243.50 <==     1.00                2.00 <==            0.00            1.00
 
-stats table=q7_group_by_2
-----
+----Stats for q7_group_by_2----
 column_names  row_count  distinct_count  null_count
 {l_year}      4          2               0
 {n_name_1}    4          2               0
@@ -188,8 +187,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {n_name_1}    974.00         243.50 <==     1.00                2.00 <==            0.00            1.00
 {sum}         974.00         243.50 <==     974.00              243.50 <==          0.00            1.00
 
-stats table=q7_project_3
-----
+----Stats for q7_project_3----
 column_names  row_count  distinct_count  null_count
 {l_year}      5924       2               0
 {n_name_1}    5924       2               0
@@ -202,8 +200,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {n_name_1}    7742.00        1.31           1.00                2.00 <==            0.00            1.00
 {volume}      7742.00        1.31           7580.00             1.28                0.00            1.00
 
-stats table=q7_inner_join_4
-----
+----Stats for q7_inner_join_4----
 column_names       row_count  distinct_count  null_count
 {c_custkey}        5924       3902            0
 {c_nationkey}      5924       2               0
@@ -238,8 +235,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {s_nationkey}      7742.00        1.31           1.00                2.00 <==            0.00            1.00
 {s_suppkey}        7742.00        1.31           7742.00             9.73 <==            0.00            1.00
 
-stats table=q7_scan_5
-----
+----Stats for q7_scan_5----
 column_names   row_count  distinct_count  null_count
 {c_custkey}    150000     148813          0
 {c_nationkey}  150000     25              0
@@ -248,8 +244,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {c_custkey}    150000.00      1.00           148813.00           1.00                0.00            1.00
 {c_nationkey}  150000.00      1.00           25.00               1.00                0.00            1.00
 
-stats table=q7_lookup_join_6
-----
+----Stats for q7_lookup_join_6----
 column_names       row_count  distinct_count  null_count
 {l_discount}       145703     11              0
 {l_extendedprice}  145703     130516          0
@@ -280,8 +275,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {s_nationkey}      101373.00      1.44           1.00                2.00 <==            0.00            1.00
 {s_suppkey}        101373.00      1.44           530.00              1.51                0.00            1.00
 
-stats table=q7_lookup_join_7
-----
+----Stats for q7_lookup_join_7----
 column_names       row_count  distinct_count  null_count
 {l_discount}       145703     11              0
 {l_extendedprice}  145703     130516          0
@@ -308,8 +302,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {s_nationkey}      101373.00      1.44           1.00                2.00 <==            0.00            1.00
 {s_suppkey}        101373.00      1.44           530.00              1.51                0.00            1.00
 
-stats table=q7_lookup_join_8
-----
+----Stats for q7_lookup_join_8----
 column_names     row_count  distinct_count  null_count
 {l_linenumber}   478523     7               0
 {l_orderkey}     478523     411655          0
@@ -332,8 +325,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_nationkey}    322646.00      1.48           1.00                2.00 <==            0.00            1.00
 {s_suppkey}      322646.00      1.48           530.00              1.51                0.00            1.00
 
-stats table=q7_lookup_join_9
-----
+----Stats for q7_lookup_join_9----
 column_names     row_count  distinct_count  null_count
 {n_name_1}       798        2               0
 {n_name}         798        2               0
@@ -350,8 +342,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_nationkey}    533.00         1.50           1.00                2.00 <==            0.00            1.00
 {s_suppkey}      533.00         1.50           530.00              1.51                0.00            1.00
 
-stats table=q7_inner_join_10
-----
+----Stats for q7_inner_join_10----
 column_names     row_count  distinct_count  null_count
 {n_name_1}       2          2               0
 {n_name}         2          2               0
@@ -364,8 +355,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {n_nationkey}    1.00           2.00 <==       1.00                2.00 <==            0.00            1.00
 {n_nationkey_1}  1.00           2.00 <==       1.00                2.00 <==            0.00            1.00
 
-stats table=q7_scan_11
-----
+----Stats for q7_scan_11----
 column_names   row_count  distinct_count  null_count
 {n_name}       25         25              0
 {n_nationkey}  25         25              0
@@ -374,8 +364,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_name}       25.00          1.00           25.00               1.00                0.00            1.00
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
 
-stats table=q7_scan_12
-----
+----Stats for q7_scan_12----
 column_names   row_count  distinct_count  null_count
 {n_name}       25         25              0
 {n_nationkey}  25         25              0
@@ -383,3 +372,5 @@ column_names   row_count  distinct_count  null_count
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {n_name}       25.00          1.00           25.00               1.00                0.00            1.00
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q08
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q08
@@ -16,7 +16,7 @@ import file=tpch_stats
 # from the given nation. The query determines this for the years 1995 and 1996
 # presented in this order.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q8
+stats-quality database=tpch stats-quality-prefix=q8
 SELECT
     o_year,
     sum(CASE
@@ -54,6 +54,7 @@ GROUP BY
     o_year
 ORDER BY
     o_year;
+----
 ----
 sort
  ├── save-table-name: q8_sort_1
@@ -230,8 +231,7 @@ sort
       └── projections
            └── sum:72 / sum:73 [as=mkt_share:74, type=float, outer=(72,73), immutable]
 
-stats table=q8_sort_1
-----
+----Stats for q8_sort_1----
 column_names  row_count  distinct_count  null_count
 {mkt_share}   2          2               0
 {o_year}      2          2               0
@@ -240,8 +240,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {mkt_share}   729.00         364.50 <==     729.00              364.50 <==          0.00            1.00
 {o_year}      729.00         364.50 <==     729.00              364.50 <==          0.00            1.00
 
-stats table=q8_project_2
-----
+----Stats for q8_project_2----
 column_names  row_count  distinct_count  null_count
 {mkt_share}   2          2               0
 {o_year}      2          2               0
@@ -250,8 +249,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {mkt_share}   729.00         364.50 <==     729.00              364.50 <==          0.00            1.00
 {o_year}      729.00         364.50 <==     729.00              364.50 <==          0.00            1.00
 
-stats table=q8_group_by_3
-----
+----Stats for q8_group_by_3----
 column_names  row_count  distinct_count  null_count
 {o_year}      2          2               0
 {sum_1}       2          2               0
@@ -262,8 +260,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {sum}         729.00         364.50 <==     729.00              364.50 <==          0.00            1.00
 {sum_1}       729.00         364.50 <==     729.00              364.50 <==          0.00            1.00
 
-stats table=q8_project_4
-----
+----Stats for q8_project_4----
 column_names  row_count  distinct_count  null_count
 {column71}    2603       108             0
 {o_year}      2603       2               0
@@ -274,8 +271,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {o_year}      4302.00        1.65           729.00              364.50 <==          0.00            1.00
 {volume}      4302.00        1.65           4268.00             1.64                0.00            1.00
 
-stats table=q8_project_5
-----
+----Stats for q8_project_5----
 column_names  row_count  distinct_count  null_count
 {n_name}      2603       25              0
 {o_year}      2603       2               0
@@ -286,8 +282,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {o_year}      4302.00        1.65           729.00              364.50 <==          0.00            1.00
 {volume}      4302.00        1.65           4268.00             1.64                0.00            1.00
 
-stats table=q8_inner_join_6
-----
+----Stats for q8_inner_join_6----
 column_names       row_count  distinct_count  null_count
 {c_custkey}        2603       2385            0
 {c_nationkey}      2603       5               0
@@ -332,8 +327,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {s_nationkey}      4302.00        1.65           25.00               1.00                0.00            1.00
 {s_suppkey}        4302.00        1.65           3491.00             1.84                0.00            1.00
 
-stats table=q8_inner_join_7
-----
+----Stats for q8_inner_join_7----
 column_names       row_count  distinct_count  null_count
 {c_custkey}        2603       2385            0
 {c_nationkey}      2603       5               0
@@ -374,8 +368,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {s_nationkey}      4118.00        1.58           25.00               1.00                0.00            1.00
 {s_suppkey}        4118.00        1.58           3370.00             1.78                0.00            1.00
 
-stats table=q8_scan_8
-----
+----Stats for q8_scan_8----
 column_names   row_count  distinct_count  null_count
 {s_nationkey}  10000      25              0
 {s_suppkey}    10000      9920            0
@@ -384,8 +377,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  10000.00       1.00           25.00               1.00                0.00            1.00
 {s_suppkey}    10000.00       1.00           9920.00             1.00                0.00            1.00
 
-stats table=q8_inner_join_9
-----
+----Stats for q8_inner_join_9----
 column_names       row_count  distinct_count  null_count
 {c_custkey}        2603       2385            0
 {c_nationkey}      2603       5               0
@@ -422,8 +414,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {r_name}           3866.00        1.49           1.00                1.00                0.00            1.00
 {r_regionkey}      3866.00        1.49           1.00                1.00                0.00            1.00
 
-stats table=q8_lookup_join_10
-----
+----Stats for q8_lookup_join_10----
 column_names   row_count  distinct_count  null_count
 {c_custkey}    29952      30253           0
 {c_nationkey}  29952      5               0
@@ -440,8 +431,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       30000.00       1.00           1.00                1.00                0.00            1.00
 {r_regionkey}  30000.00       1.00           1.00                1.00                0.00            1.00
 
-stats table=q8_merge_join_11
-----
+----Stats for q8_merge_join_11----
 column_names   row_count  distinct_count  null_count
 {n_nationkey}  5          5               0
 {n_regionkey}  5          1               0
@@ -454,8 +444,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       5.00           1.00           1.00                1.00                0.00            1.00
 {r_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q8_scan_12
-----
+----Stats for q8_scan_12----
 column_names   row_count  distinct_count  null_count
 {n_nationkey}  25         25              0
 {n_regionkey}  25         5               0
@@ -464,8 +453,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
 {n_regionkey}  25.00          1.00           5.00                1.00                0.00            1.00
 
-stats table=q8_select_13
-----
+----Stats for q8_select_13----
 column_names   row_count  distinct_count  null_count
 {r_name}       1          1               0
 {r_regionkey}  1          1               0
@@ -474,8 +462,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       1.00           1.00           1.00                1.00                0.00            1.00
 {r_regionkey}  1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q8_scan_14
-----
+----Stats for q8_scan_14----
 column_names   row_count  distinct_count  null_count
 {r_name}       5          5               0
 {r_regionkey}  5          5               0
@@ -484,8 +471,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {r_name}       5.00           1.00           5.00                1.00                0.00            1.00
 {r_regionkey}  5.00           1.00           5.00                1.00                0.00            1.00
 
-stats table=q8_lookup_join_15
-----
+----Stats for q8_lookup_join_15----
 column_names       row_count  distinct_count  null_count
 {l_discount}       13389      11              0
 {l_extendedprice}  13389      12076           0
@@ -510,8 +496,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {p_partkey}        11954.00       1.12           1333.00             1.09                0.00            1.00
 {p_type}           11954.00       1.12           1.00                1.00                0.00            1.00
 
-stats table=q8_lookup_join_16
-----
+----Stats for q8_lookup_join_16----
 column_names       row_count  distinct_count  null_count
 {l_discount}       43693      11              0
 {l_extendedprice}  43693      32247           0
@@ -530,8 +515,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {p_partkey}        40161.00       1.09           1333.00             1.09                0.00            1.00
 {p_type}           40161.00       1.09           1.00                1.00                0.00            1.00
 
-stats table=q8_lookup_join_17
-----
+----Stats for q8_lookup_join_17----
 column_names    row_count  distinct_count  null_count
 {l_linenumber}  43693      7               0
 {l_orderkey}    43693      43349           0
@@ -546,8 +530,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {p_partkey}     40161.00       1.09           1333.00             1.09                0.00            1.00
 {p_type}        40161.00       1.09           1.00                1.00                0.00            1.00
 
-stats table=q8_select_18
-----
+----Stats for q8_select_18----
 column_names  row_count  distinct_count  null_count
 {p_partkey}   1451       1451            0
 {p_type}      1451       1               0
@@ -556,8 +539,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {p_partkey}   1333.00        1.09           1333.00             1.09                0.00            1.00
 {p_type}      1333.00        1.09           1.00                1.00                0.00            1.00
 
-stats table=q8_scan_19
-----
+----Stats for q8_scan_19----
 column_names  row_count  distinct_count  null_count
 {p_partkey}   200000     199241          0
 {p_type}      200000     150             0
@@ -566,8 +548,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {p_partkey}   200000.00      1.00           199241.00           1.00                0.00            1.00
 {p_type}      200000.00      1.00           150.00              1.00                0.00            1.00
 
-stats table=q8_scan_20
-----
+----Stats for q8_scan_20----
 column_names   row_count  distinct_count  null_count
 {n_name}       25         25              0
 {n_nationkey}  25         25              0
@@ -575,3 +556,5 @@ column_names   row_count  distinct_count  null_count
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {n_name}       25.00          1.00           25.00               1.00                0.00            1.00
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q09
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q09
@@ -20,7 +20,7 @@ import file=tpch_stats
 #  nations in ascending alphabetical order and, for each nation, the year and
 #  profit in descending order by year (most recent first).
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q9
+stats-quality database=tpch stats-quality-prefix=q9
 SELECT
     nation,
     o_year,
@@ -52,6 +52,7 @@ GROUP BY
 ORDER BY
     nation,
     o_year DESC;
+----
 ----
 sort
  ├── save-table-name: q9_sort_1
@@ -177,8 +178,7 @@ sort
            └── sum [as=sum:59, type=float, outer=(58)]
                 └── amount:58 [type=float]
 
-stats table=q9_sort_1
-----
+----Stats for q9_sort_1----
 column_names  row_count  distinct_count  null_count
 {nation}      175        25              0
 {o_year}      175        7               0
@@ -189,8 +189,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {o_year}      1548.00        8.85 <==       957.00              136.71 <==          0.00            1.00
 {sum_profit}  1548.00        8.85 <==       1548.00             8.85 <==            0.00            1.00
 
-stats table=q9_group_by_2
-----
+----Stats for q9_group_by_2----
 column_names  row_count  distinct_count  null_count
 {n_name}      175        25              0
 {o_year}      175        7               0
@@ -201,8 +200,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {o_year}      1548.00        8.85 <==       957.00              136.71 <==          0.00            1.00
 {sum}         1548.00        8.85 <==       1548.00             8.85 <==            0.00            1.00
 
-stats table=q9_project_3
-----
+----Stats for q9_project_3----
 column_names  row_count  distinct_count  null_count
 {amount}      319404     315234          0
 {n_name}      319404     25              0
@@ -213,8 +211,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {n_name}      2450.00        130.37 <==     25.00               1.00                0.00            1.00
 {o_year}      2450.00        130.37 <==     957.00              136.71 <==          0.00            1.00
 
-stats table=q9_inner_join_4
-----
+----Stats for q9_inner_join_4----
 column_names       row_count  distinct_count  null_count
 {l_discount}       319404     11              0
 {l_extendedprice}  319404     212580          0
@@ -253,8 +250,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {s_nationkey}      2450.00        130.37 <==     25.00               1.00                0.00            1.00
 {s_suppkey}        2450.00        130.37 <==     1065.00             9.20 <==            0.00            1.00
 
-stats table=q9_inner_join_5
-----
+----Stats for q9_inner_join_5----
 column_names       row_count  distinct_count  null_count
 {l_discount}       319404     11              0
 {l_extendedprice}  319404     212580          0
@@ -289,8 +285,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {s_nationkey}      2450.00        130.37 <==     25.00               1.00                0.00            1.00
 {s_suppkey}        2450.00        130.37 <==     1224.00             8.01 <==            0.00            1.00
 
-stats table=q9_scan_6
-----
+----Stats for q9_scan_6----
 column_names   row_count  distinct_count  null_count
 {s_nationkey}  10000      25              0
 {s_suppkey}    10000      9920            0
@@ -299,8 +294,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  10000.00       1.00           25.00               1.00                0.00            1.00
 {s_suppkey}    10000.00       1.00           9920.00             1.00                0.00            1.00
 
-stats table=q9_lookup_join_7
-----
+----Stats for q9_lookup_join_7----
 column_names       row_count  distinct_count  null_count
 {l_discount}       319404     11              0
 {l_extendedprice}  319404     212580          0
@@ -331,8 +325,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {ps_suppkey}       2431.00        131.39 <==     1220.00             8.03 <==            0.00            1.00
 {ps_supplycost}    2431.00        131.39 <==     1217.00             28.63 <==           0.00            1.00
 
-stats table=q9_lookup_join_8
-----
+----Stats for q9_lookup_join_8----
 column_names       row_count  distinct_count  null_count
 {l_discount}       319404     11              0
 {l_extendedprice}  319404     212580          0
@@ -359,8 +352,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {ps_suppkey}       2431.00        131.39 <==     1536.00             6.38 <==            0.00            1.00
 {ps_supplycost}    2431.00        131.39 <==     1528.00             22.80 <==           0.00            1.00
 
-stats table=q9_lookup_join_9
-----
+----Stats for q9_lookup_join_9----
 column_names     row_count  distinct_count  null_count
 {l_linenumber}   319404     7               0
 {l_orderkey}     319404     288573          0
@@ -383,8 +375,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {ps_suppkey}     813.00         392.87 <==     813.00              12.05 <==           0.00            1.00
 {ps_supplycost}  813.00         392.87 <==     809.00              43.06 <==           0.00            1.00
 
-stats table=q9_merge_join_10
-----
+----Stats for q9_merge_join_10----
 column_names     row_count  distinct_count  null_count
 {p_name}         42656      10680           0
 {p_partkey}      42656      10632           0
@@ -399,8 +390,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {ps_suppkey}     267683.00      6.28 <==       9920.00             1.01                0.00            1.00
 {ps_supplycost}  267683.00      6.28 <==       93405.00            2.68 <==            0.00            1.00
 
-stats table=q9_select_11
-----
+----Stats for q9_select_11----
 column_names  row_count  distinct_count  null_count
 {p_name}      10664      10680           0
 {p_partkey}   10664      10632           0
@@ -409,8 +399,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {p_name}      66667.00       6.25 <==       66667.00            6.24 <==            0.00            1.00
 {p_partkey}   66667.00       6.25 <==       66619.00            6.27 <==            0.00            1.00
 
-stats table=q9_scan_12
-----
+----Stats for q9_scan_12----
 column_names  row_count  distinct_count  null_count
 {p_name}      200000     198131          0
 {p_partkey}   200000     199241          0
@@ -419,8 +408,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {p_name}      200000.00      1.00           198131.00           1.00                0.00            1.00
 {p_partkey}   200000.00      1.00           199241.00           1.00                0.00            1.00
 
-stats table=q9_scan_13
-----
+----Stats for q9_scan_13----
 column_names     row_count  distinct_count  null_count
 {ps_partkey}     800000     199241          0
 {ps_suppkey}     800000     9920            0
@@ -431,8 +419,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {ps_suppkey}     800000.00      1.00           9920.00             1.00                0.00            1.00
 {ps_supplycost}  800000.00      1.00           100379.00           1.00                0.00            1.00
 
-stats table=q9_scan_14
-----
+----Stats for q9_scan_14----
 column_names   row_count  distinct_count  null_count
 {n_name}       25         25              0
 {n_nationkey}  25         25              0
@@ -440,3 +427,5 @@ column_names   row_count  distinct_count  null_count
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {n_name}       25.00          1.00           25.00               1.00                0.00            1.00
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q10
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q10
@@ -18,7 +18,7 @@ import file=tpch_stats
 # Revenue lost is defined as sum(l_extendedprice*(1-l_discount)) for all
 # qualifying lineitems.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q10
+stats-quality database=tpch stats-quality-prefix=q10
 SELECT
     c_custkey,
     c_name,
@@ -51,6 +51,7 @@ GROUP BY
 ORDER BY
     revenue DESC
 LIMIT 20;
+----
 ----
 limit
  ├── save-table-name: q10_limit_1
@@ -165,8 +166,7 @@ limit
  │                   └── n_name:38 [type=char]
  └── 20 [type=int]
 
-stats table=q10_limit_1
-----
+----Stats for q10_limit_1----
 column_names  row_count  distinct_count  null_count
 {c_acctbal}   20         20              0
 {c_address}   20         20              0
@@ -187,8 +187,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {n_name}      20.00          1.00           20.00               1.54                0.00            1.00
 {revenue}     20.00          1.00           20.00               1.00                0.00            1.00
 
-stats table=q10_sort_2
-----
+----Stats for q10_sort_2----
 column_names  row_count  distinct_count  null_count
 {c_acctbal}   0          0               0
 {c_address}   0          0               0
@@ -209,8 +208,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {n_name}      34518.00       +Inf <==       34518.00            +Inf <==            0.00            1.00
 {sum}         34518.00       +Inf <==       34518.00            +Inf <==            0.00            1.00
 
-stats table=q10_group_by_3
-----
+----Stats for q10_group_by_3----
 column_names  row_count  distinct_count  null_count
 {c_acctbal}   37967      37658           0
 {c_address}   37967      38065           0
@@ -219,7 +217,7 @@ column_names  row_count  distinct_count  null_count
 {c_name}      37967      37859           0
 {c_phone}     37967      38026           0
 {n_name}      37967      25              0
-{sum}         37967      37934           0
+{sum}         37967      37881           0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {c_acctbal}   34518.00       1.10           34518.00            1.09                0.00            1.00
@@ -231,8 +229,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {n_name}      34518.00       1.10           34518.00            1380.72 <==         0.00            1.00
 {sum}         34518.00       1.10           34518.00            1.10                0.00            1.00
 
-stats table=q10_project_4
-----
+----Stats for q10_project_4----
 column_names  row_count  distinct_count  null_count
 {c_acctbal}   114705     37658           0
 {c_address}   114705     38065           0
@@ -253,8 +250,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {column42}    91241.00       1.26           45841.00            2.50 <==            0.00            1.00
 {n_name}      91241.00       1.26           25.00               1.00                0.00            1.00
 
-stats table=q10_inner_join_5
-----
+----Stats for q10_inner_join_5----
 column_names       row_count  distinct_count  null_count
 {c_acctbal}        114705     37658           0
 {c_address}        114705     38065           0
@@ -291,8 +287,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {o_orderdate}      91241.00       1.26           92.00               1.00                0.00            1.00
 {o_orderkey}       91241.00       1.26           39048.00            1.24                0.00            1.00
 
-stats table=q10_inner_join_6
-----
+----Stats for q10_inner_join_6----
 column_names       row_count  distinct_count  null_count
 {c_acctbal}        114705     37658           0
 {c_address}        114705     38065           0
@@ -325,8 +320,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {o_orderdate}      91241.00       1.26           92.00               1.00                0.00            1.00
 {o_orderkey}       91241.00       1.26           44562.00            1.09                0.00            1.00
 
-stats table=q10_scan_7
-----
+----Stats for q10_scan_7----
 column_names   row_count  distinct_count  null_count
 {c_acctbal}    150000     140628          0
 {c_address}    150000     149937          0
@@ -345,8 +339,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {c_nationkey}  150000.00      1.00           25.00               1.00                0.00            1.00
 {c_phone}      150000.00      1.00           150000.00           1.01                0.00            1.00
 
-stats table=q10_lookup_join_8
-----
+----Stats for q10_lookup_join_8----
 column_names       row_count  distinct_count  null_count
 {l_discount}       114705     11              0
 {l_extendedprice}  114705     106228          0
@@ -365,8 +358,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {o_orderdate}      90519.00       1.27           92.00               1.00                0.00            1.00
 {o_orderkey}       90519.00       1.27           55062.00            1.13                0.00            1.00
 
-stats table=q10_index_join_9
-----
+----Stats for q10_index_join_9----
 column_names   row_count  distinct_count  null_count
 {o_custkey}    57069      42598           0
 {o_orderdate}  57069      92              0
@@ -377,8 +369,16 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {o_orderdate}  55062.00       1.04           92.00               1.00                0.00            1.00
 {o_orderkey}   55062.00       1.04           55062.00            1.02                0.00            1.00
 
-stats table=q10_scan_11
-----
+----Stats for q10_scan_10----
+column_names   row_count  distinct_count  null_count
+{o_orderdate}  57069      92              0
+{o_orderkey}   57069      56240           0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_orderdate}  55062.00       1.04           92.00               1.00                0.00            1.00
+{o_orderkey}   55062.00       1.04           55062.00            1.02                0.00            1.00
+
+----Stats for q10_scan_11----
 column_names   row_count  distinct_count  null_count
 {n_name}       25         25              0
 {n_nationkey}  25         25              0
@@ -386,3 +386,5 @@ column_names   row_count  distinct_count  null_count
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {n_name}       25.00          1.00           25.00               1.00                0.00            1.00
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q11
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q11
@@ -14,7 +14,7 @@ import file=tpch_stats
 # available parts. The query displays the part number and the value of those
 # parts in descending order of value.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q11
+stats-quality database=tpch stats-quality-prefix=q11
 SELECT
     ps_partkey,
     sum(ps_supplycost * ps_availqty::float) AS value
@@ -42,6 +42,7 @@ GROUP BY
         )
 ORDER BY
     value DESC;
+----
 ----
 sort
  ├── save-table-name: q11_sort_1
@@ -190,8 +191,7 @@ sort
                           └── projections
                                └── sum:42 * 0.0001 [as="?column?":43, type=float, outer=(42), immutable]
 
-stats table=q11_sort_1
-----
+----Stats for q11_sort_1----
 column_names  row_count  distinct_count  null_count
 {ps_partkey}  1048       1048            0
 {value}       1048       1048            0
@@ -200,8 +200,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {ps_partkey}  9928.00        9.47 <==       9928.00             9.47 <==            0.00            1.00
 {value}       9928.00        9.47 <==       9928.00             9.47 <==            0.00            1.00
 
-stats table=q11_select_2
-----
+----Stats for q11_select_2----
 column_names  row_count  distinct_count  null_count
 {ps_partkey}  1048       1048            0
 {sum}         1048       1048            0
@@ -210,8 +209,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {ps_partkey}  9928.00        9.47 <==       9928.00             9.47 <==            0.00            1.00
 {sum}         9928.00        9.47 <==       9928.00             9.47 <==            0.00            1.00
 
-stats table=q11_group_by_3
-----
+----Stats for q11_group_by_3----
 column_names  row_count  distinct_count  null_count
 {ps_partkey}  29818      29669           0
 {sum}         29818      29969           0
@@ -220,8 +218,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {ps_partkey}  29783.00       1.00           29783.00            1.00                0.00            1.00
 {sum}         29783.00       1.00           29783.00            1.01                0.00            1.00
 
-stats table=q11_project_4
-----
+----Stats for q11_project_4----
 column_names  row_count  distinct_count  null_count
 {column20}    31680      31888           0
 {ps_partkey}  31680      29669           0
@@ -230,8 +227,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {column20}    32258.00       1.02           31618.00            1.01                0.00            1.00
 {ps_partkey}  32258.00       1.02           29783.00            1.00                0.00            1.00
 
-stats table=q11_lookup_join_5
-----
+----Stats for q11_lookup_join_5----
 column_names     row_count  distinct_count  null_count
 {n_name}         31680      1               0
 {n_nationkey}    31680      1               0
@@ -252,8 +248,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_nationkey}    32258.00       1.02           1.00                1.00                0.00            1.00
 {s_suppkey}      32258.00       1.02           400.00              1.01                0.00            1.00
 
-stats table=q11_lookup_join_6
-----
+----Stats for q11_lookup_join_6----
 column_names   row_count  distinct_count  null_count
 {n_name}       31680      1               0
 {n_nationkey}  31680      1               0
@@ -270,8 +265,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  32258.00       1.02           1.00                1.00                0.00            1.00
 {s_suppkey}    32258.00       1.02           400.00              1.01                0.00            1.00
 
-stats table=q11_lookup_join_7
-----
+----Stats for q11_lookup_join_7----
 column_names   row_count  distinct_count  null_count
 {n_name}       396        1               0
 {n_nationkey}  396        1               0
@@ -284,8 +278,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  400.00         1.01           1.00                1.00                0.00            1.00
 {s_suppkey}    400.00         1.01           400.00              1.01                0.00            1.00
 
-stats table=q11_select_8
-----
+----Stats for q11_select_8----
 column_names   row_count  distinct_count  null_count
 {n_name}       1          1               0
 {n_nationkey}  1          1               0
@@ -294,8 +287,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_name}       1.00           1.00           1.00                1.00                0.00            1.00
 {n_nationkey}  1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q11_scan_9
-----
+----Stats for q11_scan_9----
 column_names   row_count  distinct_count  null_count
 {n_name}       25         25              0
 {n_nationkey}  25         25              0
@@ -304,32 +296,28 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_name}       25.00          1.00           25.00               1.00                0.00            1.00
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
 
-stats table=q11_project_10
-----
+----Stats for q11_project_10----
 column_names  row_count  distinct_count  null_count
 {?column?}    1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {?column?}    1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q11_scalar_group_by_11
-----
+----Stats for q11_scalar_group_by_11----
 column_names  row_count  distinct_count  null_count
 {sum}         1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {sum}         1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q11_project_12
-----
+----Stats for q11_project_12----
 column_names  row_count  distinct_count  null_count
 {column41}    31680      31888           0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {column41}    32258.00       1.02           31618.00            1.01                0.00            1.00
 
-stats table=q11_lookup_join_13
-----
+----Stats for q11_lookup_join_13----
 column_names     row_count  distinct_count  null_count
 {n_name}         31680      1               0
 {n_nationkey}    31680      1               0
@@ -348,8 +336,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_nationkey}    32258.00       1.02           1.00                1.00                0.00            1.00
 {s_suppkey}      32258.00       1.02           400.00              1.01                0.00            1.00
 
-stats table=q11_lookup_join_14
-----
+----Stats for q11_lookup_join_14----
 column_names   row_count  distinct_count  null_count
 {n_name}       31680      1               0
 {n_nationkey}  31680      1               0
@@ -366,8 +353,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  32258.00       1.02           1.00                1.00                0.00            1.00
 {s_suppkey}    32258.00       1.02           400.00              1.01                0.00            1.00
 
-stats table=q11_lookup_join_15
-----
+----Stats for q11_lookup_join_15----
 column_names   row_count  distinct_count  null_count
 {n_name}       396        1               0
 {n_nationkey}  396        1               0
@@ -380,8 +366,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  400.00         1.01           1.00                1.00                0.00            1.00
 {s_suppkey}    400.00         1.01           400.00              1.01                0.00            1.00
 
-stats table=q11_select_16
-----
+----Stats for q11_select_16----
 column_names   row_count  distinct_count  null_count
 {n_name}       1          1               0
 {n_nationkey}  1          1               0
@@ -390,8 +375,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_name}       1.00           1.00           1.00                1.00                0.00            1.00
 {n_nationkey}  1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q11_scan_17
-----
+----Stats for q11_scan_17----
 column_names   row_count  distinct_count  null_count
 {n_name}       25         25              0
 {n_nationkey}  25         25              0
@@ -399,3 +383,5 @@ column_names   row_count  distinct_count  null_count
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {n_name}       25.00          1.00           25.00               1.00                0.00            1.00
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q12
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q12
@@ -18,7 +18,7 @@ import file=tpch_stats
 # The late lineitems are partitioned into two groups, those with priority URGENT
 # or HIGH, and those with a priority other than URGENT or HIGH.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q12
+stats-quality database=tpch stats-quality-prefix=q12
 SELECT
     l_shipmode,
     sum(CASE
@@ -47,6 +47,7 @@ GROUP BY
     l_shipmode
 ORDER BY
     l_shipmode;
+----
 ----
 sort
  ├── save-table-name: q12_sort_1
@@ -108,8 +109,7 @@ sort
            └── sum [as=sum:31, type=decimal, outer=(30)]
                 └── column30:30 [type=int]
 
-stats table=q12_sort_1
-----
+----Stats for q12_sort_1----
 column_names       row_count  distinct_count  null_count
 {high_line_count}  2          2               0
 {l_shipmode}       2          2               0
@@ -120,8 +120,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_shipmode}       2.00           1.00           2.00                1.00                0.00            1.00
 {low_line_count}   2.00           1.00           2.00                1.00                0.00            1.00
 
-stats table=q12_group_by_2
-----
+----Stats for q12_group_by_2----
 column_names  row_count  distinct_count  null_count
 {l_shipmode}  2          2               0
 {sum_1}       2          2               0
@@ -132,8 +131,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {sum}         2.00           1.00           2.00                1.00                0.00            1.00
 {sum_1}       2.00           1.00           2.00                1.00                0.00            1.00
 
-stats table=q12_project_3
-----
+----Stats for q12_project_3----
 column_names  row_count  distinct_count  null_count
 {column28}    30988      2               0
 {column30}    30988      2               0
@@ -144,8 +142,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {column30}    29823.00       1.04           5.00                2.50 <==            0.00            1.00
 {l_shipmode}  29823.00       1.04           2.00                1.00                0.00            1.00
 
-stats table=q12_lookup_join_4
-----
+----Stats for q12_lookup_join_4----
 column_names       row_count  distinct_count  null_count
 {l_commitdate}     30988      392             0
 {l_orderkey}       30988      28828           0
@@ -164,8 +161,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {o_orderkey}       29823.00       1.04           29606.00            1.03                0.00            1.00
 {o_orderpriority}  29823.00       1.04           5.00                1.00                0.00            1.00
 
-stats table=q12_select_5
-----
+----Stats for q12_select_5----
 column_names     row_count  distinct_count  null_count
 {l_commitdate}   30988      392             0
 {l_orderkey}     30988      28828           0
@@ -180,8 +176,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {l_shipdate}     29823.00       1.04           2526.00             6.46 <==            0.00            1.00
 {l_shipmode}     29823.00       1.04           2.00                1.00                0.00            1.00
 
-stats table=q12_index_join_6
-----
+----Stats for q12_index_join_6----
 column_names     row_count  distinct_count  null_count
 {l_commitdate}   909844     560             0
 {l_orderkey}     909844     267788          0
@@ -195,3 +190,16 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {l_receiptdate}  939420.00      1.03           365.00              1.00                0.00            1.00
 {l_shipdate}     939420.00      1.03           2526.00             6.41 <==            0.00            1.00
 {l_shipmode}     939420.00      1.03           7.00                1.00                0.00            1.00
+
+----Stats for q12_scan_7----
+column_names     row_count  distinct_count  null_count
+{l_linenumber}   909844     7               0
+{l_orderkey}     909844     267788          0
+{l_receiptdate}  909844     365             0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_linenumber}   939420.00      1.03           7.00                1.00                0.00            1.00
+{l_orderkey}     939420.00      1.03           744923.00           2.78 <==            0.00            1.00
+{l_receiptdate}  939420.00      1.03           365.00              1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q13
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q13
@@ -15,7 +15,7 @@ import file=tpch_stats
 # several special categories of orders. Special categories are identified in the
 # order comment column by looking for a particular pattern.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q13
+stats-quality database=tpch stats-quality-prefix=q13
 SELECT
     c_count, count(*) AS custdist
 FROM (
@@ -34,6 +34,7 @@ GROUP BY
 ORDER BY
     custdist DESC,
     c_count DESC;
+----
 ----
 sort
  ├── save-table-name: q13_sort_1
@@ -95,8 +96,7 @@ sort
       └── aggregations
            └── count-rows [as=count_rows:21, type=int]
 
-stats table=q13_sort_1
-----
+----Stats for q13_sort_1----
 column_names  row_count  distinct_count  null_count
 {c_count}     42         42              0
 {custdist}    42         41              0
@@ -105,8 +105,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {c_count}     148813.00      3543.17 <==    148813.00           3543.17 <==         0.00            1.00
 {custdist}    148813.00      3543.17 <==    148813.00           3629.59 <==         0.00            1.00
 
-stats table=q13_group_by_2
-----
+----Stats for q13_group_by_2----
 column_names  row_count  distinct_count  null_count
 {count_rows}  42         41              0
 {count}       42         42              0
@@ -115,8 +114,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {count}       148813.00      3543.17 <==    148813.00           3543.17 <==         0.00            1.00
 {count_rows}  148813.00      3543.17 <==    148813.00           3629.59 <==         0.00            1.00
 
-stats table=q13_group_by_3
-----
+----Stats for q13_group_by_3----
 column_names  row_count  distinct_count  null_count
 {c_custkey}   150000     148813          0
 {count}       150000     42              0
@@ -125,8 +123,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {c_custkey}   148813.00      1.01           148813.00           1.00                0.00            1.00
 {count}       148813.00      1.01           148813.00           3543.17 <==         0.00            1.00
 
-stats table=q13_right_join_4
-----
+----Stats for q13_right_join_4----
 column_names  row_count  distinct_count  null_count
 {c_custkey}   1533923    148813          0
 {o_comment}   1533923    1454164         50005
@@ -139,8 +136,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {o_custkey}   503988.00      3.04 <==       99620.00            1.00                0.00            +Inf <==
 {o_orderkey}  503988.00      3.04 <==       317522.00           4.76 <==            0.00            +Inf <==
 
-stats table=q13_select_5
-----
+----Stats for q13_select_5----
 column_names  row_count  distinct_count  null_count
 {o_comment}   1483918    1454164         0
 {o_custkey}   1483918    99846           0
@@ -151,8 +147,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {o_custkey}   500000.00      2.97 <==       99620.00            1.00                0.00            1.00
 {o_orderkey}  500000.00      2.97 <==       500000.00           3.02 <==            0.00            1.00
 
-stats table=q13_scan_6
-----
+----Stats for q13_scan_6----
 column_names  row_count  distinct_count  null_count
 {o_comment}   1500000    1469402         0
 {o_custkey}   1500000    99846           0
@@ -163,10 +158,11 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {o_custkey}   1500000.00     1.00           99846.00            1.00                0.00            1.00
 {o_orderkey}  1500000.00     1.00           1500000.00          1.02                0.00            1.00
 
-stats table=q13_scan_7
-----
+----Stats for q13_scan_7----
 column_names  row_count  distinct_count  null_count
 {c_custkey}   150000     148813          0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {c_custkey}   150000.00      1.00           148813.00           1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q14
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q14
@@ -15,7 +15,7 @@ import file=tpch_stats
 # shipped in that month and gives the percentage. Revenue is defined as
 # (l_extendedprice * (1-l_discount)).
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q14
+stats-quality database=tpch stats-quality-prefix=q14
 SELECT
     100.00 * sum(CASE
         WHEN p_type LIKE 'PROMO%'
@@ -29,6 +29,7 @@ WHERE
     l_partkey = p_partkey
     AND l_shipdate >= DATE '1995-09-01'
     AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' MONTH;
+----
 ----
 project
  ├── save-table-name: q14_project_1
@@ -95,16 +96,14 @@ project
  └── projections
       └── (sum:29 * 100.0) / sum:31 [as=promo_revenue:32, type=float, outer=(29,31), immutable]
 
-stats table=q14_project_1
-----
+----Stats for q14_project_1----
 column_names     row_count  distinct_count  null_count
 {promo_revenue}  1          1               0
 ~~~~
 column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {promo_revenue}  1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q14_scalar_group_by_2
-----
+----Stats for q14_scalar_group_by_2----
 column_names  row_count  distinct_count  null_count
 {sum_1}       1          1               0
 {sum}         1          1               0
@@ -113,8 +112,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {sum}         1.00           1.00           1.00                1.00                0.00            1.00
 {sum_1}       1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q14_project_3
-----
+----Stats for q14_project_3----
 column_names  row_count  distinct_count  null_count
 {column28}    75983      12638           0
 {column30}    75983      76207           0
@@ -123,8 +121,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {column28}    82727.00       1.09           82727.00            6.55 <==            0.00            1.00
 {column30}    82727.00       1.09           52210.00            1.46                0.00            1.00
 
-stats table=q14_inner_join_4
-----
+----Stats for q14_inner_join_4----
 column_names       row_count  distinct_count  null_count
 {l_discount}       75983      11              0
 {l_extendedprice}  75983      72627           0
@@ -141,8 +138,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {p_partkey}        82727.00       1.09           67871.00            1.08                0.00            1.00
 {p_type}           82727.00       1.09           150.00              1.00                0.00            1.00
 
-stats table=q14_scan_5
-----
+----Stats for q14_scan_5----
 column_names  row_count  distinct_count  null_count
 {p_partkey}   200000     199241          0
 {p_type}      200000     150             0
@@ -151,8 +147,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {p_partkey}   200000.00      1.00           199241.00           1.00                0.00            1.00
 {p_type}      200000.00      1.00           150.00              1.00                0.00            1.00
 
-stats table=q14_index_join_6
-----
+----Stats for q14_index_join_6----
 column_names       row_count  distinct_count  null_count
 {l_discount}       75983      11              0
 {l_extendedprice}  75983      72627           0
@@ -164,3 +159,16 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_extendedprice}  82413.00       1.08           79374.00            1.09                0.00            1.00
 {l_partkey}        82413.00       1.08           67871.00            1.08                0.00            1.00
 {l_shipdate}       82413.00       1.08           30.00               1.00                0.00            1.00
+
+----Stats for q14_scan_7----
+column_names    row_count  distinct_count  null_count
+{l_linenumber}  75983      7               0
+{l_orderkey}    75983      49544           0
+{l_shipdate}    75983      30              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_linenumber}  82413.00       1.08           7.00                1.00                0.00            1.00
+{l_orderkey}    82413.00       1.08           80770.00            1.63                0.00            1.00
+{l_shipdate}    82413.00       1.08           30.00               1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q15
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q15
@@ -29,7 +29,7 @@ CREATE VIEW revenue0 (supplier_no, total_revenue) AS
         l_suppkey;
 ----
 
-save-tables database=tpch save-tables-prefix=q15
+stats-quality database=tpch stats-quality-prefix=q15
 SELECT
     s_suppkey,
     s_name,
@@ -49,6 +49,7 @@ WHERE
     )
 ORDER BY
     s_suppkey;
+----
 ----
 project
  ├── save-table-name: q15_project_1
@@ -179,8 +180,7 @@ project
       │                                       └── sum:46 [type=float]
       └── filters (true)
 
-stats table=q15_project_1
-----
+----Stats for q15_project_1----
 column_names     row_count  distinct_count  null_count
 {s_address}      1          1               0
 {s_name}         1          1               0
@@ -195,8 +195,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_suppkey}      3333.00        3333.00 <==    3307.00             3307.00 <==         0.00            1.00
 {total_revenue}  3333.00        3333.00 <==    2100.00             2100.00 <==         0.00            1.00
 
-stats table=q15_merge_join_2
-----
+----Stats for q15_merge_join_2----
 column_names  row_count  distinct_count  null_count
 {l_suppkey}   1          1               0
 {s_address}   1          1               0
@@ -213,8 +212,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {s_suppkey}   3333.00        3333.00 <==    3307.00             3307.00 <==         0.00            1.00
 {sum}         3333.00        3333.00 <==    2100.00             2100.00 <==         0.00            1.00
 
-stats table=q15_scan_3
-----
+----Stats for q15_scan_3----
 column_names  row_count  distinct_count  null_count
 {s_address}   10000      10027           0
 {s_name}      10000      9990            0
@@ -227,8 +225,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {s_phone}     10000.00       1.00           10000.00            1.00                0.00            1.00
 {s_suppkey}   10000.00       1.00           9920.00             1.00                0.00            1.00
 
-stats table=q15_sort_4
-----
+----Stats for q15_sort_4----
 column_names  row_count  distinct_count  null_count
 {l_suppkey}   1          1               0
 {sum}         1          1               0
@@ -237,8 +234,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {l_suppkey}   3307.00        3307.00 <==    3307.00             3307.00 <==         0.00            1.00
 {sum}         3307.00        3307.00 <==    3307.00             3307.00 <==         0.00            1.00
 
-stats table=q15_select_5
-----
+----Stats for q15_select_5----
 column_names  row_count  distinct_count  null_count
 {l_suppkey}   1          1               0
 {sum}         1          1               0
@@ -247,8 +243,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {l_suppkey}   3307.00        3307.00 <==    3307.00             3307.00 <==         0.00            1.00
 {sum}         3307.00        3307.00 <==    3307.00             3307.00 <==         0.00            1.00
 
-stats table=q15_group_by_6
-----
+----Stats for q15_group_by_6----
 column_names  row_count  distinct_count  null_count
 {l_suppkey}   10000      9920            0
 {sum}         10000      10011           0
@@ -257,8 +252,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {l_suppkey}   9920.00        1.01           9920.00             1.00                0.00            1.00
 {sum}         9920.00        1.01           9920.00             1.01                0.00            1.00
 
-stats table=q15_project_7
-----
+----Stats for q15_project_7----
 column_names  row_count  distinct_count  null_count
 {column26}    225954     220864          0
 {l_suppkey}   225954     9920            0
@@ -267,8 +261,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {column26}    259635.00      1.15           259635.00           1.18                0.00            1.00
 {l_suppkey}   259635.00      1.15           9920.00             1.00                0.00            1.00
 
-stats table=q15_index_join_8
-----
+----Stats for q15_index_join_8----
 column_names       row_count  distinct_count  null_count
 {l_discount}       225954     11              0
 {l_extendedprice}  225954     196692          0
@@ -281,16 +274,25 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_shipdate}       259635.00      1.15           91.00               1.00                0.00            1.00
 {l_suppkey}        259635.00      1.15           9920.00             1.00                0.00            1.00
 
-stats table=q15_scalar_group_by_10
-----
+----Stats for q15_scan_9----
+column_names    row_count  distinct_count  null_count
+{l_linenumber}  225954     7               0
+{l_orderkey}    225954     95273           0
+{l_shipdate}    225954     91              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_linenumber}  259635.00      1.15           7.00                1.00                0.00            1.00
+{l_orderkey}    259635.00      1.15           243636.00           2.56 <==            0.00            1.00
+{l_shipdate}    259635.00      1.15           91.00               1.00                0.00            1.00
+
+----Stats for q15_scalar_group_by_10----
 column_names  row_count  distinct_count  null_count
 {max}         1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {max}         1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q15_group_by_11
-----
+----Stats for q15_group_by_11----
 column_names  row_count  distinct_count  null_count
 {l_suppkey}   10000      9920            0
 {sum}         10000      10011           0
@@ -299,8 +301,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {l_suppkey}   9920.00        1.01           9920.00             1.00                0.00            1.00
 {sum}         9920.00        1.01           9920.00             1.01                0.00            1.00
 
-stats table=q15_project_12
-----
+----Stats for q15_project_12----
 column_names  row_count  distinct_count  null_count
 {column45}    225954     220864          0
 {l_suppkey}   225954     9920            0
@@ -309,8 +310,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {column45}    259635.00      1.15           259635.00           1.18                0.00            1.00
 {l_suppkey}   259635.00      1.15           9920.00             1.00                0.00            1.00
 
-stats table=q15_index_join_13
-----
+----Stats for q15_index_join_13----
 column_names       row_count  distinct_count  null_count
 {l_discount}       225954     11              0
 {l_extendedprice}  225954     196692          0
@@ -322,3 +322,16 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_extendedprice}  259635.00      1.15           230767.00           1.17                0.00            1.00
 {l_shipdate}       259635.00      1.15           91.00               1.00                0.00            1.00
 {l_suppkey}        259635.00      1.15           9920.00             1.00                0.00            1.00
+
+----Stats for q15_scan_14----
+column_names    row_count  distinct_count  null_count
+{l_linenumber}  225954     7               0
+{l_orderkey}    225954     95273           0
+{l_shipdate}    225954     91              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_linenumber}  259635.00      1.15           7.00                1.00                0.00            1.00
+{l_orderkey}    259635.00      1.15           243636.00           2.56 <==            0.00            1.00
+{l_shipdate}    259635.00      1.15           91.00               1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q16
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q16
@@ -18,7 +18,7 @@ import file=tpch_stats
 # Business Bureau. Results must be presented in descending count and ascending
 # brand, type, and size.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q16
+stats-quality database=tpch stats-quality-prefix=q16
 SELECT
     p_brand,
     p_type,
@@ -49,6 +49,7 @@ ORDER BY
     p_brand,
     p_type,
     p_size;
+----
 ----
 sort
  ├── save-table-name: q16_sort_1
@@ -123,8 +124,7 @@ sort
       └── aggregations
            └── count-rows [as=count:25, type=int]
 
-stats table=q16_sort_1
-----
+----Stats for q16_sort_1----
 column_names    row_count  distinct_count  null_count
 {p_brand}       18314      24              0
 {p_size}        18314      8               0
@@ -137,8 +137,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {p_type}        3315.00        5.52 <==       150.00              1.03                0.00            1.00
 {supplier_cnt}  3315.00        5.52 <==       3315.00             221.00 <==          0.00            1.00
 
-stats table=q16_group_by_2
-----
+----Stats for q16_group_by_2----
 column_names  row_count  distinct_count  null_count
 {count}       18314      15              0
 {p_brand}     18314      24              0
@@ -151,8 +150,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {p_size}      3315.00        5.52 <==       8.00                1.00                0.00            1.00
 {p_type}      3315.00        5.52 <==       150.00              1.03                0.00            1.00
 
-stats table=q16_distinct_on_3
-----
+----Stats for q16_distinct_on_3----
 column_names  row_count  distinct_count  null_count
 {p_brand}     118250     24              0
 {p_size}      118250     8               0
@@ -165,8 +163,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {p_type}      9606.00        12.31 <==      150.00              1.03                0.00            1.00
 {ps_suppkey}  9606.00        12.31 <==      6153.00             1.61                0.00            1.00
 
-stats table=q16_anti_join_4
-----
+----Stats for q16_anti_join_4----
 column_names  row_count  distinct_count  null_count
 {p_brand}     118274     24              0
 {p_partkey}   118274     29433           0
@@ -183,8 +180,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {ps_partkey}  9606.00        12.31 <==      3555.00             8.28 <==            0.00            1.00
 {ps_suppkey}  9606.00        12.31 <==      6153.00             1.61                0.00            1.00
 
-stats table=q16_lookup_join_5
-----
+----Stats for q16_lookup_join_5----
 column_names  row_count  distinct_count  null_count
 {p_brand}     118324     24              0
 {p_partkey}   118324     29433           0
@@ -201,8 +197,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {ps_partkey}  14276.00       8.29 <==       3555.00             8.28 <==            0.00            1.00
 {ps_suppkey}  14276.00       8.29 <==       7568.00             1.31                0.00            1.00
 
-stats table=q16_select_6
-----
+----Stats for q16_select_6----
 column_names  row_count  distinct_count  null_count
 {p_brand}     29581      24              0
 {p_partkey}   29581      29433           0
@@ -215,8 +210,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {p_size}      3556.00        8.32 <==       8.00                1.00                0.00            1.00
 {p_type}      3556.00        8.32 <==       150.00              1.03                0.00            1.00
 
-stats table=q16_scan_7
-----
+----Stats for q16_scan_7----
 column_names  row_count  distinct_count  null_count
 {p_brand}     200000     25              0
 {p_partkey}   200000     199241          0
@@ -229,8 +223,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {p_size}      200000.00      1.00           50.00               1.00                0.00            1.00
 {p_type}      200000.00      1.00           150.00              1.00                0.00            1.00
 
-stats table=q16_select_8
-----
+----Stats for q16_select_8----
 column_names  row_count  distinct_count  null_count
 {s_comment}   4          4               0
 {s_suppkey}   4          4               0
@@ -239,8 +232,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {s_comment}   3333.00        833.25 <==     3333.00             833.25 <==          0.00            1.00
 {s_suppkey}   3333.00        833.25 <==     3328.00             832.00 <==          0.00            1.00
 
-stats table=q16_scan_9
-----
+----Stats for q16_scan_9----
 column_names  row_count  distinct_count  null_count
 {s_comment}   10000      9934            0
 {s_suppkey}   10000      9920            0
@@ -248,3 +240,5 @@ column_names  row_count  distinct_count  null_count
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {s_comment}   10000.00       1.00           9934.00             1.00                0.00            1.00
 {s_suppkey}   10000.00       1.00           9920.00             1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q17
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q17
@@ -20,7 +20,7 @@ import file=tpch_stats
 # TODO:
 #   1. Allow Select to be pushed below Ordinality used to add key column
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q17
+stats-quality database=tpch stats-quality-prefix=q17
 SELECT
     sum(l_extendedprice) / 7.0 AS avg_yearly
 FROM
@@ -38,6 +38,7 @@ WHERE
         WHERE
             l_partkey = p_partkey
     );
+----
 ----
 project
  ├── save-table-name: q17_project_1
@@ -137,24 +138,21 @@ project
  └── projections
       └── sum:47 / 7.0 [as=avg_yearly:48, type=float, outer=(47)]
 
-stats table=q17_project_1
-----
+----Stats for q17_project_1----
 column_names  row_count  distinct_count  null_count
 {avg_yearly}  1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {avg_yearly}  1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q17_scalar_group_by_2
-----
+----Stats for q17_scalar_group_by_2----
 column_names  row_count  distinct_count  null_count
 {sum}         1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {sum}         1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q17_lookup_join_3
-----
+----Stats for q17_lookup_join_3----
 column_names       row_count  distinct_count  null_count
 {?column?}         587        185             0
 {l_extendedprice}  587        430             0
@@ -169,8 +167,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_quantity}       2008.00        3.42 <==       50.00               8.33 <==            0.00            1.00
 {p_partkey}        2008.00        3.42 <==       200.00              1.03                0.00            1.00
 
-stats table=q17_lookup_join_4
-----
+----Stats for q17_lookup_join_4----
 column_names    row_count  distinct_count  null_count
 {?column?}      6088       194             0
 {l_linenumber}  6088       7               0
@@ -185,8 +182,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {l_partkey}     6024.00        1.01           200.00              1.02                0.00            1.00
 {p_partkey}     6024.00        1.01           200.00              1.02                0.00            1.00
 
-stats table=q17_project_5
-----
+----Stats for q17_project_5----
 column_names  row_count  distinct_count  null_count
 {?column?}    204        194             0
 {p_partkey}   204        204             0
@@ -195,8 +191,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {?column?}    200.00         1.02           200.00              1.03                0.00            1.00
 {p_partkey}   200.00         1.02           200.00              1.02                0.00            1.00
 
-stats table=q17_group_by_6
-----
+----Stats for q17_group_by_6----
 column_names  row_count  distinct_count  null_count
 {avg}         204        194             0
 {p_partkey}   204        204             0
@@ -205,8 +200,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {avg}         200.00         1.02           200.00              1.03                0.00            1.00
 {p_partkey}   200.00         1.02           200.00              1.02                0.00            1.00
 
-stats table=q17_lookup_join_7
-----
+----Stats for q17_lookup_join_7----
 column_names   row_count  distinct_count  null_count
 {l_partkey}    6088       204             0
 {l_quantity}   6088       50              0
@@ -221,8 +215,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {p_container}  6024.00        1.01           1.00                1.00                0.00            1.00
 {p_partkey}    6024.00        1.01           200.00              1.02                0.00            1.00
 
-stats table=q17_lookup_join_8
-----
+----Stats for q17_lookup_join_8----
 column_names    row_count  distinct_count  null_count
 {l_linenumber}  6088       7               0
 {l_orderkey}    6088       6116            0
@@ -239,8 +232,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {p_container}   6024.00        1.01           1.00                1.00                0.00            1.00
 {p_partkey}     6024.00        1.01           200.00              1.02                0.00            1.00
 
-stats table=q17_select_9
-----
+----Stats for q17_select_9----
 column_names   row_count  distinct_count  null_count
 {p_brand}      204        1               0
 {p_container}  204        1               0
@@ -251,8 +243,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {p_container}  200.00         1.02           1.00                1.00                0.00            1.00
 {p_partkey}    200.00         1.02           200.00              1.02                0.00            1.00
 
-stats table=q17_scan_10
-----
+----Stats for q17_scan_10----
 column_names   row_count  distinct_count  null_count
 {p_brand}      200000     25              0
 {p_container}  200000     40              0
@@ -262,3 +253,5 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {p_brand}      200000.00      1.00           25.00               1.00                0.00            1.00
 {p_container}  200000.00      1.00           40.00               1.00                0.00            1.00
 {p_partkey}    200000.00      1.00           199241.00           1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q18
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q18
@@ -15,7 +15,7 @@ import file=tpch_stats
 # orders. The query lists the customer name, customer key, the order key, date
 # and total price and the quantity for the order.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q18
+stats-quality database=tpch stats-quality-prefix=q18
 SELECT
     c_name,
     c_custkey,
@@ -49,6 +49,7 @@ ORDER BY
     o_totalprice DESC,
     o_orderdate
 LIMIT 100;
+----
 ----
 limit
  ├── save-table-name: q18_limit_1
@@ -167,8 +168,7 @@ limit
  │                   └── o_orderdate:14 [type=date]
  └── 100 [type=int]
 
-stats table=q18_limit_1
-----
+----Stats for q18_limit_1----
 column_names    row_count  distinct_count  null_count
 {c_custkey}     57         57              0
 {c_name}        57         57              0
@@ -185,8 +185,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {o_totalprice}  100.00         1.75           100.00              1.75                0.00            1.00
 {sum}           100.00         1.75           100.00              5.56 <==            0.00            1.00
 
-stats table=q18_sort_2
-----
+----Stats for q18_sort_2----
 column_names    row_count  distinct_count  null_count
 {c_custkey}     57         57              0
 {c_name}        57         57              0
@@ -203,8 +202,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {o_totalprice}  499392.00      8761.26 <==    499392.00           8761.26 <==         0.00            1.00
 {sum}           499392.00      8761.26 <==    499392.00           27744.00 <==        0.00            1.00
 
-stats table=q18_group_by_3
-----
+----Stats for q18_group_by_3----
 column_names    row_count  distinct_count  null_count
 {c_custkey}     57         57              0
 {c_name}        57         57              0
@@ -221,8 +219,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {o_totalprice}  499392.00      8761.26 <==    499392.00           8761.26 <==         0.00            1.00
 {sum}           499392.00      8761.26 <==    499392.00           27744.00 <==        0.00            1.00
 
-stats table=q18_inner_join_4
-----
+----Stats for q18_inner_join_4----
 column_names    row_count  distinct_count  null_count
 {c_custkey}     399        57              0
 {c_name}        399        57              0
@@ -243,8 +240,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {o_orderkey}    2016361.00     5053.54 <==    499392.00           8761.26 <==         0.00            1.00
 {o_totalprice}  2016361.00     5053.54 <==    488044.00           8562.18 <==         0.00            1.00
 
-stats table=q18_scan_5
-----
+----Stats for q18_scan_5----
 column_names  row_count  distinct_count  null_count
 {l_orderkey}  6001215    1527270         0
 {l_quantity}  6001215    50              0
@@ -253,8 +249,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {l_orderkey}  6001215.00     1.00           1527270.00          1.00                0.00            1.00
 {l_quantity}  6001215.00     1.00           50.00               1.00                0.00            1.00
 
-stats table=q18_inner_join_6
-----
+----Stats for q18_inner_join_6----
 column_names    row_count  distinct_count  null_count
 {c_custkey}     57         57              0
 {c_name}        57         57              0
@@ -271,8 +266,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {o_orderkey}    513151.00      9002.65 <==    323295.00           5671.84 <==         0.00            1.00
 {o_totalprice}  513151.00      9002.65 <==    322560.00           5658.95 <==         0.00            1.00
 
-stats table=q18_merge_join_7
-----
+----Stats for q18_merge_join_7----
 column_names    row_count  distinct_count  null_count
 {o_custkey}     57         57              0
 {o_orderdate}   57         57              0
@@ -285,8 +279,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {o_orderkey}    509090.00      8931.40 <==    509090.00           8931.40 <==         0.00            1.00
 {o_totalprice}  509090.00      8931.40 <==    506350.00           8883.33 <==         0.00            1.00
 
-stats table=q18_scan_8
-----
+----Stats for q18_scan_8----
 column_names    row_count  distinct_count  null_count
 {o_custkey}     1500000    99846           0
 {o_orderdate}   1500000    2406            0
@@ -299,8 +292,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {o_orderkey}    1500000.00     1.00           1500000.00          1.02                0.00            1.00
 {o_totalprice}  1500000.00     1.00           1459167.00          1.00                0.00            1.00
 
-stats table=q18_select_9
-----
+----Stats for q18_select_9----
 column_names  row_count  distinct_count  null_count
 {l_orderkey}  57         57              0
 {sum}         57         18              0
@@ -309,8 +301,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {l_orderkey}  509090.00      8931.40 <==    509090.00           8931.40 <==         0.00            1.00
 {sum}         509090.00      8931.40 <==    509090.00           28282.78 <==        0.00            1.00
 
-stats table=q18_group_by_10
-----
+----Stats for q18_group_by_10----
 column_names  row_count  distinct_count  null_count
 {l_orderkey}  1500000    1527270         0
 {sum}         1500000    318             0
@@ -319,8 +310,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {l_orderkey}  1527270.00     1.02           1527270.00          1.00                0.00            1.00
 {sum}         1527270.00     1.02           1527270.00          4802.74 <==         0.00            1.00
 
-stats table=q18_scan_11
-----
+----Stats for q18_scan_11----
 column_names  row_count  distinct_count  null_count
 {l_orderkey}  6001215    1527270         0
 {l_quantity}  6001215    50              0
@@ -329,8 +319,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {l_orderkey}  6001215.00     1.00           1527270.00          1.00                0.00            1.00
 {l_quantity}  6001215.00     1.00           50.00               1.00                0.00            1.00
 
-stats table=q18_scan_12
-----
+----Stats for q18_scan_12----
 column_names  row_count  distinct_count  null_count
 {c_custkey}   150000     148813          0
 {c_name}      150000     151126          0
@@ -338,3 +327,5 @@ column_names  row_count  distinct_count  null_count
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {c_custkey}   150000.00      1.00           148813.00           1.00                0.00            1.00
 {c_name}      150000.00      1.00           150000.00           1.01                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q19
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q19
@@ -16,7 +16,7 @@ import file=tpch_stats
 # person. Parts are selected based on the combination of specific brands, a list
 # of containers, and a range of sizes.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q19
+stats-quality database=tpch stats-quality-prefix=q19
 SELECT
     sum(l_extendedprice* (1 - l_discount)) AS revenue
 FROM
@@ -52,6 +52,7 @@ WHERE
         AND l_shipmode IN ('AIR', 'AIR REG')
         AND l_shipinstruct = 'DELIVER IN PERSON'
     );
+----
 ----
 scalar-group-by
  ├── save-table-name: q19_scalar_group_by_1
@@ -111,24 +112,21 @@ scalar-group-by
       └── sum [as=sum:29, type=float, outer=(28)]
            └── column28:28 [type=float]
 
-stats table=q19_scalar_group_by_1
-----
+----Stats for q19_scalar_group_by_1----
 column_names  row_count  distinct_count  null_count
 {revenue}     1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {revenue}     1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q19_project_2
-----
+----Stats for q19_project_2----
 column_names  row_count  distinct_count  null_count
 {column28}    121        121             0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {column28}    71.00          1.70           71.00               1.70                0.00            1.00
 
-stats table=q19_inner_join_3
-----
+----Stats for q19_inner_join_3----
 column_names       row_count  distinct_count  null_count
 {l_discount}       121        11              0
 {l_extendedprice}  121        118             0
@@ -153,8 +151,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {p_partkey}        71.00          1.70           71.00               1.45                0.00            1.00
 {p_size}           71.00          1.70           6.00                2.33 <==            0.00            1.00
 
-stats table=q19_select_4
-----
+----Stats for q19_select_4----
 column_names       row_count  distinct_count  null_count
 {l_discount}       214377     11              0
 {l_extendedprice}  214377     188952          0
@@ -171,8 +168,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_shipinstruct}   428658.00      2.00 <==       1.00                1.00                0.00            1.00
 {l_shipmode}       428658.00      2.00 <==       2.00                2.00 <==            0.00            1.00
 
-stats table=q19_scan_5
-----
+----Stats for q19_scan_5----
 column_names       row_count  distinct_count  null_count
 {l_discount}       6001215    11              0
 {l_extendedprice}  6001215    925955          0
@@ -189,8 +185,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_shipinstruct}   6001215.00     1.00           4.00                1.00                0.00            1.00
 {l_shipmode}       6001215.00     1.00           7.00                1.00                0.00            1.00
 
-stats table=q19_select_6
-----
+----Stats for q19_select_6----
 column_names   row_count  distinct_count  null_count
 {p_brand}      200000     25              0
 {p_container}  200000     40              0
@@ -203,8 +198,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {p_partkey}    66667.00       3.00 <==       66619.00            2.99 <==            0.00            1.00
 {p_size}       66667.00       3.00 <==       17.00               2.94 <==            0.00            1.00
 
-stats table=q19_scan_7
-----
+----Stats for q19_scan_7----
 column_names   row_count  distinct_count  null_count
 {p_brand}      200000     25              0
 {p_container}  200000     40              0
@@ -216,3 +210,5 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {p_container}  200000.00      1.00           40.00               1.00                0.00            1.00
 {p_partkey}    200000.00      1.00           199241.00           1.00                0.00            1.00
 {p_size}       200000.00      1.00           50.00               1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
@@ -18,7 +18,7 @@ import file=tpch_stats
 # TODO:
 #   1. Push 'forest%' prefix filter down into Scan
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q20
+stats-quality database=tpch stats-quality-prefix=q20
 SELECT
     s_name,
     s_address
@@ -56,6 +56,7 @@ WHERE
     AND n_name = 'CANADA'
 ORDER BY
     s_name;
+----
 ----
 sort
  ├── save-table-name: q20_sort_1
@@ -192,8 +193,7 @@ sort
                 └── filters
                      └── s_nationkey:4 = n_nationkey:9 [type=bool, outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
 
-stats table=q20_sort_1
-----
+----Stats for q20_sort_1----
 column_names  row_count  distinct_count  null_count
 {s_address}   186        186             0
 {s_name}      186        186             0
@@ -202,8 +202,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {s_address}   5.00           37.20 <==      5.00                37.20 <==           0.00            1.00
 {s_name}      5.00           37.20 <==      5.00                37.20 <==           0.00            1.00
 
-stats table=q20_project_2
-----
+----Stats for q20_project_2----
 column_names  row_count  distinct_count  null_count
 {s_address}   186        186             0
 {s_name}      186        186             0
@@ -212,8 +211,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {s_address}   5.00           37.20 <==      5.00                37.20 <==           0.00            1.00
 {s_name}      5.00           37.20 <==      5.00                37.20 <==           0.00            1.00
 
-stats table=q20_project_3
-----
+----Stats for q20_project_3----
 column_names   row_count  distinct_count  null_count
 {n_name}       186        1               0
 {n_nationkey}  186        1               0
@@ -230,8 +228,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  5.00           37.20 <==      1.00                1.00                0.00            1.00
 {s_suppkey}    5.00           37.20 <==      5.00                37.20 <==           0.00            1.00
 
-stats table=q20_inner_join_4
-----
+----Stats for q20_inner_join_4----
 column_names   row_count  distinct_count  null_count
 {n_name}       186        1               0
 {n_nationkey}  186        1               0
@@ -250,8 +247,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  127.00         1.46           1.00                1.00                0.00            1.00
 {s_suppkey}    127.00         1.46           127.00              1.46                0.00            1.00
 
-stats table=q20_lookup_join_5
-----
+----Stats for q20_lookup_join_5----
 column_names   row_count  distinct_count  null_count
 {ps_suppkey}   4397       4434            0
 {s_address}    4397       4369            0
@@ -266,16 +262,14 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  128.00         34.35 <==      25.00               1.00                0.00            1.00
 {s_suppkey}    128.00         34.35 <==      127.00              34.91 <==           0.00            1.00
 
-stats table=q20_distinct_on_6
-----
+----Stats for q20_distinct_on_6----
 column_names  row_count  distinct_count  null_count
 {ps_suppkey}  4397       4434            0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {ps_suppkey}  127.00         34.62 <==      127.00              34.91 <==           0.00            1.00
 
-stats table=q20_lookup_join_7
-----
+----Stats for q20_lookup_join_7----
 column_names  row_count  distinct_count  null_count
 {ps_partkey}  5833       2106            0
 {ps_suppkey}  5833       4434            0
@@ -284,8 +278,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {ps_partkey}  127.00         45.93 <==      127.00              16.58 <==           0.00            1.00
 {ps_suppkey}  127.00         45.93 <==      127.00              34.91 <==           0.00            1.00
 
-stats table=q20_project_8
-----
+----Stats for q20_project_8----
 column_names  row_count  distinct_count  null_count
 {ps_partkey}  542095     197197          0
 {ps_suppkey}  542095     9920            0
@@ -294,8 +287,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {ps_partkey}  127.00         4268.46 <==    127.00              1552.73 <==         0.00            1.00
 {ps_suppkey}  127.00         4268.46 <==    127.00              78.11 <==           0.00            1.00
 
-stats table=q20_select_9
-----
+----Stats for q20_select_9----
 column_names   row_count  distinct_count  null_count
 {ps_availqty}  542095     9920            0
 {ps_partkey}   542095     197197          0
@@ -308,8 +300,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {ps_suppkey}   127.00         4268.46 <==    127.00              78.11 <==           0.00            1.00
 {sum}          127.00         4268.46 <==    127.00              1.94 <==            0.00            1.00
 
-stats table=q20_group_by_10
-----
+----Stats for q20_group_by_10----
 column_names   row_count  distinct_count  null_count
 {ps_availqty}  543210     9920            0
 {ps_partkey}   543210     197252          0
@@ -322,8 +313,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {ps_suppkey}   380.00         1429.50 <==    380.00              26.11 <==           0.00            1.00
 {sum}          380.00         1429.50 <==    380.00              1.54                0.00            1.00
 
-stats table=q20_inner_join_11
-----
+----Stats for q20_inner_join_11----
 column_names   row_count  distinct_count  null_count
 {l_partkey}    909455     197252          0
 {l_quantity}   909455     50              0
@@ -342,8 +332,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {ps_partkey}   380.00         2393.30 <==    380.00              519.08 <==          0.00            1.00
 {ps_suppkey}   380.00         2393.30 <==    380.00              26.11 <==           0.00            1.00
 
-stats table=q20_index_join_12
-----
+----Stats for q20_index_join_12----
 column_names  row_count  distinct_count  null_count
 {l_partkey}   909455     197252          0
 {l_quantity}  909455     50              0
@@ -356,8 +345,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {l_shipdate}  938138.00      1.03           365.00              1.00                0.00            1.00
 {l_suppkey}   938138.00      1.03           9920.00             1.00                0.00            1.00
 
-stats table=q20_scan_13
-----
+----Stats for q20_scan_13----
 column_names    row_count  distinct_count  null_count
 {l_linenumber}  909455     7               0
 {l_orderkey}    909455     266035          0
@@ -368,8 +356,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {l_orderkey}    938138.00      1.03           744145.00           2.80 <==            0.00            1.00
 {l_shipdate}    938138.00      1.03           365.00              1.00                0.00            1.00
 
-stats table=q20_scan_14
-----
+----Stats for q20_scan_14----
 column_names   row_count  distinct_count  null_count
 {ps_availqty}  800000     9920            0
 {ps_partkey}   800000     199241          0
@@ -380,8 +367,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {ps_partkey}   800000.00      1.00           199241.00           1.00                0.00            1.00
 {ps_suppkey}   800000.00      1.00           9920.00             1.00                0.00            1.00
 
-stats table=q20_select_15
-----
+----Stats for q20_select_15----
 column_names   row_count  distinct_count  null_count
 {n_name}       1          1               0
 {n_nationkey}  1          1               0
@@ -390,8 +376,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_name}       1.00           1.00           1.00                1.00                0.00            1.00
 {n_nationkey}  1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q20_scan_16
-----
+----Stats for q20_scan_16----
 column_names   row_count  distinct_count  null_count
 {n_name}       25         25              0
 {n_nationkey}  25         25              0
@@ -399,3 +384,5 @@ column_names   row_count  distinct_count  null_count
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {n_name}       25.00          1.00           25.00               1.00                0.00            1.00
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q21
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q21
@@ -14,7 +14,7 @@ import file=tpch_stats
 # supplier order (with current status of 'F') where they were the only supplier
 # who failed to meet the committed delivery date.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q21
+stats-quality database=tpch stats-quality-prefix=q21
 SELECT
     s_name,
     count(*) AS numwait
@@ -55,6 +55,7 @@ ORDER BY
     numwait DESC,
     s_name
 LIMIT 100;
+----
 ----
 limit
  ├── save-table-name: q21_limit_1
@@ -160,8 +161,7 @@ limit
  │              └── count-rows [as=count_rows:75, type=int]
  └── 100 [type=int]
 
-stats table=q21_limit_1
-----
+----Stats for q21_limit_1----
 column_names  row_count  distinct_count  null_count
 {numwait}     100        8               0
 {s_name}      100        100             0
@@ -170,8 +170,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {numwait}     100.00         1.00           100.00              12.50 <==           0.00            1.00
 {s_name}      100.00         1.00           100.00              1.00                0.00            1.00
 
-stats table=q21_sort_2
-----
+----Stats for q21_sort_2----
 column_names  row_count  distinct_count  null_count
 {count_rows}  100        8               0
 {s_name}      100        100             0
@@ -180,8 +179,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {count_rows}  8389.00        83.89 <==      8389.00             1048.62 <==         0.00            1.00
 {s_name}      8389.00        83.89 <==      8389.00             83.89 <==           0.00            1.00
 
-stats table=q21_group_by_3
-----
+----Stats for q21_group_by_3----
 column_names  row_count  distinct_count  null_count
 {count_rows}  411        17              0
 {s_name}      411        411             0
@@ -190,8 +188,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {count_rows}  8389.00        20.41 <==      8389.00             493.47 <==          0.00            1.00
 {s_name}      8389.00        20.41 <==      8389.00             20.41 <==           0.00            1.00
 
-stats table=q21_lookup_join_4
-----
+----Stats for q21_lookup_join_4----
 column_names     row_count  distinct_count  null_count
 {l_commitdate}   4141       1188            0
 {l_orderkey}     4141       4127            0
@@ -218,8 +215,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_nationkey}    17925.00       4.33 <==       1.00                1.00                0.00            1.00
 {s_suppkey}      17925.00       4.33 <==       8351.00             20.32 <==           0.00            1.00
 
-stats table=q21_lookup_join_5
-----
+----Stats for q21_lookup_join_5----
 column_names     row_count  distinct_count  null_count
 {l_commitdate}   8357       2357            0
 {l_orderkey}     8357       8343            0
@@ -242,8 +238,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_nationkey}    17925.00       2.14 <==       1.00                1.00                0.00            1.00
 {s_suppkey}      17925.00       2.14 <==       400.00              1.03                0.00            1.00
 
-stats table=q21_lookup_join_6
-----
+----Stats for q21_lookup_join_6----
 column_names     row_count  distinct_count  null_count
 {l_commitdate}   151237     2464            0
 {l_orderkey}     151237     144608          0
@@ -266,8 +261,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_nationkey}    26887.00       5.62 <==       1.00                1.00                0.00            1.00
 {s_suppkey}      26887.00       5.62 <==       400.00              1.03                0.00            1.00
 
-stats table=q21_lookup_join_7
-----
+----Stats for q21_lookup_join_7----
 column_names     row_count  distinct_count  null_count
 {l_commitdate}   156739     2464            0
 {l_orderkey}     156739     149986          0
@@ -290,8 +284,7 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {s_nationkey}    80661.00       1.94 <==       1.00                1.00                0.00            1.00
 {s_suppkey}      80661.00       1.94 <==       400.00              1.03                0.00            1.00
 
-stats table=q21_lookup_join_8
-----
+----Stats for q21_lookup_join_8----
 column_names    row_count  distinct_count  null_count
 {l_linenumber}  247140     7               0
 {l_orderkey}    247140     228525          0
@@ -312,8 +305,7 @@ column_names    row_count_est  row_count_err  distinct_count_est  distinct_count
 {s_nationkey}   241984.00      1.02           1.00                1.00                0.00            1.00
 {s_suppkey}     241984.00      1.02           400.00              1.03                0.00            1.00
 
-stats table=q21_lookup_join_9
-----
+----Stats for q21_lookup_join_9----
 column_names   row_count  distinct_count  null_count
 {n_name}       411        1               0
 {n_nationkey}  411        1               0
@@ -328,8 +320,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  400.00         1.03           1.00                1.00                0.00            1.00
 {s_suppkey}    400.00         1.03           400.00              1.03                0.00            1.00
 
-stats table=q21_lookup_join_10
-----
+----Stats for q21_lookup_join_10----
 column_names   row_count  distinct_count  null_count
 {n_name}       411        1               0
 {n_nationkey}  411        1               0
@@ -342,8 +333,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {s_nationkey}  400.00         1.03           1.00                1.00                0.00            1.00
 {s_suppkey}    400.00         1.03           400.00              1.03                0.00            1.00
 
-stats table=q21_select_11
-----
+----Stats for q21_select_11----
 column_names   row_count  distinct_count  null_count
 {n_name}       1          1               0
 {n_nationkey}  1          1               0
@@ -352,8 +342,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_name}       1.00           1.00           1.00                1.00                0.00            1.00
 {n_nationkey}  1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q21_scan_12
-----
+----Stats for q21_scan_12----
 column_names   row_count  distinct_count  null_count
 {n_name}       25         25              0
 {n_nationkey}  25         25              0
@@ -361,3 +350,5 @@ column_names   row_count  distinct_count  null_count
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {n_name}       25.00          1.00           25.00               1.00                0.00            1.00
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+----
+----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q22
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q22
@@ -15,7 +15,7 @@ import file=tpch_stats
 # “positive” account balance. It also reflects the magnitude of that balance.
 # Country code is defined as the first two characters of c_phone.
 # --------------------------------------------------
-save-tables database=tpch save-tables-prefix=q22
+stats-quality database=tpch stats-quality-prefix=q22
 SELECT
     cntrycode,
     count(*) AS numcust,
@@ -52,6 +52,7 @@ GROUP BY
     cntrycode
 ORDER BY
     cntrycode;
+----
 ----
 sort
  ├── save-table-name: q22_sort_1
@@ -133,8 +134,7 @@ sort
            └── sum [as=sum:32, type=float, outer=(6)]
                 └── c_acctbal:6 [type=float]
 
-stats table=q22_sort_1
-----
+----Stats for q22_sort_1----
 column_names  row_count  distinct_count  null_count
 {cntrycode}   7          7               0
 {numcust}     7          7               0
@@ -145,8 +145,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {numcust}     0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
 {totacctbal}  0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
 
-stats table=q22_group_by_2
-----
+----Stats for q22_group_by_2----
 column_names  row_count  distinct_count  null_count
 {cntrycode}   7          7               0
 {count_rows}  7          7               0
@@ -157,8 +156,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {count_rows}  0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
 {sum}         0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
 
-stats table=q22_project_3
-----
+----Stats for q22_project_3----
 column_names  row_count  distinct_count  null_count
 {c_acctbal}   6384       6304            0
 {cntrycode}   6384       7               0
@@ -167,8 +165,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {c_acctbal}   0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
 {cntrycode}   0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
 
-stats table=q22_lookup_join_4
-----
+----Stats for q22_lookup_join_4----
 column_names  row_count  distinct_count  null_count
 {c_acctbal}   6384       6304            0
 {c_custkey}   6384       6359            0
@@ -179,8 +176,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {c_custkey}   0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
 {c_phone}     0.00           +Inf <==       0.00                +Inf <==            0.00            1.00
 
-stats table=q22_select_5
-----
+----Stats for q22_select_5----
 column_names  row_count  distinct_count  null_count
 {c_acctbal}   19000      18527           0
 {c_custkey}   19000      19097           0
@@ -191,8 +187,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {c_custkey}   16667.00       1.14           16659.00            1.15                0.00            1.00
 {c_phone}     16667.00       1.14           16667.00            1.15                0.00            1.00
 
-stats table=q22_scan_6
-----
+----Stats for q22_scan_6----
 column_names  row_count  distinct_count  null_count
 {c_acctbal}   150000     140628          0
 {c_custkey}   150000     148813          0
@@ -203,16 +198,14 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {c_custkey}   150000.00      1.00           148813.00           1.00                0.00            1.00
 {c_phone}     150000.00      1.00           150000.00           1.01                0.00            1.00
 
-stats table=q22_scalar_group_by_7
-----
+----Stats for q22_scalar_group_by_7----
 column_names  row_count  distinct_count  null_count
 {avg}         1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {avg}         1.00           1.00           1.00                1.00                0.00            1.00
 
-stats table=q22_select_8
-----
+----Stats for q22_select_8----
 column_names  row_count  distinct_count  null_count
 {c_acctbal}   38120      37172           0
 {c_phone}     38120      38046           0
@@ -221,8 +214,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {c_acctbal}   16667.00       2.29 <==       16667.00            2.23 <==            0.00            1.00
 {c_phone}     16667.00       2.29 <==       16667.00            2.28 <==            0.00            1.00
 
-stats table=q22_scan_9
-----
+----Stats for q22_scan_9----
 column_names  row_count  distinct_count  null_count
 {c_acctbal}   150000     140628          0
 {c_phone}     150000     150872          0
@@ -230,3 +222,5 @@ column_names  row_count  distinct_count  null_count
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {c_acctbal}   150000.00      1.00           140628.00           1.00                0.00            1.00
 {c_phone}     150000.00      1.00           150000.00           1.01                0.00            1.00
+----
+----


### PR DESCRIPTION
This PR pulls the `save-tables` and `stats` opttester commands into
a single command: `stats-quality`. Stats quality tests can now be
rewritten without having to manually remove `stats` tests beforehand,
or having to manually add them back afterword.

By default, stats are outputted for every expression in the plan tree.
I have added a flag: `ignore-tables` that allows a set of stats tables
to be specified for which stats should not be outputted. Note that
care should be taken when rewritting stats for a test that uses the
`ignore-tables` flag, since the expressions that are being 'ignored'
may change if the plan changes.

Release note: None