### PR TITLE
opt: generate unconstrained scans for pseudo-partial indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -725,3 +725,29 @@ DELETE FROM t52318
 
 statement ok
 COMMIT
+
+# Regression tests for #52702. Indexes with predicates that always evaluate to
+# true can be forced with any query filter. Predicates that always evaluate to
+# false can be forced for a filter that always evaluates to false.
+subtest regression_52702
+
+statement ok
+CREATE TABLE t52702 (
+    a INT,
+    b INT,
+    INDEX t52702_true (a) WHERE 1 = 1,
+    INDEX t52702_false (a) WHERE 1 = 2
+)
+
+statement ok
+SELECT * FROM t52702@t52702_true;
+SELECT * FROM t52702@t52702_true WHERE true;
+SELECT * FROM t52702@t52702_true WHERE 1 = 1;
+SELECT * FROM t52702@t52702_true WHERE 's' = 's';
+SELECT * FROM t52702@t52702_true WHERE b = 1;
+SELECT * FROM t52702@t52702_true WHERE false;
+
+statement ok
+SELECT * FROM t52702@t52702_false WHERE 1 = 2;
+SELECT * FROM t52702@t52702_false WHERE 's' = 't';
+SELECT * FROM t52702@t52702_false WHERE false;

--- a/pkg/sql/opt/partialidx/implicator.go
+++ b/pkg/sql/opt/partialidx/implicator.go
@@ -155,10 +155,9 @@ func (im *Implicator) Init(f *norm.Factory, md *opt.Metadata, evalCtx *tree.Eval
 func (im *Implicator) FiltersImplyPredicate(
 	filters memo.FiltersExpr, pred memo.FiltersExpr,
 ) (remainingFilters memo.FiltersExpr, ok bool) {
-	// An empty FiltersExpr is equivalent to True, which is only implied by
-	// True.
-	if len(pred) == 0 {
-		return filters, len(filters) == 0
+	// True is only implied by true.
+	if pred.IsTrue() {
+		return filters, filters.IsTrue()
 	}
 
 	// Check for exact matches for all FiltersItems in pred. This check is not

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -208,6 +208,20 @@ New expression 1 of 1:
 ----
 ----
 
+# Scans over partial indexes should be generated when the partial index
+# predicates always evaluate to true.
+
+exec-ddl
+CREATE TABLE p (i INT, INDEX (i) WHERE 1 = 1)
+----
+
+opt
+SELECT i FROM p ORDER BY i
+----
+scan p@secondary,partial
+ ├── columns: i:1
+ └── ordering: +1
+
 # --------------------------------------------------
 # GenerateConstrainedScans
 # --------------------------------------------------


### PR DESCRIPTION
A "pseudo-partial index" is a partial index with a predicate that always
evaluates to true. Such an index behaves the same as a non-partial
secondary index. It is guaranteed to have an index entry for every row
in the table.

Previously, forcing the optimizer to use a pseudo-partial index in a
query with a truthy filter would result in an error that incorrectly
claimed that not all rows in the table exist in the index. The root
cause was that such a query has no `Select` expression and partial index
scans were only generated in rules that match `(Select (Scan))`.

This commit changes the behavior of the GenerateIndexScans
transformation rule so that it generates scans over pseudo-partial
indexes. This allows forcing pseudo-partial indexes for any query.

Fixes #52702

Release note: None