### PR TITLE
backupccl: add SHOW BACKUPS IN Y and SHOW BACKUP x IN Y

### DIFF
--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -1,3 +1,4 @@
 show_backup_stmt ::=
 	'SHOW' 'BACKUP' location opt_with_options
+	| 'SHOW' 'BACKUP' location 'IN' location opt_with_options
 	| 'SHOW' 'BACKUP' 'SCHEMAS' location opt_with_options

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -530,7 +530,9 @@ use_stmt ::=
 	'USE' var_value
 
 show_backup_stmt ::=
-	'SHOW' 'BACKUP' string_or_placeholder opt_with_options
+	'SHOW' 'BACKUPS' 'IN' string_or_placeholder
+	| 'SHOW' 'BACKUP' string_or_placeholder opt_with_options
+	| 'SHOW' 'BACKUP' string_or_placeholder 'IN' string_or_placeholder opt_with_options
 	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder opt_with_options
 
 show_columns_stmt ::=
@@ -705,6 +707,7 @@ unreserved_keyword ::=
 	| 'AUTOMATIC'
 	| 'AUTHORIZATION'
 	| 'BACKUP'
+	| 'BACKUPS'
 	| 'BEFORE'
 	| 'BEGIN'
 	| 'BINARY'

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -10,6 +10,8 @@ package backupccl
 
 import (
 	"context"
+	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -50,9 +52,21 @@ func showBackupPlanHook(
 		return nil, nil, nil, false, err
 	}
 
+	if backup.Path == nil && backup.InCollection != nil {
+		return showBackupsInCollectionPlanHook(ctx, backup, p)
+	}
+
 	toFn, err := p.TypeAsString(ctx, backup.Path, "SHOW BACKUP")
 	if err != nil {
 		return nil, nil, nil, false, err
+	}
+
+	var inColFn func() (string, error)
+	if backup.InCollection != nil {
+		inColFn, err = p.TypeAsString(ctx, backup.InCollection, "SHOW BACKUP")
+		if err != nil {
+			return nil, nil, nil, false, err
+		}
 	}
 
 	expected := map[string]sql.KVStringOptValidate{
@@ -87,6 +101,19 @@ func showBackupPlanHook(
 		str, err := toFn()
 		if err != nil {
 			return err
+		}
+
+		if inColFn != nil {
+			collection, err := inColFn()
+			if err != nil {
+				return err
+			}
+			parsed, err := url.Parse(collection)
+			if err != nil {
+				return err
+			}
+			parsed.Path = path.Join(parsed.Path, str)
+			str = parsed.String()
 		}
 
 		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, str, p.User())
@@ -378,6 +405,42 @@ var backupShowerFiles = backupShower{
 		}
 		return rows, nil
 	},
+}
+
+// showBackupPlanHook implements PlanHookFn.
+func showBackupsInCollectionPlanHook(
+	ctx context.Context, backup *tree.ShowBackup, p sql.PlanHookState,
+) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, bool, error) {
+
+	collectionFn, err := p.TypeAsString(ctx, backup.InCollection, "SHOW BACKUPS")
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+
+	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+		ctx, span := tracing.ChildSpan(ctx, backup.StatementTag())
+		defer tracing.FinishSpan(span)
+
+		collection, err := collectionFn()
+		if err != nil {
+			return err
+		}
+
+		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, collection, p.User())
+		if err != nil {
+			return errors.Wrapf(err, "connect to external storage")
+		}
+		defer store.Close()
+		res, err := store.ListFiles(ctx, "/*/*/BACKUP")
+		if err != nil {
+			return err
+		}
+		for _, i := range res {
+			resultsCh <- tree.Datums{tree.NewDString(strings.TrimSuffix(i, "/BACKUP"))}
+		}
+		return nil
+	}
+	return fn, sqlbase.ResultColumns{{Name: "path", Typ: types.String}}, nil, false, nil
 }
 
 func init() {

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1512,6 +1512,11 @@ func TestParse(t *testing.T) {
 		{`SHOW BACKUP FILES 'bar'`},
 		{`SHOW BACKUP FILES 'bar' WITH foo = 'bar'`},
 
+		{`SHOW BACKUPS IN 'bar'`},
+		{`SHOW BACKUPS IN $1`},
+		{`SHOW BACKUP 'foo' IN 'bar'`},
+		{`SHOW BACKUP $1 IN $2 WITH foo = 'bar'`},
+
 		{`BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'`},
 		{`BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'`},
 
@@ -2249,10 +2254,10 @@ $function$`,
 		{`BACKUP foo TO 'bar' WITH OPTIONS (detached, KMS = ('foo', 'bar'), revision_history)`,
 			`BACKUP TABLE foo TO 'bar' WITH revision_history, detached, kms=('foo', 'bar')`},
 
-		{`RESTORE foo FROM 'bar' WITH OPTIONS (encryption_passphrase='secret', into_db='baz', 
+		{`RESTORE foo FROM 'bar' WITH OPTIONS (encryption_passphrase='secret', into_db='baz',
 skip_missing_foreign_keys, skip_missing_sequences, skip_missing_sequence_owners, skip_missing_views, detached)`,
 			`RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase='secret', into_db='baz', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached`},
-		{`RESTORE foo FROM 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', INTO_DB=baz, 
+		{`RESTORE foo FROM 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', INTO_DB=baz,
 SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS, SKIP_MISSING_VIEWS`,
 			`RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase='secret', into_db='baz', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views`},
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -568,7 +568,7 @@ func (u *sqlSymUnion) executorType() tree.ScheduledJobExecutorType {
 %token <str> ALL ALTER ALWAYS ANALYSE ANALYZE AND AND_AND ANY ANNOTATE_TYPE ARRAY AS ASC
 %token <str> ASYMMETRIC AT ATTRIBUTE AUTHORIZATION AUTOMATIC
 
-%token <str> BACKUP BEFORE BEGIN BETWEEN BIGINT BIGSERIAL BINARY BIT
+%token <str> BACKUP BACKUPS BEFORE BEGIN BETWEEN BIGINT BIGSERIAL BINARY BIT
 %token <str> BUCKET_COUNT
 %token <str> BOOLEAN BOTH BOX2D BUNDLE BY
 
@@ -4204,12 +4204,27 @@ show_histogram_stmt:
 // %Text: SHOW BACKUP [SCHEMAS|FILES|RANGES] <location>
 // %SeeAlso: WEBDOCS/show-backup.html
 show_backup_stmt:
-  SHOW BACKUP string_or_placeholder opt_with_options
+  SHOW BACKUPS IN string_or_placeholder
+ {
+    $$.val = &tree.ShowBackup{
+      InCollection:    $4.expr(),
+    }
+  }
+| SHOW BACKUP string_or_placeholder opt_with_options
   {
     $$.val = &tree.ShowBackup{
       Details: tree.BackupDefaultDetails,
       Path:    $3.expr(),
       Options: $4.kvOptions(),
+    }
+  }
+| SHOW BACKUP string_or_placeholder IN string_or_placeholder opt_with_options
+  {
+    $$.val = &tree.ShowBackup{
+      Details: tree.BackupDefaultDetails,
+      Path:    $3.expr(),
+      InCollection: $5.expr(),
+      Options: $6.kvOptions(),
     }
   }
 | SHOW BACKUP SCHEMAS string_or_placeholder opt_with_options
@@ -11026,6 +11041,7 @@ unreserved_keyword:
 | AUTOMATIC
 | AUTHORIZATION
 | BACKUP
+| BACKUPS
 | BEFORE
 | BEGIN
 | BINARY

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -84,6 +84,7 @@ const (
 // ShowBackup represents a SHOW BACKUP statement.
 type ShowBackup struct {
 	Path                 Expr
+	InCollection         Expr
 	Details              BackupDetails
 	ShouldIncludeSchemas bool
 	Options              KVOptions
@@ -91,6 +92,11 @@ type ShowBackup struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowBackup) Format(ctx *FmtCtx) {
+	if node.InCollection != nil && node.Path == nil {
+		ctx.WriteString("SHOW BACKUPS IN ")
+		ctx.FormatNode(node.InCollection)
+		return
+	}
 	ctx.WriteString("SHOW BACKUP ")
 	if node.Details == BackupRangeDetails {
 		ctx.WriteString("RANGES ")
@@ -101,6 +107,10 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 		ctx.WriteString("SCHEMAS ")
 	}
 	ctx.FormatNode(node.Path)
+	if node.InCollection != nil {
+		ctx.WriteString(" IN ")
+		ctx.FormatNode(node.InCollection)
+	}
 	if len(node.Options) > 0 {
 		ctx.WriteString(" WITH ")
 		ctx.FormatNode(&node.Options)


### PR DESCRIPTION
This change teaches SHOW BACKUP about collections, specifically adding
support for listing the backups in a collection with SHOW BACKUPS IN dest
and for showing an individual backup with dest using SHOW BACKUP x IN dest.
The former is a thin wrapper around 'ls' on the destination while the latter
is an even thinner wrapper around 'SHOW BACKUP dest/x', but both should make
it easier to interact with backups in collections, which often have long and
cumbersome URIs (including keys), so the more we can keep the collection URI
constant and let you just specify which element in the collection you want
to SHOW, RESTORE, etc, the easier it will be.

Release note (enterprise change): SHOW BACKUPS can be used to list backups in a backup collection created by BACKUP INTO.