### PR TITLE
sql: support alter database owner to

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1116,6 +1116,7 @@ alter_sequence_stmt ::=
 alter_database_stmt ::=
 	alter_rename_database_stmt
 	| alter_zone_database_stmt
+	| alter_database_owner
 
 alter_range_stmt ::=
 	alter_zone_range_stmt
@@ -1526,6 +1527,9 @@ alter_rename_database_stmt ::=
 
 alter_zone_database_stmt ::=
 	'ALTER' 'DATABASE' database_name set_zone_config
+
+alter_database_owner ::=
+	'ALTER' 'DATABASE' database_name 'OWNER' 'TO' role_spec
 
 alter_zone_range_stmt ::=
 	'ALTER' 'RANGE' zone_name set_zone_config
@@ -1943,6 +1947,11 @@ alter_index_cmds ::=
 
 sequence_option_list ::=
 	( sequence_option_elem ) ( ( sequence_option_elem ) )*
+
+role_spec ::=
+	non_reserved_word_or_sconst
+	| 'CURRENT_USER'
+	| 'SESSION_USER'
 
 role_option ::=
 	'CREATEROLE'
@@ -2501,11 +2510,6 @@ opt_validate_behavior ::=
 audit_mode ::=
 	'READ' 'WRITE'
 	| 'OFF'
-
-role_spec ::=
-	non_reserved_word_or_sconst
-	| 'CURRENT_USER'
-	| 'SESSION_USER'
 
 signed_iconst64 ::=
 	signed_iconst

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1,0 +1,65 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+type alterDatabaseOwnerNode struct {
+	n    *tree.AlterDatabaseOwner
+	desc *sqlbase.MutableDatabaseDescriptor
+}
+
+// AlterDatabaseOwner transforms a tree.AlterDatabaseOwner into a plan node.
+func (p *planner) AlterDatabaseOwner(
+	ctx context.Context, n *tree.AlterDatabaseOwner,
+) (planNode, error) {
+	dbDesc, err := p.ResolveMutableDatabaseDescriptor(ctx, n.Name.String(), true)
+	if err != nil {
+		return nil, err
+	}
+	privs := dbDesc.GetPrivileges()
+
+	hasOwnership, err := p.HasOwnership(ctx, dbDesc)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.checkCanAlterToNewOwner(ctx, dbDesc, privs, n.Owner, hasOwnership); err != nil {
+		return nil, err
+	}
+
+	// To alter the owner, the user also has to have CREATEDB privilege.
+	// TODO(richardjcai): Add this check once #52576 is implemented.
+
+	// If the owner we want to set to is the current owner, do a no-op.
+	if n.Owner == privs.Owner {
+		return nil, nil
+	}
+	return &alterDatabaseOwnerNode{n: n, desc: dbDesc}, nil
+}
+
+func (n *alterDatabaseOwnerNode) startExec(params runParams) error {
+	n.desc.GetPrivileges().SetOwner(n.n.Owner)
+	return params.p.writeNonDropDatabaseChange(
+		params.ctx,
+		n.desc,
+		tree.AsStringWithFQNames(n.n, params.Ann()),
+	)
+}
+
+func (n *alterDatabaseOwnerNode) Next(runParams) (bool, error) { return false, nil }
+func (n *alterDatabaseOwnerNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *alterDatabaseOwnerNode) Close(context.Context)        {}

