### PR TITLE
docs/codelabs: update code examples and error messages

### DIFF
--- a/docs/codelabs/00-sql-function.md
+++ b/docs/codelabs/00-sql-function.md
@@ -103,7 +103,7 @@ github.com/cockroachdb/cockroach
 Now, let’s run a single-node Cockroach instance:
 
 ```text
-$ rm -fr cockroach-data/ && ./cockroach start --insecure
+$ rm -fr cockroach-data/ && ./cockroach start-single-node --insecure
 ...
 status:     initialized new cluster
 ...
@@ -114,7 +114,7 @@ built-in:
 
 ```text
 $ ./cockroach sql --insecure -e "select whois()"
-Error: pq: whois(): nothing to see here
+ERROR: whois(): nothing to see here
 Failed running "sql"
 ```
 
@@ -124,7 +124,8 @@ a non-existent function we’d get a different error:
 
 ```go
 $ ./cockroach sql --insecure -e 'select nonexistent()'
-Error: pq: unknown function: nonexistent()
+ERROR: unknown function: nonexistent()
+...
 Failed running "sql"
 ```
 
@@ -184,23 +185,19 @@ function:
 
 ```text
 $ ./cockroach sql --insecure -e "select whois('pmattis')"
-+------------------+
-| whois('pmattis') |
-+------------------+
-| Peter Mattis     |
-+------------------+
+     whois
+----------------
+  Peter Mattis
 (1 row)
 
 $ ./cockroach sql --insecure -e "select whois('pmattis', 'bdarnell')"
-+------------------------------+
-| whois('pmattis', 'bdarnell') |
-+------------------------------+
-| Peter Mattis, Ben Darnell    |
-+------------------------------+
+            whois
+-----------------------------
+  Peter Mattis, Ben Darnell
 (1 row)
 
 $ ./cockroach sql --insecure -e "select whois('non-existent')"
-Error: pq: whois(): unknown username: 'non-existent'
+ERROR: whois(): unknown username: 'non-existent'
 Failed running "sql"
 ```
 
@@ -226,11 +223,9 @@ Rebuild, restart and test:
 
 ```text
 $ ./cockroach sql --insecure -e "select whois()"
-+--------------------------------------------+
-|                  whois()                   |
-+--------------------------------------------+
-| Ben Darnell, Peter Mattis, Spencer Kimball |
-+--------------------------------------------+
+                    whois
+----------------------------------------------
+  Ben Darnell, Peter Mattis, Spencer Kimball
 (1 row)
 ```
 

--- a/docs/codelabs/01-sql-statement.md
+++ b/docs/codelabs/01-sql-statement.md
@@ -199,10 +199,10 @@ Make a new file for our statement type: `pkg/sql/sem/tree/frobnicate.go`.  In
 it, put the implementation of our AST node.
 
 ```go
-package tree 
+package tree
 
 type Frobnicate struct {
-    Mode FrobnicateMode
+	Mode FrobnicateMode
 }
 
 var _ Statement = &Frobnicate{}
@@ -210,27 +210,28 @@ var _ Statement = &Frobnicate{}
 type FrobnicateMode int
 
 const (
-    FrobnicateModeAll FrobnicateMode = iota
-    FrobnicateModeCluster
-    FrobnicateModeSession
+	FrobnicateModeAll FrobnicateMode = iota
+	FrobnicateModeCluster
+	FrobnicateModeSession
 )
 
 func (node *Frobnicate) StatementType() StatementType { return Ack }
 func (node *Frobnicate) StatementTag() string { return "FROBNICATE" }
 
 func (node *Frobnicate) Format(ctx *FmtCtx) {
-    ctx.WriteString("FROBNICATE ")
-    switch node.Mode {
-    case FrobnicateModeAll:
-        ctx.WriteString("ALL")
-    case FrobnicateModeCluster:
-        ctx.WriteString("CLUSTER")
-    case FrobnicateModeSession:
-        ctx.WriteString("SESSION")
+	ctx.WriteString("FROBNICATE ")
+	switch node.Mode {
+	case FrobnicateModeAll:
+		ctx.WriteString("ALL")
+	case FrobnicateModeCluster:
+		ctx.WriteString("CLUSTER")
+	case FrobnicateModeSession:
+		ctx.WriteString("SESSION")
+	}
 }
 
 func (node *Frobnicate) String() string {
-    return AsString(node)
+	return AsString(node)
 }
 ```
 
@@ -258,8 +259,8 @@ Then rebuild and run the tests to watch them fail:
 $ make test
 ...
 --- FAIL: TestParse (0.00s)
-    parse_test.go:721: FROBNICATE CLUSTER: expected success, but found unimplemented at or near "cluster"
-        FROBNICATE CLUSTER
+    parse_test.go:1598: FROBNICATE CLUSTER: expected success, but found at or near 
+"cluster": syntax error: unimplemented: this syntax
 ...
 ```
 
@@ -330,7 +331,7 @@ import (
 )
 
 func (p *planner) Frobnicate(ctx context.Context, stmt *tree.Frobnicate) (planNode, error) {
-    return nil, AssertionFailedf("We're not quite frobnicating yet...")
+    return nil, errors.AssertionFailedf("We're not quite frobnicating yet...")
 }
 ```
 
@@ -338,7 +339,8 @@ Run `make build` again and give it another go:
 
 ```text
 $ ./cockroach sql --insecure -e "frobnicate cluster"
-Error: pq: We're not quite frobnicating yet...
+ERROR: internal error: We're not quite frobnicating yet...
+...
 Failed running "sql"
 ```
 


### PR DESCRIPTION
Some code and error messages were slightly out-of-date or incorrect.

Possible future update: `make test` takes a long time, maybe add a
PKG argument to narrow the scope.