### PR TITLE
sqlbase: deep copy JSON during decoding

### DIFF
--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -611,6 +611,10 @@ func DecodeUntaggedDatum(a *DatumAlloc, t *types.T, buf []byte) (tree.Datum, []b
 		if err != nil {
 			return nil, b, err
 		}
+		// We copy the byte buffer here, because the JSON decoding is lazy, and we
+		// do not want to hang on to the backing byte buffer, which might be an
+		// entire KV batch.
+		data = append([]byte{}, data...)
 		j, err := json.FromEncoding(data)
 		if err != nil {
 			return nil, b, err


### PR DESCRIPTION
Decoding JSON is lazy: the work is deferred by storing a handle onto the
encoded bytes of the JSON. Currently, those encoded bytes are not copied
out of the backing KV batch. This makes it possible for a single DJSON
object to retain up to 10 megabytes of backing KV data, which is
problematic for memory accounting: it's not possible for our memory
accounting system to notice this fact, which can cause severe
underaccounting.

This PR changes JSON decoding to make a fresh allocation and copy of the
bytes before instantiating the lazy DJSON object. This will reduce the
amount of retained memory at the expense of slightly reducing JSON scan
performance.

Release note (sql change): reduce memory used by scans of tables
containing JSON data.