### PR TITLE
sql: reduce struct copying during index backfill

### DIFF
--- a/pkg/sql/schemaexpr/partial_index.go
+++ b/pkg/sql/schemaexpr/partial_index.go
@@ -153,7 +153,7 @@ func FormatIndexForDisplay(
 // that are added previously in the same transaction.
 func MakePartialIndexExprs(
 	ctx context.Context,
-	indexes []descpb.IndexDescriptor,
+	indexes []*descpb.IndexDescriptor,
 	cols []descpb.ColumnDescriptor,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	evalCtx *tree.EvalContext,
@@ -177,8 +177,7 @@ func MakePartialIndexExprs(
 	nr.addIVarContainerToSemaCtx(semaCtx)
 
 	var txCtx transform.ExprTransformContext
-	for i := range indexes {
-		idx := &indexes[i]
+	for _, idx := range indexes {
 		if idx.IsPartial() {
 			expr, err := parser.ParseExpr(idx.Predicate)
 			if err != nil {

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -1213,7 +1213,7 @@ func writeColumnValues(
 func EncodeSecondaryIndexes(
 	codec keys.SQLCodec,
 	tableDesc *ImmutableTableDescriptor,
-	indexes []descpb.IndexDescriptor,
+	indexes []*descpb.IndexDescriptor,
 	colMap map[descpb.ColumnID]int,
 	values []tree.Datum,
 	secondaryIndexEntries []IndexEntry,
@@ -1223,7 +1223,7 @@ func EncodeSecondaryIndexes(
 		panic("Length of secondaryIndexEntries was non-zero")
 	}
 	for i := range indexes {
-		entries, err := EncodeSecondaryIndex(codec, tableDesc, &indexes[i], colMap, values, includeEmpty)
+		entries, err := EncodeSecondaryIndex(codec, tableDesc, indexes[i], colMap, values, includeEmpty)
 		if err != nil {
 			return secondaryIndexEntries, err
 		}

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -153,8 +153,12 @@ func (td *tableDeleter) deleteAllRowsScan(
 			resume = roachpb.Span{}
 			break
 		}
-		// TODO(mgartner): Add partial index IDs to pm that we should not delete
-		// entries from.
+		// An empty PartialIndexUpdateHelper is passed here, meaning that DEL
+		// operations will be issued for every partial index, regardless of
+		// whether or not the row is indexed by the partial index.
+		// TODO(mgartner): Try evaluating each partial index predicate
+		// expression for each row and benchmark to determine if it is faster
+		// than simply issuing DEL operations for entries that do not exist.
 		var pm row.PartialIndexUpdateHelper
 		if err = td.row(ctx, datums, pm, traceKV); err != nil {
 			return resume, err


### PR DESCRIPTION
This commit makes minor changes to partial index backfilling to remove
the need to repeatedly copy `descpb.IndexDescriptor` structs. Now, a
slice of pointers is used to represent the indexes to encode entries
for, rather than a slice of structs. This list changes for each row
backfilled. By using a slice of pointers, only pointers are copied,
not entire structs.

Fixes #52425

Release note: None