### PR TITLE
sql: introduce ContainsAggregateClass for builtins

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -185,8 +185,6 @@
 </span></td></tr>
 <tr><td><a name="sqrdiff"></a><code>sqrdiff(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the sum of squared differences from the mean of the selected values.</p>
 </span></td></tr>
-<tr><td><a name="st_makeline"></a><code>st_makeline(arg1: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Forms a LineString from Point, MultiPoint or LineStrings. Other shapes will be ignored.</p>
-</span></td></tr>
 <tr><td><a name="stddev"></a><code>stddev(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation of the selected values.</p>
 </span></td></tr>
 <tr><td><a name="stddev"></a><code>stddev(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation of the selected values.</p>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1306,6 +1306,10 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 <tr><td><a name="st_longestline"></a><code>st_longestline(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the LineString corresponds to the max distance across every pair of points comprising the given geometries.</p>
 <p>Note if geometries are the same, it will return the LineString with the maximum distance between the geometry’s vertexes. The function will return the longest line that was discovered first when comparing maximum distances if more than one is found.</p>
 </span></td></tr>
+<tr><td><a name="st_makeline"></a><code>st_makeline(arg1: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Forms a LineString from Points, MultiPoints or LineStrings. Other shapes will be ignored.</p>
+</span></td></tr>
+<tr><td><a name="st_makeline"></a><code>st_makeline(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Forms a LineString from two Points, MultiPoints or LineStrings. Other shapes will be ignored.</p>
+</span></td></tr>
 <tr><td><a name="st_makepoint"></a><code>st_makepoint(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a new Point with the given X and Y coordinates.</p>
 </span></td></tr>
 <tr><td><a name="st_makepolygon"></a><code>st_makepolygon(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a new Polygon with the given outer LineString.</p>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4011,8 +4011,12 @@ SELECT ST_Intersects('abc'::string, 'POINT(1 0)'::string)
 statement error Unknown type: 'ABC'
 SELECT ST_Intersects('POINT(1 0)'::string, 'abc'::string)
 
-query T
-SELECT ST_AsEWKT(ST_MakeLine(g::geometry)) FROM ( VALUES
+query ITT
+SELECT
+  COUNT(*),
+  ST_AsEWKT(ST_MakeLine(g::geometry)),
+  ST_AsEWKT(ST_MakeLine(g::geometry) FILTER (WHERE st_numpoints(g::geometry) > 0))
+FROM ( VALUES
   (NULL),
   ('POINT (30 10)'), -- value is used
   ('POINT EMPTY'),
@@ -4026,12 +4030,31 @@ SELECT ST_AsEWKT(ST_MakeLine(g::geometry)) FROM ( VALUES
   ('GEOMETRYCOLLECTION (POINT (40 10), LINESTRING (10 10, 20 20, 10 40), POLYGON ((40 40, 20 45, 45 30, 40 40)))')
 ) t(g)
 ----
-LINESTRING (30 10, 30 10, 10 30, 40 40, 10 40, 40 30, 20 20, 30 10)
+11  LINESTRING (30 10, 30 10, 10 30, 40 40, 10 40, 40 30, 20 20, 30 10)  LINESTRING (30 10, 10 30, 40 40)
 
 query T
 SELECT ST_AsEWKT(ST_MakeLine(g::geometry)) FROM ( VALUES
   (NULL)
 ) t(g)
+----
+NULL
+
+query T
+SELECT ST_AsEWKT(ST_MakeLine(ST_MakePoint(1, 2), ST_MakePoint(3, 4)))
+----
+LINESTRING (1 2, 3 4)
+
+query T
+SELECT ST_AsEWKT(ST_MakeLine(st_makeline(t.g::geometry), st_makepoint(1, 2))) FROM ( VALUES
+  (NULL),
+  ('POINT (30 10)'),
+  ('POINT(40 10)')
+) t(g)
+----
+LINESTRING (30 10, 40 10, 1 2)
+
+query T
+SELECT ST_AsEWKT(ST_MakeLine(ST_MakePoint(1, 2), NULL))
 ----
 NULL
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2170,6 +2170,7 @@ query O colnames
 SELECT oid::REGPROC FROM pg_proc WHERE proisagg = true EXCEPT SELECT aggfnoid FROM pg_aggregate
 ----
 oid
+st_makeline
 
 # Check whether correct operator's oid is set for max and bool_or.
 query OTO colnames

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -846,6 +846,10 @@ func (b *Builder) constructAggregate(name string, args []opt.ScalarExpr) opt.Sca
 	panic(errors.AssertionFailedf("unhandled aggregate: %s", name))
 }
 
+func isContainsAggregate(def *tree.FunctionDefinition) bool {
+	return def.Class == tree.ContainsAggregateClass
+}
+
 func isAggregate(def *tree.FunctionDefinition) bool {
 	return def.Class == tree.AggregateClass
 }

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2185,7 +2185,6 @@ CREATE TABLE pg_catalog.pg_proc (
 						continue
 					}
 					props, overloads := builtins.GetBuiltinProperties(name)
-					isAggregate := props.Class == tree.AggregateClass
 					isWindow := props.Class == tree.WindowClass
 					for _, builtin := range overloads {
 						dName := tree.NewDName(name)
@@ -2252,36 +2251,36 @@ CREATE TABLE pg_catalog.pg_proc (
 						provolatile, proleakproof := builtin.Volatility.ToPostgres()
 
 						err := addRow(
-							h.BuiltinOid(name, &builtin),             // oid
-							dName,                                    // proname
-							nspOid,                                   // pronamespace
-							tree.DNull,                               // proowner
-							oidZero,                                  // prolang
-							tree.DNull,                               // procost
-							tree.DNull,                               // prorows
-							variadicType,                             // provariadic
-							tree.DNull,                               // protransform
-							tree.MakeDBool(tree.DBool(isAggregate)),  // proisagg
-							tree.MakeDBool(tree.DBool(isWindow)),     // proiswindow
-							tree.DBoolFalse,                          // prosecdef
-							tree.MakeDBool(tree.DBool(proleakproof)), // proleakproof
-							tree.DBoolFalse,                          // proisstrict
-							tree.MakeDBool(tree.DBool(isRetSet)),     // proretset
-							tree.NewDString(provolatile),             // provolatile
-							tree.DNull,                               // proparallel
-							tree.NewDInt(tree.DInt(builtin.Types.Length())), // pronargs
-							tree.NewDInt(tree.DInt(0)),                      // pronargdefaults
-							retType,                                         // prorettype
-							tree.NewDOidVectorFromDArray(dArgTypes),         // proargtypes
-							tree.DNull,                                      // proallargtypes
-							argmodes,                                        // proargmodes
-							tree.DNull,                                      // proargnames
-							tree.DNull,                                      // proargdefaults
-							tree.DNull,                                      // protrftypes
-							dSrc,                                            // prosrc
-							tree.DNull,                                      // probin
-							tree.DNull,                                      // proconfig
-							tree.DNull,                                      // proacl
+							h.BuiltinOid(name, &builtin), // oid
+							dName,                        // proname
+							nspOid,                       // pronamespace
+							tree.DNull,                   // proowner
+							oidZero,                      // prolang
+							tree.DNull,                   // procost
+							tree.DNull,                   // prorows
+							variadicType,                 // provariadic
+							tree.DNull,                   // protransform
+							tree.MakeDBool(tree.DBool(builtin.AggregateFunc != nil)), // proisagg
+							tree.MakeDBool(tree.DBool(isWindow)),                     // proiswindow
+							tree.DBoolFalse,                                          // prosecdef
+							tree.MakeDBool(tree.DBool(proleakproof)),                 // proleakproof
+							tree.DBoolFalse,                                          // proisstrict
+							tree.MakeDBool(tree.DBool(isRetSet)),                     // proretset
+							tree.NewDString(provolatile),                             // provolatile
+							tree.DNull,                                               // proparallel
+							tree.NewDInt(tree.DInt(builtin.Types.Length())),          // pronargs
+							tree.NewDInt(tree.DInt(0)),                               // pronargdefaults
+							retType,                                                  // prorettype
+							tree.NewDOidVectorFromDArray(dArgTypes),                  // proargtypes
+							tree.DNull,                                               // proallargtypes
+							argmodes,                                                 // proargmodes
+							tree.DNull,                                               // proargnames
+							tree.DNull,                                               // proargdefaults
+							tree.DNull,                                               // protrftypes
+							dSrc,                                                     // prosrc
+							tree.DNull,                                               // probin
+							tree.DNull,                                               // proconfig
+							tree.DNull,                                               // proacl
 						)
 						if err != nil {
 							return err

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -358,23 +358,6 @@ var aggregates = map[string]builtinDefinition{
 			"Aggregates values as a JSON or JSONB object.", tree.VolatilityStable),
 	),
 
-	"st_makeline": makeBuiltin(
-		aggPropsNullableArgs(),
-		makeAggOverload(
-			[]*types.T{types.Geometry},
-			types.Geometry,
-			func(
-				params []*types.T, evalCtx *tree.EvalContext, arguments tree.Datums,
-			) tree.AggregateFunc {
-				return &stMakeLineAgg{}
-			},
-			infoBuilder{
-				info: "Forms a LineString from Point, MultiPoint or LineStrings. Other shapes will be ignored.",
-			}.String(),
-			tree.VolatilityImmutable,
-		),
-	),
-
 	AnyNotNull: makePrivate(makeBuiltin(aggProps(),
 		makeAggOverloadWithReturnType(
 			[]*types.T{types.Any},

--- a/pkg/sql/sem/transform/aggregates.go
+++ b/pkg/sql/sem/transform/aggregates.go
@@ -41,6 +41,12 @@ func (v *IsAggregateVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tre
 			v.Aggregated = true
 			return false, expr
 		}
+		if fd.Class == tree.ContainsAggregateClass {
+			if t.ResolvedOverload().AggregateFunc != nil {
+				v.Aggregated = true
+				return false, expr
+			}
+		}
 	case *tree.Subquery:
 		return false, expr
 	}

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -122,6 +122,8 @@ const (
 	// should also include a definition for Overload.Fn, which is executed
 	// like a NormalClass function and returns a Datum.
 	SQLClass
+	// ContainsAggregateClass is a builtin which may contain an aggregate function.
+	ContainsAggregateClass
 )
 
 // Avoid vet warning about unused enum value.

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -929,7 +929,7 @@ func (expr *FuncExpr) TypeCheck(
 	// chooses the overload with preferred type for the given category. For
 	// example, float8 is the preferred type for the numeric category in Postgres.
 	// To match Postgres' behavior, we should add that logic here too.
-	if !def.NullableArgs && def.FunctionProperties.Class == AggregateClass {
+	if !def.NullableArgs && (def.FunctionProperties.Class == AggregateClass || def.FunctionProperties.Class == ContainsAggregateClass) {
 		for i := range typedSubExprs {
 			if typedSubExprs[i].ResolvedType().Family() == types.UnknownFamily {
 				var filtered []overloadImpl
@@ -958,7 +958,7 @@ func (expr *FuncExpr) TypeCheck(
 	// NULL arguments, the function isn't a generator or aggregate builtin, and
 	// NULL is given as an argument.
 	if !def.NullableArgs && def.FunctionProperties.Class != GeneratorClass &&
-		def.FunctionProperties.Class != AggregateClass {
+		def.FunctionProperties.Class != AggregateClass && def.FunctionProperties.Class != ContainsAggregateClass {
 		for _, expr := range typedSubExprs {
 			if expr.ResolvedType().Family() == types.UnknownFamily {
 				return DNull, nil
@@ -1006,7 +1006,7 @@ func (expr *FuncExpr) TypeCheck(
 	}
 
 	if expr.Filter != nil {
-		if def.Class != AggregateClass {
+		if def.Class != AggregateClass && def.Class != ContainsAggregateClass {
 			// Same error message as Postgres. If we have a window function, only
 			// aggregates accept a FILTER clause.
 			return nil, pgerror.Newf(pgcode.WrongObjectType,


### PR DESCRIPTION
We formerly expected all overloads of an AggregateClass to only contain
aggregates. However, as is the case in PostGIS, this is not strictly
true. To account for this, add a new class `ContainsAggregateClass`,
which behaves mostly as AggregateClass except that it allows
non-aggregates to be included the the typename, hence showing up in the
correct places in docs and keeping the error messages for pure
AggregateClass functions.

This is demonstrated with ST_MakeLine, which has both an aggregate
version (existing and tested) and the non-aggregate version.

Resolves #51508
Resolves #48980

Release note (sql change): Implement the ST_MakeLine(a, b) variant,
which takes in two geometries and returns a line out of both.

