### PR TITLE
deps: bump cockroachdb/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/cockroachdb/cockroach-go v0.0.0-20200504194139-73ffeee90b62
 	github.com/cockroachdb/crlfmt v0.0.0-20200116191136-a78e1c207bc0
 	github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5
-	github.com/cockroachdb/errors v1.5.2
+	github.com/cockroachdb/errors v1.6.1
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/cockroachdb/cockroach-go v0.0.0-20200504194139-73ffeee90b62
 	github.com/cockroachdb/crlfmt v0.0.0-20200116191136-a78e1c207bc0
 	github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5
-	github.com/cockroachdb/errors v1.5.0
+	github.com/cockroachdb/errors v1.5.2
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5 h1:xD/lrqdv
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4 h1:Lap807SXTH5tri2TivECb/4abUkMZC9zRoLarvcKDqs=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
-github.com/cockroachdb/errors v1.5.0 h1:QR6H/GgNSyIrt+AOhC3CdMi7UExDp2pJRXZ/39vXPH8=
-github.com/cockroachdb/errors v1.5.0/go.mod h1:tm6FTP5G81vwJ5lC0SizQo374JNCOPrHyXGitRJoDqM=
+github.com/cockroachdb/errors v1.5.2 h1:Qm5ZJZhfwLGMWS6qD3ebSLF7ZCXw61B05VN0PAjRlYk=
+github.com/cockroachdb/errors v1.5.2/go.mod h1:tm6FTP5G81vwJ5lC0SizQo374JNCOPrHyXGitRJoDqM=
 github.com/cockroachdb/etcd v0.4.7-0.20200615211340-a17df30d5955 h1:1ELogBFqZl2Cj/Rn0wWAU4z2/ghBlHzhXDlbT8RlrKU=
 github.com/cockroachdb/etcd v0.4.7-0.20200615211340-a17df30d5955/go.mod h1:Vshs83p1UXI6fjU8eWVgqXeewFxRDP1fNVF5PHiSBm0=
 github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55 h1:YqzBA7tf8Gv8Oz0BbBsPenqkyjiohS7EUIwi7p1QJCU=

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5 h1:xD/lrqdv
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4 h1:Lap807SXTH5tri2TivECb/4abUkMZC9zRoLarvcKDqs=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
-github.com/cockroachdb/errors v1.5.2 h1:Qm5ZJZhfwLGMWS6qD3ebSLF7ZCXw61B05VN0PAjRlYk=
-github.com/cockroachdb/errors v1.5.2/go.mod h1:tm6FTP5G81vwJ5lC0SizQo374JNCOPrHyXGitRJoDqM=
+github.com/cockroachdb/errors v1.6.1 h1:GqOx5BYPdco9HPaoUuy8W53kZsSEbPu5P/d4WLhanmM=
+github.com/cockroachdb/errors v1.6.1/go.mod h1:tm6FTP5G81vwJ5lC0SizQo374JNCOPrHyXGitRJoDqM=
 github.com/cockroachdb/etcd v0.4.7-0.20200615211340-a17df30d5955 h1:1ELogBFqZl2Cj/Rn0wWAU4z2/ghBlHzhXDlbT8RlrKU=
 github.com/cockroachdb/etcd v0.4.7-0.20200615211340-a17df30d5955/go.mod h1:Vshs83p1UXI6fjU8eWVgqXeewFxRDP1fNVF5PHiSBm0=
 github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55 h1:YqzBA7tf8Gv8Oz0BbBsPenqkyjiohS7EUIwi7p1QJCU=

