### PR TITLE
bulkio: Add scheduled jobs monitoring metrics.

### DIFF
--- a/pkg/jobs/executor_impl.go
+++ b/pkg/jobs/executor_impl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/types"
 )
@@ -75,6 +76,11 @@ func (e *inlineScheduledJobExecutor) NotifyJobTermination(
 	if jobStatus == StatusFailed {
 		DefaultHandleFailedRun(schedule, jobID, nil)
 	}
+	return nil
+}
+
+// Metrics implements ScheduledJobExecutor interface
+func (e *inlineScheduledJobExecutor) Metrics() metric.Struct {
 	return nil
 }
 

--- a/pkg/jobs/schedule_metrics.go
+++ b/pkg/jobs/schedule_metrics.go
@@ -1,0 +1,124 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package jobs
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
+
+// ExecutorMetrics describes metrics related to scheduled
+// job executor operations.
+type ExecutorMetrics struct {
+	NumStarted   *metric.Counter
+	NumSucceeded *metric.Counter
+	NumFailed    *metric.Counter
+}
+
+var _ metric.Struct = &ExecutorMetrics{}
+
+// MetricStruct implements metric.Struct interface
+func (m *ExecutorMetrics) MetricStruct() {}
+
+// SchedulerMetrics are metrics specific to job scheduler daemon.
+type SchedulerMetrics struct {
+	// Number of schedules that were ready to execute.
+	ReadyToRun *metric.Gauge
+	// Number of scheduled jobs started.
+	NumStarted *metric.Gauge
+	// Number of jobs started by schedules that are currently running.
+	NumRunning *metric.Gauge
+	// Number of schedules rescheduled due to SKIP policy.
+	RescheduleSkip *metric.Gauge
+	// Number of schedules rescheduled due to WAIT policy.
+	RescheduleWait *metric.Gauge
+	// Number of schedules that could not be processed due to an error.
+	NumBadSchedules *metric.Counter
+}
+
+// MakeSchedulerMetrics returns metrics for scheduled job daemon.
+func MakeSchedulerMetrics() SchedulerMetrics {
+	return SchedulerMetrics{
+		ReadyToRun: metric.NewGauge(metric.Metadata{
+			Name:        "schedules.round.schedules-ready-to-run",
+			Help:        "The number of jobs ready to execute",
+			Measurement: "Schedules",
+			Unit:        metric.Unit_COUNT,
+		}),
+
+		NumRunning: metric.NewGauge(metric.Metadata{
+			Name:        "schedules.round.num-jobs-running",
+			Help:        "The number of jobs started by schedules that are currently running",
+			Measurement: "Jobs",
+			Unit:        metric.Unit_COUNT,
+		}),
+
+		NumStarted: metric.NewGauge(metric.Metadata{
+			Name:        "schedules.round.jobs-started",
+			Help:        "The number of jobs started",
+			Measurement: "Jobs",
+			Unit:        metric.Unit_COUNT,
+		}),
+
+		RescheduleSkip: metric.NewGauge(metric.Metadata{
+			Name:        "schedules.round.reschedule-skip",
+			Help:        "The number of schedules rescheduled due to SKIP policy",
+			Measurement: "Schedules",
+			Unit:        metric.Unit_COUNT,
+		}),
+
+		RescheduleWait: metric.NewGauge(metric.Metadata{
+			Name:        "schedules.round.reschedule-wait",
+			Help:        "The number of schedules rescheduled due to WAIT policy",
+			Measurement: "Schedules",
+			Unit:        metric.Unit_COUNT,
+		}),
+
+		NumBadSchedules: metric.NewCounter(metric.Metadata{
+			Name:        "schedules.corrupt",
+			Help:        "Number of corrupt/bad schedules",
+			Measurement: "Schedules",
+			Unit:        metric.Unit_COUNT,
+		}),
+	}
+}
+
+// MetricStruct implements metric.Struct interface
+func (m *SchedulerMetrics) MetricStruct() {}
+
+var _ metric.Struct = &SchedulerMetrics{}
+
+// MakeExecutorMetrics creates metrics for scheduled job executor.
+func MakeExecutorMetrics(name string) ExecutorMetrics {
+	return ExecutorMetrics{
+		NumStarted: metric.NewCounter(metric.Metadata{
+			Name:        fmt.Sprintf("schedules.%s.started", name),
+			Help:        fmt.Sprintf("Number of %s jobs started", name),
+			Measurement: "Jobs",
+			Unit:        metric.Unit_COUNT,
+		}),
+
+		NumSucceeded: metric.NewCounter(metric.Metadata{
+			Name:        fmt.Sprintf("schedules.%s.succeeded", name),
+			Help:        fmt.Sprintf("Number of %s jobs succeeded", name),
+			Measurement: "Jobs",
+			Unit:        metric.Unit_COUNT,
+		}),
+
+		NumFailed: metric.NewCounter(metric.Metadata{
+			Name:        fmt.Sprintf("schedules.%s.failed", name),
+			Help:        fmt.Sprintf("Number of %s jobs failed", name),
+			Measurement: "Entries",
+			Unit:        metric.Unit_COUNT,
+		}),
+	}
+}

