### PR TITLE
sql: disallow non-admin users from dropping admins

### DIFF
--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -95,6 +95,23 @@ func (n *DropRoleNode) startExec(params runParams) error {
 		userNames[normalizedUsername] = make([]objectAndType, 0)
 	}
 
+	// Non-admin users cannot drop admins.
+	hasAdmin, err := params.p.HasAdminRole(params.ctx)
+	if err != nil {
+		return err
+	}
+	if !hasAdmin {
+		for i := range names {
+			targetIsAdmin, err := params.p.UserHasAdminRole(params.ctx, names[i])
+			if err != nil {
+				return err
+			}
+			if targetIsAdmin {
+				return pgerror.New(pgcode.InsufficientPrivilege, "must be superuser to drop superusers")
+			}
+		}
+	}
+
 	f := tree.NewFmtCtx(tree.FmtSimple)
 	defer f.Close()
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1210,3 +1210,16 @@ INSERT INTO publicdb.publictable VALUES (1)
 query TTTI
 SHOW TABLES FROM publicdb
 ----
+
+# Test that non-admin users cannot drop admins.
+user root
+
+statement ok
+CREATE USER myadmin;
+GRANT admin TO myadmin;
+ALTER USER testuser CREATEROLE
+
+user testuser
+
+statement error must be superuser to drop superusers
+DROP USER myadmin


### PR DESCRIPTION
Fixes #52582

Release note(sql change): Non-admin users with the CREATEROLE are no
longer permitted to drop users with the admin role.