### PR TITLE
Check value of gc.ttlseconds before rendering to prevent TypeError

### DIFF
--- a/pkg/ui/src/views/shared/components/sql/highlight.tsx
+++ b/pkg/ui/src/views/shared/components/sql/highlight.tsx
@@ -10,7 +10,6 @@
 
 import * as hljs from "highlight.js";
 import React from "react";
-import get from "lodash/get";
 import classNames from "classnames/bind";
 import styles from "./sqlhighlight.module.styl";
 import { SqlBoxProps } from "./box";
@@ -49,9 +48,13 @@ export class Highlight extends React.Component<SqlBoxProps> {
         <span className="hljs-label">range_max_bytes = </span>
         <span className="hljs-built_in">{`${String(zoneConfig.range_max_bytes)},`}</span>
         <br />
-        <span className="hljs-label">gc.ttlseconds = </span>
-        <span className="hljs-built_in">{`${get(zoneConfig, "gc.ttl_seconds", null)},`}</span>
-        <br />
+        {zoneConfig.gc?.ttl_seconds && (
+          <>
+            <span className="hljs-label">gc.ttlseconds = </span>
+            <span className="hljs-built_in">{`${zoneConfig.gc.ttl_seconds},`}</span>
+            <br />
+          </>
+        )}
         <span className="hljs-label">num_replicas = </span>
         <span className="hljs-built_in">{`${zoneConfig.num_replicas},`}</span>
         <br />

--- a/pkg/ui/src/views/shared/components/sql/highlight.tsx
+++ b/pkg/ui/src/views/shared/components/sql/highlight.tsx
@@ -10,6 +10,7 @@
 
 import * as hljs from "highlight.js";
 import React from "react";
+import get from "lodash/get";
 import classNames from "classnames/bind";
 import styles from "./sqlhighlight.module.styl";
 import { SqlBoxProps } from "./box";
@@ -49,7 +50,7 @@ export class Highlight extends React.Component<SqlBoxProps> {
         <span className="hljs-built_in">{`${String(zoneConfig.range_max_bytes)},`}</span>
         <br />
         <span className="hljs-label">gc.ttlseconds = </span>
-        <span className="hljs-built_in">{`${zoneConfig.gc.ttl_seconds},`}</span>
+        <span className="hljs-built_in">{`${get(zoneConfig, "gc.ttl_seconds", null)},`}</span>
         <br />
         <span className="hljs-label">num_replicas = </span>
         <span className="hljs-built_in">{`${zoneConfig.num_replicas},`}</span>


### PR DESCRIPTION
In a reported case from a customer, `zone_config.gc` is undefined and
accessing `ttl_seconds` on a null threw an error that stopped page
rendering.

```
bundle.js:49 TypeError: Cannot read property 'ttl_seconds' of null
    at t.e.renderZone (bundle.js:83)
    at t.value (bundle.js:83)
    at Xi (bundle.js:49)
    at $i (bundle.js:49)
    at Ts (bundle.js:49)
    at Cc (bundle.js:49)
    at Pc (bundle.js:49)
    at wc (bundle.js:49)
    at bundle.js:49
    at t.unstable_runWithPriority (bundle.js:57)
```

I'm adding a lodash/get call here with `null` as a default return to
prevent a TypeError. This is generally a good idea whenever you are
accessing anything that could be undefined in javascript.

