### PR TITLE
sqlliveness: wait for migration before starting loops

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -214,10 +213,7 @@ func MakeRegistry(
 }
 
 func (r *Registry) startUsingSQLLivenessAdoption(ctx context.Context) bool {
-	return r.settings.Version.IsActive(
-		ctx,
-		clusterversion.VersionAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTable,
-	)
+	return sqlliveness.IsActive(ctx, r.settings)
 }
 
 // SetSessionBoundInternalExecutorFactory sets the

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -72,12 +72,13 @@ func (s *session) Expiration() hlc.Timestamp { return s.exp }
 // loop to extend the existing sessions' expirations or creating a new session
 // to replace a session that has expired and deleted from the table.
 type Instance struct {
-	clock   *hlc.Clock
-	stopper *stop.Stopper
-	storage Writer
-	ttl     func() time.Duration
-	hb      func() time.Duration
-	mu      struct {
+	clock    *hlc.Clock
+	settings *cluster.Settings
+	stopper  *stop.Stopper
+	storage  Writer
+	ttl      func() time.Duration
+	hb       func() time.Duration
+	mu       struct {
 		started bool
 		syncutil.Mutex
 		blockCh chan struct{}
@@ -121,8 +122,6 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 		MaxBackoff:     2 * time.Second,
 		Multiplier:     1.5,
 	}
-	ctx, cancel := l.stopper.WithCancelOnQuiesce(ctx)
-	defer cancel()
 	everySecond := log.Every(time.Second)
 	var err error
 	for i, r := 0, retry.StartWithCtx(ctx, opts); r.Next(); {
@@ -153,8 +152,6 @@ func (l *Instance) extendSession(ctx context.Context, s sqlliveness.Session) (bo
 		MaxBackoff:     2 * time.Second,
 		Multiplier:     1.5,
 	}
-	ctx, cancel := l.stopper.WithCancelOnQuiesce(ctx)
-	defer cancel()
 	var err error
 	var found bool
 	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
@@ -184,13 +181,14 @@ func (l *Instance) heartbeatLoop(ctx context.Context) {
 	defer func() {
 		log.Warning(ctx, "exiting heartbeat loop")
 	}()
+	ctx, cancel := l.stopper.WithCancelOnQuiesce(ctx)
+	defer cancel()
+	sqlliveness.WaitForActive(ctx, l.settings)
 	t := timeutil.NewTimer()
 	t.Reset(0)
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case <-l.stopper.ShouldQuiesce():
 			return
 		case <-t.C:
 			t.Read = true
@@ -229,7 +227,10 @@ func NewSQLInstance(
 	stopper *stop.Stopper, clock *hlc.Clock, storage Writer, settings *cluster.Settings,
 ) *Instance {
 	l := &Instance{
-		clock: clock, storage: storage, stopper: stopper,
+		clock:    clock,
+		settings: settings,
+		storage:  storage,
+		stopper:  stopper,
 		ttl: func() time.Duration {
 			return DefaultTTL.Get(&settings.SV)
 		},

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -250,7 +250,7 @@ func (l *Instance) Start(ctx context.Context) {
 		return
 	}
 	log.Infof(ctx, "starting SQL liveness instance")
-	l.stopper.RunWorker(ctx, l.heartbeatLoop)
+	_ = l.stopper.RunAsyncTask(ctx, "slinstance", l.heartbeatLoop)
 	l.mu.started = true
 }
 

--- a/pkg/sql/sqlliveness/slinstance/slinstance_test.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
@@ -35,7 +36,10 @@ func TestSQLInstance(t *testing.T) {
 
 	mClock := hlc.NewManualClock(hlc.UnixNano())
 	clock := hlc.NewClock(mClock.UnixNano, time.Nanosecond)
-	settings := cluster.MakeClusterSettings()
+	settings := cluster.MakeTestingClusterSettingsWithVersions(
+		clusterversion.TestingBinaryVersion,
+		clusterversion.TestingBinaryMinSupportedVersion,
+		true /* initializeVersion */)
 	slinstance.DefaultTTL.Override(&settings.SV, 2*time.Microsecond)
 	slinstance.DefaultHeartBeat.Override(&settings.SV, time.Microsecond)
 

--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -50,6 +50,7 @@ var CacheSize = settings.RegisterIntSetting(
 
 // Storage implements sqlliveness.Storage.
 type Storage struct {
+	settings   *cluster.Settings
 	stopper    *stop.Stopper
 	clock      *hlc.Clock
 	db         *kv.DB
@@ -81,7 +82,11 @@ func NewStorage(
 	settings *cluster.Settings,
 ) *Storage {
 	s := &Storage{
-		stopper: stopper, clock: clock, db: db, ex: ie,
+		settings: settings,
+		stopper:  stopper,
+		clock:    clock,
+		db:       db,
+		ex:       ie,
 		gcInterval: func() time.Duration {
 			return DefaultGCInterval.Get(&settings.SV)
 		},
@@ -201,6 +206,9 @@ SELECT expiration FROM system.sqlliveness WHERE session_id = $1`, sid.UnsafeByte
 
 // deleteSessionsLoop is launched in start and periodically deletes sessions.
 func (s *Storage) deleteSessionsLoop(ctx context.Context) {
+	ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
+	defer cancel()
+	sqlliveness.WaitForActive(ctx, s.settings)
 	t := timeutil.NewTimer()
 	t.Reset(0)
 	for {
@@ -208,8 +216,6 @@ func (s *Storage) deleteSessionsLoop(ctx context.Context) {
 			t.Reset(s.gcInterval())
 		}
 		select {
-		case <-s.stopper.ShouldStop():
-			return
 		case <-ctx.Done():
 			return
 		case <-t.C:

--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -115,7 +115,7 @@ func (s *Storage) Start(ctx context.Context) {
 	if s.mu.started {
 		return
 	}
-	s.stopper.RunWorker(ctx, s.deleteSessionsLoop)
+	_ = s.stopper.RunAsyncTask(ctx, "slstorage", s.deleteSessionsLoop)
 	s.mu.started = true
 }
 


### PR DESCRIPTION
Prior to this commit we'd hit some errors which would get retried
if the sqlmigration was slow. Better to just wait for it to happen.

Also sneaks in some changes to use the context rather than quiescence
channel because it makes the waiting cleaner.

Release note: None