### PR TITLE
kvserver,rangefeed: ensure that iterators are only constructed under tasks

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -152,8 +152,15 @@ func newTestProcessorWithTxnPusher(
 		EventChanCap:         testProcessorEventCCap,
 		CheckStreamsInterval: 10 * time.Millisecond,
 	})
-	p.Start(stopper, rtsIter)
+	p.Start(stopper, makeIteratorConstructor(rtsIter))
 	return p, stopper
+}
+
+func makeIteratorConstructor(rtsIter storage.SimpleIterator) IteratorConstructor {
+	if rtsIter == nil {
+		return nil
+	}
+	return func() storage.SimpleIterator { return rtsIter }
 }
 
 func newTestProcessor(rtsIter storage.SimpleIterator) (*Processor, *stop.Stopper) {

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -104,7 +104,7 @@ func newTestRegistration(
 		registration: newRegistration(
 			span,
 			ts,
-			catchup,
+			makeIteratorConstructor(catchup),
 			withDiff,
 			5,
 			NewMetrics(),
@@ -253,7 +253,7 @@ func TestRegistrationCatchUpScan(t *testing.T) {
 	}, hlc.Timestamp{WallTime: 4}, iter, true /* withDiff */)
 
 	require.Zero(t, r.metrics.RangeFeedCatchupScanNanos.Count())
-	require.NoError(t, r.runCatchupScan())
+	require.NoError(t, r.maybeRunCatchupScan())
 	require.True(t, iter.closed)
 	require.NotZero(t, r.metrics.RangeFeedCatchupScanNanos.Count())
 


### PR DESCRIPTION

Prior to this change, it was possible for a rangefeed request to be issued
concurrently with shutting down which could lead to an iterator being
constructed after the engine has been closed.

Touches #51544

Release note: None