### PR TITLE
importccl: fix target column populating for AVRO

### DIFF
--- a/pkg/ccl/importccl/read_import_avro.go
+++ b/pkg/ccl/importccl/read_import_avro.go
@@ -12,8 +12,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -24,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/errors"
 	"github.com/linkedin/goavro/v2"
 )
 
@@ -130,6 +133,52 @@ func nativeToDatum(
 	return d, nil
 }
 
+// getTargetColFromCodec gets the targeted columns based on codec so that
+// it can be injected into row converter. It also identifies the columns
+// that are in tableColNames but not in codec for checking, just in case
+// validation is strict.
+func getTargetColFromCodec(
+	codec *goavro.Codec, tableColNames map[string](struct{}),
+) ([]tree.Name, []string, error) {
+	schemaStr := codec.Schema()
+	var schema map[string]interface{}
+	err := json.Unmarshal([]byte(schemaStr), &schema)
+	if err != nil {
+		return []tree.Name{}, []string{}, err
+	}
+	colMap, ok := schema["fields"].([]interface{})
+	if !ok {
+		return []tree.Name{}, []string{}, errors.New("schema not found for this AVRO import")
+	}
+	targetCols := make([]tree.Name, 0)
+	targetColsMap := make(map[string]struct{})
+	for _, colInterface := range colMap {
+		col, ok := colInterface.(map[string]interface{})
+		if !ok {
+			return []tree.Name{}, []string{}, errors.New(
+				"schema fields cannot be properly casted into array of targeted columns",
+			)
+		}
+		colName, ok := col["name"].(string)
+		if !ok {
+			return []tree.Name{}, []string{}, errors.New(
+				"bad field name description for this column",
+			)
+		}
+		if _, ok := tableColNames[colName]; ok {
+			targetCols = append(targetCols, tree.Name(colName))
+			targetColsMap[colName] = struct{}{}
+		}
+	}
+	missingCols := make([]string, 0)
+	for colName := range tableColNames {
+		if _, ok := targetColsMap[colName]; !ok {
+			missingCols = append(missingCols, colName)
+		}
+	}
+	return targetCols, missingCols, nil
+}
+
 // A mapping from supported types.Family to the list of avro
 // type names that can be used to construct our target type.
 var familyToAvroT = map[types.Family][]string{
@@ -160,9 +209,10 @@ var familyToAvroT = map[types.Family][]string{
 
 // avroConsumer implements importRowConsumer interface.
 type avroConsumer struct {
-	importCtx      *parallelImportContext
-	fieldNameToIdx map[string]int
-	strict         bool
+	importCtx       *parallelImportContext
+	fieldNameToIdx  map[string]int
+	strict          bool
+	missingColNames []string
 }
 
 // Converts avro record to datums as expected by DatumRowConverter.
@@ -203,6 +253,13 @@ func (a *avroConsumer) FillDatums(
 ) error {
 	if err := a.convertNative(native, conv); err != nil {
 		return err
+	}
+
+	if a.strict && len(a.missingColNames) > 0 {
+		return fmt.Errorf(
+			"columns %s were not present in the import",
+			strings.Join(a.missingColNames, ", "),
+		)
 	}
 
 	// Set any nil datums to DNull (in case native
@@ -390,8 +447,9 @@ func newImportAvroPipeline(
 	avro *avroInputReader, input *fileReader,
 ) (importRowProducer, importRowConsumer, error) {
 	fieldIdxByName := make(map[string]int)
-	for idx, col := range avro.importContext.tableDesc.VisibleColumns() {
-		fieldIdxByName[col.Name] = idx
+	tableColNames := make(map[string](struct{}))
+	for _, col := range avro.importContext.tableDesc.VisibleColumns() {
+		tableColNames[col.Name] = struct{}{}
 	}
 
 	consumer := &avroConsumer{
@@ -405,6 +463,16 @@ func newImportAvroPipeline(
 		if err != nil {
 			return nil, nil, err
 		}
+		targetCols, missingColNames, err := getTargetColFromCodec(ocf.Codec(), tableColNames)
+		if err != nil {
+			return nil, nil, err
+		}
+		consumer.importCtx.targetCols = targetCols
+		consumer.missingColNames = missingColNames
+		for idx, col := range consumer.importCtx.targetCols {
+			fieldIdxByName[col.String()] = idx
+		}
+		consumer.fieldNameToIdx = fieldIdxByName
 		producer := &ocfStream{
 			ocf:      ocf,
 			progress: func() float32 { return input.ReadFraction() },
@@ -413,6 +481,19 @@ func newImportAvroPipeline(
 	}
 
 	codec, err := goavro.NewCodec(avro.opts.SchemaJSON)
+	if err != nil {
+		return nil, nil, err
+	}
+	targetCols, missingColNames, err := getTargetColFromCodec(codec, tableColNames)
+	if err != nil {
+		return nil, nil, err
+	}
+	consumer.importCtx.targetCols = targetCols
+	consumer.missingColNames = missingColNames
+	for idx, col := range consumer.importCtx.targetCols {
+		fieldIdxByName[col.String()] = idx
+	}
+	consumer.fieldNameToIdx = fieldIdxByName
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Target columns for AVRO are not properly populated when starting a job for IMPORT INTO. This hinders the ability for default expressions to be supported, and therefore this PR does that by extracting these information out from the AVRO schema to be populated into `importCtx`. It also extracts the columns present in the table but missing from the AVRO schema so that an error could be returned if strict validation is turned on, but when some columns in the table are not specified in the AVRO schema.

Fixed #52160

The default values for each column follows the precendence:
1. Data of that column specified in an AVRO row;
2. Default value specified in AVRO schema:
3. Default value of a table.

For example, say we have 
`CREATE TABLE t (a INT, b INT DEFAULT 42)`
Consider, also, an Avro file `myfile.avro`. Then for each row: 
1. If a value is present in column (b), then the value is used. 
2. If the value is not present in column (b) but the AVRO schema specifies 
```schema: (a, "INT", b, "INT", default: 20)```
then the default value of 20 is automatically populated into the Avro values, and we'll therefore use this default value 20 instead of 42. 
3. If none of (1) and (2) holds, then the value 42 is used. 

Release note: None