### PR TITLE
*: skip a couple of flakey tests

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -197,6 +197,7 @@ func TestOracleFactory(t *testing.T) {
 func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	skip.WithIssue(t, 52681)
 	// This test sleeps for a few sec.
 	skip.UnderShort(t)
 

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -275,6 +275,8 @@ func runGossipPeerings(ctx context.Context, t *test, c *cluster) {
 }
 
 func runGossipRestart(ctx context.Context, t *test, c *cluster) {
+	t.Skip("skipping flaky acceptance/gossip/restart", "https://github.com/cockroachdb/cockroach/issues/48423")
+
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, t)
 

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -334,6 +334,8 @@ func TestDistSQLRangeCachesIntegrationTest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 52682)
+
 	// We're going to setup a cluster with 4 nodes. The last one will not be a
 	// target of any replication so that its caches stay virgin.
 


### PR DESCRIPTION
- TestFollowerReadsWithStaleDescriptor (#52681)
- TestDistSQLRangeCachesIntegrationTest (#52682)
- acceptance/gossip/restart (#48423)

Release note: None

---

+cc @andreimatei, @asubiotto who are the current assignees on those tests.