### PR TITLE
kvclient: get rid of ReplicaSlice from gRPCTransport

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1747,7 +1747,7 @@ func (ds *DistSender) sendToReplicas(
 		class:   rpc.ConnectionClassForKey(desc.RSpan().Key),
 		metrics: &ds.metrics,
 	}
-	transport, err := ds.transportFactory(opts, ds.nodeDialer, replicas)
+	transport, err := ds.transportFactory(opts, ds.nodeDialer, replicas.Descriptors())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -236,7 +236,7 @@ func (ds *DistSender) singleRangeFeed(
 	// The RangeFeed is not used for system critical traffic so use a DefaultClass
 	// connection regardless of the range.
 	opts := SendOptions{class: rpc.DefaultClass}
-	transport, err := ds.transportFactory(opts, ds.nodeDialer, replicas)
+	transport, err := ds.transportFactory(opts, ds.nodeDialer, replicas.Descriptors())
 	if err != nil {
 		return args.Timestamp, err
 	}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -3420,15 +3420,15 @@ func TestCanSendToFollower(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	var sentTo ReplicaInfo
+	var sentTo roachpb.ReplicaDescriptor
 	var testFn simpleSendFn = func(
 		_ context.Context,
 		_ SendOptions,
-		r ReplicaSlice,
-		args roachpb.BatchRequest,
+		_ ReplicaSlice,
+		ba roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, error) {
-		sentTo = r[0]
-		return args.CreateReply(), nil
+		sentTo = ba.Replica
+		return ba.CreateReply(), nil
 	}
 	cfg := DistSenderConfig{
 		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
@@ -3482,7 +3482,7 @@ func TestCanSendToFollower(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			sentTo = ReplicaInfo{}
+			sentTo = roachpb.ReplicaDescriptor{}
 			canSend = c.canSendToFollower
 			ds := NewDistSender(cfg)
 			ds.clusterID = &base.ClusterIDContainer{}

--- a/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
+++ b/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
@@ -96,7 +96,7 @@ func NewDistSenderForLocalTestCluster(
 			TransportFactory: func(
 				opts SendOptions,
 				nodeDialer *nodedialer.Dialer,
-				replicas ReplicaSlice,
+				replicas []roachpb.ReplicaDescriptor,
 			) (Transport, error) {
 				transport, err := senderTransportFactory(opts, nodeDialer, replicas)
 				if err != nil {

--- a/pkg/kv/kvclient/kvcoord/replica_slice.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice.go
@@ -197,3 +197,12 @@ func (rs ReplicaSlice) OptimizeReplicaOrder(
 		return attrMatchI > attrMatchJ
 	})
 }
+
+// Descriptors returns the ReplicaDescriptors inside the ReplicaSlice.
+func (rs ReplicaSlice) Descriptors() []roachpb.ReplicaDescriptor {
+	reps := make([]roachpb.ReplicaDescriptor, len(rs))
+	for i := range rs {
+		reps[i] = rs[i].ReplicaDescriptor
+	}
+	return reps
+}

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -99,7 +99,7 @@ func TestSendToOneClient(t *testing.T) {
 // firstNErrorTransport is a mock transport that sends an error on
 // requests to the first N addresses, then succeeds.
 type firstNErrorTransport struct {
-	replicas  ReplicaSlice
+	replicas  []roachpb.ReplicaDescriptor
 	numErrors int
 	numSent   int
 }
@@ -126,7 +126,7 @@ func (f *firstNErrorTransport) NextInternalClient(
 }
 
 func (f *firstNErrorTransport) NextReplica() roachpb.ReplicaDescriptor {
-	return f.replicas[f.numSent].ReplicaDescriptor
+	return f.replicas[f.numSent]
 }
 
 func (f *firstNErrorTransport) SkipReplica() {
@@ -185,7 +185,7 @@ func TestComplexScenarios(t *testing.T) {
 			func(
 				_ SendOptions,
 				_ *nodedialer.Dialer,
-				replicas ReplicaSlice,
+				replicas []roachpb.ReplicaDescriptor,
 			) (Transport, error) {
 				return &firstNErrorTransport{
 					replicas:  replicas,

--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -38,9 +38,8 @@ type SendOptions struct {
 // function returns a Transport object which is used to send requests
 // to one or more replicas in the slice.
 //
-// In addition to actually sending RPCs, the transport is responsible
-// for ordering replicas in accordance with SendOptions.Ordering and
-// transport-specific knowledge such as connection health or latency.
+// The caller is responsible for ordering the replicas in the slice according to
+// the order in which the should be tried.
 //
 // TODO(bdarnell): clean up this crufty interface; it was extracted
 // verbatim from the non-abstracted code.

--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -204,10 +204,6 @@ func (gt *grpcTransport) SkipReplica() {
 }
 
 func (gt *grpcTransport) MoveToFront(replica roachpb.ReplicaDescriptor) {
-	gt.moveToFront(replica)
-}
-
-func (gt *grpcTransport) moveToFront(replica roachpb.ReplicaDescriptor) {
 	for i := range gt.replicas {
 		if gt.replicas[i] == replica {
 			// If we've already processed the replica, decrement the current

--- a/pkg/kv/kvclient/kvcoord/transport_race.go
+++ b/pkg/kv/kvclient/kvcoord/transport_race.go
@@ -94,7 +94,7 @@ func (tr raceTransport) SendNext(
 // a) the server doesn't hold on to any memory, and
 // b) the server doesn't mutate the request
 func GRPCTransportFactory(
-	opts SendOptions, nodeDialer *nodedialer.Dialer, replicas ReplicaSlice,
+	opts SendOptions, nodeDialer *nodedialer.Dialer, replicas []roachpb.ReplicaDescriptor,
 ) (Transport, error) {
 	if atomic.AddInt32(&running, 1) <= 1 {
 		// NB: We can't use Stopper.RunWorker because doing so would race with

--- a/pkg/kv/kvclient/kvcoord/transport_regular.go
+++ b/pkg/kv/kvclient/kvcoord/transport_regular.go
@@ -12,11 +12,14 @@
 
 package kvcoord
 
-import "github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+)
 
 // GRPCTransportFactory is the default TransportFactory, using GRPC.
 func GRPCTransportFactory(
-	opts SendOptions, nodeDialer *nodedialer.Dialer, replicas ReplicaSlice,
+	opts SendOptions, nodeDialer *nodedialer.Dialer, replicas []roachpb.ReplicaDescriptor,
 ) (Transport, error) {
 	return grpcTransportFactoryImpl(opts, nodeDialer, replicas)
 }

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -54,20 +54,20 @@ func TestTransportMoveToFront(t *testing.T) {
 	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd1, rd2})
 
 	// Advance the client index and move replica 3 back to front.
-	gt.clientIndex++
+	gt.nextReplicaIdx++
 	gt.MoveToFront(rd3)
 	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd1, rd2})
-	if gt.clientIndex != 0 {
-		t.Fatalf("expected client index 0; got %d", gt.clientIndex)
+	if gt.nextReplicaIdx != 0 {
+		t.Fatalf("expected client index 0; got %d", gt.nextReplicaIdx)
 	}
 
 	// Advance the client index again and verify replica 3 can
 	// be moved to front for a second retry.
-	gt.clientIndex++
+	gt.nextReplicaIdx++
 	gt.MoveToFront(rd3)
 	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd1, rd2})
-	if gt.clientIndex != 0 {
-		t.Fatalf("expected client index 0; got %d", gt.clientIndex)
+	if gt.nextReplicaIdx != 0 {
+		t.Fatalf("expected client index 0; got %d", gt.nextReplicaIdx)
 	}
 
 	// Move replica 2 to the front.
@@ -75,25 +75,25 @@ func TestTransportMoveToFront(t *testing.T) {
 	verifyOrder([]roachpb.ReplicaDescriptor{rd2, rd1, rd3})
 
 	// Advance client index and move rd1 front; should be no change.
-	gt.clientIndex++
+	gt.nextReplicaIdx++
 	gt.MoveToFront(rd1)
 	verifyOrder([]roachpb.ReplicaDescriptor{rd2, rd1, rd3})
 
 	// Advance client index and and move rd1 to front. Should move
 	// client index back for a retry.
-	gt.clientIndex++
+	gt.nextReplicaIdx++
 	gt.MoveToFront(rd1)
 	verifyOrder([]roachpb.ReplicaDescriptor{rd2, rd1, rd3})
-	if gt.clientIndex != 1 {
-		t.Fatalf("expected client index 1; got %d", gt.clientIndex)
+	if gt.nextReplicaIdx != 1 {
+		t.Fatalf("expected client index 1; got %d", gt.nextReplicaIdx)
 	}
 
 	// Advance client index once more; verify second retry.
-	gt.clientIndex++
+	gt.nextReplicaIdx++
 	gt.MoveToFront(rd2)
 	verifyOrder([]roachpb.ReplicaDescriptor{rd1, rd2, rd3})
-	if gt.clientIndex != 1 {
-		t.Fatalf("expected client index 1; got %d", gt.clientIndex)
+	if gt.nextReplicaIdx != 1 {
+		t.Fatalf("expected client index 1; got %d", gt.nextReplicaIdx)
 	}
 }
 

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -201,12 +201,10 @@ func TestTxnCoordSenderCondenseLockSpans(t *testing.T) {
 	// Check end transaction locks, which should be condensed and split
 	// at range boundaries.
 	expLocks := []roachpb.Span{aToBClosed, cToEClosed, fTog1Closed}
-	var sendFn simpleSendFn = func(
-		_ context.Context, _ SendOptions, _ ReplicaSlice, args roachpb.BatchRequest,
-	) (*roachpb.BatchResponse, error) {
-		resp := args.CreateReply()
-		resp.Txn = args.Txn
-		if req, ok := args.GetArg(roachpb.EndTxn); ok {
+	sendFn := func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
+		resp := ba.CreateReply()
+		resp.Txn = ba.Txn
+		if req, ok := ba.GetArg(roachpb.EndTxn); ok {
 			if !req.(*roachpb.EndTxnRequest).Commit {
 				t.Errorf("expected commit to be true")
 			}

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -84,7 +84,7 @@ func TestAmbiguousCommit(t *testing.T) {
 
 		params.Knobs.KVClient = &kvcoord.ClientTestingKnobs{
 			TransportFactory: func(
-				opts kvcoord.SendOptions, nodeDialer *nodedialer.Dialer, replicas kvcoord.ReplicaSlice,
+				opts kvcoord.SendOptions, nodeDialer *nodedialer.Dialer, replicas []roachpb.ReplicaDescriptor,
 			) (kvcoord.Transport, error) {
 				transport, err := kvcoord.GRPCTransportFactory(opts, nodeDialer, replicas)
 				return &interceptingTransport{


### PR DESCRIPTION
The transport was taking in a ReplicaSlice, but it only needs a simpler
[]RangeDescriptor. The ReplicaSlice also has NodeDescriptors in it, but
passing those in was confusing since the transport doesn't use them to
contact the nodes; it uses a NodeDialer that has its own way of mapping
node ids to connections.

This patch also cleans up the crufty transport used in DistSender tests.
That transport was built from a sender function that combined things
related to constructing a transport (taking in a list of replicas) with
the act of sending a request to a particular replica (which, in the case
of this test mock transport, means generating a reply). The tests only
care about the latter part (the few that cared about transport creation
have been dealt with in prior commits), so now they can use a simpler
sender function that just takes in a request (as opposed to request +
list of replicas).

Release note: None