### PR TITLE
builtins: add st_asgeojson for recordsets

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -892,6 +892,14 @@ has no relationship with the commit order of concurrent transactions.</p>
 </ul>
 <p>This variant will cast all geometry_str arguments into Geometry types.</p>
 </span></td></tr>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(row: tuple) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geometry. Coordinates have a maximum of 9 decimal digits.</p>
+</span></td></tr>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(row: tuple, geo_column: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geometry, using geo_column as the geometry for the given Feature. Coordinates have a maximum of 9 decimal digits.</p>
+</span></td></tr>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(row: tuple, geo_column: <a href="string.html">string</a>, max_decimal_digits: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geometry, using geo_column as the geometry for the given Feature. max_decimal_digits will be output for each coordinate value.</p>
+</span></td></tr>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(row: tuple, geo_column: <a href="string.html">string</a>, max_decimal_digits: <a href="int.html">int</a>, pretty: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geometry, using geo_column as the geometry for the given Feature. max_decimal_digits will be output for each coordinate value. Output will be pretty printed in JSON if pretty is true.</p>
+</span></td></tr>
 <tr><td><a name="st_ashexewkb"></a><code>st_ashexewkb(geography: geography) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the EWKB representation in hex of a given Geography.</p>
 </span></td></tr>
 <tr><td><a name="st_ashexewkb"></a><code>st_ashexewkb(geography: geography, xdr_or_ndr: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the EWKB representation in hex of a given Geography. This variant has a second argument denoting the encoding - <code>xdr</code> for big endian and <code>ndr</code> for little endian.</p>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -420,6 +420,219 @@ FROM parse_test ORDER BY id ASC
 {"type":"Point","coordinates":[]}                                                             {"type":"Point","coordinates":[]}                                                             {"type":"Point","coordinates":[]}
 NULL                                                                                          NULL                                                                                          NULL
 
+# Since id in parse_test can change between tests, make a new table
+# that has a consistent id over multiple logic test runs.
+statement ok
+CREATE TABLE parse_test_geojson AS
+  SELECT
+    row_number() OVER (ORDER BY id) as id,
+    geom,
+    geog
+  FROM parse_test
+
+query T
+SELECT
+  ST_AsGeoJSON(t.*)
+FROM ( VALUES
+  (1),
+  (2)
+) t(row_id)
+----
+{"geometry": {"type": null}, "properties": {"row_id": 1}, "type": "Feature"}
+{"geometry": {"type": null}, "properties": {"row_id": 2}, "type": "Feature"}
+
+query TTT
+SELECT
+  ST_AsGeoJSON(parse_test_geojson.*),
+  ST_AsGeoJSON(parse_test_geojson.*, 'geom'),
+  ST_AsGeoJSON(parse_test_geojson.*, 'geog')
+FROM parse_test_geojson ORDER BY id ASC
+----
+{"geometry": {"coordinates": [1.555, -2], "type": "Point"}, "properties": {"geog": {"coordinates": [1.555, -2], "type": "Point"}, "id": 1}, "type": "Feature"}  {"geometry": {"coordinates": [1.555, -2], "type": "Point"}, "properties": {"geog": {"coordinates": [1.555, -2], "type": "Point"}, "id": 1}, "type": "Feature"}  {"geometry": {"coordinates": [1.555, -2], "type": "Point"}, "properties": {"geom": {"coordinates": [1.555, -2], "type": "Point"}, "id": 1}, "type": "Feature"}
+{"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 2], "type": "Point"}, "id": 2}, "type": "Feature"}            {"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 2], "type": "Point"}, "id": 2}, "type": "Feature"}            {"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geom": {"coordinates": [1, 2], "type": "Point"}, "id": 2}, "type": "Feature"}
+{"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 2], "type": "Point"}, "id": 3}, "type": "Feature"}            {"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 2], "type": "Point"}, "id": 3}, "type": "Feature"}            {"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geom": {"coordinates": [1, 2], "type": "Point"}, "id": 3}, "type": "Feature"}
+{"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 2], "type": "Point"}, "id": 4}, "type": "Feature"}            {"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 2], "type": "Point"}, "id": 4}, "type": "Feature"}            {"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geom": {"coordinates": [1, 2], "type": "Point"}, "id": 4}, "type": "Feature"}
+{"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 2], "type": "Point"}, "id": 5}, "type": "Feature"}            {"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 2], "type": "Point"}, "id": 5}, "type": "Feature"}            {"geometry": {"coordinates": [1, 2], "type": "Point"}, "properties": {"geom": {"coordinates": [1, 2], "type": "Point"}, "id": 5}, "type": "Feature"}
+{"geometry": {"coordinates": [1, 1], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 1], "type": "Point"}, "id": 6}, "type": "Feature"}            {"geometry": {"coordinates": [1, 1], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 1], "type": "Point"}, "id": 6}, "type": "Feature"}            {"geometry": {"coordinates": [1, 1], "type": "Point"}, "properties": {"geom": {"coordinates": [1, 1], "type": "Point"}, "id": 6}, "type": "Feature"}
+{"geometry": {"coordinates": [1, 1], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 1], "type": "Point"}, "id": 7}, "type": "Feature"}            {"geometry": {"coordinates": [1, 1], "type": "Point"}, "properties": {"geog": {"coordinates": [1, 1], "type": "Point"}, "id": 7}, "type": "Feature"}            {"geometry": {"coordinates": [1, 1], "type": "Point"}, "properties": {"geom": {"coordinates": [1, 1], "type": "Point"}, "id": 7}, "type": "Feature"}
+{"geometry": {"coordinates": [], "type": "Point"}, "properties": {"geog": {"coordinates": [], "type": "Point"}, "id": 8}, "type": "Feature"}                    {"geometry": {"coordinates": [], "type": "Point"}, "properties": {"geog": {"coordinates": [], "type": "Point"}, "id": 8}, "type": "Feature"}                    {"geometry": {"coordinates": [], "type": "Point"}, "properties": {"geom": {"coordinates": [], "type": "Point"}, "id": 8}, "type": "Feature"}
+{"geometry": {"type": null}, "properties": {"geog": null, "geom": null, "id": 9}, "type": "Feature"}                                                            {"geometry": {"type": null}, "properties": {"geog": null, "id": 9}, "type": "Feature"}                                                                          {"geometry": {"type": null}, "properties": {"geom": null, "id": 9}, "type": "Feature"}
+
+query T
+SELECT
+  ST_AsGeoJSON(parse_test_geojson.*, 'geog', 3, true)
+FROM parse_test_geojson ORDER BY id ASC
+----
+{
+   "geometry": {
+     "coordinates": [
+       1.555,
+       -2
+     ],
+     "type": "Point"
+   },
+   "properties": {
+     "geom": {
+       "coordinates": [
+         1.555,
+         -2
+       ],
+       "type": "Point"
+     },
+     "id": 1
+   },
+   "type": "Feature"
+}
+{
+   "geometry": {
+     "coordinates": [
+       1,
+       2
+     ],
+     "type": "Point"
+   },
+   "properties": {
+     "geom": {
+       "coordinates": [
+         1,
+         2
+       ],
+       "type": "Point"
+     },
+     "id": 2
+   },
+   "type": "Feature"
+}
+{
+   "geometry": {
+     "coordinates": [
+       1,
+       2
+     ],
+     "type": "Point"
+   },
+   "properties": {
+     "geom": {
+       "coordinates": [
+         1,
+         2
+       ],
+       "type": "Point"
+     },
+     "id": 3
+   },
+   "type": "Feature"
+}
+{
+   "geometry": {
+     "coordinates": [
+       1,
+       2
+     ],
+     "type": "Point"
+   },
+   "properties": {
+     "geom": {
+       "coordinates": [
+         1,
+         2
+       ],
+       "type": "Point"
+     },
+     "id": 4
+   },
+   "type": "Feature"
+}
+{
+   "geometry": {
+     "coordinates": [
+       1,
+       2
+     ],
+     "type": "Point"
+   },
+   "properties": {
+     "geom": {
+       "coordinates": [
+         1,
+         2
+       ],
+       "type": "Point"
+     },
+     "id": 5
+   },
+   "type": "Feature"
+}
+{
+   "geometry": {
+     "coordinates": [
+       1,
+       1
+     ],
+     "type": "Point"
+   },
+   "properties": {
+     "geom": {
+       "coordinates": [
+         1,
+         1
+       ],
+       "type": "Point"
+     },
+     "id": 6
+   },
+   "type": "Feature"
+}
+{
+   "geometry": {
+     "coordinates": [
+       1,
+       1
+     ],
+     "type": "Point"
+   },
+   "properties": {
+     "geom": {
+       "coordinates": [
+         1,
+         1
+       ],
+       "type": "Point"
+     },
+     "id": 7
+   },
+   "type": "Feature"
+}
+{
+   "geometry": {
+     "coordinates": [],
+     "type": "Point"
+   },
+   "properties": {
+     "geom": {
+       "coordinates": [],
+       "type": "Point"
+     },
+     "id": 8
+   },
+   "type": "Feature"
+}
+{
+   "geometry": {
+     "type": null
+   },
+   "properties": {
+     "geom": null,
+     "id": 9
+   },
+   "type": "Feature"
+}
+
+statement error "geom_no_exist" column not found
+SELECT
+  ST_AsGeoJSON(parse_test.*, 'geom_no_exist')
+FROM parse_test ORDER BY id asc
+
 # tests casts
 query TTT
 SELECT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -11,6 +11,7 @@
 package builtins
 
 import (
+	gojson "encoding/json"
 	"fmt"
 	"strings"
 
@@ -1162,6 +1163,99 @@ var geoBuiltins = map[string]builtinDefinition{
 
 	"st_asgeojson": makeBuiltin(
 		defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"row", types.AnyTuple}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				tuple := args[0].(*tree.DTuple)
+				return stAsGeoJSONFromTuple(
+					ctx,
+					tuple,
+					"", /* geoColumn */
+					geo.DefaultGeoJSONDecimalDigits,
+					false, /* pretty */
+				)
+			},
+			Info: infoBuilder{
+				info: fmt.Sprintf(
+					"Returns the GeoJSON representation of a given Geometry. Coordinates have a maximum of %d decimal digits.",
+					geo.DefaultGeoJSONDecimalDigits,
+				),
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"row", types.AnyTuple}, {"geo_column", types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				tuple := args[0].(*tree.DTuple)
+				return stAsGeoJSONFromTuple(
+					ctx,
+					tuple,
+					string(tree.MustBeDString(args[1])),
+					geo.DefaultGeoJSONDecimalDigits,
+					false, /* pretty */
+				)
+			},
+			Info: infoBuilder{
+				info: fmt.Sprintf(
+					"Returns the GeoJSON representation of a given Geometry, using geo_column as the geometry for the given Feature. Coordinates have a maximum of %d decimal digits.",
+					geo.DefaultGeoJSONDecimalDigits,
+				),
+			}.String(),
+			Volatility: tree.VolatilityStable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"row", types.AnyTuple},
+				{"geo_column", types.String},
+				{"max_decimal_digits", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				tuple := args[0].(*tree.DTuple)
+				return stAsGeoJSONFromTuple(
+					ctx,
+					tuple,
+					string(tree.MustBeDString(args[1])),
+					int(tree.MustBeDInt(args[2])),
+					false, /* pretty */
+				)
+			},
+			Info: infoBuilder{
+				info: fmt.Sprintf(
+					"Returns the GeoJSON representation of a given Geometry, using geo_column as the geometry for the given Feature. " +
+						"max_decimal_digits will be output for each coordinate value.",
+				),
+			}.String(),
+			Volatility: tree.VolatilityStable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"row", types.AnyTuple},
+				{"geo_column", types.String},
+				{"max_decimal_digits", types.Int},
+				{"pretty", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				tuple := args[0].(*tree.DTuple)
+				return stAsGeoJSONFromTuple(
+					ctx,
+					tuple,
+					string(tree.MustBeDString(args[1])),
+					int(tree.MustBeDInt(args[2])),
+					bool(tree.MustBeDBool(args[3])),
+				)
+			},
+			Info: infoBuilder{
+				info: fmt.Sprintf(
+					"Returns the GeoJSON representation of a given Geometry, using geo_column as the geometry for the given Feature. " +
+						"max_decimal_digits will be output for each coordinate value. Output will be pretty printed in JSON if pretty is true.",
+				),
+			}.String(),
+			Volatility: tree.VolatilityStable,
+		},
 		geometryOverload1(
 			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
 				geojson, err := geo.SpatialObjectToGeoJSON(g.Geometry.SpatialObject(), geo.DefaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagShortCRSIfNot4326)
@@ -4145,4 +4239,104 @@ This variant will cast all geometry_str arguments into Geometry types.
 
 	def.overloads = newOverloads
 	return def
+}
+
+// stAsGeoJSONFromTuple returns a *tree.DString representing JSON output
+// for ST_AsGeoJSON.
+func stAsGeoJSONFromTuple(
+	ctx *tree.EvalContext, tuple *tree.DTuple, geoColumn string, numDecimalDigits int, pretty bool,
+) (*tree.DString, error) {
+	typ := tuple.ResolvedType()
+	labels := typ.TupleLabels()
+
+	var geometry json.JSON
+	properties := json.NewObjectBuilder(len(tuple.D))
+
+	foundGeoColumn := false
+	for i, d := range tuple.D {
+		var label string
+		if labels != nil {
+			label = labels[i]
+		}
+		// If label is not specified, append `f + index` as the name, in line with
+		// row_to_json.
+		if label == "" {
+			label = fmt.Sprintf("f%d", i+1)
+		}
+		// If the geoColumn is not specified and the geometry is not found,
+		// take a look.
+		// Also take a look if the column label is the column we desire.
+		if (geoColumn == "" && geometry == nil) || geoColumn == label {
+			// If we can parse the data type as Geometry or Geography,
+			// we've found it.
+			if g, ok := d.(*tree.DGeometry); ok {
+				foundGeoColumn = true
+				var err error
+				geometry, err = json.FromSpatialObject(g.SpatialObject(), numDecimalDigits)
+				if err != nil {
+					return nil, err
+				}
+				continue
+			}
+			if g, ok := d.(*tree.DGeography); ok {
+				foundGeoColumn = true
+				var err error
+				geometry, err = json.FromSpatialObject(g.SpatialObject(), numDecimalDigits)
+				if err != nil {
+					return nil, err
+				}
+				continue
+			}
+
+			if geoColumn == label {
+				foundGeoColumn = true
+				// If the entry is NULL, skip the current entry.
+				// Otherwise, we found the column but it was the wrong type, in which case,
+				// we error out.
+				if d == tree.DNull {
+					continue
+				}
+				return nil, errors.Newf(
+					"expected column %s to be a geo type, but it is of type %s",
+					geoColumn,
+					d.ResolvedType().SQLString(),
+				)
+			}
+		}
+		tupleJSON, err := tree.AsJSON(d, ctx.GetLocation())
+		if err != nil {
+			return nil, err
+		}
+		properties.Add(label, tupleJSON)
+	}
+	// If we have not found a column with the matching name, error out.
+	if !foundGeoColumn && geoColumn != "" {
+		return nil, errors.Newf("%q column not found", geoColumn)
+	}
+	// If geometry is still NULL, we either found no geometry columns
+	// or the found geometry column is NULL. Return a NULL type, a la
+	// PostGIS.
+	if geometry == nil {
+		geometryBuilder := json.NewObjectBuilder(1)
+		geometryBuilder.Add("type", json.NullJSONValue)
+		geometry = geometryBuilder.Build()
+	}
+	retJSON := json.NewObjectBuilder(3)
+	retJSON.Add("type", json.FromString("Feature"))
+	retJSON.Add("geometry", geometry)
+	retJSON.Add("properties", properties.Build())
+	retString := retJSON.Build().String()
+	if !pretty {
+		return tree.NewDString(retString), nil
+	}
+	var reserializedJSON map[string]interface{}
+	err := gojson.Unmarshal([]byte(retString), &reserializedJSON)
+	if err != nil {
+		return nil, err
+	}
+	marshalledIndent, err := gojson.MarshalIndent(reserializedJSON, "", "\t")
+	if err != nil {
+		return nil, err
+	}
+	return tree.NewDString(string(marshalledIndent)), nil
 }

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3056,9 +3056,9 @@ func AsJSON(d Datum, loc *time.Location) (json.JSON, error) {
 	case *DDate, *DUuid, *DOid, *DInterval, *DBytes, *DIPAddr, *DTime, *DTimeTZ, *DBitArray:
 		return json.FromString(AsStringWithFlags(t, FmtBareStrings)), nil
 	case *DGeometry:
-		return json.FromSpatialObject(t.Geometry.SpatialObject())
+		return json.FromSpatialObject(t.Geometry.SpatialObject(), geo.DefaultGeoJSONDecimalDigits)
 	case *DGeography:
-		return json.FromSpatialObject(t.Geography.SpatialObject())
+		return json.FromSpatialObject(t.Geography.SpatialObject(), geo.DefaultGeoJSONDecimalDigits)
 	default:
 		if d == DNull {
 			return json.NullJSONValue, nil

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -915,8 +915,8 @@ func (j jsonObject) allPaths() ([]JSON, error) {
 }
 
 // FromSpatialObject transforms a SpatialObject into the json.JSON type.
-func FromSpatialObject(so geopb.SpatialObject) (JSON, error) {
-	j, err := geo.SpatialObjectToGeoJSON(so, geo.DefaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
+func FromSpatialObject(so geopb.SpatialObject, numDecimalDigits int) (JSON, error) {
+	j, err := geo.SpatialObjectToGeoJSON(so, numDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Release note (sql change): Add ST_AsGeoJSON for recordsets, putting row
contents into the properties field of a GeoJSON object.