### PR TITLE
sql: owning a schema gives privilege to drop tables in schema

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -890,6 +890,7 @@ func (tc *Collection) ResolveSchemaByID(
 
 	// If this collection is attached to a session and the session has created
 	// a temporary schema, then check if the schema ID matches.
+	// This check doesn't work after switching databases. Issue #53163.
 	if tc.sessionData != nil && tc.sessionData.TemporarySchemaID == uint32(schemaID) {
 		return catalog.ResolvedSchema{
 			Kind: catalog.SchemaTemporary,

--- a/pkg/sql/drop_cascade.go
+++ b/pkg/sql/drop_cascade.go
@@ -100,7 +100,7 @@ func (d *dropCascadeState) resolveCollectedObjects(
 						" dropped or made public before dropping database %s",
 					objName.FQString(), tree.AsString((*tree.Name)(&dbName)))
 			}
-			if err := p.prepareDropWithTableDesc(ctx, tbDesc); err != nil {
+			if err := p.canDropTable(ctx, tbDesc); err != nil {
 				return err
 			}
 			// Recursively check permissions on all dependent views, since some may

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -56,3 +56,22 @@ CREATE TABLE a (id INT PRIMARY KEY)
 query I
 SELECT * FROM a
 ----
+
+user testuser
+
+statement ok
+SET experimental_enable_user_defined_schemas = true
+
+statement ok
+CREATE SCHEMA s
+
+user root
+
+statement ok
+CREATE TABLE s.t()
+
+user testuser
+
+# Being the owner of schema s should allow testuser to drop table s.t.
+statement ok
+DROP TABLE s.t


### PR DESCRIPTION
sql: owning a schema gives privilege to drop tables in schema

Release note (sql change): Schema owners can drop tables inside
the schema without explicit DROP privilege on the table.

Fixes #51931