### PR TITLE
roachtest: skip acceptance/version-upgrade

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -64,6 +64,7 @@ func registerAcceptance(r *testRegistry) {
 			// to head after 19.2 fails.
 			minVersion: "v19.2.0",
 			timeout:    30 * time.Minute,
+			skip:       "https://github.com/cockroachdb/cockroach/issues/52627",
 		},
 	}
 	tags := []string{"default", "quick"}


### PR DESCRIPTION
This has been failing CI, and is being tracked in #52627. This is a
pretty critical test to have so we'll be addressing it shortly.

Release note: None