### PR TITLE
distsql: skip TestAggregatorAgainstProcessor

### DIFF
--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -13,6 +13,7 @@ package distsql
 import (
 	"context"
 	"fmt"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"math/rand"
 	"sort"
 	"strings"
@@ -83,6 +84,8 @@ func TestAggregateFuncToNumArguments(t *testing.T) {
 
 func TestAggregatorAgainstProcessor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 52742)
+
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())


### PR DESCRIPTION
This is holding up CI. #52742.

Release note: None