### PR TITLE
sql: avoid flake in scan_test

### DIFF
--- a/pkg/sql/scan_test.go
+++ b/pkg/sql/scan_test.go
@@ -132,6 +132,9 @@ func TestScanBatches(t *testing.T) {
 	s, db, _ := serverutils.StartServer(
 		t, base.TestServerArgs{UseDatabase: "test"})
 	defer s.Stopper().Stop(context.Background())
+	if _, err := db.Exec("SET CLUSTER SETTING server.sqlliveness.heartbeat='1000s'"); err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS test`); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The new sqlliveness package doesn't get along well with the kv batch
size "atomic", so turn down its check frequency in the test. Possibly we
should make the "atomic" actually atomic, but I'm not sure about the
runtime performance change.

Fixes #52683

Release note: None