### PR TITLE
util/log: indicate when sentry reports come from `log.Fatal`

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -544,6 +545,8 @@ func TestRegistryLifecycle(t *testing.T) {
 
 	// Verify that pause and cancel in a rollback do nothing.
 	t.Run("rollback", func(t *testing.T) {
+		skip.WithIssue(t, 52767, "flaky")
+
 		rts := registryTestSuite{}
 		rts.setUp(t)
 		defer rts.tearDown()

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -245,6 +245,9 @@ const (
 	// ReportTypeError signifies that this is just a report of an error but it
 	// still may include an exception and stack trace.
 	ReportTypeError
+	// ReportTypeLogFatal signifies that this is an error report that
+	// was generated via a log.Fatal call.
+	ReportTypeLogFatal
 )
 
 // sendCrashReport posts to sentry.
@@ -302,6 +305,8 @@ func SendReport(
 		event.Tags["report_type"] = "panic"
 	case ReportTypeError:
 		event.Tags["report_type"] = "error"
+	case ReportTypeLogFatal:
+		event.Tags["report_type"] = "log_fatal"
 	}
 
 	for _, f := range tagFns {

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -39,8 +39,8 @@ func addStructured(
 		// We load the ReportingSettings from the a global singleton in this
 		// call path. See the singleton's comment for a rationale.
 		if sv := settings.TODO(); sv != nil {
-			err := errors.NewWithDepthf(depth+1, format, args...)
-			sendCrashReport(ctx, sv, err, ReportTypePanic)
+			err := errors.NewWithDepthf(depth+1, "log.Fatal: "+format, args...)
+			sendCrashReport(ctx, sv, err, ReportTypeLogFatal)
 		}
 	}
 


### PR DESCRIPTION
First commit from #52696.

Requested by @andreimatei  in https://github.com/cockroachdb/cockroach/issues/52600#issuecomment-672944490

Before:

![image](https://user-images.githubusercontent.com/642886/90043609-9fc2bc00-dccc-11ea-95a9-008939771225.png)
![image](https://user-images.githubusercontent.com/642886/90043633-a6513380-dccc-11ea-8530-c64ad250f348.png)
![image](https://user-images.githubusercontent.com/642886/90043649-ab15e780-dccc-11ea-9778-48ab885326ff.png)

After:

![image](https://user-images.githubusercontent.com/642886/90043668-b23cf580-dccc-11ea-909b-ec59e646039d.png)
![image](https://user-images.githubusercontent.com/642886/90043674-b701a980-dccc-11ea-8718-bdb3b3b50a11.png)
![image](https://user-images.githubusercontent.com/642886/90043693-bc5ef400-dccc-11ea-9ab1-76e4e95b300c.png)

For example: https://sentry.io/organizations/cockroach-labs/issues/1837472473/