--- a/pkg/jobs/scheduled_job_executor.go
+++ b/pkg/jobs/scheduled_job_executor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/errors"
 )
 
@@ -45,6 +46,9 @@ type ScheduledJobExecutor interface {
 		schedule *ScheduledJob,
 		txn *kv.Txn,
 	) error
+
+	// Metrics returns optional metric.Struct object for this executor.
+	Metrics() metric.Struct
 }
 
 // ScheduledJobExecutorFactory is a callback to create a ScheduledJobExecutor.

--- a/pkg/jobs/scheduled_job_executor_test.go
+++ b/pkg/jobs/scheduled_job_executor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,6 +42,10 @@ func (s *statusTrackingExecutor) NotifyJobTermination(
 	ctx context.Context, jobID int64, jobStatus Status, schedule *ScheduledJob, txn *kv.Txn,
 ) error {
 	s.counts[jobStatus]++
+	return nil
+}
+
+func (s *statusTrackingExecutor) Metrics() metric.Struct {
 	return nil
 }
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -90,6 +90,7 @@ type sqlServer struct {
 	sqlMemMetrics           sql.MemoryMetrics
 	stmtDiagnosticsRegistry *stmtdiagnostics.Registry
 	sqlLivenessProvider     sqlliveness.Provider
+	metricsRegistry         *metric.Registry
 }
 
 // sqlServerOptionalKVArgs are the arguments supplied to newSQLServer which are
@@ -617,6 +618,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		sqlMemMetrics:           sqlMemMetrics,
 		stmtDiagnosticsRegistry: stmtDiagnosticsRegistry,
 		sqlLivenessProvider:     cfg.sqlLivenessProvider,
+		metricsRegistry:         cfg.registry,
 	}, nil
 }
 
@@ -747,6 +749,7 @@ func (s *sqlServer) start(
 	jobs.StartJobSchedulerDaemon(
 		ctx,
 		stopper,
+		s.metricsRegistry,
 		&scheduledjobs.JobExecutionConfig{
 			Settings:         s.execCfg.Settings,
 			InternalExecutor: s.internalExecutor,

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -905,8 +905,8 @@ func TestChartCatalogGen(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Ensure each of the 7 constant sections of the chart catalog exist.
-	if len(chartCatalog) != 7 {
+	// Ensure each of the 8 constant sections of the chart catalog exist.
+	if len(chartCatalog) != 8 {
 		t.Fatal("Chart catalog failed to generate.")
 	}
 

--- a/pkg/ts/catalog/catalog_generator.go
+++ b/pkg/ts/catalog/catalog_generator.go
@@ -44,6 +44,7 @@ const (
 	ReplicationLayer   = `Replication Layer`
 	StorageLayer       = `Storage Layer`
 	Timeseries         = `Timeseries`
+	Jobs               = `Jobs`
 )
 
 // sectionDescription describes either a section or subsection of the chart.
@@ -190,6 +191,13 @@ var chartCatalog = []ChartSection{
 		power the very charts you\'re using, among other things.`,
 		Level: 0,
 	},
+	{
+		Title:           Jobs,
+		LongTitle:       Jobs,
+		CollectionTitle: "jobs-all",
+		Description:     `Your cluster executes various background jobs, as well as scheduled jobs`,
+		Level:           0,
+	},
 }
 
 var catalogGenerated = false
@@ -204,6 +212,7 @@ var catalogKey = map[string]int{
 	ReplicationLayer:   4,
 	StorageLayer:       5,
 	Timeseries:         6,
+	Jobs:               7,
 }
 
 // unitsKey converts between metric.Unit and catalog.AxisUnits which is

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2120,4 +2120,44 @@ var charts = []sectionDescription{
 			},
 		},
 	},
+	{
+		Organization: [][]string{{Jobs, "Schedules", "Daemon"}},
+		Charts: []chartDescription{
+			{
+				Title: "Round",
+				Metrics: []string{
+
+					"schedules.round.schedules-ready-to-run",
+					"schedules.round.reschedule-skip",
+					"schedules.round.reschedule-wait",
+					"schedules.round.jobs-started",
+					"schedules.round.num-jobs-running",
+				},
+				AxisLabel: "Count",
+			},
+			{
+				Title: "Total",
+				Metrics: []string{
+					"schedules.corrupt",
+					"schedules.total.started",
+					"schedules.total.succeeded",
+					"schedules.total.failed",
+				},
+				AxisLabel: "Count",
+			},
+		},
+	},
+	{
+		Organization: [][]string{{Jobs, "Schedules", "Backup"}},
+		Charts: []chartDescription{
+			{
+				Title: "Counts",
+				Metrics: []string{
+					"schedules.BACKUP.started",
+					"schedules.BACKUP.succeeded",
+					"schedules.BACKUP.failed",
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
Informs #51847 

Add scheduled jobs monitoring metrics.

The scheduler daemon exports metrics related to each
execution loop, as well as the total counts on the number
of schedules executed, succeeded or failed.
Each executor may also optionally export executor specific metrics.

In addition, improve logging when executing schedules.

Release Notes: None