### PR TITLE
kvserver: deflake acceptance/version-upgrade

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -64,7 +64,6 @@ func registerAcceptance(r *testRegistry) {
 			// to head after 19.2 fails.
 			minVersion: "v19.2.0",
 			timeout:    30 * time.Minute,
-			skip:       "https://github.com/cockroachdb/cockroach/issues/52627",
 		},
 	}
 	tags := []string{"default", "quick"}

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -130,6 +130,7 @@ func (r *Replica) CheckConsistency(
 
 	if minoritySHA != "" {
 		var buf bytes.Buffer
+		_, _ = fmt.Fprintf(&buf, "\n") // New line to align checksums below.
 		for sha, idxs := range shaToIdxs {
 			minority := ""
 			if sha == minoritySHA {

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -818,8 +818,8 @@ func (r *Replica) evaluateProposal(
 		}
 
 		// If the cluster version doesn't track abort span size in MVCCStats, we
-		// zero it out to prevent inconsistencies in MVCCStats across nodes in a possibly
-		// mixed-version cluster.
+		// zero it out to prevent inconsistencies in MVCCStats across nodes in a
+		// possibly mixed-version cluster.
 		if !r.ClusterSettings().Version.IsActive(ctx, clusterversion.VersionAbortSpanBytes) {
 			res.Replicated.Delta.AbortSpanBytes = 0
 		}


### PR DESCRIPTION
Fixes #52627.

In #50938 we were careful to not transmit non-zero MVCCStats through the
replica proposal codepaths, but there seems to have been another
instance where we end up transmitting MVCCStats across replicas - during
splits. We similarly zero AbortSpanBytes out when VersionAbortSpanBytes
is inactive to avoid replica divergence.

Release note: None