### PR TITLE
*: ensure that log and error messages start with lowercase

### DIFF
--- a/pkg/ccl/cmdccl/enc_utils/main.go
+++ b/pkg/ccl/cmdccl/enc_utils/main.go
@@ -90,7 +90,7 @@ func loadFileRegistry() {
 
 func loadStoreKey() {
 	if len(*storeKeyPath) == 0 || *storeKeyPath == "plain" {
-		log.Infof(context.Background(), "No store key specified")
+		log.Infof(context.Background(), "no store key specified")
 		return
 	}
 

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -996,7 +996,7 @@ func removeDeadReplicas(
 		removeDeadReplicasOpts.deadStoreIDs)
 
 	if _, ok := deadStoreIDs[storeIdent.StoreID]; ok {
-		return nil, errors.Errorf("This store's ID (%s) marked as dead, aborting", storeIdent.StoreID)
+		return nil, errors.Errorf("this store's ID (%s) marked as dead, aborting", storeIdent.StoreID)
 	}
 
 	var newDescs []roachpb.RangeDescriptor

--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -699,7 +699,7 @@ func (c *transientCluster) runWorkload(
 						// Only log an error and return when the workload function throws
 						// an error, because errors these errors should be ignored, and
 						// should not interrupt the rest of the demo.
-						log.Warningf(ctx, "Error running workload query: %+v\n", err)
+						log.Warningf(ctx, "error running workload query: %+v", err)
 						return
 					}
 				}

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -321,7 +321,7 @@ func runDecommissionNode(cmd *cobra.Command, args []string) error {
 
 	conn, _, finish, err := getClientGRPCConn(ctx, serverCfg)
 	if err != nil {
-		return errors.Wrap(err, "Failed to connect to the node")
+		return errors.Wrap(err, "failed to connect to the node")
 	}
 	defer finish()
 
@@ -544,7 +544,7 @@ func runRecommissionNode(cmd *cobra.Command, args []string) error {
 
 	conn, _, finish, err := getClientGRPCConn(ctx, serverCfg)
 	if err != nil {
-		return errors.Wrap(err, "Failed to connect to the node")
+		return errors.Wrap(err, "failed to connect to the node")
 	}
 	defer finish()
 

--- a/pkg/cli/quit.go
+++ b/pkg/cli/quit.go
@@ -248,7 +248,7 @@ func doShutdown(ctx context.Context, c serverpb.AdminClient) (hardError bool, er
 func getAdminClient(ctx context.Context, cfg server.Config) (serverpb.AdminClient, func(), error) {
 	conn, _, finish, err := getClientGRPCConn(ctx, cfg)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "Failed to connect to the node")
+		return nil, nil, errors.Wrap(err, "failed to connect to the node")
 	}
 	return serverpb.NewAdminClient(conn), finish, nil
 }

--- a/pkg/cli/systembench/disk_bench.go
+++ b/pkg/cli/systembench/disk_bench.go
@@ -69,7 +69,7 @@ func newWorkerSeqWrite(
 	data := make([]byte, diskOptions.WriteSize)
 	_, err := rand.Read(data)
 	if err != nil {
-		log.Fatalf(ctx, "Failed to fill byte array with random bytes %s", err)
+		log.Fatalf(ctx, "failed to fill byte array with random bytes %s", err)
 	}
 
 	w := &workerSeqWrite{data: data,

--- a/pkg/geo/geohash.go
+++ b/pkg/geo/geohash.go
@@ -19,7 +19,7 @@ import (
 // using a Lng/Lat Point representation of the GeoHash.
 func NewGeometryPointFromGeoHash(g string, precision int) (*Geometry, error) {
 	if len(g) == 0 {
-		return nil, errors.Newf("Length of geohash must be greater than 0")
+		return nil, errors.Newf("length of geohash must be greater than 0")
 	}
 
 	// If precision is more than the length of the geohash

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -388,7 +388,7 @@ func NewTestWithLocality(
 // AssertNotStarted fatals if the Gossip instance was already started.
 func (g *Gossip) AssertNotStarted(ctx context.Context) {
 	if g.started {
-		log.Fatalf(ctx, "Gossip instance was already started")
+		log.Fatalf(ctx, "gossip instance was already started")
 	}
 }
 

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -277,7 +277,7 @@ func (s *jobScheduler) executeSchedules(
 func (s *jobScheduler) runDaemon(ctx context.Context, stopper *stop.Stopper) {
 	stopper.RunWorker(ctx, func(ctx context.Context) {
 		initialDelay := getInitialScanDelay(s.TestingKnobs)
-		log.Infof(ctx, "Waiting %s before scheduled jobs daemon start", initialDelay.String())
+		log.Infof(ctx, "waiting %s before scheduled jobs daemon start", initialDelay.String())
 
 		for timer := time.NewTimer(initialDelay); ; timer.Reset(
 			getWaitPeriod(&s.Settings.SV, s.TestingKnobs)) {
@@ -286,7 +286,7 @@ func (s *jobScheduler) runDaemon(ctx context.Context, stopper *stop.Stopper) {
 				return
 			case <-timer.C:
 				if !schedulerEnabledSetting.Get(&s.Settings.SV) {
-					log.Info(ctx, "Scheduled job daemon disabled")
+					log.Info(ctx, "scheduled job daemon disabled")
 					continue
 				}
 

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -327,8 +327,8 @@ func (j *Job) FractionProgressed(ctx context.Context, progressedFn FractionProgr
 		}
 		if fractionCompleted < 0.0 || fractionCompleted > 1.0 {
 			return errors.Errorf(
-				"Job: fractionCompleted %f is outside allowable range [0.0, 1.0] (job %d)",
-				fractionCompleted, *j.ID(),
+				"job %d: fractionCompleted %f is outside allowable range [0.0, 1.0]",
+				*j.ID(), fractionCompleted,
 			)
 		}
 		md.Progress.Progress = &jobspb.Progress_FractionCompleted{
@@ -353,8 +353,8 @@ func (j *Job) HighWaterProgressed(ctx context.Context, progressedFn HighWaterPro
 		}
 		if highWater.Less(hlc.Timestamp{}) {
 			return errors.Errorf(
-				"Job: high-water %s is outside allowable range > 0.0 (job %d)",
-				highWater, *j.ID(),
+				"job %d: high-water %s is outside allowable range > 0.0",
+				*j.ID(), highWater,
 			)
 		}
 		md.Progress.Progress = &jobspb.Progress_HighWater{
@@ -591,7 +591,7 @@ func (j *Job) succeeded(ctx context.Context, fn func(context.Context, *kv.Txn) e
 			return nil
 		}
 		if md.Status != StatusRunning && md.Status != StatusPending {
-			return errors.Errorf("Job with status %s cannot be marked as succeeded", md.Status)
+			return errors.Errorf("job with status %s cannot be marked as succeeded", md.Status)
 		}
 		if fn != nil {
 			if err := fn(ctx, txn); err != nil {
@@ -807,7 +807,7 @@ func UnmarshalPayload(datum tree.Datum) (*jobspb.Payload, error) {
 	bytes, ok := datum.(*tree.DBytes)
 	if !ok {
 		return nil, errors.Errorf(
-			"Job: failed to unmarshal payload as DBytes (was %T)", datum)
+			"job: failed to unmarshal payload as DBytes (was %T)", datum)
 	}
 	if err := protoutil.Unmarshal([]byte(*bytes), payload); err != nil {
 		return nil, err
@@ -822,7 +822,7 @@ func UnmarshalProgress(datum tree.Datum) (*jobspb.Progress, error) {
 	bytes, ok := datum.(*tree.DBytes)
 	if !ok {
 		return nil, errors.Errorf(
-			"Job: failed to unmarshal Progress as DBytes (was %T)", datum)
+			"job: failed to unmarshal Progress as DBytes (was %T)", datum)
 	}
 	if err := protoutil.Unmarshal([]byte(*bytes), progress); err != nil {
 		return nil, err
@@ -841,10 +841,10 @@ func unmarshalCreatedBy(createdByType, createdByID tree.Datum) (*CreatedByInfo, 
 			return &CreatedByInfo{Name: string(*ds), ID: int64(*id)}, nil
 		}
 		return nil, errors.Errorf(
-			"Job: failed to unmarshal created_by_type as DInt (was %T)", createdByID)
+			"job: failed to unmarshal created_by_type as DInt (was %T)", createdByID)
 	}
 	return nil, errors.Errorf(
-		"Job: failed to unmarshal created_by_type as DString (was %T)", createdByType)
+		"job: failed to unmarshal created_by_type as DString (was %T)", createdByType)
 }
 
 // CurrentStatus returns the current job status from the jobs table or error.

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -603,7 +603,7 @@ func (r *Registry) Start(
 			log.Errorf(ctx, "error getting live session: %s", err)
 			return
 		}
-		log.VEventf(ctx, 1, "Registry live claim (instance_id: %s, sid: %s)", r.ID(), s.ID())
+		log.VEventf(ctx, 1, "registry live claim (instance_id: %s, sid: %s)", r.ID(), s.ID())
 
 		if _, err := r.ex.QueryRowEx(
 			ctx, "expire-sessions", nil,

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -99,7 +99,7 @@ func (ju *JobUpdater) hasUpdates() bool {
 // defined in jobs.go.
 func (j *Job) Update(ctx context.Context, updateFn UpdateFn) error {
 	if j.id == nil {
-		return errors.New("Job: cannot update: job not created")
+		return errors.New("job: cannot update: job not created")
 	}
 
 	var payload *jobspb.Payload
@@ -118,7 +118,7 @@ func (j *Job) Update(ctx context.Context, updateFn UpdateFn) error {
 
 		statusString, ok := row[0].(*tree.DString)
 		if !ok {
-			return errors.Errorf("Job: expected string status on job %d, but got %T", *j.id, statusString)
+			return errors.AssertionFailedf("job %d: expected string status, but got %T", *j.id, statusString)
 		}
 		status := Status(*statusString)
 		if payload, err = UnmarshalPayload(row[1]); err != nil {
@@ -194,7 +194,7 @@ func (j *Job) Update(ctx context.Context, updateFn UpdateFn) error {
 		}
 		if n != 1 {
 			return errors.Errorf(
-				"Job: expected exactly one row affected, but %d rows affected by job update", n,
+				"job %d: expected exactly one row affected, but %d rows affected by job update", *j.id, n,
 			)
 		}
 		return nil

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -128,7 +128,9 @@ func MakeBulkAdder(
 	// it will store in-memory before sending it to RocksDB.
 	b.memAcc = bulkMon.MakeBoundAccount()
 	if err := b.memAcc.Grow(ctx, b.curBufferSize); err != nil {
-		return nil, errors.Wrap(err, "Not enough memory available to create a BulkAdder. Try setting a higher --max-sql-memory.")
+		return nil, errors.WithHint(
+			errors.Wrap(err, "not enough memory available to create a BulkAdder"),
+			"Try setting a higher --max-sql-memory.")
 	}
 
 	return b, nil

--- a/pkg/kv/kvserver/tenantrate/limiter.go
+++ b/pkg/kv/kvserver/tenantrate/limiter.go
@@ -195,7 +195,7 @@ func (rb *tokenBuckets) Merge(val interface{}) (shouldNotify bool) {
 		// further in the future.
 		return false
 	default:
-		panic(errors.AssertionFailedf("Merge not implemented for %T", val))
+		panic(errors.AssertionFailedf("merge not implemented for %T", val))
 	}
 }
 

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -952,7 +952,7 @@ func (ctx *Context) grpcDialRaw(
 	dialerFunc := dialer.dial
 	if ctx.Knobs.ArtificialLatencyMap != nil {
 		latency := ctx.Knobs.ArtificialLatencyMap[target]
-		log.VEventf(ctx.masterCtx, 1, "Connecting to node %s (%d) with simulated latency %dms", target, remoteNodeID,
+		log.VEventf(ctx.masterCtx, 1, "connecting to node %s (%d) with simulated latency %dms", target, remoteNodeID,
 			latency)
 		dialer := artificialLatencyDialer{
 			dialerFunc: dialerFunc,

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -181,7 +181,7 @@ func createCACertAndKey(
 			return errors.Errorf("could not write CA key to file %s: %v", caKeyPath, err)
 		}
 
-		log.Infof(context.Background(), "Generated CA key %s", caKeyPath)
+		log.Infof(context.Background(), "generated CA key %s", caKeyPath)
 	} else {
 		if !allowKeyReuse {
 			return errors.Errorf("CA key %s exists, but key reuse is disabled", caKeyPath)
@@ -197,7 +197,7 @@ func createCACertAndKey(
 			return errors.Errorf("could not parse CA key file %s: %v", caKeyPath, err)
 		}
 
-		log.Infof(context.Background(), "Using CA key from file %s", caKeyPath)
+		log.Infof(context.Background(), "using CA key from file %s", caKeyPath)
 	}
 
 	// Generate certificate.
@@ -233,7 +233,7 @@ func createCACertAndKey(
 		if err != nil {
 			return errors.Errorf("could not parse existing CA cert file %s: %v", certPath, err)
 		}
-		log.Infof(context.Background(), "Found %d certificates in %s",
+		log.Infof(context.Background(), "found %d certificates in %s",
 			len(existingCertificates), certPath)
 	} else if !os.IsNotExist(err) {
 		return errors.Errorf("could not stat CA cert file %s: %v", certPath, err)
@@ -247,7 +247,7 @@ func createCACertAndKey(
 		return errors.Errorf("could not write CA certificate file %s: %v", certPath, err)
 	}
 
-	log.Infof(context.Background(), "Wrote %d certificates to %s", len(certificates), certPath)
+	log.Infof(context.Background(), "wrote %d certificates to %s", len(certificates), certPath)
 
 	return nil
 }
@@ -300,13 +300,13 @@ func CreateNodePair(
 	if err := writeCertificateToFile(certPath, nodeCert, overwrite); err != nil {
 		return errors.Errorf("error writing node server certificate to %s: %v", certPath, err)
 	}
-	log.Infof(context.Background(), "Generated node certificate: %s", certPath)
+	log.Infof(context.Background(), "generated node certificate: %s", certPath)
 
 	keyPath := cm.NodeKeyPath()
 	if err := writeKeyToFile(keyPath, nodeKey, overwrite); err != nil {
 		return errors.Errorf("error writing node server key to %s: %v", keyPath, err)
 	}
-	log.Infof(context.Background(), "Generated node key: %s", keyPath)
+	log.Infof(context.Background(), "generated node key: %s", keyPath)
 
 	return nil
 }
@@ -355,13 +355,13 @@ func CreateUIPair(
 	if err := writeCertificateToFile(certPath, uiCert, overwrite); err != nil {
 		return errors.Errorf("error writing UI server certificate to %s: %v", certPath, err)
 	}
-	log.Infof(context.Background(), "Generated UI certificate: %s", certPath)
+	log.Infof(context.Background(), "generated UI certificate: %s", certPath)
 
 	keyPath := cm.UIKeyPath()
 	if err := writeKeyToFile(keyPath, uiKey, overwrite); err != nil {
 		return errors.Errorf("error writing UI server key to %s: %v", keyPath, err)
 	}
-	log.Infof(context.Background(), "Generated UI key: %s", keyPath)
+	log.Infof(context.Background(), "generated UI key: %s", keyPath)
 
 	return nil
 }
@@ -426,20 +426,20 @@ func CreateClientPair(
 	if err := writeCertificateToFile(certPath, clientCert, overwrite); err != nil {
 		return errors.Errorf("error writing client certificate to %s: %v", certPath, err)
 	}
-	log.Infof(context.Background(), "Generated client certificate: %s", certPath)
+	log.Infof(context.Background(), "generated client certificate: %s", certPath)
 
 	keyPath := cm.ClientKeyPath(user)
 	if err := writeKeyToFile(keyPath, clientKey, overwrite); err != nil {
 		return errors.Errorf("error writing client key to %s: %v", keyPath, err)
 	}
-	log.Infof(context.Background(), "Generated client key: %s", keyPath)
+	log.Infof(context.Background(), "generated client key: %s", keyPath)
 
 	if wantPKCS8Key {
 		pkcs8KeyPath := keyPath + ".pk8"
 		if err := writePKCS8KeyToFile(pkcs8KeyPath, clientKey, overwrite); err != nil {
 			return errors.Errorf("error writing client PKCS8 key to %s: %v", pkcs8KeyPath, err)
 		}
-		log.Infof(context.Background(), "Generated PKCS8 client key: %s", pkcs8KeyPath)
+		log.Infof(context.Background(), "generated PKCS8 client key: %s", pkcs8KeyPath)
 	}
 
 	return nil
@@ -523,13 +523,13 @@ func WriteTenantClientPair(certsDir string, cp *TenantClientPair, overwrite bool
 	if err := writeCertificateToFile(certPath, cp.Cert, overwrite); err != nil {
 		return errors.Errorf("error writing tenant certificate to %s: %v", certPath, err)
 	}
-	log.Infof(context.Background(), "Wrote SQL tenant client certificate: %s", certPath)
+	log.Infof(context.Background(), "wrote SQL tenant client certificate: %s", certPath)
 
 	keyPath := cm.TenantClientKeyPath(tenantIdentifier)
 	if err := writeKeyToFile(keyPath, cp.PrivateKey, overwrite); err != nil {
 		return errors.Errorf("error writing tenant key to %s: %v", keyPath, err)
 	}
-	log.Infof(context.Background(), "Generated tenant key: %s", keyPath)
+	log.Infof(context.Background(), "generated tenant key: %s", keyPath)
 	return nil
 }
 

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -394,7 +394,7 @@ func (am *authenticationMux) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		ctx = context.WithValue(ctx, webSessionIDKey{}, cookie.ID)
 		req = req.WithContext(ctx)
 	} else if !am.allowAnonymous {
-		log.Infof(req.Context(), "Web session error: %s", err)
+		log.Infof(req.Context(), "web session error: %s", err)
 		http.Error(w, "a valid authentication cookie is required", http.StatusUnauthorized)
 		return
 	}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -356,7 +356,7 @@ func (n *Node) start(
 		select {
 		case <-n.storeCfg.Gossip.Connected:
 		default:
-			log.Fatalf(ctx, "Gossip is not connected yet")
+			log.Fatalf(ctx, "gossip is not connected yet")
 		}
 		ctxWithSpan, span := n.AnnotateCtxWithSpan(ctx, "alloc-node-id")
 		newID, err := allocateNodeID(ctxWithSpan, n.storeCfg.DB)

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -464,7 +464,7 @@ func (mr *MetricsRecorder) GenerateNodeStatus(ctx context.Context) *statuspb.Nod
 		// Gather descriptor from store.
 		descriptor, err := mr.mu.stores[storeID].Descriptor(ctx, false /* useCached */)
 		if err != nil {
-			log.Errorf(ctx, "Could not record status summaries: Store %d could not return descriptor, error: %s", storeID, err)
+			log.Errorf(ctx, "could not record status summaries: Store %d could not return descriptor, error: %s", storeID, err)
 			continue
 		}
 

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -307,7 +307,7 @@ func NewRuntimeStatSampler(ctx context.Context, clock *hlc.Clock) *RuntimeStatSa
 	timestamp, err := info.Timestamp()
 	if err != nil {
 		// We can't panic here, tests don't have a build timestamp.
-		log.Warningf(ctx, "Could not parse build timestamp: %v", err)
+		log.Warningf(ctx, "could not parse build timestamp: %v", err)
 	}
 
 	// Build information.

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -227,7 +227,7 @@ func (s *Server) checkForUpdates(ctx context.Context) bool {
 
 	err = decoder.Decode(&r)
 	if err != nil && err != io.EOF {
-		log.Warningf(ctx, "Error decoding updates info: %v", err)
+		log.Warningf(ctx, "error decoding updates info: %v", err)
 		return false
 	}
 
@@ -238,7 +238,7 @@ func (s *Server) checkForUpdates(ctx context.Context) bool {
 		r.Details = r.Details[len(r.Details)-updateMaxVersionsToReport:]
 	}
 	for _, v := range r.Details {
-		log.Infof(ctx, "A new version is available: %s, details: %s", v.Version, v.Details)
+		log.Infof(ctx, "a new version is available: %s, details: %s", v.Version, v.Details)
 	}
 	return true
 }

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -550,7 +550,7 @@ func dumpStmtStats(ctx context.Context, appName string, stats map[stmtKey]*stmtS
 		}
 		fmt.Fprintf(&buf, "%q: %s\n", key.String(), json)
 	}
-	log.Infof(ctx, "Statistics for %q:\n%s", appName, buf.String())
+	log.Infof(ctx, "statistics for %q:\n%s", appName, buf.String())
 }
 
 func constructStatementIDFromStmtKey(key stmtKey) roachpb.StmtID {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -177,7 +177,7 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 	}
 	version := tableDesc.Version
 
-	log.Infof(ctx, "Running backfill for %q, v=%d", tableDesc.Name, tableDesc.Version)
+	log.Infof(ctx, "running backfill for %q, v=%d", tableDesc.Name, tableDesc.Version)
 
 	needColumnBackfill := false
 	for _, m := range tableDesc.Mutations {
@@ -303,7 +303,7 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 		}
 	}
 
-	log.Infof(ctx, "Completed backfill for %q, v=%d", tableDesc.Name, tableDesc.Version)
+	log.Infof(ctx, "completed backfill for %q, v=%d", tableDesc.Name, tableDesc.Version)
 
 	if sc.testingKnobs.RunAfterBackfill != nil {
 		if err := sc.testingKnobs.RunAfterBackfill(*sc.job.ID()); err != nil {

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1353,7 +1353,7 @@ func (c *nameCache) get(
 	defer desc.mu.Unlock()
 
 	if !NameMatchesDescriptor(desc, parentID, parentSchemaID, name) {
-		panic(errors.AssertionFailedf("Out of sync entry in the name cache. "+
+		panic(errors.AssertionFailedf("out of sync entry in the name cache. "+
 			"Cache entry: (%d, %d, %q) -> %d. Lease: (%d, %d, %q).",
 			parentID, parentSchemaID, name,
 			desc.GetID(),

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -51,7 +51,7 @@ func validateCheckExpr(
 	colSelectors := sqlbase.ColumnsSelectors(tableDesc.Columns)
 	columns := tree.AsStringWithFlags(&colSelectors, tree.FmtSerializable)
 	queryStr := fmt.Sprintf(`SELECT %s FROM [%d AS t] WHERE NOT (%s) LIMIT 1`, columns, tableDesc.GetID(), exprStr)
-	log.Infof(ctx, "Validating check constraint %q with query %q", expr, queryStr)
+	log.Infof(ctx, "validating check constraint %q with query %q", expr, queryStr)
 
 	rows, err := ie.QueryRow(ctx, "validate check constraint", txn, queryStr)
 	if err != nil {
@@ -259,7 +259,7 @@ func validateForeignKey(
 			return err
 		}
 
-		log.Infof(ctx, "Validating MATCH FULL FK %q (%q [%v] -> %q [%v]) with query %q",
+		log.Infof(ctx, "validating MATCH FULL FK %q (%q [%v] -> %q [%v]) with query %q",
 			fk.Name,
 			srcTable.Name, colNames,
 			targetTable.GetName(), referencedColumnNames,
@@ -285,7 +285,7 @@ func validateForeignKey(
 		return err
 	}
 
-	log.Infof(ctx, "Validating FK %q (%q [%v] -> %q [%v]) with query %q",
+	log.Infof(ctx, "validating FK %q (%q [%v] -> %q [%v]) with query %q",
 		fk.Name,
 		srcTable.Name, colNames, targetTable.GetName(), referencedColumnNames,
 		query,

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -712,7 +712,7 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 			var foundNull bool
 			if rf.mustDecodeIndexKey || rf.traceKV {
 				if debugState {
-					log.Infof(ctx, "Decoding first key %s", rf.machine.nextKV.Key)
+					log.Infof(ctx, "decoding first key %s", rf.machine.nextKV.Key)
 				}
 				var (
 					key     []byte
@@ -741,7 +741,7 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 					// We found an interleave. Set our skip prefix.
 					seekPrefix := rf.machine.nextKV.Key[:len(key)+rf.table.knownPrefixLength]
 					if debugState {
-						log.Infof(ctx, "Setting seek prefix to %s", seekPrefix)
+						log.Infof(ctx, "setting seek prefix to %s", seekPrefix)
 					}
 					rf.machine.seekPrefix = seekPrefix
 					rf.machine.state[0] = stateSeekPrefix
@@ -868,7 +868,7 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 			// prefix and indicate that it needs decoding.
 			rf.machine.nextKV = kv
 			if debugState {
-				log.Infof(ctx, "Decoding next key %s", rf.machine.nextKV.Key)
+				log.Infof(ctx, "decoding next key %s", rf.machine.nextKV.Key)
 			}
 
 			// TODO(jordan): optimize this prefix check by skipping span prefix.
@@ -1305,7 +1305,7 @@ func (rf *cFetcher) fillNulls() error {
 					indexColValues = append(indexColValues, "?")
 				}
 				return scrub.WrapError(scrub.UnexpectedNullValueError, errors.Errorf(
-					"Non-nullable column \"%s:%s\" with no value! Index scanned was %q with the index key columns (%s) and the values (%s)",
+					"non-nullable column \"%s:%s\" with no value! Index scanned was %q with the index key columns (%s) and the values (%s)",
 					table.desc.GetName(), table.cols[i].Name, table.index.Name,
 					strings.Join(table.index.ColumnNames, ","), strings.Join(indexColValues, ",")))
 			}

--- a/pkg/sql/delegate/show_partitions.go
+++ b/pkg/sql/delegate/show_partitions.go
@@ -113,7 +113,7 @@ func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Stateme
 	if tn.ObjectName == "" {
 		err := errors.New("no table specified")
 		err = pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)
-		err = errors.WithHint(err, "Specify a table using the hint syntax of table@index")
+		err = errors.WithHint(err, "Specify a table using the hint syntax of table@index.")
 		return nil, err
 	}
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -372,9 +372,9 @@ func (dsp *DistSQLPlanner) Run(
 		}
 		_, url, err := execinfrapb.GeneratePlanDiagramURL(stmtStr, flows, false /* showInputTypes */)
 		if err != nil {
-			log.Infof(ctx, "Error generating diagram: %s", err)
+			log.Infof(ctx, "error generating diagram: %s", err)
 		} else {
-			log.Infof(ctx, "Plan diagram URL:\n%s", url.String())
+			log.Infof(ctx, "plan diagram URL:\n%s", url.String())
 		}
 	}
 
@@ -419,7 +419,7 @@ func (dsp *DistSQLPlanner) Run(
 
 	// TODO(radu): this should go through the flow scheduler.
 	if err := flow.Run(ctx, func() {}); err != nil {
-		log.Fatalf(ctx, "unexpected error from syncFlow.Start(): %s "+
+		log.Fatalf(ctx, "unexpected error from syncFlow.Start(): %v\n"+
 			"The error should have gone to the consumer.", err)
 	}
 

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -411,10 +411,10 @@ func (m *Outbox) listenForDrainSignalFromConsumer(ctx context.Context) (<-chan d
 					return
 				}
 			case signal.SetupFlowRequest != nil:
-				log.Fatalf(ctx, "Unexpected SetupFlowRequest. "+
+				log.Fatalf(ctx, "unexpected SetupFlowRequest.\n"+
 					"This SyncFlow specific message should have been handled in RunSyncFlow.")
 			case signal.Handshake != nil:
-				log.Eventf(ctx, "Consumer sent handshake. Consuming flow scheduled: %t",
+				log.Eventf(ctx, "consumer sent handshake.\nConsuming flow scheduled: %t",
 					signal.Handshake.ConsumerScheduled)
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2420,7 +2420,7 @@ SELECT width_bucket(now(), array['yesterday', 'today', 'tomorrow']::timestamptz[
 ----
 2
 
-query error pq: width_bucket\(\): Operand and thresholds must be of the same type
+query error pq: width_bucket\(\): operand and thresholds must be of the same type
 SELECT width_bucket(1, array['a', 'h', 'l', 'z']);
 
 # Regression for #40623

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -830,7 +830,7 @@ POINT (90 0)
 statement error pq: st_pointfromgeohash\(\): geohash decode '----': invalid character at index 0
 SELECT ST_AsText(ST_PointFromGeoHash('----'))
 
-statement error pq: st_pointfromgeohash\(\): Length of geohash must be greater than 0
+statement error pq: st_pointfromgeohash\(\): length of geohash must be greater than 0
 SELECT ST_AsText(ST_PointFromGeoHash(''))
 
 query TTTTTTTT

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -303,10 +303,10 @@ func checkFilters(filters FiltersExpr) {
 	for _, item := range filters {
 		if item.Condition.Op() == opt.RangeOp {
 			if !item.scalar.TightConstraints {
-				panic(errors.AssertionFailedf("Range operator should always have tight constraints"))
+				panic(errors.AssertionFailedf("range operator should always have tight constraints"))
 			}
 			if item.scalar.OuterCols.Len() != 1 {
-				panic(errors.AssertionFailedf("Range operator should have exactly one outer col"))
+				panic(errors.AssertionFailedf("range operator should have exactly one outer col"))
 			}
 		}
 	}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1976,7 +1976,7 @@ CREATE TABLE pg_catalog.pg_operator (
 				leftType = tree.NewDOid(tree.DInt(params.Types()[0].Oid()))
 				rightType = tree.NewDOid(tree.DInt(params.Types()[1].Oid()))
 			default:
-				panic(errors.AssertionFailedf("Unexpected operator %s with %d params",
+				panic(errors.AssertionFailedf("unexpected operator %s with %d params",
 					opName, params.Length()))
 			}
 			returnType := tree.NewDOid(tree.DInt(returnTyper(nil).Oid()))

--- a/pkg/sql/physicalplan/fake_span_resolver.go
+++ b/pkg/sql/physicalplan/fake_span_resolver.go
@@ -82,7 +82,7 @@ func (fit *fakeSpanResolverIterator) Seek(
 	// Scan the range and keep a list of all potential split keys.
 	kvs, err := fit.txn.Scan(ctx, span.Key, span.EndKey, 0)
 	if err != nil {
-		log.Errorf(ctx, "Error in fake span resolver scan: %s", err)
+		log.Errorf(ctx, "error in fake span resolver scan: %s", err)
 		fit.err = err
 		return
 	}

--- a/pkg/sql/rowexec/stream_merger.go
+++ b/pkg/sql/rowexec/stream_merger.go
@@ -179,7 +179,7 @@ func makeStreamMerger(
 	}
 	for i, ord := range leftOrdering {
 		if ord.Direction != rightOrdering[i].Direction {
-			return streamMerger{}, errors.New("Ordering mismatch")
+			return streamMerger{}, errors.New("ordering mismatch")
 		}
 	}
 

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -255,7 +255,7 @@ func (n *scrubNode) startScrubTable(
 			}
 			n.run.checkQueue = append(n.run.checkQueue, constraintsToCheck...)
 		default:
-			panic(errors.AssertionFailedf("Unhandled SCRUB option received: %+v", v))
+			panic(errors.AssertionFailedf("unhandled SCRUB option received: %+v", v))
 		}
 	}
 

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -563,7 +563,7 @@ var mathBuiltins = map[string]builtinDefinition{
 				thresholds := tree.MustBeDArray(args[1])
 
 				if !operand.ResolvedType().Equivalent(thresholds.ParamTyp) {
-					return tree.NewDInt(0), errors.New("Operand and thresholds must be of the same type")
+					return tree.NewDInt(0), errors.New("operand and thresholds must be of the same type")
 				}
 
 				for i, v := range thresholds.Array {

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -1318,7 +1318,7 @@ func datumTypeToArrayElementEncodingType(t *types.T) (encoding.Type, error) {
 	case types.INetFamily:
 		return encoding.IPAddr, nil
 	default:
-		return 0, errors.Errorf("Don't know encoding type for %s", t)
+		return 0, errors.AssertionFailedf("no known encoding type for %s", t)
 	}
 }
 

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -168,7 +168,7 @@ func EncDatumValueFromBufferWithOffsetsAndType(
 // DatumToEncDatum initializes an EncDatum with the given Datum.
 func DatumToEncDatum(ctyp *types.T, d tree.Datum) EncDatum {
 	if d == nil {
-		panic(errors.AssertionFailedf("Cannot convert nil datum to EncDatum"))
+		panic(errors.AssertionFailedf("cannot convert nil datum to EncDatum"))
 	}
 
 	dTyp := d.ResolvedType()

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -131,7 +131,7 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 				break
 			}
 			if everySecond.ShouldLog() {
-				log.Errorf(ctx, "Failed to create a session at %d-th attempt: %v", i, err.Error())
+				log.Errorf(ctx, "failed to create a session at %d-th attempt: %v", i, err.Error())
 			}
 			continue
 		}
@@ -140,7 +140,7 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Infof(ctx, "Created new SQL liveness session %s", s.ID())
+	log.Infof(ctx, "created new SQL liveness session %s", s.ID())
 	return s, nil
 }
 
@@ -214,7 +214,7 @@ func (l *Instance) heartbeatLoop(ctx context.Context) {
 				continue
 			}
 			if log.V(2) {
-				log.Infof(ctx, "Extended SQL liveness session %s", s.ID())
+				log.Infof(ctx, "extended SQL liveness session %s", s.ID())
 			}
 			t.Reset(l.hb())
 		}

--- a/pkg/sql/sqlliveness/slinstance/slinstance_test.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance_test.go
@@ -62,7 +62,7 @@ func TestSQLInstance(t *testing.T) {
 	require.Equal(t, s1.ID(), s2.ID())
 
 	_ = fakeStorage.Delete(ctx, s2.ID())
-	t.Logf("Deleted session %s", s2.ID())
+	t.Logf("deleted session %s", s2.ID())
 	a, err = fakeStorage.IsAlive(ctx, s2.ID())
 	require.NoError(t, err)
 	require.False(t, a)

--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -189,7 +189,7 @@ func (s *Storage) fetchSession(
 			ctx, "expire-single-session", txn, `
 SELECT expiration FROM system.sqlliveness WHERE session_id = $1`, sid.UnsafeBytes(),
 		)
-		return errors.Wrapf(err, "Could not query session id: %s", sid)
+		return errors.Wrapf(err, "could not query session id: %s", sid)
 	}); err != nil {
 		return false, hlc.Timestamp{}, err
 	}
@@ -269,7 +269,7 @@ func (s *Storage) Insert(
 		return err
 	}); err != nil {
 		s.metrics.WriteFailures.Inc(1)
-		return errors.Wrapf(err, "Could not insert session %s", sid)
+		return errors.Wrapf(err, "could not insert session %s", sid)
 	}
 	log.Infof(ctx, "inserted sqlliveness session %s", sid)
 	s.metrics.WriteSuccesses.Inc(1)
@@ -297,7 +297,7 @@ UPDATE system.sqlliveness SET expiration = $1 WHERE session_id = $2 RETURNING se
 		s.metrics.WriteFailures.Inc(1)
 	}
 	if err != nil {
-		return false, errors.Wrapf(err, "Could not update session %s", sid)
+		return false, errors.Wrapf(err, "could not update session %s", sid)
 	}
 	s.metrics.WriteSuccesses.Inc(1)
 	return sessionExists, nil

--- a/pkg/sql/sqlliveness/slstorage/test_helpers.go
+++ b/pkg/sql/sqlliveness/slstorage/test_helpers.go
@@ -51,7 +51,7 @@ func (s *FakeStorage) Insert(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.mu.sessions[sid]; ok {
-		return errors.Errorf("Session %s already exists", sid)
+		return errors.Errorf("session %s already exists", sid)
 	}
 	s.mu.sessions[sid] = expiration
 	return nil

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -227,7 +227,7 @@ func (ts *txnState) finishSQLTxn() {
 		ts.cancel = nil
 	}
 	if ts.sp == nil {
-		panic("No span in context? Was resetForNewSQLTxn() called previously?")
+		panic(errors.AssertionFailedf("No span in context? Was resetForNewSQLTxn() called previously?"))
 	}
 
 	if ts.recordingThreshold > 0 {
@@ -240,7 +240,7 @@ func (ts *txnState) finishSQLTxn() {
 				}
 			}
 		} else {
-			log.Warning(ts.Ctx, "Missing trace when sampled was enabled.")
+			log.Warning(ts.Ctx, "missing trace when sampled was enabled")
 		}
 	}
 

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -857,7 +857,7 @@ func (m *Manager) migrateSystemNamespace(
 			if err != nil {
 				return err
 			}
-			log.Infof(ctx, "Migrating system.namespace chunk with %d rows", len(rows))
+			log.Infof(ctx, "migrating system.namespace chunk with %d rows", len(rows))
 			for i, row := range rows {
 				workLeft = false
 				// We found some rows from the query, which means that we can't quit
@@ -878,7 +878,7 @@ func (m *Manager) migrateSystemNamespace(
 					}
 					// Also create a 'public' schema for this database.
 					schemaKey := sqlbase.NewSchemaKey(id, "public")
-					log.VEventf(ctx, 2, "Migrating system.namespace entry for database %s", name)
+					log.VEventf(ctx, 2, "migrating system.namespace entry for database %s", name)
 					if err := txn.Put(ctx, schemaKey.Key(r.codec), keys.PublicSchemaID); err != nil {
 						return err
 					}
@@ -892,7 +892,7 @@ func (m *Manager) migrateSystemNamespace(
 						continue
 					}
 					tableKey := sqlbase.NewTableKey(parentID, keys.PublicSchemaID, name)
-					log.VEventf(ctx, 2, "Migrating system.namespace entry for table %s", name)
+					log.VEventf(ctx, 2, "migrating system.namespace entry for table %s", name)
 					if err := txn.Put(ctx, tableKey.Key(r.codec), id); err != nil {
 						return err
 					}

--- a/pkg/storage/cloudimpl/nodelocal_storage.go
+++ b/pkg/storage/cloudimpl/nodelocal_storage.go
@@ -57,7 +57,7 @@ func makeLocalStorage(
 	ioConf base.ExternalIODirConfig,
 ) (cloud.ExternalStorage, error) {
 	if cfg.Path == "" {
-		return nil, errors.Errorf("Local storage requested but path not provided")
+		return nil, errors.Errorf("local storage requested but path not provided")
 	}
 	client, err := blobClientFactory(ctx, cfg.NodeID)
 	if err != nil {

--- a/pkg/util/log/doc.go
+++ b/pkg/util/log/doc.go
@@ -35,8 +35,8 @@
 //
 // Examples:
 //
-//	log.Info(ctx, "Prepare to repel boarders")
-//	log.Fatal(ctx, "Initialization failed", err)
+//	log.Info(ctx, "prepare to repel boarders")
+//	log.Fatal(ctx, "initialization failed", err)
 //	log.Infof(ctx, "client error: %s", err)
 //
 // V-Style
@@ -49,7 +49,7 @@
 // Examples:
 //
 //	if log.V(2) {
-//		log.Info(ctx, "Starting transaction...")
+//		log.Info(ctx, "starting transaction...")
 //	}
 //
 // Events

--- a/pkg/util/metric/registry.go
+++ b/pkg/util/metric/registry.go
@@ -71,7 +71,7 @@ func (r *Registry) AddMetric(metric Iterable) {
 	defer r.Unlock()
 	r.tracked = append(r.tracked, metric)
 	if log.V(2) {
-		log.Infof(context.TODO(), "Added metric: %s (%T)", metric.GetName(), metric)
+		log.Infof(context.TODO(), "added metric: %s (%T)", metric.GetName(), metric)
 	}
 }
 
@@ -90,7 +90,7 @@ func (r *Registry) AddMetricStruct(metricStruct interface{}) {
 		tname := tfield.Name
 		if !vfield.CanInterface() {
 			if log.V(2) {
-				log.Infof(ctx, "Skipping unexported field %s", tname)
+				log.Infof(ctx, "skipping unexported field %s", tname)
 			}
 			continue
 		}
@@ -119,10 +119,10 @@ func (r *Registry) addMetricValue(
 		if val.Kind() == reflect.Ptr && val.IsNil() {
 			if skipNil {
 				if log.V(2) {
-					log.Infof(ctx, "Skipping nil metric field %s", name)
+					log.Infof(ctx, "skipping nil metric field %s", name)
 				}
 			} else {
-				log.Fatalf(ctx, "Found nil metric field %s", name)
+				log.Fatalf(ctx, "found nil metric field %s", name)
 			}
 			return
 		}
@@ -131,7 +131,7 @@ func (r *Registry) addMetricValue(
 		r.AddMetricStruct(typ)
 	default:
 		if log.V(2) {
-			log.Infof(ctx, "Skipping non-metric field %s", name)
+			log.Infof(ctx, "skipping non-metric field %s", name)
 		}
 	}
 }

--- a/pkg/util/randutil/rand.go
+++ b/pkg/util/randutil/rand.go
@@ -82,5 +82,5 @@ func ReadTestdataBytes(r *rand.Rand, arr []byte) {
 func SeedForTests() {
 	seed := envutil.EnvOrDefaultInt64("COCKROACH_RANDOM_SEED", NewPseudoSeed())
 	rand.Seed(seed)
-	log.Printf("Random seed: %v", seed)
+	log.Printf("random seed: %v", seed)
 }


### PR DESCRIPTION
This commit adjusts a few log and error calls to ensure the texts
start with a lowercase letter. (Messages that start with a code
identifier keep their capital if any - these are treated as proper
nouns.)

Good: `log.Infof(ctx, "this is my message: %s", err)`
Less good: `log.Info(ctx, "This is my message: %s", err)`

Good: `errors.Wrap(err, "some context")`
Less good: `errors.Wrap(err, "Some context")`

This aligns the code with the prevalent convention valid throughout
the project. The reason for adjusting this now is that log entries
will soon receive additional scrutiny from users in the shape of
documentation. We want the UX to be consistent throughout all logging
and error outputs.

A linter may be introduced later to enforce this convention.

For context, why we use lowercase:

Both log and error messages are always reported to users in a text
format after a colon, for example, `file.go:123: this is the log
message`. 
In English, random capital letters are not allowed in the
middle of sentences (unlike in German) and distract from the flow of
reading.

This is particularly important for error objects, which can receive an
arbitrary amount of text prefixes using `errors.Wrap()` in
callers. Additionally, error objects can be included inside a larger
sentence, for example `while handling "this is my error"`. Here, as
well, capitals are not welcome after an opening quote in the middle of
a sentence.

Release note: None