### PR TITLE
storage: refactor MVCCIterate to use iterutil.State

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -63,11 +64,13 @@ func RefreshRange(
 			Inconsistent: true,
 			Tombstones:   true,
 		},
-		func(kv roachpb.KeyValue) (bool, error) {
+		func(cur iterutil.Cur) error {
+			kv := *cur.Elem.(*roachpb.KeyValue)
 			if ts := kv.Value.Timestamp; refreshFrom.LessEq(ts) {
-				return true, errors.Errorf("encountered recently written key %s @%s", kv.Key, ts)
+				cur.Stop()
+				return errors.Errorf("encountered recently written key %s @%s", kv.Key, ts)
 			}
-			return false, nil
+			return nil
 		})
 	if err != nil {
 		return result.Result{}, err

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -484,8 +485,9 @@ func processLocalKeyRange(
 	endKey := keys.MakeRangeKeyPrefix(desc.EndKey)
 
 	_, err := storage.MVCCIterate(ctx, snap, startKey, endKey, hlc.Timestamp{}, storage.MVCCScanOptions{},
-		func(kv roachpb.KeyValue) (bool, error) {
-			return false, handleOne(kv)
+		func(cur iterutil.Cur) error {
+			kv := *cur.Elem.(*roachpb.KeyValue)
+			return handleOne(kv)
 		})
 	return err
 }

--- a/pkg/kv/kvserver/gc_queue_test.go
+++ b/pkg/kv/kvserver/gc_queue_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -893,9 +894,9 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	outsideTxnPrefixEnd := keys.TransactionKey(outsideKey.Next(), uuid.UUID{})
 	var count int
 	if _, err := storage.MVCCIterate(ctx, tc.store.Engine(), outsideTxnPrefix, outsideTxnPrefixEnd, hlc.Timestamp{},
-		storage.MVCCScanOptions{}, func(roachpb.KeyValue) (bool, error) {
+		storage.MVCCScanOptions{}, func(iterutil.Cur) error {
 			count++
-			return false, nil
+			return nil
 		}); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1311,35 +1311,43 @@ func IterateIDPrefixKeys(
 // from the provided Engine. The return values of this method and fn have
 // semantics similar to engine.MVCCIterate.
 func IterateRangeDescriptors(
-	ctx context.Context,
-	reader storage.Reader,
-	fn func(desc roachpb.RangeDescriptor) (done bool, err error),
+	ctx context.Context, reader storage.Reader, fn func(cur iterutil.Cur) error,
 ) error {
 	log.Event(ctx, "beginning range descriptor iteration")
 	// Iterator over all range-local key-based data.
 	start := keys.RangeDescriptorKey(roachpb.RKeyMin)
 	end := keys.RangeDescriptorKey(roachpb.RKeyMax)
-
+	iterState := iterutil.NewState()
+	iterState.Elem = new(roachpb.RangeDescriptor)
 	allCount := 0
 	matchCount := 0
 	bySuffix := make(map[string]int)
-	kvToDesc := func(kv roachpb.KeyValue) (bool, error) {
+	kvToDesc := func(cur iterutil.Cur) error {
+		kv := *cur.Elem.(*roachpb.KeyValue)
 		allCount++
 		// Only consider range metadata entries; ignore others.
 		_, suffix, _, err := keys.DecodeRangeKey(kv.Key)
 		if err != nil {
-			return false, err
+			return err
 		}
 		bySuffix[string(suffix)]++
 		if !bytes.Equal(suffix, keys.LocalRangeDescriptorSuffix) {
-			return false, nil
+			return nil
 		}
+		// NB: each iteration gets its own RangeDescriptor since, at the time of writing,
+		// some uses of this code hold on to the descriptor.
 		var desc roachpb.RangeDescriptor
 		if err := kv.Value.GetProto(&desc); err != nil {
-			return false, err
+			return err
 		}
 		matchCount++
-		return fn(desc)
+		*iterState.Elem.(*roachpb.RangeDescriptor) = desc
+		err = fn(iterState.Current())
+		if iterState.Done() {
+			cur.Stop()
+			return err
+		}
+		return err
 	}
 
 	_, err := storage.MVCCIterate(ctx, reader, start, end, hlc.MaxTimestamp,
@@ -1445,9 +1453,10 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// concurrently, all of the initialization must be performed before we start
 	// listening for Raft messages and starting the process Raft loop.
 	err = IterateRangeDescriptors(ctx, s.engine,
-		func(desc roachpb.RangeDescriptor) (bool, error) {
+		func(cur iterutil.Cur) error {
+			desc := *cur.Elem.(*roachpb.RangeDescriptor)
 			if !desc.IsInitialized() {
-				return false, errors.Errorf("found uninitialized RangeDescriptor: %+v", desc)
+				return errors.Errorf("found uninitialized RangeDescriptor: %+v", desc)
 			}
 			replicaDesc, found := desc.GetReplicaDescriptor(s.StoreID())
 			if !found {
@@ -1459,7 +1468,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 				// 20.2 or after as there was a migration in 20.1 to remove them and
 				// no pre-emptive snapshot should have been sent since 19.2 was
 				// finalized.
-				return false /* done */, errors.AssertionFailedf(
+				return errors.AssertionFailedf(
 					"found RangeDescriptor for range %d at generation %d which does not"+
 						" contain this store %d",
 					log.Safe(desc.RangeID),
@@ -1469,7 +1478,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 
 			rep, err := newReplica(ctx, &desc, s, replicaDesc.ReplicaID)
 			if err != nil {
-				return false, err
+				return err
 			}
 
 			// We can't lock s.mu across NewReplica due to the lock ordering
@@ -1479,7 +1488,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			err = s.addReplicaInternalLocked(rep)
 			s.mu.Unlock()
 			if err != nil {
-				return false, err
+				return err
 			}
 
 			// Add this range and its stats to our counter.
@@ -1487,7 +1496,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			if tenantID, ok := rep.TenantID(); ok {
 				s.metrics.addMVCCStats(ctx, tenantID, rep.GetMVCCStats())
 			} else {
-				return false, errors.AssertionFailedf("found newly constructed replica"+
+				return errors.AssertionFailedf("found newly constructed replica"+
 					" for range %d at generation %d with an invalid tenant ID in store %d",
 					log.Safe(desc.RangeID),
 					log.Safe(desc.Generation),
@@ -1508,7 +1517,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			// TODO(bdarnell): Also initialize raft groups when read leases are needed.
 			// TODO(bdarnell): Scan all ranges at startup for unapplied log entries
 			// and initialize those groups.
-			return false, nil
+			return nil
 		})
 	if err != nil {
 		return err

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -365,7 +365,7 @@ func (s *statusServer) Allocator(
 					rep, err := store.GetReplica(desc.RangeID)
 					if err != nil {
 						if errors.HasType(err, (*roachpb.RangeNotFoundError)(nil)) {
-							return true, nil // continue
+							return false, nil // continue
 						}
 						return true, err
 					}

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -1874,9 +1875,10 @@ func TestMVCCDeleteRange(t *testing.T) {
 			kvs := []roachpb.KeyValue{}
 			if _, err = MVCCIterate(
 				ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2}, MVCCScanOptions{Tombstones: true},
-				func(kv roachpb.KeyValue) (bool, error) {
+				func(cur iterutil.Cur) error {
+					kv := *cur.Elem.(*roachpb.KeyValue)
 					kvs = append(kvs, kv)
-					return false, nil
+					return nil
 				},
 			); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
This pull request also makes a couple of other changes:

 - Fixes Allocator function in server package (0cd7ccd)
 - Adds StopE method for iterutil.Cur (13bf5c4)

Context: #48709