### PR TITLE
logictest: add 3node-tenant directive to logictests with non-default configs

### DIFF
--- a/pkg/ccl/logictestccl/logic_test.go
+++ b/pkg/ccl/logictestccl/logic_test.go
@@ -30,7 +30,7 @@ func TestCCLLogic(t *testing.T) {
 // configuration (i.e. "# LogicTest: !3node-tenant") are not run.
 func TestTenantLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	logictest.RunLogicTestWithDefaultConfig(t, logictest.TestServerArgs{}, "3node-tenant", logictestPkg+testdataGlob)
+	logictest.RunLogicTestWithDefaultConfig(t, logictest.TestServerArgs{}, "3node-tenant", true /* runCCLConfigs */, logictestPkg+testdataGlob)
 }
 
 func TestTenantSQLLiteLogic(t *testing.T) {

--- a/pkg/sql/logictest/testdata/logic_test/column_families
+++ b/pkg/sql/logictest/testdata/logic_test/column_families
@@ -1,4 +1,4 @@
-# LogicTest: local local-vec-auto
+# LogicTest: local local-vec-auto 3node-tenant
 
 # Test that different operations still succeed when the primary key is not in column family 0.
 

--- a/pkg/sql/logictest/testdata/logic_test/inv_stats
+++ b/pkg/sql/logictest/testdata/logic_test/inv_stats
@@ -1,4 +1,4 @@
-# LogicTest: 5node
+# LogicTest: 5node 3node-tenant
 
 # Tests that verify we retrieve the stats correctly. Note that we can't create
 # statistics if distsql mode is OFF.

--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -1,6 +1,6 @@
 # TODO(mjibson): The fakedist-disk config produces an error. When fixed,
 # remove this config line. See #38985.
-# LogicTest: local fakedist fakedist-metadata
+# LogicTest: local fakedist fakedist-metadata 3node-tenant
 
 ## This test file contains various complex queries that ORMs issue during
 ## startup or general use.

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local !3node-tenant(52567)
 
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local !3node-tenant(52567)
 
 ## Tests for ensuring that prepared statements can't get overwritten and for
 ## deallocate and deallocate all.

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local 3node-tenant
 
 statement error a role/user named admin already exists
 CREATE ROLE admin

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local !3node-tenant(52763)
 
 # Check that node_statement_statistics report per application
 

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local 3node-tenant
 
 query TTT colnames
 SHOW USERS

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1,4 +1,4 @@
-# LogicTest: local fakedist fakedist-disk
+# LogicTest: local fakedist fakedist-disk 3node-tenant
 
 # Note that there is no much benefit from running this file with other logic
 # test configurations because we override vectorize setting.


### PR DESCRIPTION
This commit is the result of running all logictests that specify non-default
configs after applying #52680, and adding the 3node-tenant directive to tests
that pass.

For all tests with non-default configs that fail with the 3node-tenant
configuration, the failures were analyzed and marked as either expected (no
action necessary) or unexpected, in which case a 3node-tenant blocklist
directive with an associated issue was added to the list of directives.

Release note: None (testing change)

Closes #52410 