### PR TITLE
keys: fix addressing of RKeyMin derivates

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -517,12 +517,13 @@ func SpanAddr(span roachpb.Span) (roachpb.RSpan, error) {
 // RangeMetaKey returns a range metadata (meta1, meta2) indexing key for the
 // given key.
 //
-// - For RKeyMin, KeyMin is returned.
-// - For a meta1 key, KeyMin is returned.
+// - For RKeyMin, or RKeyMin.Next(), RKeyMin is returned.
+// - For a meta1 key, RKeyMin is returned.
 // - For a meta2 key, a meta1 key is returned.
 // - For an ordinary key, a meta2 key is returned.
 func RangeMetaKey(key roachpb.RKey) roachpb.RKey {
-	if len(key) == 0 { // key.Equal(roachpb.RKeyMin)
+	// RKeyMin or RKeyMin.Next()(.Next()...)
+	if len(key) == 0 || key[0] == '\x00' {
 		return roachpb.RKeyMin
 	}
 	var prefix roachpb.Key

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -242,6 +242,14 @@ func TestRangeMetaKey(t *testing.T) {
 			expKey: roachpb.RKeyMin,
 		},
 		{
+			key:    roachpb.RKey{}.Next(),
+			expKey: roachpb.RKeyMin,
+		},
+		{
+			key:    roachpb.RKey{}.Next().Next(),
+			expKey: roachpb.RKeyMin,
+		},
+		{
 			key:    roachpb.RKey("\x03\x04zonefoo"),
 			expKey: roachpb.RKey("\x02\x04zonefoo"),
 		},


### PR DESCRIPTION
This patch fixes a problem with RangeMetaKey(RKeyMin.Next()). This was
returning a Meta2 key, when it should have returned a Meta1 key (like
RangeMetaKey(RKeyMin) does).
This was having spectacular consequences for the range cache: evicting
the Meta1 descriptor from the cache was always failing because the
eviction is trying to find the descriptor by startKey.Next() (so
RKeyMin.Next()), and that retrieval was failing to find the descriptor
since it was skipping over the right cache entry (the cache entry is
keyed by RangeMetaKey(endKey), so it was a Meta1 key). This was causing
requests that were encoutering a NLHE on the Meta1 range to spin forever
since it was looking to the DistSender like the lease received in the
error was perpetualy stale (since it was failing to evict anything from
the cache).

Fixes #52468
Fixes #52391

Release note: None