### PR TITLE
geo/geomfn: implement ST_Reverse

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1460,6 +1460,8 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 </span></td></tr>
 <tr><td><a name="st_relatematch"></a><code>st_relatematch(intersection_matrix: <a href="string.html">string</a>, pattern: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the given DE-9IM intersection matrix satisfies the given pattern.</p>
 </span></td></tr>
+<tr><td><a name="st_reverse"></a><code>st_reverse(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified geometry by reversing the order of its vertices.</p>
+</span></td></tr>
 <tr><td><a name="st_scale"></a><code>st_scale(g: geometry, factor: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified Geometry scaled by taking in a Geometry as the factor</p>
 </span></td></tr>
 <tr><td><a name="st_scale"></a><code>st_scale(g: geometry, factor: geometry, origin: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a modified Geometry scaled by the Geometry factor relative to a false origin</p>

--- a/pkg/geo/geomfn/reverse.go
+++ b/pkg/geo/geomfn/reverse.go
@@ -1,0 +1,101 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/twpayne/go-geom"
+)
+
+// Reverse returns a modified geometry by reversing the order of its vertexes
+func Reverse(geometry *geo.Geometry) (*geo.Geometry, error) {
+	g, err := geometry.AsGeomT()
+	if err != nil {
+		return nil, err
+	}
+
+	g, err = reverse(g)
+	if err != nil {
+		return nil, err
+	}
+
+	return geo.NewGeometryFromGeomT(g)
+}
+
+func reverse(g geom.T) (geom.T, error) {
+	if geomCollection, ok := g.(*geom.GeometryCollection); ok {
+		return reverseCollection(geomCollection)
+	}
+
+	switch t := g.(type) {
+	case *geom.Point, *geom.MultiPoint: // cases where reverse does change the order
+		return g, nil
+	case *geom.LineString:
+		g = geom.NewLineStringFlat(t.Layout(), reverseCoords(g.FlatCoords(), g.Stride())).SetSRID(g.SRID())
+	case *geom.Polygon:
+		g = geom.NewPolygonFlat(t.Layout(), reverseCoords(g.FlatCoords(), g.Stride()), t.Ends()).SetSRID(g.SRID())
+	case *geom.MultiLineString:
+		g = geom.NewMultiLineStringFlat(t.Layout(), reverseMulti(g, t.Ends()), t.Ends()).SetSRID(g.SRID())
+	case *geom.MultiPolygon:
+		var ends []int
+		for _, e := range t.Endss() {
+			ends = append(ends, e...)
+		}
+		g = geom.NewMultiPolygonFlat(t.Layout(), reverseMulti(g, ends), t.Endss()).SetSRID(g.SRID())
+
+	default:
+		return nil, geom.ErrUnsupportedType{Value: g}
+	}
+
+	return g, nil
+}
+
+func reverseCoords(coords []float64, stride int) []float64 {
+	for i := 0; i < len(coords)/2; i += stride {
+		for j := 0; j < stride; j++ {
+			coords[i+j], coords[len(coords)-stride-i+j] = coords[len(coords)-stride-i+j], coords[i+j]
+		}
+	}
+
+	return coords
+}
+
+// reverseMulti handles reversing coordinates of MULTI* geometries with nested sub-structures
+func reverseMulti(g geom.T, ends []int) []float64 {
+	coords := g.FlatCoords()
+	prevEnd := 0
+
+	for _, end := range ends {
+		copy(
+			coords[prevEnd:end],
+			reverseCoords(coords[prevEnd:end], g.Stride()),
+		)
+		prevEnd = end
+	}
+
+	return coords
+}
+
+// reverseCollection iterates through a GeometryCollection and calls reverse() on each geometry.
+func reverseCollection(geomCollection *geom.GeometryCollection) (*geom.GeometryCollection, error) {
+	res := geom.NewGeometryCollection()
+	for _, subG := range geomCollection.Geoms() {
+		subGeom, err := reverse(subG)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := res.Push(subGeom); err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}

--- a/pkg/geo/geomfn/reverse_test.go
+++ b/pkg/geo/geomfn/reverse_test.go
@@ -1,0 +1,126 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
+)
+
+func TestReverse(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		input    geom.T
+		expected geom.T
+	}{
+		{
+			desc:     "reverse a line string",
+			input:    geom.NewLineStringFlat(geom.XY, []float64{1, -1, 2, -2, 3, -3, 4, -4, 5, -5}),
+			expected: geom.NewLineStringFlat(geom.XY, []float64{5, -5, 4, -4, 3, -3, 2, -2, 1, -1}),
+		},
+		{
+			desc:     "reverse a polygon",
+			input:    geom.NewPolygonFlat(geom.XY, []float64{0, 0, 5, 5, 0, 10, 0, 0}, []int{8}),
+			expected: geom.NewPolygonFlat(geom.XY, []float64{0, 0, 0, 10, 5, 5, 0, 0}, []int{8}),
+		},
+		{
+			desc:     "reverse multiple line strings",
+			input:    geom.NewMultiLineStringFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3, -1, -1, -2, -2}, []int{6, 10}),
+			expected: geom.NewMultiLineStringFlat(geom.XY, []float64{3, 3, 2, 2, 1, 1, -2, -2, -1, -1}, []int{6, 10}),
+		},
+		{
+			desc:     "reverse multiple polygons",
+			input:    geom.NewMultiPolygonFlat(geom.XY, []float64{0, 0, 5, 0, 4, 4, 0, 4, 0, 0, 1, 1, 2, 3, 2, 2, 1, 2, 1, 1}, [][]int{{10}, {20}}),
+			expected: geom.NewMultiPolygonFlat(geom.XY, []float64{0, 0, 0, 4, 4, 4, 5, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 1, 1}, [][]int{{10}, {20}}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			geometry, err := geo.NewGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+
+			got, err := Reverse(geometry)
+			require.NoError(t, err)
+
+			want, err := geo.NewGeometryFromGeomT(tc.expected)
+			require.NoError(t, err)
+
+			require.Equal(t, want, got)
+			require.EqualValues(t, tc.input.SRID(), got.SRID())
+		})
+	}
+
+	collectionTestCases := []struct {
+		input    *geom.GeometryCollection
+		expected *geom.GeometryCollection
+	}{
+		{
+			input: geom.NewGeometryCollection().MustPush(
+				geom.NewLineStringFlat(geom.XY, []float64{1, -1, 2, -2}),
+				geom.NewPolygonFlat(geom.XY, []float64{0, 0, 5, 5, 0, 10, 0, 0}, []int{8}),
+				geom.NewPointFlat(geom.XY, []float64{1, 2}),
+			),
+			expected: geom.NewGeometryCollection().MustPush(
+				geom.NewLineStringFlat(geom.XY, []float64{2, -2, 1, -1}),
+				geom.NewPolygonFlat(geom.XY, []float64{0, 0, 0, 10, 5, 5, 0, 0}, []int{8}),
+				geom.NewPointFlat(geom.XY, []float64{1, 2}),
+			),
+		},
+	}
+
+	for i, tc := range collectionTestCases {
+		t.Run(fmt.Sprintf("collection-%d", i), func(t *testing.T) {
+			geometry, err := geo.NewGeometryFromGeomT(tc.input)
+			require.NoError(t, err)
+
+			geometry, err = Reverse(geometry)
+			require.NoError(t, err)
+
+			g, err := geometry.AsGeomT()
+			require.NoError(t, err)
+
+			gotCollection, ok := g.(*geom.GeometryCollection)
+			require.True(t, ok)
+
+			require.Equal(t, tc.expected, gotCollection)
+		})
+
+	}
+
+	noChangeTestCases := []geom.T{
+		geom.NewPointFlat(geom.XY, []float64{1, 2}),
+		geom.NewMultiPointFlat(geom.XY, []float64{1, 1, 2, 2}),
+		geom.NewLineString(geom.XY),
+		geom.NewPolygon(geom.XY),
+		geom.NewGeometryCollection(),
+	}
+
+	for i, input := range noChangeTestCases {
+		t.Run(fmt.Sprintf("no-change-%d", i), func(t *testing.T) {
+			geometry, err := geo.NewGeometryFromGeomT(input)
+			require.NoError(t, err)
+
+			got, err := Reverse(geometry)
+			require.NoError(t, err)
+
+			want, err := geo.NewGeometryFromGeomT(input)
+			require.NoError(t, err)
+
+			require.Equal(t, want, got)
+			require.EqualValues(t, input.SRID(), got.SRID())
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4052,3 +4052,25 @@ LINESTRING (10 10, -1 3)
 LINESTRING (0 0, 1 1, 10 10)
 LINESTRING (0 0, 1 1, 2 2, 10 10)
 LINESTRING (10 10, 1 1, 2 2, 3 3)
+
+subtest reverse_test
+
+query TT
+SELECT
+  ST_AsText(a.geom) d,
+  ST_AsText(ST_Reverse(a.geom))
+FROM geom_operators_test a
+ORDER BY d ASC
+----
+NULL                                                   NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY
+LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (0.5 0.5, -0.5 0.5)
+LINESTRING EMPTY                                       LINESTRING EMPTY
+POINT (-0.5 0.5)                                       POINT (-0.5 0.5)
+POINT (0.5 0.5)                                        POINT (0.5 0.5)
+POINT (5 5)                                            POINT (5 5)
+POINT EMPTY                                            POINT EMPTY
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3163,6 +3163,29 @@ For flags=1, validity considers self-intersecting rings forming holes as valid a
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_reverse": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry", types.Geometry},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				geometry := args[0].(*tree.DGeometry)
+
+				ret, err := geomfn.Reverse(geometry.Geometry)
+				if err != nil {
+					return nil, err
+				}
+
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: `Returns a modified geometry by reversing the order of its vertices.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 	"st_segmentize": makeBuiltin(
 		defProps(),
 		tree.Overload{


### PR DESCRIPTION
Implement ST_Reverse on arguments {geometry}, which should adopt PostGIS behaviour.

Release note (sql change): Implemented geometry builtin `ST_Reverse`

Closes #49018 