### PR TITLE
server: don't attempt to upgrade the version until the SQL server starts

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1633,9 +1633,6 @@ func (s *Server) Start(ctx context.Context) error {
 
 	log.Event(ctx, "added http endpoints")
 
-	// Attempt to upgrade cluster version.
-	s.startAttemptUpgrade(ctx)
-
 	// Record node start in telemetry. Get the right counter for this storage
 	// engine type as well as type of start (initial boot vs restart).
 	nodeStartCounter := "storage.engine."
@@ -1675,6 +1672,11 @@ func (s *Server) Start(ctx context.Context) error {
 	if err := s.debug.RegisterEngines(s.cfg.Stores.Specs, s.engines); err != nil {
 		return errors.Wrapf(err, "failed to register engines with debug server")
 	}
+
+	// Attempt to upgrade cluster version now that the sql server has been
+	// started. At this point we know that all sqlmigrations have successfully
+	// been run so it is safe to upgrade to the binary's current version.
+	s.startAttemptUpgrade(ctx)
 
 	log.Event(ctx, "server ready")
 	return nil

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -30,12 +30,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/diagutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckVersion(t *testing.T) {
@@ -494,4 +496,37 @@ func TestReportUsage(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestUpgradeHappensAfterMigration is a regression test to ensure that
+// migrations run prior to attempting to upgrade the cluster to the current
+// version.
+func TestUpgradeHappensAfterMigrations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettingsWithVersions(
+		clusterversion.TestingBinaryVersion,
+		clusterversion.TestingBinaryMinSupportedVersion,
+		false, /* initializeVersion */
+	)
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: st,
+		Knobs: base.TestingKnobs{
+			Server: &TestingKnobs{
+				BootstrapVersionOverride: clusterversion.TestingBinaryMinSupportedVersion,
+			},
+			SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
+				AfterEnsureMigrations: func() {
+					// Try to encourage other goroutines to run.
+					const N = 100
+					for i := 0; i < N; i++ {
+						runtime.Gosched()
+					}
+					require.True(t, st.Version.ActiveVersion(ctx).Less(clusterversion.TestingBinaryVersion))
+				},
+			},
+		},
+	})
+	s.Stopper().Stop(context.Background())
 }

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -61,6 +61,9 @@ type MigrationManagerTestingKnobs struct {
 	// AlwaysRunJobMigration controls whether to always run the schema change job
 	// migration regardless of whether it has been marked as complete.
 	AlwaysRunJobMigration bool
+
+	// AfterEnsureMigrations is called after each call to EnsureMigrations.
+	AfterEnsureMigrations func()
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
@@ -552,6 +555,9 @@ func ExpectedDescriptorIDs(
 // required migrations have been run (and running all those that are definitely
 // safe to run).
 func (m *Manager) EnsureMigrations(ctx context.Context, bootstrapVersion roachpb.Version) error {
+	if m.testingKnobs.AfterEnsureMigrations != nil {
+		defer m.testingKnobs.AfterEnsureMigrations()
+	}
 	// First, check whether there are any migrations that need to be run.
 	completedMigrations, err := getCompletedMigrations(ctx, m.db, m.codec)
 	if err != nil {


### PR DESCRIPTION
This attempt to upgrade the server prior to the sql server starting means that
we might mark a version as active before the associated sqlmigration has been
performed, which can cause big problems.

Release note: None