### PR TITLE
sql: fix TestTelemetry flake

### DIFF
--- a/pkg/sql/testdata/telemetry/planning
+++ b/pkg/sql/testdata/telemetry/planning
@@ -137,8 +137,6 @@ sql.plan.stats.created
 # Test various planning counters.
 feature-allowlist
 sql.plan.cte.*
-sql.plan.lateral-join
-sql.plan.subquery.*
 ----
 
 feature-usage
@@ -151,6 +149,11 @@ WITH RECURSIVE a AS (SELECT 1 UNION ALL SELECT * FROM a WHERE false) SELECT * FR
 ----
 sql.plan.cte
 sql.plan.cte.recursive
+
+feature-allowlist
+sql.plan.lateral-join
+sql.plan.subquery.*
+----
 
 feature-usage
 SELECT * FROM (VALUES (1), (2)) AS a(x), LATERAL (SELECT a.x+1)


### PR DESCRIPTION
This test started showing `sql.plan.cte` for an unrelated query. I am
guessing we added some background query that uses CTEs. Improving the
test to ignore this counter outside of the specific testcase that
checks for it.

Fixes #52679.

Release note: None