### PR TITLE
kv: delete reasonReplicaIDChanged refreshRaftReason

### DIFF
--- a/pkg/kv/kvserver/refreshraftreason_string.go
+++ b/pkg/kv/kvserver/refreshraftreason_string.go
@@ -12,13 +12,12 @@ func _() {
 	_ = x[reasonNewLeader-1]
 	_ = x[reasonNewLeaderOrConfigChange-2]
 	_ = x[reasonSnapshotApplied-3]
-	_ = x[reasonReplicaIDChanged-4]
-	_ = x[reasonTicks-5]
+	_ = x[reasonTicks-4]
 }
 
-const _refreshRaftReason_name = "noReasonreasonNewLeaderreasonNewLeaderOrConfigChangereasonSnapshotAppliedreasonReplicaIDChangedreasonTicks"
+const _refreshRaftReason_name = "noReasonreasonNewLeaderreasonNewLeaderOrConfigChangereasonSnapshotAppliedreasonTicks"
 
-var _refreshRaftReason_index = [...]uint8{0, 8, 23, 52, 73, 95, 106}
+var _refreshRaftReason_index = [...]uint8{0, 8, 23, 52, 73, 84}
 
 func (i refreshRaftReason) String() string {
 	if i < 0 || i >= refreshRaftReason(len(_refreshRaftReason_index)-1) {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -949,7 +949,6 @@ const (
 	// proposed whose proposal we still consider to be inflight. These commands
 	// will never receive a response through the regular channel.
 	reasonSnapshotApplied
-	reasonReplicaIDChanged
 	reasonTicks
 )
 


### PR DESCRIPTION
The last use of this was removed in 2020115.