### PR TITLE
rowexec,distsql: fix a couple of things around aggregators

### DIFF
--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -162,18 +162,22 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 						for j := range aggFnInputTypes {
 							aggFnInputTypes[j] = sqlbase.RandType(rng)
 						}
-						// There is a special case for string_agg when at least
-						// one of the arguments is an empty tuple. Such case
-						// passes GetAggregateInfo check below, but it is
-						// actually invalid, and during normal execution it is
-						// caught during type-checking. However, we don't want
-						// to do fully-fledged type checking, so we hard-code
-						// an exception here.
+						// There is a special case for concat_agg, string_agg,
+						// and st_makeline when at least one argument is a
+						// tuple. Such cases pass GetAggregateInfo check below,
+						// but they are actually invalid, and during normal
+						// execution it is caught during type-checking.
+						// However, we don't want to do fully-fledged type
+						// checking, so we hard-code an exception here.
 						invalid := false
-						if aggFn == execinfrapb.AggregatorSpec_STRING_AGG {
+						switch aggFn {
+						case execinfrapb.AggregatorSpec_CONCAT_AGG,
+							execinfrapb.AggregatorSpec_STRING_AGG,
+							execinfrapb.AggregatorSpec_ST_MAKELINE:
 							for _, typ := range aggFnInputTypes {
-								if typ.Family() == types.TupleFamily && len(typ.TupleContents()) == 0 {
+								if typ.Family() == types.TupleFamily {
 									invalid = true
+									break
 								}
 							}
 						}

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -555,9 +555,12 @@ func (ag *orderedAggregator) accumulateRows() (
 	return aggEmittingRows, nil, nil
 }
 
+// getAggResults returns the new aggregatorState and the results from the
+// bucket. The bucket is closed.
 func (ag *aggregatorBase) getAggResults(
 	bucket aggregateFuncs,
 ) (aggregatorState, sqlbase.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	defer bucket.close(ag.Ctx)
 	for i, b := range bucket {
 		result, err := b.Result()
 		if err != nil {
@@ -570,7 +573,6 @@ func (ag *aggregatorBase) getAggResults(
 		}
 		ag.row[i] = sqlbase.DatumToEncDatum(ag.outputTypes[i], result)
 	}
-	bucket.close(ag.Ctx)
 
 	if outRow := ag.ProcessRowHelper(ag.row); outRow != nil {
 		return aggEmittingRows, outRow, nil
@@ -640,7 +642,7 @@ func (ag *hashAggregator) emitRow() (
 	// NOTE: accounting for the memory under aggregate builtins in the bucket
 	// is updated in getAggResults (the bucket will be closed), however, we
 	// choose to not reduce our estimate of the map's internal footprint
-	// because it is error-prone to estimate the new footprint (we don't
+	// because it is error-prone to estimate the new footprint (we don't know
 	// whether and when Go runtime will release some of the underlying memory).
 	// This behavior is ok, though, since actual usage of buckets will be lower
 	// than what we accounted for - in the worst case, the query might hit a


### PR DESCRIPTION
**rowexec: fix closing of aggregator bucket in case of an error**

Previously, the bucket of aggregate functions wouldn't get properly
closed if an aggregate function returned an error on `Result` call. Now
this is fixed.

Release note: None

**distsql: fix TestAggregatorAgainstProcessor**

In `TestAggregatorAgainstProcessor` we generate input types randomly
relying on `execinfrapb.GetAggregateInfo` function to perform the
"type-checking". That function, however, can have "false negative" for
several aggregate functions when a tuple is chosen as an input type, so
we have special handling for those cases.

Fixes: #52742.

Release note: None