### PR TITLE
release-19.2: rowexec: fix closing of aggregator bucket in case of an error

### DIFF
--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -555,9 +555,12 @@ func (ag *orderedAggregator) accumulateRows() (
 	return aggEmittingRows, nil, nil
 }
 
+// getAggResults returns the new aggregatorState and the results from the
+// bucket. The bucket is closed.
 func (ag *aggregatorBase) getAggResults(
 	bucket aggregateFuncs,
 ) (aggregatorState, sqlbase.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	defer bucket.close(ag.Ctx)
 	for i, b := range bucket {
 		result, err := b.Result()
 		if err != nil {
@@ -570,7 +573,6 @@ func (ag *aggregatorBase) getAggResults(
 		}
 		ag.row[i] = sqlbase.DatumToEncDatum(&ag.outputTypes[i], result)
 	}
-	bucket.close(ag.Ctx)
 
 	if outRow := ag.ProcessRowHelper(ag.row); outRow != nil {
 		return aggEmittingRows, outRow, nil
@@ -640,7 +642,7 @@ func (ag *hashAggregator) emitRow() (
 	// NOTE: accounting for the memory under aggregate builtins in the bucket
 	// is updated in getAggResults (the bucket will be closed), however, we
 	// choose to not reduce our estimate of the map's internal footprint
-	// because it is error-prone to estimate the new footprint (we don't
+	// because it is error-prone to estimate the new footprint (we don't know
 	// whether and when Go runtime will release some of the underlying memory).
 	// This behavior is ok, though, since actual usage of buckets will be lower
 	// than what we accounted for - in the worst case, the query might hit a


### PR DESCRIPTION
Backport 1/2 commits from #52749.

/cc @cockroachdb/release

---

**rowexec: fix closing of aggregator bucket in case of an error**

Previously, the bucket of aggregate functions wouldn't get properly
closed if an aggregate function returned an error on `Result` call. Now
this is fixed.

Release note: None