### PR TITLE
sql/col*: speed up disk queue tests

### DIFF
--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -59,7 +59,7 @@ func TestDiskQueue(t *testing.T) {
 					dequeuedProbabilityBeforeAllEnqueuesAreDone = 0
 					prefix, suffix = "Rewindable/", ""
 				}
-				numBatches := 1 + rng.Intn(1024)
+				numBatches := 1 + rng.Intn(16)
 				t.Run(fmt.Sprintf("%sDiskQueueCacheMode=%d/AlwaysCompress=%t%s/NumBatches=%d",
 					prefix, diskQueueCacheMode, alwaysCompress, suffix, numBatches), func(t *testing.T) {
 					// Create random input.

--- a/pkg/sql/colexec/spilling_queue_test.go
+++ b/pkg/sql/colexec/spilling_queue_test.go
@@ -55,7 +55,7 @@ func TestSpillingQueue(t *testing.T) {
 				dequeuedProbabilityBeforeAllEnqueuesAreDone = 0
 				prefix = "Rewindable/"
 			}
-			numBatches := 1 + rng.Intn(1024)
+			numBatches := 1 + rng.Intn(16)
 			log.Infof(context.Background(), "%sMemoryLimit=%s/DiskQueueCacheMode=%d/AlwaysCompress=%t/NumBatches=%d",
 				prefix, humanizeutil.IBytes(memoryLimit), diskQueueCacheMode, alwaysCompress, numBatches)
 			// Create random input.


### PR DESCRIPTION
Disk queue tests make sure that batches that are read from disk are
equivalent to the batches that have been written down. The equivalence
is checked via a string-matching, and stringifying can take non-trivial
amount of time. Previously, the tests would create up to 1024 batches,
and if random operator chose `types.Geography` as one of the random
types, stringifying would take long time timing out the test. This
commit reduces that number to 16.

Fixes: #52398.
Fixes: #52532.

Release note: None