### PR TITLE
sql: fix ALTER TABLE descriptorChanged bug

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -645,7 +645,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			if err != nil {
 				return err
 			}
-			descriptorChanged = !proto.Equal(
+			descriptorChanged = descriptorChanged || !proto.Equal(
 				&n.tableDesc.PrimaryIndex.Partitioning,
 				&partitioning,
 			)
@@ -660,11 +660,11 @@ func (n *alterTableNode) startExec(params runParams) error {
 			n.tableDesc.PrimaryIndex.Partitioning = partitioning
 
 		case *tree.AlterTableSetAudit:
-			var err error
-			descriptorChanged, err = params.p.setAuditMode(params.ctx, n.tableDesc, t.Mode)
+			changed, err := params.p.setAuditMode(params.ctx, n.tableDesc, t.Mode)
 			if err != nil {
 				return err
 			}
+			descriptorChanged = descriptorChanged || changed
 
 		case *tree.AlterTableInjectStats:
 			sd, ok := n.statsData[i]
@@ -685,7 +685,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			if err != nil {
 				return err
 			}
-			descriptorChanged = descChanged
+			descriptorChanged = descriptorChanged || descChanged
 
 		case *tree.AlterTableRenameConstraint:
 			info, err := n.tableDesc.GetConstraintInfo(params.ctx, nil, params.ExecCfg().Codec)

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1358,3 +1358,9 @@ child  CREATE TABLE public.child (
        CONSTRAINT "primary" PRIMARY KEY (c ASC),
        FAMILY fam_0_c_p (c)
 )
+
+# Regression test for #52816.
+statement ok
+CREATE TABLE t52816 (x INT, y INT);
+ALTER TABLE t52816 RENAME COLUMN x TO x2, RENAME COLUMN y TO y;
+SELECT x2, y FROM t52816


### PR DESCRIPTION
There was some bad accounting in the ALTER TABLE command for whether the
table descriptor had changed or not. This meant that for ALTER TABLE
statements with multiple actions, we might incorrectly treat the whole
statement as a no-op if the last action had no effect.

Fixes #52816

Release note (bug fix): Fixed a bug for ALTER TABLE statements with
multiple actions. In certain cases if the last action had no effect, the
entire statement would be treated as a no-op.