### PR TITLE
roachtest: unskip acceptance/many-splits

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -50,7 +50,6 @@ func registerAcceptance(r *testRegistry) {
 		{
 			name: "many-splits", fn: runManySplits,
 			minVersion: "v19.2.0", // SQL syntax unsupported on 19.1.x
-			skip:       "https://github.com/cockroachdb/cockroach/issues/47325",
 		},
 		{name: "status-server", fn: runStatusServer},
 		{


### PR DESCRIPTION
Unskipping since we haven't been able to reproduce this issue in the
last couple weeks, and it's possible it was fixed by intervening changes
since it was first skipped.

Related to #47325

Release note: None
