### PR TITLE
cat: change Column to a struct and related improvements

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -615,7 +615,7 @@ func importPlanHook(
 			// expressions are nullable.
 			if len(isTargetCol) != 0 {
 				for _, col := range found.VisibleColumns() {
-					if !(isTargetCol[col.Name] || col.IsNullable() || col.HasDefault()) {
+					if !(isTargetCol[col.Name] || col.Nullable || col.HasDefault()) {
 						return errors.Newf(
 							"all non-target columns in IMPORT INTO must be nullable "+
 								"or have default expressions but violated by column %q",

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -293,7 +293,7 @@ func alterColumnTypeGeneral(
 
 		oldColComputeExpr := tree.CastExpr{
 			Expr:       &tree.ColumnItem{ColumnName: tree.Name(col.Name)},
-			Type:       col.DatumType(),
+			Type:       col.Type,
 			SyntaxMode: tree.CastShort,
 		}
 		inverseExpr = tree.Serialize(&oldColComputeExpr)
@@ -309,7 +309,7 @@ func alterColumnTypeGeneral(
 		} else {
 			// The default expression for the new column is applying the
 			// computed expression to the previous default expression.
-			expr, err := parser.ParseExpr(col.DefaultExprStr())
+			expr, err := parser.ParseExpr(*col.DefaultExpr)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/catalog/descpb/column.go
+++ b/pkg/sql/catalog/descpb/column.go
@@ -54,28 +54,6 @@ func (desc *ColumnDescriptor) DatumType() *types.T {
 	return desc.Type
 }
 
-// ColTypePrecision is part of the cat.Column interface.
-func (desc *ColumnDescriptor) ColTypePrecision() int {
-	if desc.Type.Family() == types.ArrayFamily {
-		if desc.Type.ArrayContents().Family() == types.ArrayFamily {
-			panic(errors.AssertionFailedf("column type should never be a nested array"))
-		}
-		return int(desc.Type.ArrayContents().Precision())
-	}
-	return int(desc.Type.Precision())
-}
-
-// ColTypeWidth is part of the cat.Column interface.
-func (desc *ColumnDescriptor) ColTypeWidth() int {
-	if desc.Type.Family() == types.ArrayFamily {
-		if desc.Type.ArrayContents().Family() == types.ArrayFamily {
-			panic(errors.AssertionFailedf("column type should never be a nested array"))
-		}
-		return int(desc.Type.ArrayContents().Width())
-	}
-	return int(desc.Type.Width())
-}
-
 // IsHidden is part of the cat.Column interface.
 func (desc *ColumnDescriptor) IsHidden() bool {
 	return desc.Hidden

--- a/pkg/sql/catalog/descpb/column.go
+++ b/pkg/sql/catalog/descpb/column.go
@@ -76,11 +76,6 @@ func (desc *ColumnDescriptor) ColTypeWidth() int {
 	return int(desc.Type.Width())
 }
 
-// ColTypeStr is part of the cat.Column interface.
-func (desc *ColumnDescriptor) ColTypeStr() string {
-	return desc.Type.SQLString()
-}
-
 // IsHidden is part of the cat.Column interface.
 func (desc *ColumnDescriptor) IsHidden() bool {
 	return desc.Hidden

--- a/pkg/sql/catalog/descpb/column.go
+++ b/pkg/sql/catalog/descpb/column.go
@@ -11,20 +11,11 @@
 package descpb
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
-
-var _ cat.Column = &ColumnDescriptor{}
-
-// IsNullable is part of the cat.Column interface.
-func (desc *ColumnDescriptor) IsNullable() bool {
-	return desc.Nullable
-}
 
 // HasNullDefault checks that the column descriptor has a default of NULL.
 func (desc *ColumnDescriptor) HasNullDefault() bool {
@@ -39,49 +30,19 @@ func (desc *ColumnDescriptor) HasNullDefault() bool {
 	return defaultExpr == tree.DNull
 }
 
-// ColID is part of the cat.Column interface.
-func (desc *ColumnDescriptor) ColID() cat.StableID {
-	return cat.StableID(desc.ID)
-}
-
-// ColName is part of the cat.Column interface.
-func (desc *ColumnDescriptor) ColName() tree.Name {
-	return tree.Name(desc.Name)
-}
-
-// DatumType is part of the cat.Column interface.
-func (desc *ColumnDescriptor) DatumType() *types.T {
-	return desc.Type
-}
-
-// IsHidden is part of the cat.Column interface.
-func (desc *ColumnDescriptor) IsHidden() bool {
-	return desc.Hidden
-}
-
-// HasDefault is part of the cat.Column interface.
+// HasDefault returns true if the column has a default value.
 func (desc *ColumnDescriptor) HasDefault() bool {
 	return desc.DefaultExpr != nil
 }
 
-// IsComputed is part of the cat.Column interface.
+// IsComputed returns true if this is a computed column.
 func (desc *ColumnDescriptor) IsComputed() bool {
 	return desc.ComputeExpr != nil
 }
 
-// DefaultExprStr is part of the cat.Column interface.
-func (desc *ColumnDescriptor) DefaultExprStr() string {
-	return *desc.DefaultExpr
-}
-
-// ComputedExprStr is part of the cat.Column interface.
-func (desc *ColumnDescriptor) ComputedExprStr() string {
-	return *desc.ComputeExpr
-}
-
-// InvertedSourceColumnOrdinal is part of the cat.Column interface.
-func (desc *ColumnDescriptor) InvertedSourceColumnOrdinal() int {
-	panic(errors.AssertionFailedf("not a virtual column"))
+// ColName returns the name of the column as a tree.Name.
+func (desc *ColumnDescriptor) ColName() tree.Name {
+	return tree.Name(desc.Name)
 }
 
 // CheckCanBeFKRef returns whether the given column is computed.

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1993,7 +1993,7 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 			}
 			def := tree.ColumnTableDef{
 				Name: tree.Name(c.Name),
-				Type: c.DatumType(),
+				Type: c.Type,
 			}
 			if c.Nullable {
 				def.Nullable.Nullability = tree.Null

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -102,13 +102,12 @@ func makeScanColumnsConfig(table cat.Table, cols exec.TableColumnOrdinalSet) sca
 		wantedColumns: make([]tree.ColumnID, 0, cols.Len()),
 		visibility:    execinfra.ScanVisibilityPublicAndNotPublic,
 	}
-	for c, ok := cols.Next(0); ok; c, ok = cols.Next(c + 1) {
-		ord := c
-		if cat.IsVirtualColumn(table, c) {
-			ord = table.Column(ord).InvertedSourceColumnOrdinal()
+	for ord, ok := cols.Next(0); ok; ord, ok = cols.Next(ord + 1) {
+		col := table.Column(ord)
+		if col.Kind() == cat.Virtual {
+			col = table.Column(col.InvertedSourceColumnOrdinal())
 		}
-		desc := table.Column(ord).(*descpb.ColumnDescriptor)
-		colCfg.wantedColumns = append(colCfg.wantedColumns, tree.ColumnID(desc.ID))
+		colCfg.wantedColumns = append(colCfg.wantedColumns, tree.ColumnID(col.ColID()))
 	}
 	return colCfg
 }

--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -13,7 +13,110 @@ package cat
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
 )
+
+// Column stores information about table columns, exposing only the information
+// needed by the query optimizer.
+type Column struct {
+	// The fields in this struct correspond to the getter methods below. Refer to
+	// those for documentation.
+	//
+	// Warning! If any fields are added here, make sure both Init methods below
+	// set all fields (even if they are the empty value).
+	stableID                    StableID
+	name                        tree.Name
+	kind                        ColumnKind
+	datumType                   *types.T
+	nullable                    bool
+	hidden                      bool
+	defaultExpr                 *string
+	computedExpr                *string
+	invertedSourceColumnOrdinal int
+}
+
+// ColID is the unique, stable identifier for this column within its table.
+// Each new column in the table will be assigned a new ID that is different than
+// every column allocated before or after. This is true even if a column is
+// dropped and then re-added with the same name; the new column will have a
+// different ID. See the comment for StableID for more detail.
+//
+// Virtual columns don't have stable IDs; for these columns ColID() must not be
+// called.
+func (c *Column) ColID() StableID {
+	if c.kind == Virtual {
+		panic(errors.AssertionFailedf("virtual columns have no StableID"))
+	}
+	return c.stableID
+}
+
+// ColName returns the name of the column.
+func (c *Column) ColName() tree.Name {
+	return c.name
+}
+
+// Kind returns what kind of column this is.
+func (c *Column) Kind() ColumnKind {
+	return c.kind
+}
+
+// DatumType returns the data type of the column.
+func (c *Column) DatumType() *types.T {
+	return c.datumType
+}
+
+// IsNullable returns true if the column is nullable.
+func (c *Column) IsNullable() bool {
+	return c.nullable
+}
+
+// IsHidden returns true if the column is hidden (e.g., there is always a hidden
+// column called rowid if there is no primary key on the table).
+func (c *Column) IsHidden() bool {
+	return c.hidden
+}
+
+// HasDefault returns true if the column has a default value. DefaultExprStr
+// will be set to the SQL expression string in that case.
+func (c *Column) HasDefault() bool {
+	return c.defaultExpr != nil
+}
+
+// DefaultExprStr is set to the SQL expression string that describes the
+// column's default value. It is used when the user does not provide a value for
+// the column when inserting a row. Default values cannot depend on other
+// columns.
+func (c *Column) DefaultExprStr() string {
+	return *c.defaultExpr
+}
+
+// IsComputed returns true if the column is a computed value. ComputedExprStr
+// will be set to the SQL expression string in that case.
+func (c *Column) IsComputed() bool {
+	return c.computedExpr != nil
+}
+
+// ComputedExprStr is set to the SQL expression string that describes the
+// column's computed value. It is always used to provide the column's value when
+// inserting or updating a row. Computed values cannot depend on other computed
+// columns, but they can depend on all other columns, including columns with
+// default values.
+func (c *Column) ComputedExprStr() string {
+	return *c.computedExpr
+}
+
+// InvertedSourceColumnOrdinal is used for virtual columns that are part
+// of inverted indexes. It returns the ordinal of the table column from which
+// the inverted column is derived.
+//
+// For example, if we have an inverted index on a JSON column `j`, the index is
+// on a virtual `j_inverted` column and calling InvertedSourceColumnOrdinal() on
+// `j_inverted` returns the ordinal of the `j` column.
+//
+// Must not be called if this is not a virtual column.
+func (c *Column) InvertedSourceColumnOrdinal() int {
+	return c.invertedSourceColumnOrdinal
+}
 
 // ColumnKind differentiates between different kinds of table columns.
 type ColumnKind uint8
@@ -50,66 +153,6 @@ func (kind ColumnKind) IsSelectable() bool {
 	return kind == Ordinary || kind == System
 }
 
-// Column is an interface to a table column, exposing only the information
-// needed by the query optimizer.
-type Column interface {
-	// ColID is the unique, stable identifier for this column within its table.
-	// Each new column in the table will be assigned a new ID that is different
-	// than every column allocated before or after. This is true even if a column
-	// is dropped and then re-added with the same name; the new column will have
-	// a different ID. See the comment for StableID for more detail.
-	//
-	// Virtual columns don't have stable IDs; for these columns ColID() must not
-	// be called.
-	ColID() StableID
-
-	// ColName returns the name of the column.
-	ColName() tree.Name
-
-	// DatumType returns the data type of the column.
-	DatumType() *types.T
-
-	// IsNullable returns true if the column is nullable.
-	IsNullable() bool
-
-	// IsHidden returns true if the column is hidden (e.g., there is always a
-	// hidden column called rowid if there is no primary key on the table).
-	IsHidden() bool
-
-	// HasDefault returns true if the column has a default value. DefaultExprStr
-	// will be set to the SQL expression string in that case.
-	HasDefault() bool
-
-	// DefaultExprStr is set to the SQL expression string that describes the
-	// column's default value. It is used when the user does not provide a value
-	// for the column when inserting a row. Default values cannot depend on other
-	// columns.
-	DefaultExprStr() string
-
-	// IsComputed returns true if the column is a computed value. ComputedExprStr
-	// will be set to the SQL expression string in that case.
-	IsComputed() bool
-
-	// ComputedExprStr is set to the SQL expression string that describes the
-	// column's computed value. It is always used to provide the column's value
-	// when inserting or updating a row. Computed values cannot depend on other
-	// computed columns, but they can depend on all other columns, including
-	// columns with default values.
-	ComputedExprStr() string
-
-	// InvertedSourceColumnOrdinal is implemented by virtual columns that are part
-	// of inverted indexes. It returns the ordinal of the table column from which
-	// the inverted column is derived.
-	//
-	// For example, if we have an inverted index on a JSON column `j`, the index
-	// is on a virtual `j_inverted` column and calling
-	// InvertedSourceColumnOrdinal() on `j_inverted` returns the ordinal of the
-	// `j` column.
-	//
-	// Must not be called if this is not a virtual column.
-	InvertedSourceColumnOrdinal() int
-}
-
 // IsMutationColumn is a convenience function that returns true if the column at
 // the given ordinal position is a mutation column.
 func IsMutationColumn(table Table, ord int) bool {
@@ -132,4 +175,46 @@ func IsSelectableColumn(table Table, ord int) bool {
 // the given ordinal position is a virtual column.
 func IsVirtualColumn(table Table, ord int) bool {
 	return table.ColumnKind(ord) == Virtual
+}
+
+// InitNonVirtual is used by catalog implementations to populate a non-virtual
+// Column. It should not be used anywhere else.
+func (c *Column) InitNonVirtual(
+	stableID StableID,
+	name tree.Name,
+	kind ColumnKind,
+	datumType *types.T,
+	nullable bool,
+	hidden bool,
+	defaultExpr *string,
+	computedExpr *string,
+) {
+	if kind == Virtual {
+		panic(errors.AssertionFailedf("incorrect init method"))
+	}
+	c.stableID = stableID
+	c.name = name
+	c.kind = kind
+	c.datumType = datumType
+	c.nullable = nullable
+	c.hidden = hidden
+	c.defaultExpr = defaultExpr
+	c.computedExpr = computedExpr
+	c.invertedSourceColumnOrdinal = -1
+}
+
+// InitVirtual is used by catalog implementations to populate a virtual Column.
+// It should not be used anywhere else.
+func (c *Column) InitVirtual(
+	name tree.Name, datumType *types.T, nullable bool, invertedSourceColumnOrdinal int,
+) {
+	c.stableID = 0
+	c.name = name
+	c.kind = Virtual
+	c.datumType = datumType
+	c.nullable = nullable
+	c.hidden = true
+	c.defaultExpr = nil
+	c.computedExpr = nil
+	c.invertedSourceColumnOrdinal = invertedSourceColumnOrdinal
 }

--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -60,6 +60,17 @@ func (c *Column) Kind() ColumnKind {
 	return c.kind
 }
 
+// IsMutation returns true if this is a mutation column (based on its Kind).
+func (c *Column) IsMutation() bool {
+	return c.kind == WriteOnly || c.kind == DeleteOnly
+}
+
+// IsSelectable returns true if this column should be accessible from user
+// queries (based on its Kind).
+func (c *Column) IsSelectable() bool {
+	return c.kind == Ordinary || c.kind == System
+}
+
 // DatumType returns the data type of the column.
 func (c *Column) DatumType() *types.T {
 	return c.datumType
@@ -140,42 +151,6 @@ const (
 	// later, expression-based indexes).
 	Virtual
 )
-
-// IsMutation is a convenience method that returns true if the column kind is
-// a mutation column.
-func (kind ColumnKind) IsMutation() bool {
-	return kind == WriteOnly || kind == DeleteOnly
-}
-
-// IsSelectable is a convenience method that returns true if the column
-// kind is a selectable column.
-func (kind ColumnKind) IsSelectable() bool {
-	return kind == Ordinary || kind == System
-}
-
-// IsMutationColumn is a convenience function that returns true if the column at
-// the given ordinal position is a mutation column.
-func IsMutationColumn(table Table, ord int) bool {
-	return table.ColumnKind(ord).IsMutation()
-}
-
-// IsSystemColumn is a convenience function that returns true if the column at
-// the given ordinal position is a system column.
-func IsSystemColumn(table Table, ord int) bool {
-	return table.ColumnKind(ord) == System
-}
-
-// IsSelectableColumn is a convenience function that returns true if the column
-// at the given ordinal position is a selectable column.
-func IsSelectableColumn(table Table, ord int) bool {
-	return table.ColumnKind(ord).IsSelectable()
-}
-
-// IsVirtualColumn is a convenience function that returns true if the column at
-// the given ordinal position is a virtual column.
-func IsVirtualColumn(table Table, ord int) bool {
-	return table.ColumnKind(ord) == Virtual
-}
 
 // InitNonVirtual is used by catalog implementations to populate a non-virtual
 // Column. It should not be used anywhere else.

--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -86,11 +86,6 @@ type Column interface {
 	// TODO(andyk): Switch calling code to use DatumType.
 	ColTypeWidth() int
 
-	// ColTypeStr returns the SQL data type of the column, as a string. Note that
-	// this is sometimes different than DatumType().String(), since datum types
-	// are a subset of column types.
-	ColTypeStr() string
-
 	// IsNullable returns true if the column is nullable.
 	IsNullable() bool
 

--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -69,23 +69,6 @@ type Column interface {
 	// DatumType returns the data type of the column.
 	DatumType() *types.T
 
-	// ColTypePrecision returns the precision of the column's SQL data type. This
-	// is only defined for the Decimal data type and represents the max number of
-	// decimal digits in the decimal (including fractional digits). If precision
-	// is 0, then the decimal has no max precision.
-	ColTypePrecision() int
-
-	// ColTypeWidth returns the width of the column's SQL data type. This has
-	// different meanings depending on the data type:
-	//
-	//   Decimal  : scale
-	//   Int      : # bits (16, 32, 64, etc)
-	//   Bit Array: # bits
-	//   String   : rune count
-	//
-	// TODO(andyk): Switch calling code to use DatumType.
-	ColTypeWidth() int
-
 	// IsNullable returns true if the column is nullable.
 	IsNullable() bool
 

--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -24,6 +24,7 @@ type Column struct {
 	//
 	// Warning! If any fields are added here, make sure both Init methods below
 	// set all fields (even if they are the empty value).
+	ordinal                     int
 	stableID                    StableID
 	name                        tree.Name
 	kind                        ColumnKind
@@ -33,6 +34,13 @@ type Column struct {
 	defaultExpr                 *string
 	computedExpr                *string
 	invertedSourceColumnOrdinal int
+}
+
+// Ordinal returns the position of the column in its table. The following always
+// holds:
+//   tab.Column(i).Ordinal() == i
+func (c *Column) Ordinal() int {
+	return c.ordinal
 }
 
 // ColID is the unique, stable identifier for this column within its table.
@@ -155,6 +163,7 @@ const (
 // InitNonVirtual is used by catalog implementations to populate a non-virtual
 // Column. It should not be used anywhere else.
 func (c *Column) InitNonVirtual(
+	ordinal int,
 	stableID StableID,
 	name tree.Name,
 	kind ColumnKind,
@@ -167,6 +176,7 @@ func (c *Column) InitNonVirtual(
 	if kind == Virtual {
 		panic(errors.AssertionFailedf("incorrect init method"))
 	}
+	c.ordinal = ordinal
 	c.stableID = stableID
 	c.name = name
 	c.kind = kind
@@ -181,8 +191,9 @@ func (c *Column) InitNonVirtual(
 // InitVirtual is used by catalog implementations to populate a virtual Column.
 // It should not be used anywhere else.
 func (c *Column) InitVirtual(
-	name tree.Name, datumType *types.T, nullable bool, invertedSourceColumnOrdinal int,
+	ordinal int, name tree.Name, datumType *types.T, nullable bool, invertedSourceColumnOrdinal int,
 ) {
+	c.ordinal = ordinal
 	c.stableID = 0
 	c.name = name
 	c.kind = Virtual

--- a/pkg/sql/opt/cat/family.go
+++ b/pkg/sql/opt/cat/family.go
@@ -39,7 +39,7 @@ type Family interface {
 type FamilyColumn struct {
 	// Column is a reference to the column returned by Table.Column, given the
 	// column ordinal.
-	Column
+	*Column
 
 	// Ordinal is the ordinal position of the family column in the table. It is
 	// always >= 0 and < Table.ColumnCount.

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -228,10 +228,6 @@ type IndexColumn struct {
 	// column ordinal.
 	*Column
 
-	// Ordinal is the ordinal position of the indexed column in the table being
-	// indexed. It is always >= 0 and < Table.ColumnCount.
-	Ordinal int
-
 	// Descending is true if the index is ordered from greatest to least on
 	// this column, rather than least to greatest.
 	Descending bool

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -226,7 +226,7 @@ type Index interface {
 type IndexColumn struct {
 	// Column is a reference to the column returned by Table.Column, given the
 	// column ordinal.
-	Column
+	*Column
 
 	// Ordinal is the ordinal position of the indexed column in the table being
 	// indexed. It is always >= 0 and < Table.ColumnCount.

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -59,7 +59,7 @@ type Table interface {
 	//
 	//   cockroachdb/cockroach/docs/RFCS/20151014_online_schema_change.md
 	//
-	Column(i int) Column
+	Column(i int) *Column
 
 	// ColumnKind returns the column kind.
 	// Note: this is not a method in Column for the efficiency of the

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -61,12 +61,6 @@ type Table interface {
 	//
 	Column(i int) *Column
 
-	// ColumnKind returns the column kind.
-	// Note: this is not a method in Column for the efficiency of the
-	// Column implementation (which can't access this information without using
-	// extra objects).
-	ColumnKind(i int) ColumnKind
-
 	// IndexCount returns the number of public indexes defined on this table.
 	// Public indexes are not currently being added or dropped from the table.
 	// This method should be used when mutation columns can be ignored (the common

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -132,7 +132,7 @@ func FormatTable(cat Catalog, tab Table, tp treeprinter.Node) {
 	var buf bytes.Buffer
 	for i := 0; i < tab.ColumnCount(); i++ {
 		buf.Reset()
-		formatColumn(tab.Column(i), tab.ColumnKind(i), &buf)
+		formatColumn(tab.Column(i), &buf)
 		child.Child(buf.String())
 	}
 
@@ -189,7 +189,7 @@ func formatCatalogIndex(tab Table, ord int, tp treeprinter.Node) {
 		buf.Reset()
 
 		idxCol := idx.Column(i)
-		formatColumn(idxCol.Column, tab.ColumnKind(idxCol.Ordinal), &buf)
+		formatColumn(idxCol.Column, &buf)
 		if idxCol.Descending {
 			fmt.Fprintf(&buf, " desc")
 		}
@@ -288,7 +288,7 @@ func formatCatalogFKRef(
 	)
 }
 
-func formatColumn(col Column, kind ColumnKind, buf *bytes.Buffer) {
+func formatColumn(col *Column, buf *bytes.Buffer) {
 	fmt.Fprintf(buf, "%s %s", col.ColName(), col.DatumType())
 	if !col.IsNullable() {
 		fmt.Fprintf(buf, " not null")
@@ -302,7 +302,7 @@ func formatColumn(col Column, kind ColumnKind, buf *bytes.Buffer) {
 	if col.IsHidden() {
 		fmt.Fprintf(buf, " [hidden]")
 	}
-	switch kind {
+	switch col.Kind() {
 	case WriteOnly, DeleteOnly:
 		fmt.Fprintf(buf, " [mutation]")
 	case System:

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -722,7 +722,7 @@ func mutationOutputColMap(mutation memo.RelExpr) opt.ColMap {
 	for i, n := 0, tab.ColumnCount(); i < n; i++ {
 		colID := private.Table.ColumnID(i)
 		// System columns should not be included in mutations.
-		if outCols.Contains(colID) && !cat.IsSystemColumn(tab, i) {
+		if outCols.Contains(colID) && tab.Column(i).Kind() != cat.System {
 			colMap.Set(int(colID), ord)
 			ord++
 		}

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -594,10 +594,10 @@ func (b *Builder) tryBuildDeleteRangeOnInterleaving(
 				return execPlan{}, false, nil
 			}
 			for i := 0; i < numCols; i++ {
-				if fk.OriginColumnOrdinal(child, i) != childIdx.Column(i).Ordinal {
+				if fk.OriginColumnOrdinal(child, i) != childIdx.Column(i).Ordinal() {
 					return execPlan{}, false, nil
 				}
-				if fk.ReferencedColumnOrdinal(parent, i) != parentIdx.Column(i).Ordinal {
+				if fk.ReferencedColumnOrdinal(parent, i) != parentIdx.Column(i).Ordinal() {
 					return execPlan{}, false, nil
 				}
 			}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1010,11 +1010,11 @@ func (b *Builder) tryBuildInterleavedJoin(join *memo.MergeJoinExpr) (_ execPlan,
 		return execPlan{}, false, nil
 	}
 	for i := range join.LeftEq {
-		if join.LeftEq[i].ID() != leftScan.Table.ColumnID(leftIdx.Column(i).Ordinal) {
+		if join.LeftEq[i].ID() != leftScan.Table.ColumnID(leftIdx.Column(i).Ordinal()) {
 			// Condition 5 is not satisfied.
 			return execPlan{}, false, nil
 		}
-		if join.RightEq[i].ID() != rightScan.Table.ColumnID(rightIdx.Column(i).Ordinal) {
+		if join.RightEq[i].ID() != rightScan.Table.ColumnID(rightIdx.Column(i).Ordinal()) {
 			// Condition 5 is not satisfied.
 			return execPlan{}, false, nil
 		}
@@ -1487,7 +1487,7 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	pri := tab.Index(cat.PrimaryIndex)
 	keyCols := make([]exec.NodeColumnOrdinal, pri.KeyColumnCount())
 	for i := range keyCols {
-		keyCols[i] = input.getNodeColumnOrdinal(join.Table.ColumnID(pri.Column(i).Ordinal))
+		keyCols[i] = input.getNodeColumnOrdinal(join.Table.ColumnID(pri.Column(i).Ordinal()))
 	}
 
 	cols := join.Cols

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -425,7 +425,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		inputCols := a.Input.Columns()
 		rightEqCols := make([]string, len(a.EqCols))
 		for i := range rightEqCols {
-			rightEqCols[i] = string(a.Table.Column(a.Index.Column(i).Ordinal).ColName())
+			rightEqCols[i] = string(a.Index.Column(i).ColName())
 		}
 		ob.Attrf(
 			"equality", "(%s) = (%s)",

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -383,7 +383,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			var b strings.Builder
 			for i := 0; i < idx.KeyColumnCount(); i++ {
 				b.WriteRune('/')
-				b.WriteString(fmt.Sprintf("%d", t.Table.ColumnID(idx.Column(i).Ordinal)))
+				b.WriteString(fmt.Sprintf("%d", t.Table.ColumnID(idx.Column(i).Ordinal())))
 			}
 			n := tp.Childf("inverted constraint: %s", b.String())
 			ic.Format(n, "spans")
@@ -449,7 +449,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		idxCols := make(opt.ColList, len(t.KeyCols))
 		idx := md.Table(t.Table).Index(t.Index)
 		for i := range idxCols {
-			idxCols[i] = t.Table.ColumnID(idx.Column(i).Ordinal)
+			idxCols[i] = t.Table.ColumnID(idx.Column(i).Ordinal())
 		}
 		if !f.HasFlags(ExprFmtHideColumns) {
 			tp.Childf("key columns: %v = %v", t.KeyCols, idxCols)

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1591,7 +1591,7 @@ func MakeTableFuncDep(md *opt.Metadata, tabID opt.TableID) *props.FuncDepSet {
 		// If index has a separate lax key, add a lax key FD. Otherwise, add a
 		// strict key. See the comment for cat.Index.LaxKeyColumnCount.
 		for col := 0; col < index.LaxKeyColumnCount(); col++ {
-			ord := index.Column(col).Ordinal
+			ord := index.Column(col).Ordinal()
 			keyCols.Add(tabID.ColumnID(ord))
 		}
 		if index.LaxKeyColumnCount() < index.KeyColumnCount() {
@@ -1739,7 +1739,7 @@ func ensureLookupJoinInputProps(join *LookupJoinExpr, sb *statisticsBuilder) *pr
 		// Include the key columns in the output columns.
 		index := md.Table(join.Table).Index(join.Index)
 		for i := range join.KeyCols {
-			indexColID := join.Table.ColumnID(index.Column(i).Ordinal)
+			indexColID := join.Table.ColumnID(index.Column(i).Ordinal())
 			relational.OutputCols.Add(indexColID)
 		}
 
@@ -1880,7 +1880,7 @@ func (h *joinPropsHelper) init(b *logicalPropsBuilder, joinExpr RelExpr) {
 		md := join.Memo().Metadata()
 		index := md.Table(join.Table).Index(join.Index)
 		for i, colID := range join.KeyCols {
-			indexColID := join.Table.ColumnID(index.Column(i).Ordinal)
+			indexColID := join.Table.ColumnID(index.Column(i).Ordinal())
 			h.filterNotNullCols.Add(colID)
 			h.filterNotNullCols.Add(indexColID)
 			h.filtersFD.AddEquivalency(colID, indexColID)

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1826,9 +1826,10 @@ func tableNotNullCols(md *opt.Metadata, tabID opt.TableID) opt.ColSet {
 
 	// Only iterate over non-mutation columns, since even non-null mutation
 	// columns can be null during backfill.
-	for i := 0; i < tab.ColumnCount(); i++ {
+	for i, n := 0, tab.ColumnCount(); i < n; i++ {
+		col := tab.Column(i)
 		// Non-null mutation columns can be null during backfill.
-		if !cat.IsMutationColumn(tab, i) && !tab.Column(i).IsNullable() {
+		if !col.IsMutation() && !col.IsNullable() {
 			cs.Add(tabID.ColumnID(i))
 		}
 	}

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -183,13 +183,23 @@ func TestMetadataTables(t *testing.T) {
 	a := &testcat.Table{TabID: 1}
 	a.TabName = tree.MakeUnqualifiedTableName(tree.Name("a"))
 
-	mkCol := func(name string) cat.Column {
+	mkCol := func(ordinal int, name string) cat.Column {
 		var c cat.Column
-		c.InitNonVirtual(1, tree.Name(name), cat.Ordinary, types.Int, false, false, nil, nil)
+		c.InitNonVirtual(
+			ordinal,
+			cat.StableID(ordinal+1),
+			tree.Name(name),
+			cat.Ordinary,
+			types.Int,
+			false, /* nullable */
+			false, /* hidden */
+			nil,   /* defaultExpr */
+			nil,   /* computedExpr */
+		)
 		return c
 	}
-	x := mkCol("x")
-	y := mkCol("y")
+	x := mkCol(0, "x")
+	y := mkCol(1, "y")
 	a.Columns = append(a.Columns, x, y)
 
 	tabID := md.AddTable(a, &tree.TableName{})
@@ -215,7 +225,7 @@ func TestMetadataTables(t *testing.T) {
 	// Add another table reference to the metadata.
 	b := &testcat.Table{TabID: 1}
 	b.TabName = tree.MakeUnqualifiedTableName(tree.Name("b"))
-	b.Columns = append(b.Columns, mkCol("x"))
+	b.Columns = append(b.Columns, mkCol(0, "x"))
 
 	otherTabID := md.AddTable(b, &tree.TableName{})
 	if otherTabID == tabID {

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -182,8 +182,14 @@ func TestMetadataTables(t *testing.T) {
 	// Add a table reference to the metadata.
 	a := &testcat.Table{TabID: 1}
 	a.TabName = tree.MakeUnqualifiedTableName(tree.Name("a"))
-	x := &testcat.Column{Name: "x"}
-	y := &testcat.Column{Name: "y"}
+
+	mkCol := func(name string) cat.Column {
+		var c cat.Column
+		c.InitNonVirtual(1, tree.Name(name), cat.Ordinary, types.Int, false, false, nil, nil)
+		return c
+	}
+	x := mkCol("x")
+	y := mkCol("y")
 	a.Columns = append(a.Columns, x, y)
 
 	tabID := md.AddTable(a, &tree.TableName{})
@@ -209,7 +215,7 @@ func TestMetadataTables(t *testing.T) {
 	// Add another table reference to the metadata.
 	b := &testcat.Table{TabID: 1}
 	b.TabName = tree.MakeUnqualifiedTableName(tree.Name("b"))
-	b.Columns = append(b.Columns, &testcat.Column{Name: "x"})
+	b.Columns = append(b.Columns, mkCol("x"))
 
 	otherTabID := md.AddTable(b, &tree.TableName{})
 	if otherTabID == tabID {

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -186,7 +186,7 @@ func neededMutationFetchCols(
 				indexCols.ForEach(func(col opt.ColumnID) {
 					ord := tabMeta.MetaID.ColumnOrdinal(col)
 					// We don't want to include system columns.
-					if !cat.IsSystemColumn(tabMeta.Table, ord) {
+					if tabMeta.Table.Column(ord).Kind() != cat.System {
 						cols.Add(col)
 					}
 				})

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -888,7 +888,7 @@ func (b *Builder) allowImplicitGroupingColumn(colID opt.ColumnID, g *groupby) bo
 	}
 	primaryIndex := tab.Index(cat.PrimaryIndex)
 	for i := 0; i < primaryIndex.KeyColumnCount(); i++ {
-		pkCols.Add(colMeta.Table.ColumnID(primaryIndex.Column(i).Ordinal))
+		pkCols.Add(colMeta.Table.IndexColumnID(primaryIndex, i))
 	}
 	// Remove PK columns that are grouping cols and see if there's anything left.
 	groupingCols := g.groupingCols()

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -420,7 +420,7 @@ func (mb *mutationBuilder) checkPrimaryKeyForInsert() {
 			continue
 		}
 
-		colID := mb.tabID.ColumnID(col.Ordinal)
+		colID := mb.tabID.ColumnID(col.Ordinal())
 		if mb.targetColSet.Contains(colID) {
 			// The column is explicitly specified in the target name list.
 			continue
@@ -723,10 +723,10 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, conflictOrds u
 		var on memo.FiltersExpr
 		for i, n := 0, index.LaxKeyColumnCount(); i < n; i++ {
 			indexCol := index.Column(i)
-			scanColID := scanScope.cols[indexCol.Ordinal].id
+			scanColID := scanScope.cols[indexCol.Ordinal()].id
 
 			condition := mb.b.factory.ConstructEq(
-				mb.b.factory.ConstructVariable(mb.insertColIDs[indexCol.Ordinal]),
+				mb.b.factory.ConstructVariable(mb.insertColIDs[indexCol.Ordinal()]),
 				mb.b.factory.ConstructVariable(scanColID),
 			)
 			on = append(on, mb.b.factory.ConstructFiltersItem(condition))
@@ -760,7 +760,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, conflictOrds u
 		var conflictCols opt.ColSet
 		for i, n := 0, index.LaxKeyColumnCount(); i < n; i++ {
 			indexCol := index.Column(i)
-			conflictCols.Add(mb.insertColIDs[indexCol.Ordinal])
+			conflictCols.Add(mb.insertColIDs[indexCol.Ordinal()])
 		}
 
 		// Treat NULL values as distinct from one another. And if duplicates are
@@ -935,7 +935,7 @@ func (mb *mutationBuilder) setUpsertCols(insertCols tree.NameList) {
 	// Never update primary key columns.
 	conflictIndex := mb.tab.Index(cat.PrimaryIndex)
 	for i, n := 0, conflictIndex.KeyColumnCount(); i < n; i++ {
-		mb.updateColIDs[conflictIndex.Column(i).Ordinal] = 0
+		mb.updateColIDs[conflictIndex.Column(i).Ordinal()] = 0
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -398,7 +398,7 @@ func (mb *mutationBuilder) addTargetColsByName(names tree.NameList) {
 		// add it as a target column.
 		if ord := findPublicTableColumnByName(mb.tab, name); ord != -1 {
 			// System columns are invalid target columns.
-			if cat.IsSystemColumn(mb.tab, ord) {
+			if mb.tab.Column(ord).Kind() == cat.System {
 				panic(pgerror.Newf(pgcode.InvalidColumnReference, "cannot modify system column %q", name))
 			}
 			mb.addTargetCol(ord)
@@ -415,7 +415,7 @@ func (mb *mutationBuilder) addTargetCol(ord int) {
 	tabCol := mb.tab.Column(ord)
 
 	// Don't allow targeting of mutation columns.
-	if cat.IsMutationColumn(mb.tab, ord) {
+	if tabCol.IsMutation() {
 		panic(makeBackfillError(tabCol.ColName()))
 	}
 
@@ -547,7 +547,8 @@ func (mb *mutationBuilder) addSynthesizedCols(colIDs opt.ColList, addCol func(co
 	var projectionsScope *scope
 
 	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
-		kind := mb.tab.ColumnKind(i)
+		tabCol := mb.tab.Column(i)
+		kind := tabCol.Kind()
 		// Skip delete-only mutation columns, since they are ignored by all
 		// mutation operators that synthesize columns.
 		if kind == cat.DeleteOnly {
@@ -574,7 +575,6 @@ func (mb *mutationBuilder) addSynthesizedCols(colIDs opt.ColList, addCol func(co
 			projectionsScope.appendColumnsFromScope(mb.outScope)
 		}
 		tabColID := mb.tabID.ColumnID(i)
-		tabCol := mb.tab.Column(i)
 		expr := mb.parseDefaultOrComputedExpr(tabColID)
 		texpr := mb.outScope.resolveAndRequireType(expr, tabCol.DatumType())
 		scopeCol := mb.b.addColumn(projectionsScope, "" /* alias */, texpr)
@@ -866,7 +866,7 @@ func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationP
 	if needResults {
 		private.ReturnCols = make(opt.ColList, mb.tab.ColumnCount())
 		for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
-			if mb.tab.ColumnKind(i) != cat.Ordinary {
+			if mb.tab.Column(i).Kind() != cat.Ordinary {
 				// Only non-mutation and non-system columns are output columns.
 				continue
 			}
@@ -991,19 +991,16 @@ func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.E
 		exprStr = tabCol.ComputedExprStr()
 	case tabCol.HasDefault():
 		exprStr = tabCol.DefaultExprStr()
-	case tabCol.IsNullable():
-		return tree.DNull
-	default:
+	case tabCol.IsMutation() && !tabCol.IsNullable():
 		// Synthesize default value for NOT NULL mutation column so that it can be
 		// set when in the write-only state. This is only used when no other value
 		// is possible (no default value available, NULL not allowed).
-		if cat.IsMutationColumn(mb.tab, ord) {
-			datum, err := tree.NewDefaultDatum(mb.b.evalCtx, tabCol.DatumType())
-			if err != nil {
-				panic(err)
-			}
-			return datum
+		datum, err := tree.NewDefaultDatum(mb.b.evalCtx, tabCol.DatumType())
+		if err != nil {
+			panic(err)
 		}
+		return datum
+	default:
 		return tree.DNull
 	}
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1060,7 +1060,7 @@ func resultsNeeded(r tree.ReturningClause) bool {
 // be different (eg. TEXT and VARCHAR will fit the same scalar type String).
 //
 // This is used by the UPDATE, INSERT and UPSERT code.
-func checkDatumTypeFitsColumnType(col cat.Column, typ *types.T) {
+func checkDatumTypeFitsColumnType(col *cat.Column, typ *types.T) {
 	if typ.Equivalent(col.DatumType()) {
 		return
 	}

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -305,7 +305,7 @@ func (mb *mutationBuilder) buildInputForUpdate(
 		// key columns.
 		primaryIndex := mb.tab.Index(cat.PrimaryIndex)
 		for i := 0; i < primaryIndex.KeyColumnCount(); i++ {
-			pkCol := mb.outScope.cols[primaryIndex.Column(i).Ordinal]
+			pkCol := mb.outScope.cols[primaryIndex.Column(i).Ordinal()]
 
 			// If the primary key column is hidden, then we don't need to use it
 			// for the distinct on.
@@ -1019,7 +1019,7 @@ func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.E
 func getIndexLaxKeyOrdinals(index cat.Index) util.FastIntSet {
 	var keyOrds util.FastIntSet
 	for i, n := 0, index.LaxKeyColumnCount(); i < n; i++ {
-		keyOrds.Add(index.Column(i).Ordinal)
+		keyOrds.Add(index.Column(i).Ordinal())
 	}
 	return keyOrds
 }
@@ -1031,7 +1031,7 @@ func findNotNullIndexCol(index cat.Index) int {
 	for i, n := 0, index.KeyColumnCount(); i < n; i++ {
 		indexCol := index.Column(i)
 		if !indexCol.IsNullable() {
-			return indexCol.Ordinal
+			return indexCol.Ordinal()
 		}
 	}
 	panic(errors.AssertionFailedf("should have found not null column in index"))

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -226,10 +226,10 @@ func (s *scope) appendOrdinaryColumnsFromTable(tabMeta *opt.TableMeta, alias *tr
 		s.cols = make([]scopeColumn, 0, tab.ColumnCount())
 	}
 	for i, n := 0, tab.ColumnCount(); i < n; i++ {
-		if tab.ColumnKind(i) != cat.Ordinary {
+		tabCol := tab.Column(i)
+		if tabCol.Kind() != cat.Ordinary {
 			continue
 		}
-		tabCol := tab.Column(i)
 		s.cols = append(s.cols, scopeColumn{
 			name:   tabCol.ColName(),
 			table:  *alias,

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -458,7 +458,7 @@ func (b *Builder) buildScan(
 		colID := tabID.ColumnID(ord)
 		tabColIDs.Add(colID)
 		name := col.ColName()
-		kind := tab.ColumnKind(ord)
+		kind := col.Kind()
 		outScope.cols[i] = scopeColumn{
 			id:           colID,
 			name:         name,
@@ -569,8 +569,8 @@ func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
 	// Find the non-nullable table columns. Mutation columns can be NULL during
 	// backfill, so they should be excluded.
 	var notNullCols opt.ColSet
-	for i := 0; i < tab.ColumnCount(); i++ {
-		if !tab.Column(i).IsNullable() && !cat.IsMutationColumn(tab, i) {
+	for i, n := 0, tab.ColumnCount(); i < n; i++ {
+		if col := tab.Column(i); !col.IsNullable() && !col.IsMutation() {
 			notNullCols.Add(tabMeta.MetaID.ColumnID(i))
 		}
 	}
@@ -623,7 +623,7 @@ func (b *Builder) addComputedColsForTable(tabMeta *opt.TableMeta) {
 		if !tabCol.IsComputed() {
 			continue
 		}
-		if cat.IsMutationColumn(tab, i) {
+		if tabCol.IsMutation() {
 			// Mutation columns can be NULL during backfill, so they won't equal the
 			// computed column expression value (in general).
 			continue

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -293,7 +292,8 @@ func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 	mb.addSynthesizedCols(
 		mb.updateColIDs,
 		func(colOrd int) bool {
-			return !mb.tab.Column(colOrd).IsComputed() && cat.IsMutationColumn(mb.tab, colOrd)
+			col := mb.tab.Column(colOrd)
+			return !col.IsComputed() && col.IsMutation()
 		},
 	)
 

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -645,7 +645,8 @@ func resolveNumericColumnRefs(tab cat.Table, columns []tree.ColumnID) (ordinals 
 		ord := 0
 		cnt := tab.ColumnCount()
 		for ord < cnt {
-			if tab.Column(ord).ColID() == cat.StableID(c) && cat.IsSelectableColumn(tab, ord) {
+			col := tab.Column(ord)
+			if col.IsSelectable() && col.ColID() == cat.StableID(c) {
 				break
 			}
 			ord++
@@ -663,7 +664,8 @@ func resolveNumericColumnRefs(tab cat.Table, columns []tree.ColumnID) (ordinals 
 // returns -1.
 func findPublicTableColumnByName(tab cat.Table, name tree.Name) int {
 	for ord, n := 0, tab.ColumnCount(); ord < n; ord++ {
-		if tab.Column(ord).ColName() == name && !cat.IsMutationColumn(tab, ord) {
+		col := tab.Column(ord)
+		if col.ColName() == name && !col.IsMutation() {
 			return ord
 		}
 	}
@@ -696,7 +698,7 @@ func tableOrdinals(tab cat.Table, k columnKinds) []int {
 	}
 	ordinals := make([]int, 0, n)
 	for i := 0; i < n; i++ {
-		if shouldInclude[tab.ColumnKind(i)] {
+		if shouldInclude[tab.Column(i).Kind()] {
 			ordinals = append(ordinals, i)
 		}
 	}

--- a/pkg/sql/opt/ordering/lookup_join.go
+++ b/pkg/sql/opt/ordering/lookup_join.go
@@ -85,7 +85,7 @@ func lookupJoinBuildProvided(expr memo.RelExpr, required *physical.OrderingChoic
 	md := lookupJoin.Memo().Metadata()
 	index := md.Table(lookupJoin.Table).Index(lookupJoin.Index)
 	for i, colID := range lookupJoin.KeyCols {
-		indexColID := lookupJoin.Table.ColumnID(index.Column(i).Ordinal)
+		indexColID := lookupJoin.Table.ColumnID(index.Column(i).Ordinal())
 		fds.AddEquivalency(colID, indexColID)
 	}
 

--- a/pkg/sql/opt/ordering/scan.go
+++ b/pkg/sql/opt/ordering/scan.go
@@ -85,7 +85,7 @@ func ScanPrivateCanProvide(
 			return false, false
 		}
 		indexCol := index.Column(left)
-		indexColID := s.Table.ColumnID(indexCol.Ordinal)
+		indexColID := s.Table.ColumnID(indexCol.Ordinal())
 		if required.Optional.Contains(indexColID) {
 			left++
 			continue
@@ -130,7 +130,7 @@ func scanBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt
 	provided := make(opt.Ordering, 0, numCols)
 	for i := 0; i < numCols; i++ {
 		indexCol := index.Column(i)
-		colID := scan.Table.ColumnID(indexCol.Ordinal)
+		colID := scan.Table.ColumnID(indexCol.Ordinal())
 		if !scan.Cols.Contains(colID) {
 			// Column not in output; we are done.
 			break

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -40,6 +40,12 @@ func (t TableID) ColumnID(ord int) ColumnID {
 	return t.firstColID() + ColumnID(ord)
 }
 
+// IndexColumnID returns the metadata id of the idxOrd-th index column in the
+// given index.
+func (t TableID) IndexColumnID(idx cat.Index, idxOrd int) ColumnID {
+	return t.ColumnID(idx.Column(idxOrd).Ordinal())
+}
+
 // ColumnOrdinal returns the ordinal position of the given column in its base
 // table.
 //
@@ -176,7 +182,7 @@ func (tm *TableMeta) IndexColumns(indexOrd int) ColSet {
 
 	var indexCols ColSet
 	for i, n := 0, index.ColumnCount(); i < n; i++ {
-		ord := index.Column(i).Ordinal
+		ord := index.Column(i).Ordinal()
 		indexCols.Add(tm.MetaID.ColumnID(ord))
 	}
 	return indexCols
@@ -189,7 +195,7 @@ func (tm *TableMeta) IndexKeyColumns(indexOrd int) ColSet {
 
 	var indexCols ColSet
 	for i, n := 0, index.KeyColumnCount(); i < n; i++ {
-		ord := index.Column(i).Ordinal
+		ord := index.Column(i).Ordinal()
 		indexCols.Add(tm.MetaID.ColumnID(ord))
 	}
 	return indexCols
@@ -207,7 +213,7 @@ func (tm *TableMeta) IndexKeyColumnsMapVirtual(indexOrd int) ColSet {
 		if i == 0 && index.IsInverted() {
 			ord = index.Column(i).InvertedSourceColumnOrdinal()
 		} else {
-			ord = index.Column(i).Ordinal
+			ord = index.Column(i).Ordinal()
 		}
 		indexCols.Add(tm.MetaID.ColumnID(ord))
 	}

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1411,6 +1411,7 @@ func (ot *OptTester) createTableAs(name tree.TableName, rel memo.RelExpr) (*test
 		colName := colNameGen.GenerateName(col)
 
 		columns[i].InitNonVirtual(
+			i,
 			cat.StableID(i+1),
 			tree.Name(colName),
 			cat.Ordinary,

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1403,19 +1403,23 @@ func (ot *OptTester) createTableAs(name tree.TableName, rel memo.RelExpr) (*test
 
 	// Create each of the columns and their estimated stats for the test catalog
 	// table.
-	columns := make([]*testcat.Column, outputCols.Len())
+	columns := make([]cat.Column, outputCols.Len())
 	jsonStats := make([]stats.JSONStatistic, outputCols.Len())
 	i := 0
 	for col, ok := outputCols.Next(0); ok; col, ok = outputCols.Next(col + 1) {
 		colMeta := rel.Memo().Metadata().ColumnMeta(col)
 		colName := colNameGen.GenerateName(col)
 
-		columns[i] = &testcat.Column{
-			Ordinal:  i,
-			Name:     colName,
-			Type:     colMeta.Type,
-			Nullable: !relProps.NotNullCols.Contains(col),
-		}
+		columns[i].InitNonVirtual(
+			cat.StableID(i+1),
+			tree.Name(colName),
+			cat.Ordinary,
+			colMeta.Type,
+			!relProps.NotNullCols.Contains(col),
+			false, /* hidden */
+			nil,   /* defaultExpr */
+			nil,   /* computedExpr */
+		)
 
 		// Make sure we have estimated stats for this column.
 		colSet := opt.MakeColSet(col)

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -98,14 +98,18 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	}
 
 	if !hasPrimaryIndex {
-		rowid := &Column{
-			Ordinal:                  tab.ColumnCount(),
-			Name:                     "rowid",
-			Type:                     types.Int,
-			Hidden:                   true,
-			DefaultExpr:              &uniqueRowIDString,
-			InvertedSourceColOrdinal: -1,
-		}
+		var rowid cat.Column
+		ordinal := len(tab.Columns)
+		rowid.InitNonVirtual(
+			cat.StableID(1+ordinal),
+			"rowid",
+			cat.Ordinary,
+			types.Int,
+			false,              /* nullable */
+			true,               /* hidden */
+			&uniqueRowIDString, /* defaultExpr */
+			nil,                /* computedExpr */
+		)
 		tab.Columns = append(tab.Columns, rowid)
 	}
 
@@ -120,15 +124,19 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	}
 
 	// Add the MVCC timestamp system column.
-	tab.Columns = append(tab.Columns, &Column{
-		Ordinal:                  len(tab.Columns),
-		Name:                     sqlbase.MVCCTimestampColumnName,
-		Type:                     sqlbase.MVCCTimestampColumnType,
-		Nullable:                 true,
-		Hidden:                   true,
-		Kind:                     cat.System,
-		InvertedSourceColOrdinal: -1,
-	})
+	var mvcc cat.Column
+	ordinal := len(tab.Columns)
+	mvcc.InitNonVirtual(
+		cat.StableID(1+ordinal),
+		sqlbase.MVCCTimestampColumnName,
+		cat.System,
+		sqlbase.MVCCTimestampColumnType,
+		true, /* nullable */
+		true, /* hidden */
+		nil,  /* defaultExpr */
+		nil,  /* computedExpr */
+	)
+	tab.Columns = append(tab.Columns, mvcc)
 
 	// Add the primary index.
 	if hasPrimaryIndex {
@@ -197,10 +205,11 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 		tab.Families = []*Family{{FamName: "primary", Ordinal: 0, table: tab}}
 	}
 OuterLoop:
-	for colOrd, col := range tab.Columns {
+	for colOrd := range tab.Columns {
+		col := &tab.Columns[colOrd]
 		for _, fam := range tab.Families {
 			for _, famCol := range fam.Columns {
-				if col.Name == string(famCol.ColName()) {
+				if col.ColName() == famCol.ColName() {
 					continue OuterLoop
 				}
 			}
@@ -234,14 +243,19 @@ func (tc *Catalog) createVirtualTable(stmt *tree.CreateTable) *Table {
 	}
 
 	// Add the dummy PK column.
-	tab.Columns = []*Column{{
-		Ordinal:                  0,
-		Hidden:                   true,
-		Nullable:                 false,
-		Name:                     "crdb_internal_vtable_pk",
-		Type:                     types.Int,
-		InvertedSourceColOrdinal: -1,
-	}}
+	var pk cat.Column
+	pk.InitNonVirtual(
+		0,
+		"crdb_internal_vtable_pk",
+		cat.Ordinary,
+		types.Int,
+		false, /* nullable */
+		true,  /* hidden */
+		nil,   /* defaultExpr */
+		nil,   /* computedExpr */
+	)
+
+	tab.Columns = []cat.Column{pk}
 
 	for _, def := range stmt.Defs {
 		switch def := def.(type) {
@@ -251,12 +265,12 @@ func (tc *Catalog) createVirtualTable(stmt *tree.CreateTable) *Table {
 	}
 
 	tab.Families = []*Family{{FamName: "primary", Ordinal: 0, table: tab}}
-	for colOrd, col := range tab.Columns {
+	for colOrd := range tab.Columns {
 		tab.Families[0].Columns = append(tab.Families[0].Columns,
-			cat.FamilyColumn{Column: col, Ordinal: colOrd})
+			cat.FamilyColumn{Column: &tab.Columns[colOrd], Ordinal: colOrd})
 	}
 
-	tab.addPrimaryColumnIndex(tab.Columns[0].Name)
+	tab.addPrimaryColumnIndex(string(tab.Columns[0].ColName()))
 	return tab
 }
 
@@ -265,20 +279,25 @@ func (tc *Catalog) createVirtualTable(stmt *tree.CreateTable) *Table {
 // AS <query> syntax. In addition to the provided columns, CreateTableAs adds a
 // unique rowid column as the primary key. It returns a pointer to the new
 // table.
-func (tc *Catalog) CreateTableAs(name tree.TableName, columns []*Column) *Table {
+func (tc *Catalog) CreateTableAs(name tree.TableName, columns []cat.Column) *Table {
 	// Update the table name to include catalog and schema if not provided.
 	tc.qualifyTableName(&name)
 
 	tab := &Table{TabID: tc.nextStableID(), TabName: name, Catalog: tc, Columns: columns}
 
-	rowid := &Column{
-		Ordinal:                  tab.ColumnCount(),
-		Name:                     "rowid",
-		Type:                     types.Int,
-		Hidden:                   true,
-		DefaultExpr:              &uniqueRowIDString,
-		InvertedSourceColOrdinal: -1,
-	}
+	var rowid cat.Column
+	ordinal := len(columns)
+	rowid.InitNonVirtual(
+		cat.StableID(1+ordinal),
+		"rowid",
+		cat.Ordinary,
+		types.Int,
+		false,              /* nullable */
+		true,               /* hidden */
+		&uniqueRowIDString, /* defaultExpr */
+		nil,                /* computedExpr */
+	)
+
 	tab.Columns = append(tab.Columns, rowid)
 	tab.addPrimaryColumnIndex("rowid")
 
@@ -399,35 +418,44 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 }
 
 func (tt *Table) addColumn(def *tree.ColumnTableDef) {
+	ordinal := len(tt.Columns)
 	nullable := !def.PrimaryKey.IsPrimaryKey && def.Nullable.Nullability != tree.NotNull
-	col := &Column{
-		Ordinal:                  tt.ColumnCount(),
-		Name:                     string(def.Name),
-		Type:                     tree.MustBeStaticallyKnownType(def.Type),
-		Nullable:                 nullable,
-		Kind:                     cat.Ordinary,
-		InvertedSourceColOrdinal: -1,
-	}
+	typ := tree.MustBeStaticallyKnownType(def.Type)
+
+	name := def.Name
+	kind := cat.Ordinary
 
 	// Look for name suffixes indicating this is a mutation column.
-	if name, ok := extractWriteOnlyColumn(def); ok {
-		col.Name = name
-		col.Kind = cat.WriteOnly
-	} else if name, ok := extractDeleteOnlyColumn(def); ok {
-		col.Name = name
-		col.Kind = cat.DeleteOnly
+	if n, ok := extractWriteOnlyColumn(def); ok {
+		name = n
+		kind = cat.WriteOnly
+	} else if n, ok := extractDeleteOnlyColumn(def); ok {
+		name = n
+		kind = cat.DeleteOnly
 	}
 
+	var defaultExpr, computedExpr *string
 	if def.DefaultExpr.Expr != nil {
 		s := serializeTableDefExpr(def.DefaultExpr.Expr)
-		col.DefaultExpr = &s
+		defaultExpr = &s
 	}
 
 	if def.Computed.Expr != nil {
 		s := serializeTableDefExpr(def.Computed.Expr)
-		col.ComputedExpr = &s
+		computedExpr = &s
 	}
 
+	var col cat.Column
+	col.InitNonVirtual(
+		cat.StableID(1+ordinal),
+		name,
+		kind,
+		typ,
+		nullable,
+		false, /* hidden */
+		defaultExpr,
+		computedExpr,
+	)
 	tt.Columns = append(tt.Columns, col)
 }
 
@@ -456,16 +484,36 @@ func (tt *Table) addIndex(def *tree.IndexTableDef, typ indexType) *Index {
 	for i, colDef := range def.Columns {
 		col := idx.addColumn(tt, string(colDef.Column), colDef.Direction, keyCol)
 
-		if typ == primaryIndex {
-			col.Nullable = false
+		if typ == primaryIndex && col.IsNullable() {
+			// Reinitialize the column to make it non-nullable.
+			// TODO(radu): this is very hacky
+			var defaultExpr, computedExpr *string
+			if col.HasDefault() {
+				e := col.DefaultExprStr()
+				defaultExpr = &e
+			}
+			if col.IsComputed() {
+				e := col.ComputedExprStr()
+				computedExpr = &e
+			}
+			col.InitNonVirtual(
+				col.ColID(),
+				col.ColName(),
+				col.Kind(),
+				col.DatumType(),
+				false, /* nullable */
+				col.IsHidden(),
+				defaultExpr,
+				computedExpr,
+			)
 		}
 
-		if col.Nullable {
+		if col.IsNullable() {
 			notNullIndex = false
 		}
 
 		if i == 0 && def.Inverted {
-			switch tt.Columns[col.InvertedSourceColOrdinal].Type.Family() {
+			switch tt.Columns[col.InvertedSourceColumnOrdinal()].DatumType().Family() {
 			case types.GeometryFamily:
 				// Don't use the default config because it creates a huge number of spans.
 				idx.geoConfig = &geoindex.Config{
@@ -504,7 +552,7 @@ func (tt *Table) addIndex(def *tree.IndexTableDef, typ indexType) *Index {
 		}
 		// Add the rest of the columns in the table.
 		for i, col := range tt.Columns {
-			if !pkOrdinals.Contains(i) && col.Kind != cat.Virtual {
+			if !pkOrdinals.Contains(i) && col.Kind() != cat.Virtual {
 				idx.addColumnByOrdinal(tt, i, tree.Ascending, nonKeyCol)
 			}
 		}
@@ -612,26 +660,25 @@ func (tt *Table) addFamily(def *tree.FamilyTableDef) {
 
 func (ti *Index) addColumn(
 	tt *Table, name string, direction tree.Direction, colType colType,
-) *Column {
+) *cat.Column {
 	ordinal := tt.FindOrdinal(name)
 	if ti.Inverted && len(ti.Columns) == 0 {
 		// First column of an inverted index is special: the index key does not
 		// contain values from the column itself, but contains inverted index
 		// entries derived from that column. Create a virtual column to be able to
 		// refer to it separately.
-		col := &Column{
-			Ordinal: len(tt.Columns),
-			Name:    name + "_inverted_key",
-			// TODO(radu,mjibson): update this when the corresponding type in the real
-			// catalog is fixed (see sql.newOptTable).
-			Type:                     tt.Columns[ordinal].DatumType(),
-			Hidden:                   true,
-			Nullable:                 false,
-			InvertedSourceColOrdinal: ordinal,
-			Kind:                     cat.Virtual,
-		}
+		var col cat.Column
+		// TODO(radu,mjibson): update this when the corresponding type in the real
+		// catalog is fixed (see sql.newOptTable).
+		typ := tt.Columns[ordinal].DatumType()
+		col.InitVirtual(
+			tree.Name(name+"_inverted_key"),
+			typ,
+			false,   /* nullable */
+			ordinal, /* invertedSourceColumnOrdinal */
+		)
+		ordinal = len(tt.Columns)
 		tt.Columns = append(tt.Columns, col)
-		ordinal = col.Ordinal
 	}
 
 	return ti.addColumnByOrdinal(tt, ordinal, direction, colType)
@@ -639,7 +686,7 @@ func (ti *Index) addColumn(
 
 func (ti *Index) addColumnByOrdinal(
 	tt *Table, ord int, direction tree.Direction, colType colType,
-) *Column {
+) *cat.Column {
 	col := tt.Column(ord)
 	idxCol := cat.IndexColumn{
 		Column:     col,
@@ -660,7 +707,7 @@ func (ti *Index) addColumnByOrdinal(
 		ti.KeyCount++
 	}
 
-	return col.(*Column)
+	return col
 }
 
 func (tt *Table) addPrimaryColumnIndex(colName string) {
@@ -670,18 +717,18 @@ func (tt *Table) addPrimaryColumnIndex(colName string) {
 	tt.addIndex(&def, primaryIndex)
 }
 
-func extractWriteOnlyColumn(def *tree.ColumnTableDef) (name string, ok bool) {
+func extractWriteOnlyColumn(def *tree.ColumnTableDef) (name tree.Name, ok bool) {
 	if !strings.HasSuffix(string(def.Name), ":write-only") {
 		return "", false
 	}
-	return strings.TrimSuffix(string(def.Name), ":write-only"), true
+	return tree.Name(strings.TrimSuffix(string(def.Name), ":write-only")), true
 }
 
-func extractDeleteOnlyColumn(def *tree.ColumnTableDef) (name string, ok bool) {
+func extractDeleteOnlyColumn(def *tree.ColumnTableDef) (name tree.Name, ok bool) {
 	if !strings.HasSuffix(string(def.Name), ":delete-only") {
 		return "", false
 	}
-	return strings.TrimSuffix(string(def.Name), ":delete-only"), true
+	return tree.Name(strings.TrimSuffix(string(def.Name), ":delete-only")), true
 }
 
 func isMutationColumn(def *tree.ColumnTableDef) bool {

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -555,7 +555,7 @@ type Table struct {
 	TabID      cat.StableID
 	TabVersion int
 	TabName    tree.TableName
-	Columns    []*Column
+	Columns    []cat.Column
 	Indexes    []*Index
 	Stats      TableStats
 	Checks     []cat.CheckConstraint
@@ -630,13 +630,13 @@ func (tt *Table) ColumnCount() int {
 }
 
 // Column is part of the cat.Table interface.
-func (tt *Table) Column(i int) cat.Column {
-	return tt.Columns[i]
+func (tt *Table) Column(i int) *cat.Column {
+	return &tt.Columns[i]
 }
 
 // ColumnKind is part of the cat.Table interface.
 func (tt *Table) ColumnKind(i int) cat.ColumnKind {
-	return tt.Columns[i].Kind
+	return tt.Columns[i].Kind()
 }
 
 // IndexCount is part of the cat.Table interface.
@@ -712,7 +712,7 @@ func (tt *Table) InboundForeignKey(i int) cat.ForeignKeyConstraint {
 // FindOrdinal returns the ordinal of the column with the given name.
 func (tt *Table) FindOrdinal(name string) int {
 	for i, col := range tt.Columns {
-		if col.Name == name {
+		if col.ColName() == tree.Name(name) {
 			return i
 		}
 	}
@@ -917,77 +917,6 @@ func (ti *Index) InterleavedBy(i int) (table, index cat.StableID) {
 // GeoConfig is part of the cat.Index interface.
 func (ti *Index) GeoConfig() *geoindex.Config {
 	return ti.geoConfig
-}
-
-// Column implements the cat.Column interface for testing purposes.
-type Column struct {
-	Ordinal                  int
-	Hidden                   bool
-	Nullable                 bool
-	Name                     string
-	Type                     *types.T
-	DefaultExpr              *string
-	ComputedExpr             *string
-	Kind                     cat.ColumnKind
-	InvertedSourceColOrdinal int
-}
-
-var _ cat.Column = &Column{}
-
-// ColID is part of the cat.Index interface.
-func (tc *Column) ColID() cat.StableID {
-	if tc.Kind == cat.Virtual {
-		return 0
-	}
-	return 1 + cat.StableID(tc.Ordinal)
-}
-
-// IsNullable is part of the cat.Column interface.
-func (tc *Column) IsNullable() bool {
-	return tc.Nullable
-}
-
-// ColName is part of the cat.Column interface.
-func (tc *Column) ColName() tree.Name {
-	return tree.Name(tc.Name)
-}
-
-// DatumType is part of the cat.Column interface.
-func (tc *Column) DatumType() *types.T {
-	return tc.Type
-}
-
-// IsHidden is part of the cat.Column interface.
-func (tc *Column) IsHidden() bool {
-	return tc.Hidden
-}
-
-// HasDefault is part of the cat.Column interface.
-func (tc *Column) HasDefault() bool {
-	return tc.DefaultExpr != nil
-}
-
-// IsComputed is part of the cat.Column interface.
-func (tc *Column) IsComputed() bool {
-	return tc.ComputedExpr != nil
-}
-
-// DefaultExprStr is part of the cat.Column interface.
-func (tc *Column) DefaultExprStr() string {
-	return *tc.DefaultExpr
-}
-
-// ComputedExprStr is part of the cat.Column interface.
-func (tc *Column) ComputedExprStr() string {
-	return *tc.ComputedExpr
-}
-
-// InvertedSourceColumnOrdinal is part of the cat.Column interface.
-func (tc *Column) InvertedSourceColumnOrdinal() int {
-	if tc.InvertedSourceColOrdinal < 0 {
-		panic(errors.AssertionFailedf("InvertedSourceColumnOrdinal called on non-virtual column"))
-	}
-	return tc.InvertedSourceColOrdinal
 }
 
 // TableStat implements the cat.TableStatistic interface for testing purposes.

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -979,11 +979,6 @@ func (tc *Column) ColTypeWidth() int {
 	return int(tc.Type.Width())
 }
 
-// ColTypeStr is part of the cat.Column interface.
-func (tc *Column) ColTypeStr() string {
-	return tc.Type.SQLString()
-}
-
 // IsHidden is part of the cat.Column interface.
 func (tc *Column) IsHidden() bool {
 	return tc.Hidden

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -634,11 +634,6 @@ func (tt *Table) Column(i int) *cat.Column {
 	return &tt.Columns[i]
 }
 
-// ColumnKind is part of the cat.Table interface.
-func (tt *Table) ColumnKind(i int) cat.ColumnKind {
-	return tt.Columns[i].Kind()
-}
-
 // IndexCount is part of the cat.Table interface.
 func (tt *Table) IndexCount() int {
 	return len(tt.Indexes) - tt.writeOnlyIdxCount - tt.deleteOnlyIdxCount

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -957,28 +957,6 @@ func (tc *Column) DatumType() *types.T {
 	return tc.Type
 }
 
-// ColTypePrecision is part of the cat.Column interface.
-func (tc *Column) ColTypePrecision() int {
-	if tc.Type.Family() == types.ArrayFamily {
-		if tc.Type.ArrayContents().Family() == types.ArrayFamily {
-			panic(errors.AssertionFailedf("column type should never be a nested array"))
-		}
-		return int(tc.Type.ArrayContents().Precision())
-	}
-	return int(tc.Type.Precision())
-}
-
-// ColTypeWidth is part of the cat.Column interface.
-func (tc *Column) ColTypeWidth() int {
-	if tc.Type.Family() == types.ArrayFamily {
-		if tc.Type.ArrayContents().Family() == types.ArrayFamily {
-			panic(errors.AssertionFailedf("column type should never be a nested array"))
-		}
-		return int(tc.Type.ArrayContents().Width())
-	}
-	return int(tc.Type.Width())
-}
-
 // IsHidden is part of the cat.Column interface.
 func (tc *Column) IsHidden() bool {
 	return tc.Hidden

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -1014,7 +1014,7 @@ func (c *coster) rowScanCost(tabID opt.TableID, idxOrd int, numScannedCols int) 
 	numCols := idx.ColumnCount()
 	// Remove any system columns from numCols.
 	for i := 0; i < idx.ColumnCount(); i++ {
-		if col := tab.Column(idx.Column(i).Ordinal); col.Kind() == cat.System {
+		if idx.Column(i).Kind() == cat.System {
 			numCols--
 		}
 	}

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -1014,7 +1014,7 @@ func (c *coster) rowScanCost(tabID opt.TableID, idxOrd int, numScannedCols int) 
 	numCols := idx.ColumnCount()
 	// Remove any system columns from numCols.
 	for i := 0; i < idx.ColumnCount(); i++ {
-		if cat.IsSystemColumn(tab, idx.Column(i).Ordinal) {
+		if col := tab.Column(idx.Column(i).Ordinal); col.Kind() == cat.System {
 			numCols--
 		}
 	}

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -2133,7 +2133,7 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 	// don't generate any if some system columns are requested.
 	foundSystemCol := false
 	scanPrivate.Cols.ForEach(func(colID opt.ColumnID) {
-		if cat.IsSystemColumn(tab, scanPrivate.Table.ColumnOrdinal(colID)) {
+		if tab.Column(scanPrivate.Table.ColumnOrdinal(colID)).Kind() == cat.System {
 			foundSystemCol = true
 		}
 	})

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -409,7 +409,7 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 		var partitionFilters, inBetweenFilters memo.FiltersExpr
 
 		indexColumns := tabMeta.IndexKeyColumns(iter.IndexOrdinal())
-		firstIndexCol := scanPrivate.Table.ColumnID(iter.Index().Column(0).Ordinal)
+		firstIndexCol := scanPrivate.Table.IndexColumnID(iter.Index(), 0)
 		if !filterColumns.Contains(firstIndexCol) && indexColumns.Intersects(filterColumns) {
 			// Calculate any partition filters if appropriate (see below).
 			partitionFilters, inBetweenFilters = c.partitionValuesFilters(scanPrivate.Table, iter.Index())
@@ -796,7 +796,7 @@ func (c *CustomFuncs) columnComparison(
 	scalarValues := make(memo.ScalarListExpr, len(values))
 
 	for i, val := range values {
-		colID := tabID.ColumnID(index.Column(i).Ordinal)
+		colID := tabID.IndexColumnID(index, i)
 		columnVariables[i] = c.e.f.ConstructVariable(colID)
 		scalarValues[i] = c.e.f.ConstructConstVal(val, val.ResolvedType())
 	}
@@ -1022,7 +1022,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 		// inverted filter.
 		pkCols := sb.primaryKeyCols()
 		newScanPrivate.Cols = pkCols.Copy()
-		invertedCol := scanPrivate.Table.ColumnID(iter.Index().Column(0).Ordinal)
+		invertedCol := scanPrivate.Table.IndexColumnID(iter.Index(), 0)
 		if spanExpr != nil {
 			newScanPrivate.Cols.Add(invertedCol)
 		}
@@ -1067,7 +1067,7 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 	var notNullCols opt.ColSet
 	for i := range columns {
 		col := index.Column(i)
-		ordinal := col.Ordinal
+		ordinal := col.Ordinal()
 		nullable := col.IsNullable()
 		if isInverted && i == 0 {
 			// We pass the real column to the index constraint generator (instead of
@@ -1075,7 +1075,7 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 			// TODO(radu): improve the inverted index constraint generator to handle
 			// this internally.
 			ordinal = col.InvertedSourceColumnOrdinal()
-			nullable = tab.Column(ordinal).IsNullable()
+			nullable = col.IsNullable()
 		}
 		colID := tabID.ColumnID(ordinal)
 		columns[i] = opt.MakeOrderingColumn(colID, col.Descending)
@@ -1164,7 +1164,7 @@ func (c *CustomFuncs) canMaybeConstrainNonInvertedIndex(
 
 		// If the filter involves the first index column, then the index can
 		// possibly be constrained.
-		firstIndexCol := tabID.ColumnID(index.Column(0).Ordinal)
+		firstIndexCol := tabID.IndexColumnID(index, 0)
 		if filterProps.OuterCols.Contains(firstIndexCol) {
 			return true
 		}
@@ -1461,7 +1461,7 @@ func indexHasOrderingSequence(
 	fds.CopyFrom(&scan.Relational().FuncDeps)
 	prefixCols := opt.ColSet{}
 	for i := 0; i < keyLength; i++ {
-		col := sp.Table.ColumnID(index.Column(i).Ordinal)
+		col := sp.Table.IndexColumnID(index, i)
 		prefixCols.Add(col)
 	}
 	fds.AddConstants(prefixCols)
@@ -1717,7 +1717,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 		// it is constrained to a constant value. This check doesn't guarantee that
 		// we will find lookup join key columns, but it avoids the unnecessary work
 		// in most cases.
-		firstIdxCol := scanPrivate.Table.ColumnID(iter.Index().Column(0).Ordinal)
+		firstIdxCol := scanPrivate.Table.IndexColumnID(iter.Index(), 0)
 		if _, ok := rightEq.Find(firstIdxCol); !ok {
 			if _, _, ok := c.findConstantFilter(on, firstIdxCol); !ok {
 				continue
@@ -1737,7 +1737,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 		// All the lookup conditions must apply to the prefix of the index and so
 		// the projected columns created must be created in order.
 		for j := 0; j < numIndexKeyCols; j++ {
-			idxCol := scanPrivate.Table.ColumnID(iter.Index().Column(j).Ordinal)
+			idxCol := scanPrivate.Table.IndexColumnID(iter.Index(), j)
 			if eqIdx, ok := rightEq.Find(idxCol); ok {
 				lookupJoin.KeyCols = append(lookupJoin.KeyCols, leftEq[eqIdx])
 				rightSideCols = append(rightSideCols, idxCol)
@@ -1824,7 +1824,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 			pkIndex := md.Table(scanPrivate.Table).Index(cat.PrimaryIndex)
 			pkCols = make(opt.ColList, pkIndex.KeyColumnCount())
 			for i := range pkCols {
-				pkCols[i] = scanPrivate.Table.ColumnID(pkIndex.Column(i).Ordinal)
+				pkCols[i] = scanPrivate.Table.IndexColumnID(pkIndex, i)
 			}
 		}
 
@@ -1933,7 +1933,7 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 			pkIndex := tab.Index(cat.PrimaryIndex)
 			pkCols = make(opt.ColList, pkIndex.KeyColumnCount())
 			for i := range pkCols {
-				pkCols[i] = scanPrivate.Table.ColumnID(pkIndex.Column(i).Ordinal)
+				pkCols[i] = scanPrivate.Table.IndexColumnID(pkIndex, i)
 			}
 		}
 
@@ -1948,7 +1948,7 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 		lookupJoin.Table = scanPrivate.Table
 		lookupJoin.Index = iter.IndexOrdinal()
 		lookupJoin.InvertedExpr = invertedExpr
-		lookupJoin.InvertedCol = scanPrivate.Table.ColumnID(iter.Index().Column(0).Ordinal)
+		lookupJoin.InvertedCol = scanPrivate.Table.IndexColumnID(iter.Index(), 0)
 		lookupJoin.Cols = indexCols.Union(inputCols)
 
 		var indexJoin memo.LookupJoinExpr
@@ -2033,21 +2033,21 @@ func eqColsForZigzag(
 	i, leftCnt := 0, leftIndex.LaxKeyColumnCount()
 	j, rightCnt := 0, rightIndex.LaxKeyColumnCount()
 	for ; i < leftCnt; i++ {
-		colID := tabID.ColumnID(leftIndex.Column(i).Ordinal)
+		colID := tabID.IndexColumnID(leftIndex, i)
 		if !fixedCols.Contains(colID) {
 			break
 		}
 	}
 	for ; j < rightCnt; j++ {
-		colID := tabID.ColumnID(rightIndex.Column(j).Ordinal)
+		colID := tabID.IndexColumnID(rightIndex, j)
 		if !fixedCols.Contains(colID) {
 			break
 		}
 	}
 
 	for i < leftCnt && j < rightCnt {
-		leftColID := tabID.ColumnID(leftIndex.Column(i).Ordinal)
-		rightColID := tabID.ColumnID(rightIndex.Column(j).Ordinal)
+		leftColID := tabID.IndexColumnID(leftIndex, i)
+		rightColID := tabID.IndexColumnID(rightIndex, j)
 		i++
 		j++
 
@@ -2084,7 +2084,7 @@ func (c *CustomFuncs) fixedColsForZigzag(
 	index cat.Index, tabID opt.TableID, filters memo.FiltersExpr,
 ) (fixedCols opt.ColList, vals memo.ScalarListExpr, typs []*types.T) {
 	for i, cnt := 0, index.ColumnCount(); i < cnt; i++ {
-		colID := tabID.ColumnID(index.Column(i).Ordinal)
+		colID := tabID.IndexColumnID(index, i)
 		val := memo.ExtractValueForConstColumn(filters, c.e.mem, c.e.evalCtx, colID)
 		if val == nil {
 			break
@@ -2234,7 +2234,7 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 			pkCols := make(opt.ColList, pkIndex.KeyColumnCount())
 			pkColsFound := true
 			for i := range pkCols {
-				pkCols[i] = scanPrivate.Table.ColumnID(pkIndex.Column(i).Ordinal)
+				pkCols[i] = scanPrivate.Table.IndexColumnID(pkIndex, i)
 
 				if _, ok := leftEqCols.Find(pkCols[i]); !ok {
 					pkColsFound = false
@@ -2348,7 +2348,7 @@ func (c *CustomFuncs) indexConstrainedCols(
 ) opt.ColSet {
 	var constrained opt.ColSet
 	for i, n := 0, idx.ColumnCount(); i < n; i++ {
-		col := tab.ColumnID(idx.Column(i).Ordinal)
+		col := tab.IndexColumnID(idx, i)
 		if allFixedCols.Contains(col) {
 			constrained.Add(col)
 		} else {
@@ -2453,7 +2453,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 		zigzagJoin.LeftEqCols = make(opt.ColList, eqColLen)
 		zigzagJoin.RightEqCols = make(opt.ColList, eqColLen)
 		for i := minPrefix; i < iter.Index().ColumnCount(); i++ {
-			colID := scanPrivate.Table.ColumnID(iter.Index().Column(i).Ordinal)
+			colID := scanPrivate.Table.IndexColumnID(iter.Index(), i)
 			zigzagJoin.LeftEqCols[i-minPrefix] = colID
 			zigzagJoin.RightEqCols[i-minPrefix] = colID
 		}
@@ -2465,7 +2465,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 		// it makes little sense.
 		zigzagCols := iter.IndexColumns()
 		for i, cnt := 0, iter.Index().KeyColumnCount(); i < cnt; i++ {
-			colID := scanPrivate.Table.ColumnID(iter.Index().Column(i).Ordinal)
+			colID := scanPrivate.Table.IndexColumnID(iter.Index(), i)
 			zigzagCols.Remove(colID)
 		}
 
@@ -2473,7 +2473,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 		pkIndex := tab.Index(cat.PrimaryIndex)
 		pkCols := make(opt.ColList, pkIndex.KeyColumnCount())
 		for i := range pkCols {
-			pkCols[i] = scanPrivate.Table.ColumnID(pkIndex.Column(i).Ordinal)
+			pkCols[i] = scanPrivate.Table.IndexColumnID(pkIndex, i)
 			// Ensure primary key columns are always retrieved from the zigzag
 			// join.
 			zigzagCols.Add(pkCols[i])
@@ -2597,7 +2597,7 @@ func (c *CustomFuncs) ConvertIndexToLookupJoinPrivate(
 	primaryIndex := md.Table(indexPrivate.Table).Index(cat.PrimaryIndex)
 	lookupCols := make(opt.ColList, primaryIndex.KeyColumnCount())
 	for i := 0; i < primaryIndex.KeyColumnCount(); i++ {
-		lookupCols[i] = indexPrivate.Table.ColumnID(primaryIndex.Column(i).Ordinal)
+		lookupCols[i] = indexPrivate.Table.IndexColumnID(primaryIndex, i)
 	}
 
 	return &memo.LookupJoinPrivate{
@@ -2984,7 +2984,7 @@ func (c *CustomFuncs) canMaybeConstrainIndexWithCols(sp *memo.ScanPrivate, cols 
 		// intersect with the index's key columns.
 		index := iter.Index()
 		for i, n := 0, index.KeyColumnCount(); i < n; i++ {
-			ord := index.Column(i).Ordinal
+			ord := index.Column(i).Ordinal()
 			if i == 0 && index.IsInverted() {
 				ord = index.Column(i).InvertedSourceColumnOrdinal()
 			}

--- a/pkg/sql/opt/xform/index_scan_builder.go
+++ b/pkg/sql/opt/xform/index_scan_builder.go
@@ -63,7 +63,7 @@ func (b *indexScanBuilder) primaryKeyCols() opt.ColSet {
 	if b.pkCols.Empty() {
 		primaryIndex := b.c.e.mem.Metadata().Table(b.tabID).Index(cat.PrimaryIndex)
 		for i, cnt := 0, primaryIndex.KeyColumnCount(); i < cnt; i++ {
-			b.pkCols.Add(b.tabID.ColumnID(primaryIndex.Column(i).Ordinal))
+			b.pkCols.Add(b.tabID.IndexColumnID(primaryIndex, i))
 		}
 	}
 	return b.pkCols

--- a/pkg/sql/opt/xform/interesting_orderings.go
+++ b/pkg/sql/opt/xform/interesting_orderings.go
@@ -74,7 +74,7 @@ func interestingOrderingsForScan(scan *memo.ScanExpr) opt.OrderingSet {
 		var o opt.Ordering
 		for j := 0; j < numIndexCols; j++ {
 			indexCol := index.Column(j)
-			colID := scan.Table.ColumnID(indexCol.Ordinal)
+			colID := scan.Table.ColumnID(indexCol.Ordinal())
 			if !scan.Cols.Contains(colID) {
 				break
 			}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -766,11 +766,11 @@ func newOptTable(
 	// Synthesize any check constraints for user defined types.
 	var synthesizedChecks []cat.CheckConstraint
 	for i := 0; i < ot.ColumnCount(); i++ {
-		// We do not synthesize check constraints for mutation columns.
-		if cat.IsMutationColumn(ot, i) {
+		col := ot.Column(i)
+		if col.IsMutation() {
+			// We do not synthesize check constraints for mutation columns.
 			continue
 		}
-		col := ot.Column(i)
 		colType := col.DatumType()
 		if colType.UserDefined() {
 			switch colType.Family() {
@@ -925,11 +925,6 @@ func (ot *optTable) ColumnCount() int {
 // Column is part of the cat.Table interface.
 func (ot *optTable) Column(i int) *cat.Column {
 	return &ot.columns[i]
-}
-
-// ColumnKind is part of the cat.Table interface.
-func (ot *optTable) ColumnKind(i int) cat.ColumnKind {
-	return ot.columns[i].Kind()
 }
 
 // getColDesc is part of optCatalogTableInterface.
@@ -1674,11 +1669,6 @@ func (ot *optVirtualTable) ColumnCount() int {
 // Column is part of the cat.Table interface.
 func (ot *optVirtualTable) Column(i int) *cat.Column {
 	return &ot.columns[i]
-}
-
-// ColumnKind is part of the cat.Table interface.
-func (ot *optVirtualTable) ColumnKind(i int) cat.ColumnKind {
-	return cat.Ordinary
 }
 
 // getColDesc is part of optCatalogTableInterface.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1292,11 +1292,6 @@ func (vc *optVirtualColumn) ColTypeWidth() int {
 	return int(vc.typ.Width())
 }
 
-// ColTypeStr is part of the cat.Column interface.
-func (vc *optVirtualColumn) ColTypeStr() string {
-	return vc.typ.SQLString()
-}
-
 // IsHidden is part of the cat.Column interface.
 func (vc *optVirtualColumn) IsHidden() bool {
 	return true
@@ -1813,11 +1808,6 @@ func (optDummyVirtualPKColumn) ColTypePrecision() int {
 // ColTypeWidth is part of the cat.Column interface.
 func (optDummyVirtualPKColumn) ColTypeWidth() int {
 	return int(types.Int.Width())
-}
-
-// ColTypeStr is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) ColTypeStr() string {
-	return types.Int.SQLString()
 }
 
 // IsNullable is part of the cat.Column interface.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -543,16 +543,12 @@ func (os *optSequence) SequenceMarker() {}
 type optTable struct {
 	desc *sqlbase.ImmutableTableDescriptor
 
-	// systemColumnDescs is the set of implicit system columns for the table.
-	// It contains column definitions for system columns like the MVCC Timestamp
-	// column and others. System columns have ordinals larger than the ordinals
-	// of physical columns and columns in mutations.
-	systemColumnDescs []cat.Column
-
-	// virtualColumns is the set of virtual columns, which correspond to inverted
-	// indexes. The virtual columns have ordinals larger than the system column
-	// ordinals.
-	virtualColumns []optVirtualColumn
+	// columns contains all the columns presented to the catalog. This includes:
+	//  - ordinary table columns (those in the table descriptor)
+	//  - MVCC timestamp system column
+	//  - virtual columns (for inverted indexes).
+	// They are stored in this order, though we shouldn't rely on that anywhere.
+	columns []cat.Column
 
 	// indexes are the inlined wrappers for the table's primary and secondary
 	// indexes.
@@ -609,31 +605,87 @@ func newOptTable(
 		zone:     tblZone,
 	}
 
+	// First, determine how many columns we will potentially need.
+	colDescs := ot.desc.DeletableColumns()
+	numCols := len(colDescs)
+	// One for the MVCC timestamp system column.
+	numCols++
+	// One for each inverted index virtual column.
+	secondaryIndexes := ot.desc.DeletableIndexes()
+	for i := range secondaryIndexes {
+		if secondaryIndexes[i].Type == descpb.IndexDescriptor_INVERTED {
+			numCols++
+		}
+	}
+
+	ot.columns = make([]cat.Column, len(colDescs), numCols)
+	numOrdinary := len(ot.desc.Columns)
+	numWritable := len(ot.desc.WritableColumns())
+	for i := range colDescs {
+		desc := colDescs[i]
+
+		var kind cat.ColumnKind
+		switch {
+		case i < numOrdinary:
+			kind = cat.Ordinary
+		case i < numWritable:
+			kind = cat.WriteOnly
+		default:
+			kind = cat.DeleteOnly
+		}
+
+		ot.columns[i].InitNonVirtual(
+			cat.StableID(desc.ID),
+			tree.Name(desc.Name),
+			kind,
+			desc.Type,
+			desc.Nullable,
+			desc.Hidden,
+			desc.DefaultExpr,
+			desc.ComputeExpr,
+		)
+	}
+
+	newColumn := func() (col *cat.Column, ordinal int) {
+		ordinal = len(ot.columns)
+		ot.columns = ot.columns[:ordinal+1]
+		return &ot.columns[ordinal], ordinal
+	}
+
 	// Set up the MVCC timestamp system column. However, we won't add it
 	// in case a column with the same name already exists in the table.
 	// Note that the column does not exist when err != nil. This check is done
 	// for migration purposes. We need to avoid adding the system column if the
 	// table has a column with this name for some reason.
 	if _, _, err := desc.FindColumnByName(sqlbase.MVCCTimestampColumnName); err != nil {
-		ot.systemColumnDescs = append(ot.systemColumnDescs, &sqlbase.MVCCTimestampColumnDesc)
+		col, _ := newColumn()
+		col.InitNonVirtual(
+			cat.StableID(sqlbase.MVCCTimestampColumnID),
+			tree.Name(sqlbase.MVCCTimestampColumnName),
+			cat.System,
+			sqlbase.MVCCTimestampColumnType,
+			true, /* nullable */
+			true, /* hidden */
+			nil,  /* defaultExpr */
+			nil,  /* computedExpr */
+		)
 	}
 
 	// Create the table's column mapping from descpb.ColumnID to column ordinal.
 	ot.colMap = make(map[descpb.ColumnID]int, ot.ColumnCount())
-	for i, n := 0, ot.ColumnCount(); i < n; i++ {
-		ot.colMap[descpb.ColumnID(ot.Column(i).ColID())] = i
+	for i := range ot.columns {
+		ot.colMap[descpb.ColumnID(ot.columns[i].ColID())] = i
 	}
 
-	// Build the indexes (add 1 to account for lack of primary index in
-	// DeletableIndexes slice).
-	ot.indexes = make([]optIndex, 1+len(ot.desc.DeletableIndexes()))
+	// Build the indexes.
+	ot.indexes = make([]optIndex, 1+len(secondaryIndexes))
 
 	for i := range ot.indexes {
 		var idxDesc *descpb.IndexDescriptor
 		if i == 0 {
 			idxDesc = &desc.PrimaryIndex
 		} else {
-			idxDesc = &ot.desc.DeletableIndexes()[i-1]
+			idxDesc = &secondaryIndexes[i-1]
 		}
 
 		// If there is a subzone that applies to the entire index, use that,
@@ -648,7 +700,6 @@ func newOptTable(
 				idxZone = &copyZone
 			}
 		}
-		virtualColOrd := -1
 		if idxDesc.Type == descpb.IndexDescriptor_INVERTED {
 			// The first column of an inverted index is special: in the descriptors,
 			// it looks as if the table column is part of the index; in fact the key
@@ -657,20 +708,24 @@ func newOptTable(
 			invertedSourceColOrdinal, _ := ot.lookupColumnOrdinal(idxDesc.ColumnIDs[0])
 
 			// Add a virtual column that refers to the inverted index key.
-			virtualColOrd = ot.ColumnCount()
-			ot.virtualColumns = append(ot.virtualColumns, optVirtualColumn{
-				ordinal: virtualColOrd,
-				name:    string(ot.Column(invertedSourceColOrdinal).ColName()) + "_inverted_key",
-				// TODO(radu, mjibson): figure out what the type should be here. Geo is Int,
-				// but JSON isn't anything decodable (including Bytes). The disk fetecher will
-				// need to be taught about inverted indexes and dump the read data directly
-				// into a DBytes (i.e., don't call encoding.DecodeBytesAscending).
-				typ:                      ot.Column(invertedSourceColOrdinal).DatumType(),
-				nullable:                 false,
-				invertedSourceColOrdinal: invertedSourceColOrdinal,
-			})
+			virtualCol, virtualColOrd := newColumn()
+
+			// TODO(radu, mjibson): figure out what the type should be here. Geo is
+			// Int, but JSON isn't anything decodable (including Bytes). The disk
+			// fetecher will need to be taught about inverted indexes and dump the
+			// read data directly into a DBytes (i.e., don't call
+			// encoding.DecodeBytesAscending).
+			typ := ot.Column(invertedSourceColOrdinal).DatumType()
+			virtualCol.InitVirtual(
+				tree.Name(string(ot.Column(invertedSourceColOrdinal).ColName())+"_inverted_key"),
+				typ,
+				false, /* nullable */
+				invertedSourceColOrdinal,
+			)
+			ot.indexes[i].init(ot, i, idxDesc, idxZone, virtualColOrd)
+		} else {
+			ot.indexes[i].init(ot, i, idxDesc, idxZone, -1 /* virtualColOrd */)
 		}
-		ot.indexes[i].init(ot, i, idxDesc, idxZone, virtualColOrd)
 	}
 
 	for i := range ot.desc.OutboundFKs {
@@ -864,55 +919,28 @@ func (ot *optTable) IsMaterializedView() bool {
 
 // ColumnCount is part of the cat.Table interface.
 func (ot *optTable) ColumnCount() int {
-	return len(ot.desc.DeletableColumns()) + len(ot.systemColumnDescs) + len(ot.virtualColumns)
+	return len(ot.columns)
 }
 
 // Column is part of the cat.Table interface.
-func (ot *optTable) Column(i int) cat.Column {
-	{
-		n := len(ot.desc.DeletableColumns())
-		if i < n {
-			return &ot.desc.DeletableColumns()[i]
-		}
-		i -= n
-	}
-	{
-		n := len(ot.systemColumnDescs)
-		if i < n {
-			return ot.systemColumnDescs[i]
-		}
-		i -= n
-	}
-	return &ot.virtualColumns[i]
+func (ot *optTable) Column(i int) *cat.Column {
+	return &ot.columns[i]
 }
 
 // ColumnKind is part of the cat.Table interface.
 func (ot *optTable) ColumnKind(i int) cat.ColumnKind {
-	switch {
-	case i < len(ot.desc.Columns):
-		return cat.Ordinary
-	case i < len(ot.desc.WritableColumns()):
-		return cat.WriteOnly
-	case i < len(ot.desc.DeletableColumns()):
-		return cat.DeleteOnly
-	}
-	i -= len(ot.desc.DeletableColumns())
-	{
-		n := len(ot.systemColumnDescs)
-		if i < n {
-			return cat.System
-		}
-		i -= n
-	}
-	{
-		n := len(ot.virtualColumns)
-		if i < n {
-			return cat.Virtual
-		}
-		i -= n
-	}
+	return ot.columns[i].Kind()
+}
 
-	panic(errors.AssertionFailedf("invalid column ordinal"))
+// getColDesc is part of optCatalogTableInterface.
+func (ot *optTable) getColDesc(i int) *descpb.ColumnDescriptor {
+	if i < len(ot.desc.DeletableColumns()) {
+		return &ot.desc.DeletableColumns()[i]
+	}
+	if ot.columns[i].ColID() == cat.StableID(sqlbase.MVCCTimestampColumnID) {
+		return &sqlbase.MVCCTimestampColumnDesc
+	}
+	return nil
 }
 
 // IndexCount is part of the cat.Table interface.
@@ -1245,73 +1273,6 @@ func (oi *optIndex) GeoConfig() *geoindex.Config {
 	return &oi.desc.GeoConfig
 }
 
-type optVirtualColumn struct {
-	// ordinal of the virtual column itself.
-	ordinal int
-	name    string
-	// typ is the type reported by the virtual column via DatumType. For now it is
-	// the same as the source column, but this is not really correct.
-	// TODO(radu): we need to fix execution to wrap the index keys in a DBytes and
-	// then we should change this to DBytes.
-	typ      *types.T
-	nullable bool
-	// invertedSourceColOrdinal is the ordinal of the physical table column from
-	// which the inverted index keys are derived.
-	invertedSourceColOrdinal int
-}
-
-var _ cat.Column = &optVirtualColumn{}
-
-// ColID is part of the cat.Index interface.
-func (vc *optVirtualColumn) ColID() cat.StableID {
-	panic(errors.AssertionFailedf("virtual columns have no StableID"))
-}
-
-// IsNullable is part of the cat.Column interface.
-func (vc *optVirtualColumn) IsNullable() bool {
-	return vc.nullable
-}
-
-// ColName is part of the cat.Column interface.
-func (vc *optVirtualColumn) ColName() tree.Name {
-	return tree.Name(vc.name)
-}
-
-// DatumType is part of the cat.Column interface.
-func (vc *optVirtualColumn) DatumType() *types.T {
-	return vc.typ
-}
-
-// IsHidden is part of the cat.Column interface.
-func (vc *optVirtualColumn) IsHidden() bool {
-	return true
-}
-
-// HasDefault is part of the cat.Column interface.
-func (vc *optVirtualColumn) HasDefault() bool {
-	return false
-}
-
-// IsComputed is part of the cat.Column interface.
-func (vc *optVirtualColumn) IsComputed() bool {
-	return false
-}
-
-// DefaultExprStr is part of the cat.Column interface.
-func (vc *optVirtualColumn) DefaultExprStr() string {
-	return ""
-}
-
-// ComputedExprStr is part of the cat.Column interface.
-func (vc *optVirtualColumn) ComputedExprStr() string {
-	return ""
-}
-
-// InvertedSourceColumnOrdinal is part of the cat.Column interface.
-func (vc *optVirtualColumn) InvertedSourceColumnOrdinal() int {
-	return vc.invertedSourceColOrdinal
-}
-
 type optTableStat struct {
 	stat           *stats.TableStatistic
 	columnOrdinals []int
@@ -1518,6 +1479,10 @@ func (fk *optForeignKeyConstraint) UpdateReferenceAction() tree.ReferenceAction 
 type optVirtualTable struct {
 	desc *sqlbase.ImmutableTableDescriptor
 
+	// columns contains all the columns presented to the catalog. This includes
+	// the dummy PK column and the columns in the table descriptor.
+	columns []cat.Column
+
 	// A virtual table can effectively have multiple instances, with different
 	// contents. For example `db1.pg_catalog.pg_sequence` contains info about
 	// sequences in db1, whereas `db2.pg_catalog.pg_sequence` contains info about
@@ -1588,10 +1553,36 @@ func newOptVirtualTable(
 		name: *name,
 	}
 
+	ot.columns = make([]cat.Column, len(desc.Columns)+1)
+	// Init dummy PK column.
+	ot.columns[0].InitNonVirtual(
+		math.MaxInt64, /* stableID */
+		"crdb_internal_vtable_pk",
+		cat.Ordinary,
+		types.Int,
+		false, /* nullable */
+		true,  /* hidden */
+		nil,   /* defaultExpr */
+		nil,   /* computedExpr */
+	)
+	for i := range desc.Columns {
+		d := desc.Columns[i]
+		ot.columns[i+1].InitNonVirtual(
+			cat.StableID(d.ID),
+			tree.Name(d.Name),
+			cat.Ordinary,
+			d.Type,
+			d.Nullable,
+			d.Hidden,
+			d.DefaultExpr,
+			d.ComputeExpr,
+		)
+	}
+
 	// Create the table's column mapping from descpb.ColumnID to column ordinal.
 	ot.colMap = make(map[descpb.ColumnID]int, ot.ColumnCount())
-	for i, n := 0, ot.ColumnCount(); i < n; i++ {
-		ot.colMap[descpb.ColumnID(ot.Column(i).ColID())] = i
+	for i := range ot.columns {
+		ot.colMap[descpb.ColumnID(ot.columns[i].ColID())] = i
 	}
 
 	ot.name.ExplicitSchema = true
@@ -1677,21 +1668,25 @@ func (ot *optVirtualTable) IsMaterializedView() bool {
 
 // ColumnCount is part of the cat.Table interface.
 func (ot *optVirtualTable) ColumnCount() int {
-	return len(ot.desc.Columns) + 1
+	return len(ot.columns)
 }
 
 // Column is part of the cat.Table interface.
-func (ot *optVirtualTable) Column(i int) cat.Column {
-	if i == 0 {
-		// Column 0 is a dummy PK column.
-		return optDummyVirtualPKColumn{}
-	}
-	return &ot.desc.Columns[i-1]
+func (ot *optVirtualTable) Column(i int) *cat.Column {
+	return &ot.columns[i]
 }
 
 // ColumnKind is part of the cat.Table interface.
 func (ot *optVirtualTable) ColumnKind(i int) cat.ColumnKind {
 	return cat.Ordinary
+}
+
+// getColDesc is part of optCatalogTableInterface.
+func (ot *optVirtualTable) getColDesc(i int) *descpb.ColumnDescriptor {
+	if i > 0 && i <= len(ot.desc.Columns) {
+		return &ot.desc.Columns[i-1]
+	}
+	return nil
 }
 
 // IndexCount is part of the cat.Table interface.
@@ -1769,60 +1764,6 @@ func (ot *optVirtualTable) InboundForeignKeyCount() int {
 // InboundForeignKey is part of the cat.Table interface.
 func (ot *optVirtualTable) InboundForeignKey(i int) cat.ForeignKeyConstraint {
 	panic("no FKs")
-}
-
-type optDummyVirtualPKColumn struct{}
-
-var _ cat.Column = optDummyVirtualPKColumn{}
-
-// ColID is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) ColID() cat.StableID {
-	return math.MaxInt64
-}
-
-// ColName is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) ColName() tree.Name {
-	return "crdb_internal_vtable_pk"
-}
-
-// DatumType is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) DatumType() *types.T {
-	return types.Int
-}
-
-// IsNullable is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) IsNullable() bool {
-	return false
-}
-
-// IsHidden is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) IsHidden() bool {
-	return true
-}
-
-// HasDefault is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) HasDefault() bool {
-	return false
-}
-
-// DefaultExprStr is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) DefaultExprStr() string {
-	return ""
-}
-
-// IsComputed is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) IsComputed() bool {
-	return false
-}
-
-// ComputedExprStr is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) ComputedExprStr() string {
-	return ""
-}
-
-// InvertedSourceColumnOrdinal is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) InvertedSourceColumnOrdinal() int {
-	panic(errors.AssertionFailedf("not a virtual column"))
 }
 
 // optVirtualIndex is a dummy implementation of cat.Index for the indexes
@@ -2001,3 +1942,12 @@ func (oi *optVirtualFamily) Column(i int) cat.FamilyColumn {
 func (oi *optVirtualFamily) Table() cat.Table {
 	return oi.tab
 }
+
+type optCatalogTableInterface interface {
+	// getColDesc returns the column descriptor that is backing a given column,
+	// (or nil if it is a virtual column).
+	getColDesc(i int) *descpb.ColumnDescriptor
+}
+
+var _ optCatalogTableInterface = &optTable{}
+var _ optCatalogTableInterface = &optVirtualTable{}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1282,16 +1282,6 @@ func (vc *optVirtualColumn) DatumType() *types.T {
 	return vc.typ
 }
 
-// ColTypePrecision is part of the cat.Column interface.
-func (vc *optVirtualColumn) ColTypePrecision() int {
-	return int(vc.typ.Precision())
-}
-
-// ColTypeWidth is part of the cat.Column interface.
-func (vc *optVirtualColumn) ColTypeWidth() int {
-	return int(vc.typ.Width())
-}
-
 // IsHidden is part of the cat.Column interface.
 func (vc *optVirtualColumn) IsHidden() bool {
 	return true
@@ -1798,16 +1788,6 @@ func (optDummyVirtualPKColumn) ColName() tree.Name {
 // DatumType is part of the cat.Column interface.
 func (optDummyVirtualPKColumn) DatumType() *types.T {
 	return types.Int
-}
-
-// ColTypePrecision is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) ColTypePrecision() int {
-	return int(types.Int.Precision())
-}
-
-// ColTypeWidth is part of the cat.Column interface.
-func (optDummyVirtualPKColumn) ColTypeWidth() int {
-	return int(types.Int.Width())
 }
 
 // IsNullable is part of the cat.Column interface.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1905,12 +1905,13 @@ func (rb *renderBuilder) setOutput(exprs tree.TypedExprs, columns sqlbase.Result
 // makeColDescList returns a list of table column descriptors. Columns are
 // included if their ordinal position in the table schema is in the cols set.
 func makeColDescList(table cat.Table, cols exec.TableColumnOrdinalSet) []descpb.ColumnDescriptor {
+	tab := table.(optCatalogTableInterface)
 	colDescs := make([]descpb.ColumnDescriptor, 0, cols.Len())
 	for i, n := 0, table.ColumnCount(); i < n; i++ {
 		if !cols.Contains(i) {
 			continue
 		}
-		colDescs = append(colDescs, *table.Column(i).(*descpb.ColumnDescriptor))
+		colDescs = append(colDescs, *tab.getColDesc(i))
 	}
 	return colDescs
 }

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -289,7 +289,7 @@ func NewDatumRowConverter(
 	c.VisibleCols = targetColDescriptors
 	c.VisibleColTypes = make([]*types.T, len(c.VisibleCols))
 	for i := range c.VisibleCols {
-		c.VisibleColTypes[i] = c.VisibleCols[i].DatumType()
+		c.VisibleColTypes[i] = c.VisibleCols[i].Type
 	}
 
 	c.Datums = make([]tree.Datum, len(targetColDescriptors), len(cols))
@@ -375,7 +375,7 @@ func (c *DatumRowConverter) Row(ctx context.Context, sourceID int32, rowIndex in
 			if !isTargetCol(i) {
 				if err != nil {
 					return errors.Wrapf(
-						err, "error evaluating default expression %q", col.DefaultExprStr())
+						err, "error evaluating default expression %q", *col.DefaultExpr)
 				}
 				c.Datums[i] = datum
 			}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3527,7 +3527,7 @@ may increase either contention or retry errors, or both.`,
 						}
 						newDatum = tree.DNull
 					} else {
-						expectedTyp := col.DatumType()
+						expectedTyp := col.Type
 						newDatum, err = tree.PerformCast(ctx, d, expectedTyp)
 						if err != nil {
 							return nil, errors.WithHint(err, "try to explicitly cast each value to the corresponding column type")


### PR DESCRIPTION
#### cat: remove unneeded ColTypeStr API

Release note: None

#### cat: change Column to a struct

The opt catalog currently  exposes ` ColumnDescriptors` as `cat.Column`s.  The
intent here was to avoid allocating more objects, but with the addition of
system and virtual columns this approach has outlived its usefulness. This
design is limiting because we can't add more fields, like the `Kind`.

This change switches `optTable` and ` optVirtualTable` to storing all columns in
a single slice. Because we no longer have any real implementations of
`cat.Column`, we change it to a struct. The struct has private members and the
same getter interface. This removes the need to have multiple similar
implementations and avoids vtable dispatch for all these getters.

Release note: None

#### cat: remove Table.ColumnKind

Now that we have `Column.Kind()`, we no longer need the awkward `ColumnKind` on
the table.

Release note: None

#### cat: add Column.Ordinal()

This change adds the column ordinal to `cat.Column`, and removes the ordinal in
`cat.IndexColumn` (which can now be accessed as `Ordinal()` thanks to the
embedded `*Column`).

Release note: None