### PR TITLE
geo: fix to_json representation of GeoJSON

### DIFF
--- a/pkg/geo/encode.go
+++ b/pkg/geo/encode.go
@@ -31,6 +31,9 @@ import (
 	"github.com/twpayne/go-geom/encoding/wkt"
 )
 
+// DefaultGeoJSONDecimalDigits is the default number of digits coordinates in GeoJSON.
+const DefaultGeoJSONDecimalDigits = 9
+
 // SpatialObjectToWKT transforms a given SpatialObject to WKT.
 func SpatialObjectToWKT(so geopb.SpatialObject, maxDecimalDigits int) (geopb.WKT, error) {
 	t, err := ewkb.Unmarshal([]byte(so.EWKB))

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -225,6 +225,31 @@ SELECT ST_Azimuth(ST_Point(0, 0), ST_Point(0, 0))
 ----
 NULL
 
+subtest json_test
+
+# All values here should be true.
+query BB
+SELECT
+  to_json(g::geometry) = st_asgeojson(g::geometry)::jsonb,
+  to_json(g::geography) = st_asgeojson(g::geography)::jsonb
+FROM ( VALUES
+  ('POINT (30 10)'),
+  ('LINESTRING (30 10, 10 30, 40 40)'),
+  ('POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))'),
+  ('MULTIPOINT (10 40, 40 30, 20 20, 30 10)'),
+  ('MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))'),
+  ('MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))'),
+  ('GEOMETRYCOLLECTION (POINT (40 10), LINESTRING (10 10, 20 20, 10 40), POLYGON ((40 40, 20 45, 45 30, 40 40)))')
+) tbl(g)
+----
+true  true
+true  true
+true  true
+true  true
+true  true
+true  true
+true  true
+
 subtest cast_test
 
 query T

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -51,8 +51,7 @@ const spheroidDistanceMessage = `"\n\nWhen operating on a spheroid, this functio
 	`This follows observed PostGIS behavior.`
 
 const (
-	defaultGeoJSONDecimalDigits = 9
-	defaultWKTDecimalDigits     = 15
+	defaultWKTDecimalDigits = 15
 )
 
 // infoBuilder is used to build a detailed info string that is consistent between
@@ -1165,14 +1164,14 @@ var geoBuiltins = map[string]builtinDefinition{
 		defProps(),
 		geometryOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				geojson, err := geo.SpatialObjectToGeoJSON(g.Geometry.SpatialObject(), defaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagShortCRSIfNot4326)
+				geojson, err := geo.SpatialObjectToGeoJSON(g.Geometry.SpatialObject(), geo.DefaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagShortCRSIfNot4326)
 				return tree.NewDString(string(geojson)), err
 			},
 			types.String,
 			infoBuilder{
 				info: fmt.Sprintf(
 					"Returns the GeoJSON representation of a given Geometry. Coordinates have a maximum of %d decimal digits.",
-					defaultGeoJSONDecimalDigits,
+					geo.DefaultGeoJSONDecimalDigits,
 				),
 			},
 			tree.VolatilityImmutable,
@@ -1222,14 +1221,14 @@ Options is a flag that can be bitmasked. The options are:
 		},
 		geographyOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
-				geojson, err := geo.SpatialObjectToGeoJSON(g.Geography.SpatialObject(), defaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
+				geojson, err := geo.SpatialObjectToGeoJSON(g.Geography.SpatialObject(), geo.DefaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
 				return tree.NewDString(string(geojson)), err
 			},
 			types.String,
 			infoBuilder{
 				info: fmt.Sprintf(
 					"Returns the GeoJSON representation of a given Geography. Coordinates have a maximum of %d decimal digits.",
-					defaultGeoJSONDecimalDigits,
+					geo.DefaultGeoJSONDecimalDigits,
 				),
 			},
 			tree.VolatilityImmutable,

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3046,9 +3046,12 @@ func AsJSON(d Datum, loc *time.Location) (json.JSON, error) {
 	case *DTimestamp:
 		// This is RFC3339Nano, but without the TZ fields.
 		return json.FromString(t.UTC().Format("2006-01-02T15:04:05.999999999")), nil
-	case *DDate, *DUuid, *DOid, *DInterval, *DBytes, *DIPAddr, *DTime, *DTimeTZ, *DBitArray,
-		*DGeography, *DGeometry:
+	case *DDate, *DUuid, *DOid, *DInterval, *DBytes, *DIPAddr, *DTime, *DTimeTZ, *DBitArray:
 		return json.FromString(AsStringWithFlags(t, FmtBareStrings)), nil
+	case *DGeometry:
+		return json.FromSpatialObject(t.Geometry.SpatialObject())
+	case *DGeography:
+		return json.FromSpatialObject(t.Geography.SpatialObject())
 	default:
 		if d == DNull {
 			return json.NullJSONValue, nil

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -23,6 +23,8 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/apd/v2"
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -910,6 +912,15 @@ func (j jsonObject) allPaths() ([]JSON, error) {
 		}
 	}
 	return ret, nil
+}
+
+// FromSpatialObject transforms a SpatialObject into the json.JSON type.
+func FromSpatialObject(so geopb.SpatialObject) (JSON, error) {
+	j, err := geo.SpatialObjectToGeoJSON(so, geo.DefaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
+	if err != nil {
+		return nil, err
+	}
+	return ParseJSON(string(j))
 }
 
 // FromDecimal returns a JSON value given a apd.Decimal.


### PR DESCRIPTION
Fixed the to_json() representation of geospatial objects to be the
same as the GeoJSON format.

Release note: None