--- a/pkg/kv/kvserver/raft_test.go
+++ b/pkg/kv/kvserver/raft_test.go
@@ -48,24 +48,23 @@ func TestWrapNumbersAsSafe(t *testing.T) {
 	const format = "some reportables"
 	err := errors.WithSafeDetails(leafErr{}, format, reportables...)
 
-	const expected = `<kvserver.leafErr>
-wrapper: <*safedetails.withSafeDetails>
-(more details:)
-some reportables
--- arg 1: 4294967295
--- arg 2: 255
--- arg 3: 65535
--- arg 4: 4294967295
--- arg 5: 18446744073709551615
--- arg 6: 2147483647
--- arg 7: 127
--- arg 8: 32767
--- arg 9: 2147483647
--- arg 10: 9223372036854775807
--- arg 11: 3.4028235e+38
--- arg 12: 1.7976931348623157e+308
--- arg 13: <string>
--- arg 14: <string>`
+	const expected = `kvserver.leafErr: <redacted>
+*safedetails.withSafeDetails: format: "some reportables"
+  (more details:)
+  -- arg 1: 4294967295
+  -- arg 2: 255
+  -- arg 3: 65535
+  -- arg 4: 4294967295
+  -- arg 5: 18446744073709551615
+  -- arg 6: 2147483647
+  -- arg 7: 127
+  -- arg 8: 32767
+  -- arg 9: 2147483647
+  -- arg 10: 9223372036854775807
+  -- arg 11: 3.4028235e+38
+  -- arg 12: 1.7976931348623157e+308
+  -- arg 13: string:<redacted>
+  -- arg 14: string:<redacted>`
 
 	if redacted := errors.Redact(err); expected != redacted {
 		t.Fatalf("expected error to be:\n%s\n\nbut was:\n%s", expected, redacted)

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -72,19 +72,18 @@ INSERT INTO sensitive(super, sensible) VALUES('that', 'nobody', 'must', 'see')
 		t.Errorf("wanted: %s\ngot: %s", expMessage, actMessage)
 	}
 
-	const expSafeRedactedMessage = `...conn_executor_test.go:NN: <*errors.errorString>
-wrapper: <*withstack.withStack>
-(more details:)
-github.com/cockroachdb/cockroach/pkg/sql_test.TestAnonymizeStatementsForReporting
-	...conn_executor_test.go:NN
-testing.tRunner
-	...testing.go:NN
-runtime.goexit
-	...asm_amd64.s:NN
-wrapper: <*safedetails.withSafeDetails>
-(more details:)
-while executing: %s
--- arg 1: INSERT INTO _(_, _) VALUES (_, _, __more2__)`
+	const expSafeRedactedMessage = `...conn_executor_test.go:NN: *errors.errorString: <redacted>
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/sql_test.TestAnonymizeStatementsForReporting
+  	...conn_executor_test.go:NN
+  testing.tRunner
+  	...testing.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN
+*safedetails.withSafeDetails: format: "while executing: %s"
+  (more details:)
+  -- arg 1: INSERT INTO _(_, _) VALUES (_, _, __more2__)`
 
 	// Edit non-determinstic stack trace filenames from the message.
 	actSafeRedactedMessage := fileref.ReplaceAllString(

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -63,16 +63,17 @@ INSERT INTO sensitive(super, sensible) VALUES('that', 'nobody', 'must', 'see')
 		t.Fatal(err)
 	}
 
-	rUnsafe := errors.New("panic: i'm not safe")
+	rUnsafe := errors.New("some error")
 	safeErr := sql.WithAnonymizedStatement(rUnsafe, stmt1.AST)
 
-	const expMessage = "panic: i'm not safe"
+	const expMessage = "some error"
 	actMessage := safeErr.Error()
 	if actMessage != expMessage {
 		t.Errorf("wanted: %s\ngot: %s", expMessage, actMessage)
 	}
 
 	const expSafeRedactedMessage = `...conn_executor_test.go:NN: *errors.errorString: <redacted>
+*safedetails.withSafeDetails: some error
 *withstack.withStack
   (more details:)
   github.com/cockroachdb/cockroach/pkg/sql_test.TestAnonymizeStatementsForReporting

--- a/pkg/util/log/crash_reporting_packet_test.go
+++ b/pkg/util/log/crash_reporting_packet_test.go
@@ -125,7 +125,7 @@ func TestCrashReportingPacket(t *testing.T) {
 			message += " (TestCrashReportingPacket)"
 			return message
 		}(), []extraPair{
-			{"1: details", "panic: %v\n-- arg 1: " + panicPre},
+			{"1: details", "format: \"panic: %v\"\n-- arg 1: " + panicPre},
 		}},
 		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 11, func() string {
 			message := prefix
@@ -138,7 +138,7 @@ func TestCrashReportingPacket(t *testing.T) {
 			message += " (TestCrashReportingPacket)"
 			return message
 		}(), []extraPair{
-			{"1: details", "panic: %v\n-- arg 1: " + panicPost},
+			{"1: details", "format: \"panic: %v\"\n-- arg 1: " + panicPost},
 		}},
 	}
 
@@ -244,11 +244,11 @@ func TestInternalErrorReporting(t *testing.T) {
 	t.Logf("%# v", pretty.Formatter(p))
 
 	assert.Regexp(t, `\*errors.errorString\n`+
-		`\*safedetails.withSafeDetails: %s \(1\)\n`+
+		`\*safedetails.withSafeDetails: format: "%s" \(1\)\n`+
 		`builtins.go:\d+: \*withstack.withStack \(top exception\)\n`+
 		`\*assert.withAssertionFailure\n`+
 		`\*errutil.withMessage\n`+
-		`\*safedetails.withSafeDetails: %s\(\) \(2\)\n`+
+		`\*safedetails.withSafeDetails: format: "%s\(\)" \(2\)\n`+
 		`eval.go:\d+: \*withstack.withStack \(3\)\n`+
 		`\*telemetrykeys.withTelemetry: crdb_internal.force_assertion_error\(\) \(4\)\n`+
 		`\(check the extra data payloads\)`, p.Message)
@@ -257,8 +257,8 @@ func TestInternalErrorReporting(t *testing.T) {
 		key   string
 		reVal string
 	}{
-		{"1: details", "%s\n.*<string>"},
-		{"2: details", `%s\(\).*\n.*force_assertion_error`},
+		{"1: details", "format: \"%s\"\n.*string:<redacted>"},
+		{"2: details", `format: "%s\(\)".*\n.*force_assertion_error`},
 		{"4: details", `crdb_internal\.force_assertion_error\(\)`},
 	}
 	for _, ex := range expectedExtra {
@@ -282,7 +282,7 @@ func TestInternalErrorReporting(t *testing.T) {
 	// The innermost stack trace (and main exception object) is the last
 	// one in the Sentry event.
 	assert.Regexp(t, `^builtins.go:\d+ \(.*\)$`, p.Exception[1].Type)
-	assert.Regexp(t, `^\*errors\.errorString: %s`, p.Exception[1].Value)
+	assert.Regexp(t, `^\*errors\.errorString: format: "%s"`, p.Exception[1].Value)
 	fr := p.Exception[1].Stacktrace.Frames
 	assert.Regexp(t, `.*/builtins.go`, fr[len(fr)-1].Filename)
 	assert.Regexp(t, `.*/eval.go`, fr[len(fr)-2].Filename)

--- a/pkg/util/log/crash_reporting_test.go
+++ b/pkg/util/log/crash_reporting_test.go
@@ -43,6 +43,7 @@ var safeErrorTestCases = func() []safeErrorTestCase {
 	var errWrapped1 = errors.Wrap(errFundamental, "not recoverable :(")
 	var errWrapped2 = errors.Wrapf(errWrapped1, "this is reportable")
 	var errWrapped3 = errors.Wrap(errWrapped2, "not recoverable :(")
+	var errFormatted = errors.Newf("this embed an error: %v", errWrapped2)
 	var errWrappedSentinel = errors.Wrap(errors.Wrapf(errSentinel, "this is reportable"), "seecret")
 
 	runtimeErr := makeTypeAssertionErr()
@@ -62,217 +63,205 @@ var safeErrorTestCases = func() []safeErrorTestCase {
 			// Same as last, but skipping through to the cause: panic(errors.Wrap(safeErr, "gibberish")).
 			err: errors.Wrap(runtimeErr, "unseen"),
 			expErr: `...crash_reporting_test.go:NN: *runtime.TypeAssertionError: interface conversion: interface {} is nil, not int
-wrapper: <*errutil.withMessage>
-wrapper: <*withstack.withStack>
-(more details:)
-github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
-	...crash_reporting_test.go:NN
-github.com/cockroachdb/cockroach/pkg/util/log.init
-	...crash_reporting_test.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.main
-	...proc.go:NN
-runtime.goexit
-	...asm_amd64.s:NN`,
+*errutil.withMessage: <redacted>
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+  	...crash_reporting_test.go:NN
+  github.com/cockroachdb/cockroach/pkg/util/log.init
+  	...crash_reporting_test.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.main
+  	...proc.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN`,
 		},
 		{
 			// Safe errors revealed in safe details of error wraps/objects.
 			err: errors.Newf("%s", runtimeErr),
-			expErr: `...crash_reporting_test.go:NN: <*errors.errorString>
-wrapper: <*safedetails.withSafeDetails>
-(more details:)
-%s
--- arg 1: *runtime.TypeAssertionError: interface conversion: interface {} is nil, not int
-wrapper: <*withstack.withStack>
-(more details:)
-github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
-	...crash_reporting_test.go:NN
-github.com/cockroachdb/cockroach/pkg/util/log.init
-	...crash_reporting_test.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.main
-	...proc.go:NN
-runtime.goexit
-	...asm_amd64.s:NN`,
+			expErr: `...crash_reporting_test.go:NN: *errors.errorString: <redacted>
+*safedetails.withSafeDetails: format: "%s"
+  (more details:)
+  -- arg 1 (error): *runtime.TypeAssertionError: interface conversion: interface {} is nil, not int
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+  	...crash_reporting_test.go:NN
+  github.com/cockroachdb/cockroach/pkg/util/log.init
+  	...crash_reporting_test.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.main
+  	...proc.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN`,
 		},
 		{
 			// More embedding of safe details.
 			err: errors.WithSafeDetails(runtimeErr, "foo"),
 			expErr: `*runtime.TypeAssertionError: interface conversion: interface {} is nil, not int
-wrapper: <*safedetails.withSafeDetails>
-(more details:)
-foo`,
+*safedetails.withSafeDetails: foo`,
 		},
 		{
 			err: errors.Newf("I like %s and my pin code is %d or %d", Safe("A"), 1234, Safe(9999)),
-			expErr: `...crash_reporting_test.go:NN: <*errors.errorString>
-wrapper: <*safedetails.withSafeDetails>
-(more details:)
-I like %s and my pin code is %d or %d
--- arg 1: A
--- arg 2: <int>
--- arg 3: 9999
-wrapper: <*withstack.withStack>
-(more details:)
-github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
-	...crash_reporting_test.go:NN
-github.com/cockroachdb/cockroach/pkg/util/log.init
-	...crash_reporting_test.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.main
-	...proc.go:NN
-runtime.goexit
-	...asm_amd64.s:NN`,
+			expErr: `...crash_reporting_test.go:NN: *errors.errorString: <redacted>
+*safedetails.withSafeDetails: format: "I like %s and my pin code is %d or %d"
+  (more details:)
+  -- arg 1: A
+  -- arg 2: int:<redacted>
+  -- arg 3: 9999
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+  	...crash_reporting_test.go:NN
+  github.com/cockroachdb/cockroach/pkg/util/log.init
+  	...crash_reporting_test.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.main
+  	...proc.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN`,
 		},
 		{
 			err: errors.Wrapf(context.Canceled, "this is preserved: %d", Safe(6)),
 			expErr: `...crash_reporting_test.go:NN: *errors.errorString: context canceled
-wrapper: <*errutil.withMessage>
-wrapper: <*safedetails.withSafeDetails>
-(more details:)
-this is preserved: %d
--- arg 1: 6
-wrapper: <*withstack.withStack>
-(more details:)
-github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
-	...crash_reporting_test.go:NN
-github.com/cockroachdb/cockroach/pkg/util/log.init
-	...crash_reporting_test.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.main
-	...proc.go:NN
-runtime.goexit
-	...asm_amd64.s:NN`,
+*errutil.withMessage: <redacted>
+*safedetails.withSafeDetails: format: "this is preserved: %d"
+  (more details:)
+  -- arg 1: 6
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+  	...crash_reporting_test.go:NN
+  github.com/cockroachdb/cockroach/pkg/util/log.init
+  	...crash_reporting_test.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.main
+  	...proc.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN`,
 		},
 		{
 			// Verify that the special case still scrubs inside of the error.
 			err: &os.LinkError{Op: "moo", Old: "sec", New: "cret", Err: errors.WithSafeDetails(leafErr{}, "assumed safe")},
-			expErr: `<log.leafErr>
-wrapper: <*safedetails.withSafeDetails>
-(more details:)
-assumed safe
-wrapper: *os.LinkError: moo <redacted> <redacted>`,
+			expErr: `log.leafErr: <redacted>
+*safedetails.withSafeDetails: assumed safe
+*os.LinkError: moo <redacted> <redacted>`,
 		},
 		{
 			// Verify that unknown sentinel errors print at least their type (regression test).
 			// Also, that its Error() is never called (since it would panic).
 			err: errWrappedSentinel,
-			expErr: `...crash_reporting_test.go:NN: <struct { error }>
-wrapper: <*errutil.withMessage>
-wrapper: <*safedetails.withSafeDetails>
-(more details:)
-this is reportable
-wrapper: <*withstack.withStack>
-(more details:)
-github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
-	...crash_reporting_test.go:NN
-github.com/cockroachdb/cockroach/pkg/util/log.init
-	...crash_reporting_test.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.main
-	...proc.go:NN
-runtime.goexit
-	...asm_amd64.s:NN
-wrapper: <*errutil.withMessage>
-wrapper: <*withstack.withStack>
-(more details:)
-github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
-	...crash_reporting_test.go:NN
-github.com/cockroachdb/cockroach/pkg/util/log.init
-	...crash_reporting_test.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.main
-	...proc.go:NN
-runtime.goexit
-	...asm_amd64.s:NN`,
+			expErr: `...crash_reporting_test.go:NN: struct { error }: <redacted>
+*errutil.withMessage: <redacted>
+*safedetails.withSafeDetails: this is reportable
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+  	...crash_reporting_test.go:NN
+  github.com/cockroachdb/cockroach/pkg/util/log.init
+  	...crash_reporting_test.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.main
+  	...proc.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN
+*errutil.withMessage: <redacted>
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+  	...crash_reporting_test.go:NN
+  github.com/cockroachdb/cockroach/pkg/util/log.init
+  	...crash_reporting_test.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.main
+  	...proc.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN`,
 		},
 		{
 			err: errWrapped3,
-			expErr: `...crash_reporting_test.go:NN: <*errors.errorString>
-wrapper: <*safedetails.withSafeDetails>
-(more details:)
-%s
--- arg 1: <string>
-wrapper: <*withstack.withStack>
-(more details:)
-github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
-	...crash_reporting_test.go:NN
-github.com/cockroachdb/cockroach/pkg/util/log.init
-	...crash_reporting_test.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.main
-	...proc.go:NN
-runtime.goexit
-	...asm_amd64.s:NN
-wrapper: <*errutil.withMessage>
-wrapper: <*withstack.withStack>
-(more details:)
-github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
-	...crash_reporting_test.go:NN
-github.com/cockroachdb/cockroach/pkg/util/log.init
-	...crash_reporting_test.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.main
-	...proc.go:NN
-runtime.goexit
-	...asm_amd64.s:NN
-wrapper: <*errutil.withMessage>
-wrapper: <*safedetails.withSafeDetails>
-(more details:)
-this is reportable
-wrapper: <*withstack.withStack>
-(more details:)
-github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
-	...crash_reporting_test.go:NN
-github.com/cockroachdb/cockroach/pkg/util/log.init
-	...crash_reporting_test.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.main
-	...proc.go:NN
-runtime.goexit
-	...asm_amd64.s:NN
-wrapper: <*errutil.withMessage>
-wrapper: <*withstack.withStack>
-(more details:)
-github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
-	...crash_reporting_test.go:NN
-github.com/cockroachdb/cockroach/pkg/util/log.init
-	...crash_reporting_test.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.doInit
-	...proc.go:NN
-runtime.main
-	...proc.go:NN
-runtime.goexit
-	...asm_amd64.s:NN`,
+			expErr: `...crash_reporting_test.go:NN: *errors.errorString: <redacted>
+*safedetails.withSafeDetails: format: "%s"
+  (more details:)
+  -- arg 1: string:<redacted>
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+  	...crash_reporting_test.go:NN
+  github.com/cockroachdb/cockroach/pkg/util/log.init
+  	...crash_reporting_test.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.main
+  	...proc.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN
+*errutil.withMessage: <redacted>
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+  	...crash_reporting_test.go:NN
+  github.com/cockroachdb/cockroach/pkg/util/log.init
+  	...crash_reporting_test.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.main
+  	...proc.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN
+*errutil.withMessage: <redacted>
+*safedetails.withSafeDetails: this is reportable
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+  	...crash_reporting_test.go:NN
+  github.com/cockroachdb/cockroach/pkg/util/log.init
+  	...crash_reporting_test.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.main
+  	...proc.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN
+*errutil.withMessage: <redacted>
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+  	...crash_reporting_test.go:NN
+  github.com/cockroachdb/cockroach/pkg/util/log.init
+  	...crash_reporting_test.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.main
+  	...proc.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN`,
 		},
 		{
 			err: &net.OpError{
@@ -282,8 +271,77 @@ runtime.goexit
 				Addr:   &util.UnresolvedAddr{AddressField: "sensitive-addr"},
 				Err:    leafErr{},
 			},
-			expErr: `<log.leafErr>
-wrapper: *net.OpError: write tcp<redacted>-><redacted>`,
+			expErr: `log.leafErr: <redacted>
+*net.OpError: write tcp <redacted> -> <redacted>`,
+		},
+		{
+			err: errFormatted,
+			expErr: `...crash_reporting_test.go:NN: *errors.errorString: <redacted>
+*safedetails.withSafeDetails: format: "this embed an error: %v"
+  (more details:)
+  -- arg 1 (error): ...crash_reporting_test.go:NN: *errors.errorString: <redacted>
+  *safedetails.withSafeDetails: format: "%s"
+    (more details:)
+    -- arg 1: string:<redacted>
+  *withstack.withStack
+    (more details:)
+    github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+    	...crash_reporting_test.go:NN
+    github.com/cockroachdb/cockroach/pkg/util/log.init
+    	...crash_reporting_test.go:NN
+    runtime.doInit
+    	...proc.go:NN
+    runtime.doInit
+    	...proc.go:NN
+    runtime.main
+    	...proc.go:NN
+    runtime.goexit
+    	...asm_amd64.s:NN
+  *errutil.withMessage: <redacted>
+  *withstack.withStack
+    (more details:)
+    github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+    	...crash_reporting_test.go:NN
+    github.com/cockroachdb/cockroach/pkg/util/log.init
+    	...crash_reporting_test.go:NN
+    runtime.doInit
+    	...proc.go:NN
+    runtime.doInit
+    	...proc.go:NN
+    runtime.main
+    	...proc.go:NN
+    runtime.goexit
+    	...asm_amd64.s:NN
+  *errutil.withMessage: <redacted>
+  *safedetails.withSafeDetails: this is reportable
+  *withstack.withStack
+    (more details:)
+    github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+    	...crash_reporting_test.go:NN
+    github.com/cockroachdb/cockroach/pkg/util/log.init
+    	...crash_reporting_test.go:NN
+    runtime.doInit
+    	...proc.go:NN
+    runtime.doInit
+    	...proc.go:NN
+    runtime.main
+    	...proc.go:NN
+    runtime.goexit
+    	...asm_amd64.s:NN
+*withstack.withStack
+  (more details:)
+  github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+  	...crash_reporting_test.go:NN
+  github.com/cockroachdb/cockroach/pkg/util/log.init
+  	...crash_reporting_test.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.doInit
+  	...proc.go:NN
+  runtime.main
+  	...proc.go:NN
+  runtime.goexit
+  	...asm_amd64.s:NN`,
 		},
 	}
 }()

--- a/pkg/util/log/crash_reporting_unix_test.go
+++ b/pkg/util/log/crash_reporting_unix_test.go
@@ -22,6 +22,6 @@ func init() {
 	safeErrorTestCases = append(safeErrorTestCases, safeErrorTestCase{
 		err: os.NewSyscallError("write", unix.ENOSPC),
 		expErr: `syscall.Errno: no space left on device
-wrapper: *os.SyscallError: write`,
+*os.SyscallError: write`,
 	})
 }


### PR DESCRIPTION
Two changes here:

First change enhances the clarity of Sentry reports. See https://github.com/cockroachdb/errors/pull/43 for details.

Second change:

This updates to the new major release v1.6.
See release notes here: https://github.com/cockroachdb/errors/releases/tag/v1.6.0

This makes the string argument to New() and Wrap()
reportable to Sentry. This is now safe in CockroachdB
since the introduction of linters that assert
that their argument is a literal string.

**This code is not safe to back-port to previous release
branches unless the corresponding linters are also
back-ported and report the code is clean.**

Fixes #49752