--- a/pkg/sql/logictest/testdata/logic_test/alter_database_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_database_owner
@@ -1,0 +1,63 @@
+statement ok
+CREATE DATABASE d
+
+# Ensure user must exist for set owner.
+statement error pq: role/user "fake_user" does not exist
+ALTER DATABASE d OWNER TO fake_user
+
+# Ensure the current user is a member of the role we're setting to.
+statement error pq: must be member of role "testuser"
+ALTER DATABASE d OWNER TO testuser
+
+user testuser
+
+# Ensure the user has to be an owner alter the owner.
+statement error pq: must be owner of database d
+ALTER DATABASE d OWNER TO testuser
+
+user root
+
+statement ok
+GRANT testuser TO root
+
+# testuser satisfies all the requirements to become an owner.
+statement ok
+ALTER DATABASE d OWNER TO testuser
+
+statement ok
+CREATE USER testuser2
+
+# setup to allow testuser2 as a member of testuser to alter the owner.
+statement ok
+REVOKE testuser FROM root
+
+statement ok
+GRANT testuser TO testuser2
+
+statement ok
+GRANT root TO testuser
+
+user testuser2
+
+# testuser2 should be able to alter the owner since it is a member of testuser.
+statement ok
+ALTER DATABASE d OWNER TO root
+
+# set the owner back to testuser.
+
+user root
+
+statement ok
+REVOKE root FROM testuser
+
+statement ok
+GRANT testuser TO root
+
+statement ok
+ALTER DATABASE d OWNER TO testuser
+
+user testuser
+
+# Ensure testuser is owner by dropping the database.
+statement ok
+DROP DATABASE d

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -49,6 +49,8 @@ func buildOpaque(
 	var plan planNode
 	var err error
 	switch n := stmt.(type) {
+	case *tree.AlterDatabaseOwner:
+		plan, err = p.AlterDatabaseOwner(ctx, n)
 	case *tree.AlterIndex:
 		plan, err = p.AlterIndex(ctx, n)
 	case *tree.AlterSchema:
@@ -177,6 +179,7 @@ func buildOpaque(
 
 func init() {
 	for _, stmt := range []tree.Statement{
+		&tree.AlterDatabaseOwner{},
 		&tree.AlterIndex{},
 		&tree.AlterSchema{},
 		&tree.AlterTable{},

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1268,6 +1268,8 @@ func TestParse(t *testing.T) {
 		{`ALTER DATABASE a RENAME TO b`},
 		{`EXPLAIN ALTER DATABASE a RENAME TO b`},
 
+		{`ALTER DATABASE a OWNER TO foo`},
+
 		{`ALTER INDEX b RENAME TO b`},
 		{`EXPLAIN ALTER INDEX b RENAME TO b`},
 		{`ALTER INDEX a@b RENAME TO b`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -715,6 +715,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 // ALTER DATABASE
 %type <tree.Statement> alter_rename_database_stmt
 %type <tree.Statement> alter_zone_database_stmt
+%type <tree.Statement> alter_database_owner
 
 // ALTER INDEX
 %type <tree.Statement> alter_oneindex_stmt
@@ -1380,13 +1381,21 @@ alter_sequence_options_stmt:
 // %Category: DDL
 // %Text:
 // ALTER DATABASE <name> RENAME TO <newname>
+// ALTER DATABASE <name> OWNER TO <newowner>
 // %SeeAlso: WEBDOCS/alter-database.html
 alter_database_stmt:
   alter_rename_database_stmt
 |  alter_zone_database_stmt
+|  alter_database_owner
 // ALTER DATABASE has its error help token here because the ALTER DATABASE
 // prefix is spread over multiple non-terminals.
 | ALTER DATABASE error // SHOW HELP: ALTER DATABASE
+
+alter_database_owner:
+	ALTER DATABASE database_name OWNER TO role_spec
+	{
+		$$.val = &tree.AlterDatabaseOwner{Name: tree.Name($3), Owner: $6}
+	}
 
 // %Help: ALTER RANGE - change the parameters of a range
 // %Category: DDL

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -69,4 +69,7 @@ type (
 	// TableNames is provided for convenience and to make the interface
 	// definitions below more intuitive.
 	TableNames = tree.TableNames
+	// MutableSchemaDescriptor is provided for convenience and to make the
+	// interface definitions below more intuitive.
+	MutableSchemaDescriptor = sqlbase.MutableSchemaDescriptor
 )

--- a/pkg/sql/sem/tree/alter_database.go
+++ b/pkg/sql/sem/tree/alter_database.go
@@ -1,0 +1,25 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// AlterDatabaseOwner represents a ALTER DATABASE OWNER TO statement.
+type AlterDatabaseOwner struct {
+	Name  Name
+	Owner string
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterDatabaseOwner) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER DATABASE ")
+	ctx.FormatNode(&node.Name)
+	ctx.WriteString(" OWNER TO ")
+	ctx.FormatNameP(&node.Owner)
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -171,6 +171,14 @@ var _ CCLOnlyStatement = &Export{}
 var _ CCLOnlyStatement = &ScheduledBackup{}
 
 // StatementType implements the Statement interface.
+func (*AlterDatabaseOwner) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*AlterDatabaseOwner) StatementTag() string { return "ALTER DATABSE OWNER" }
+
+func (*AlterDatabaseOwner) hiddenFromShowQueries() {}
+
+// StatementType implements the Statement interface.
 func (*AlterIndex) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -977,6 +985,7 @@ func (*ValuesClause) StatementType() StatementType { return Rows }
 func (*ValuesClause) StatementTag() string { return "VALUES" }
 
 func (n *AlterIndex) String() string                     { return AsString(n) }
+func (n *AlterDatabaseOwner) String() string             { return AsString(n) }
 func (n *AlterSchema) String() string                    { return AsString(n) }
 func (n *AlterTable) String() string                     { return AsString(n) }
 func (n *AlterTableCmds) String() string                 { return AsString(n) }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -335,6 +335,7 @@ func nodeName(plan planNode) string {
 // strings are constant and not precomputed so that the type names can
 // be changed without changing the output of "EXPLAIN".
 var planNodeNames = map[reflect.Type]string{
+	reflect.TypeOf(&alterDatabaseOwnerNode{}):      "alter database owner",
 	reflect.TypeOf(&alterIndexNode{}):              "alter index",
 	reflect.TypeOf(&alterSequenceNode{}):           "alter sequence",
 	reflect.TypeOf(&alterSchemaNode{}):             "alter schema",


### PR DESCRIPTION
Release note (sql change): Support ALTER DATABASE OWNER TO
The command changes the owner of a database.

The user must be an explicit owner of the database to run the
command.
The user must also be a member of the new owner role directly or
indirectly.

Fixes https://github.com/cockroachdb/cockroach/issues/52019