### PR TITLE
Makefile: bump lint timeout to 30m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ TESTCONFIG :=
 SUBTESTS :=
 
 ## Test timeout to use for the linter.
-LINTTIMEOUT := 20m
+LINTTIMEOUT := 30m
 
 ## Test timeout to use for regular tests.
 TESTTIMEOUT := 30m


### PR DESCRIPTION
We have too much code that the linter needs more than 20 minutes these
days (the ones that don't take ~19). Better make that 30.

Resolves #52264.

Release note: None