### PR TITLE
sql: migrate planToString to new infrastructure

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -204,7 +204,7 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		plan := p.(*planTop)
+		plan := p.(*planComponents)
 
 		if err := a.runRightSidePlan(params, plan); err != nil {
 			return false, err
@@ -220,7 +220,7 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 // a.run.rightRows, ready for retrieval. An error indicates that something went
 // wrong during execution of the right hand side of the join, and that we should
 // completely give up on the outer join.
-func (a *applyJoinNode) runRightSidePlan(params runParams, plan *planTop) error {
+func (a *applyJoinNode) runRightSidePlan(params runParams, plan *planComponents) error {
 	a.run.curRightRow = 0
 	a.run.rightRows.Clear(params.ctx)
 	return runPlanInsidePlan(params, plan, a.run.rightRows)
@@ -229,7 +229,7 @@ func (a *applyJoinNode) runRightSidePlan(params runParams, plan *planTop) error 
 // runPlanInsidePlan is used to run a plan and gather the results in a row
 // container, as part of the execution of an "outer" plan.
 func runPlanInsidePlan(
-	params runParams, plan *planTop, rowContainer *rowcontainer.RowContainer,
+	params runParams, plan *planComponents, rowContainer *rowcontainer.RowContainer,
 ) error {
 	rowResultWriter := NewRowResultWriter(rowContainer)
 	recv := MakeDistSQLReceiver(
@@ -263,7 +263,7 @@ func runPlanInsidePlan(
 	planCtx := params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.NewPlanningCtx(
 		params.ctx, evalCtx, &plannerCopy, params.p.txn, false, /* distribute */
 	)
-	planCtx.planner.curPlan = *plan
+	planCtx.planner.curPlan.planComponents = *plan
 	planCtx.ExtendedEvalCtx.Planner = &plannerCopy
 	planCtx.stmtType = recv.stmtType
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
@@ -841,8 +842,8 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	ex.sessionTracing.TracePlanCheckStart(ctx)
 	distributePlan := getPlanDistribution(
 		ctx, planner, planner.execCfg.NodeID, ex.sessionData.DistSQLMode, planner.curPlan.main,
-	).WillDistribute()
-	ex.sessionTracing.TracePlanCheckEnd(ctx, nil, distributePlan)
+	)
+	ex.sessionTracing.TracePlanCheckEnd(ctx, nil, distributePlan.WillDistribute())
 
 	if ex.server.cfg.TestingKnobs.BeforeExecute != nil {
 		ex.server.cfg.TestingKnobs.BeforeExecute(ctx, stmt.String())
@@ -858,7 +859,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	}
 	queryMeta.phase = executing
 	// TODO(yuzefovich): introduce ternary PlanDistribution into queryMeta.
-	queryMeta.isDistributed = distributePlan
+	queryMeta.isDistributed = distributePlan.WillDistribute()
 	progAtomic := &queryMeta.progressAtomic
 	ex.mu.Unlock()
 
@@ -877,13 +878,18 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		planner.curPlan.flags.Set(planFlagTenant)
 	}
 
-	if distributePlan {
-		planner.curPlan.flags.Set(planFlagDistributed)
-	} else {
-		planner.curPlan.flags.Set(planFlagDistSQLLocal)
+	switch distributePlan {
+	case physicalplan.FullyDistributedPlan:
+		planner.curPlan.flags.Set(planFlagFullyDistributed)
+	case physicalplan.PartiallyDistributedPlan:
+		planner.curPlan.flags.Set(planFlagPartiallyDistributed)
+	default:
+		planner.curPlan.flags.Set(planFlagNotDistributed)
 	}
 	ex.sessionTracing.TraceExecStart(ctx, "distributed")
-	stats, err := ex.execWithDistSQLEngine(ctx, planner, stmt.AST.StatementType(), res, distributePlan, progAtomic)
+	stats, err := ex.execWithDistSQLEngine(
+		ctx, planner, stmt.AST.StatementType(), res, distributePlan.WillDistribute(), progAtomic,
+	)
 	ex.sessionTracing.TraceExecEnd(ctx, res.Err(), res.RowsAffected())
 	ex.statsCollector.phaseTimes[plannerEndExecStmt] = timeutil.Now()
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -905,7 +905,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 func (ex *connExecutor) makeExecPlan(ctx context.Context, planner *planner) error {
 	planner.curPlan.init(planner.stmt, ex.appStats)
 	if planner.collectBundle {
-		planner.curPlan.instrumentation.savePlanString = true
+		planner.curPlan.savePlanString = true
 	}
 
 	if err := planner.makeOptimizerPlan(ctx); err != nil {

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1056,7 +1056,7 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 			recv.SetError(err)
 			return false
 		}
-		cp := cascadePlan.(*planTop)
+		cp := cascadePlan.(*planComponents)
 		plan.cascades[i].plan = cp.main
 		if len(cp.subqueryPlans) > 0 {
 			recv.SetError(errors.AssertionFailedf("cascades should not have subqueries"))

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -755,7 +755,7 @@ func (e *distSQLSpecExecFactory) ConstructExplain(
 	// variants of EXPLAIN when subqueries are present as we do in the old path.
 	// TODO(yuzefovich): make sure that local plan nodes that create
 	// distributed jobs are shown as "distributed". See distSQLExplainable.
-	p := plan.(*planTop)
+	p := plan.(*planComponents)
 	explain, err := constructExplainPlanNode(options, stmtType, p, e.planner)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -108,7 +108,7 @@ func makeScanColumnsConfig(table cat.Table, cols exec.TableColumnOrdinalSet) sca
 }
 
 func constructExplainPlanNode(
-	options *tree.ExplainOptions, stmtType tree.StatementType, p *planTop, planner *planner,
+	options *tree.ExplainOptions, stmtType tree.StatementType, p *planComponents, planner *planner,
 ) (exec.Node, error) {
 	analyzeSet := options.Flags[tree.ExplainFlagAnalyze]
 
@@ -120,7 +120,7 @@ func constructExplainPlanNode(
 	case tree.ExplainDistSQL:
 		return &explainDistSQLNode{
 			options:  options,
-			plan:     p.planComponents,
+			plan:     *p,
 			analyze:  analyzeSet,
 			stmtType: stmtType,
 		}, nil
@@ -128,7 +128,7 @@ func constructExplainPlanNode(
 	case tree.ExplainVec:
 		return &explainVecNode{
 			options: options,
-			plan:    p.planComponents,
+			plan:    *p,
 		}, nil
 
 	case tree.ExplainPlan:
@@ -138,7 +138,7 @@ func constructExplainPlanNode(
 		return planner.makeExplainPlanNodeWithPlan(
 			context.TODO(),
 			options,
-			p.planComponents,
+			*p,
 		)
 
 	default:

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -33,13 +33,7 @@ func constructPlan(
 	cascades []exec.Cascade,
 	checks []exec.Node,
 ) (exec.Plan, error) {
-	res := &planTop{
-		// TODO(radu): these fields can be modified by planning various opaque
-		// statements. We should have a cleaner way of plumbing these.
-		avoidBuffering:  planner.curPlan.avoidBuffering,
-		auditEvents:     planner.curPlan.auditEvents,
-		instrumentation: planner.curPlan.instrumentation,
-	}
+	res := &planComponents{}
 	assignPlan := func(plan *planMaybePhysical, node exec.Node) {
 		switch n := node.(type) {
 		case planNode:

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -159,7 +159,7 @@ func (ex *connExecutor) recordStatementSummary(
 	}
 
 	ex.statsCollector.recordStatement(
-		stmt, planner.curPlan.instrumentation.savedPlanForStats,
+		stmt, planner.curPlan.savedPlanForStats,
 		flags.IsSet(planFlagDistributed), flags.IsSet(planFlagVectorized),
 		flags.IsSet(planFlagImplicitTxn), automaticRetryCount, rowsAffected, err,
 		parseLat, planLat, runLat, svcLat, execOverhead, stats,

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -147,7 +147,7 @@ func (ex *connExecutor) recordStatementSummary(
 	if automaticRetryCount == 0 {
 		ex.updateOptCounters(flags)
 		m := &ex.metrics.EngineMetrics
-		if flags.IsSet(planFlagDistributed) {
+		if flags.IsDistributed() {
 			if _, ok := stmt.AST.(*tree.Select); ok {
 				m.DistSQLSelectCount.Inc(1)
 			}
@@ -160,7 +160,7 @@ func (ex *connExecutor) recordStatementSummary(
 
 	ex.statsCollector.recordStatement(
 		stmt, planner.curPlan.savedPlanForStats,
-		flags.IsSet(planFlagDistributed), flags.IsSet(planFlagVectorized),
+		flags.IsDistributed(), flags.IsSet(planFlagVectorized),
 		flags.IsSet(planFlagImplicitTxn), automaticRetryCount, rowsAffected, err,
 		parseLat, planLat, runLat, svcLat, execOverhead, stats,
 	)

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -223,7 +223,7 @@ func (b *stmtBundleBuilder) addOptPlans() {
 
 // addExecPlan adds the EXPLAIN (VERBOSE) plan as file plan.txt.
 func (b *stmtBundleBuilder) addExecPlan() {
-	if plan := b.plan.instrumentation.planString; plan != "" {
+	if plan := b.plan.planString; plan != "" {
 		b.z.AddFile("plan.txt", plan)
 	}
 }

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -282,17 +282,6 @@ func observePlan(
 	return nil
 }
 
-// planToString builds a string representation of a plan using the EXPLAIN
-// infrastructure.
-func planToString(ctx context.Context, p *planTop) string {
-	var e explainer
-	e.init(explain.Flags{Verbose: true, ShowTypes: true}, p.flags.IsSet(planFlagTenant))
-	e.fmtFlags = tree.FmtExpr(tree.FmtSymbolicSubqueries, true, true, true)
-
-	e.populate(ctx, &p.planComponents, explainSubqueryFmtFlags)
-	return e.ob.BuildString()
-}
-
 func getAttrForSpansAll(hardLimitSet bool) string {
 	if hardLimitSet {
 		return "LIMITED SCAN"

--- a/pkg/sql/explain_plan_new.go
+++ b/pkg/sql/explain_plan_new.go
@@ -14,10 +14,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -39,13 +41,33 @@ type explainNewPlanNodeRun struct {
 }
 
 func (e *explainNewPlanNode) startExec(params runParams) error {
-	ob := explain.NewOutputBuilder(e.flags)
-
 	realPlan := e.plan.WrappedPlan.(*planComponents)
 	distribution, willVectorize := explainGetDistributedAndVectorized(params, realPlan)
-	ob.AddField("distribution", distribution.String())
-	ob.AddField("vectorized", fmt.Sprintf("%t", willVectorize))
 
+	ob := explain.NewOutputBuilder(e.flags)
+	if err := emitExplain(ob, params.p.ExecCfg().Codec, e.plan, distribution, willVectorize); err != nil {
+		return err
+	}
+	v := params.p.newContainerValuesNode(e.columns, 0)
+	for _, row := range ob.BuildExplainRows() {
+		if _, err := v.rows.AddRow(params.ctx, row); err != nil {
+			return err
+		}
+	}
+	e.run.results = v
+
+	return nil
+}
+
+func emitExplain(
+	ob *explain.OutputBuilder,
+	codec keys.SQLCodec,
+	explainPlan *explain.Plan,
+	distribution physicalplan.PlanDistribution,
+	vectorized bool,
+) error {
+	ob.AddField("distribution", distribution.String())
+	ob.AddField("vectorized", fmt.Sprintf("%t", vectorized))
 	spanFormatFn := func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string {
 		var tabDesc *sqlbase.ImmutableTableDescriptor
 		var idxDesc *descpb.IndexDescriptor
@@ -56,7 +78,7 @@ func (e *explainNewPlanNode) startExec(params runParams) error {
 			tabDesc = table.(*optTable).desc
 			idxDesc = index.(*optIndex).desc
 		}
-		spans, err := generateScanSpans(params.p, tabDesc, idxDesc, scanParams)
+		spans, err := generateScanSpans(codec, tabDesc, idxDesc, scanParams)
 		if err != nil {
 			return err.Error()
 		}
@@ -69,25 +91,13 @@ func (e *explainNewPlanNode) startExec(params runParams) error {
 		//    four values are the special tenant prefix byte and tenant ID, followed
 		//    by the table ID and the index ID.
 		skip := 2
-		if !params.p.ExecCfg().Codec.ForSystemTenant() {
+		if !codec.ForSystemTenant() {
 			skip = 4
 		}
 		return sqlbase.PrettySpans(idxDesc, spans, skip)
 	}
 
-	if err := explain.Emit(e.plan, ob, spanFormatFn); err != nil {
-		return err
-	}
-
-	v := params.p.newContainerValuesNode(e.columns, 0)
-	for _, row := range ob.BuildExplainRows() {
-		if _, err := v.rows.AddRow(params.ctx, row); err != nil {
-			return err
-		}
-	}
-	e.run.results = v
-
-	return nil
+	return explain.Emit(explainPlan, ob, spanFormatFn)
 }
 
 func (e *explainNewPlanNode) Next(params runParams) (bool, error) { return e.run.results.Next(params) }

--- a/pkg/sql/explain_plan_new.go
+++ b/pkg/sql/explain_plan_new.go
@@ -41,8 +41,8 @@ type explainNewPlanNodeRun struct {
 func (e *explainNewPlanNode) startExec(params runParams) error {
 	ob := explain.NewOutputBuilder(e.flags)
 
-	realPlan := e.plan.WrappedPlan.(*planTop)
-	distribution, willVectorize := explainGetDistributedAndVectorized(params, &realPlan.planComponents)
+	realPlan := e.plan.WrappedPlan.(*planComponents)
+	distribution, willVectorize := explainGetDistributedAndVectorized(params, realPlan)
 	ob.AddField("distribution", distribution.String())
 	ob.AddField("vectorized", fmt.Sprintf("%t", willVectorize))
 

--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -65,11 +65,14 @@ func TestPlanToTreeAndPlanToString(t *testing.T) {
 			p := internalPlanner.(*planner)
 
 			p.stmt = &Statement{Statement: stmt}
+			p.curPlan.savePlanString = true
 			if err := p.makeOptimizerPlan(ctx); err != nil {
 				t.Fatal(err)
 			}
 			if d.Cmd == "plan-string" {
-				return planToString(ctx, &p.curPlan)
+				p.curPlan.flags.Set(planFlagExecDone)
+				p.curPlan.close(ctx)
+				return p.curPlan.planString
 			}
 			tree := planToTree(ctx, &p.curPlan)
 			treeYaml, err := yaml.Marshal(tree)

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -139,13 +139,17 @@ func (f *Factory) ConstructPlan(
 	for i := range wrappedSubqueries {
 		wrappedSubqueries[i].Root = wrappedSubqueries[i].Root.(*Node).WrappedNode()
 	}
+	wrappedCascades := append([]exec.Cascade(nil), cascades...)
+	for i := range wrappedCascades {
+		wrappedCascades[i].Buffer = wrappedCascades[i].Buffer.(*Node).WrappedNode()
+	}
 	wrappedChecks := make([]exec.Node, len(checks))
 	for i := range wrappedChecks {
 		wrappedChecks[i] = checks[i].(*Node).WrappedNode()
 	}
 	var err error
 	p.WrappedPlan, err = f.wrappedFactory.ConstructPlan(
-		p.Root.WrappedNode(), wrappedSubqueries, cascades, wrappedChecks,
+		p.Root.WrappedNode(), wrappedSubqueries, wrappedCascades, wrappedChecks,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1157,7 +1157,7 @@ func (ef *execFactory) ConstructExplainOpt(
 func (ef *execFactory) ConstructExplain(
 	options *tree.ExplainOptions, stmtType tree.StatementType, plan exec.Plan,
 ) (exec.Node, error) {
-	return constructExplainPlanNode(options, stmtType, plan.(*planTop), ef.planner)
+	return constructExplainPlanNode(options, stmtType, plan.(*planComponents), ef.planner)
 }
 
 // ConstructShowTrace is part of the exec.Factory interface.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -104,7 +105,7 @@ func (ef *execFactory) ConstructScan(
 	scan.reverse = params.Reverse
 	scan.parallelize = params.Parallelize
 	var err error
-	scan.spans, err = generateScanSpans(ef.planner, tabDesc, indexDesc, params)
+	scan.spans, err = generateScanSpans(ef.planner.ExecCfg().Codec, tabDesc, indexDesc, params)
 	if err != nil {
 		return nil, err
 	}
@@ -125,12 +126,12 @@ func (ef *execFactory) ConstructScan(
 }
 
 func generateScanSpans(
-	planner *planner,
+	codec keys.SQLCodec,
 	tabDesc *sqlbase.ImmutableTableDescriptor,
 	indexDesc *descpb.IndexDescriptor,
 	params exec.ScanParams,
 ) (roachpb.Spans, error) {
-	sb := span.MakeBuilder(planner.ExecCfg().Codec, tabDesc, indexDesc)
+	sb := span.MakeBuilder(codec, tabDesc, indexDesc)
 	if params.InvertedConstraint != nil {
 		return GenerateInvertedSpans(params.InvertedConstraint, sb)
 	}

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -1335,7 +1335,7 @@ const (
 	// locally.
 	PartiallyDistributedPlan
 
-	// FullyDistributedPlan indicates the the whole plan is distributed.
+	// FullyDistributedPlan indicates that the whole plan is distributed.
 	FullyDistributedPlan
 )
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -422,7 +422,7 @@ func (p *planTop) close(ctx context.Context) {
 		// specs directly in the optimizer (see #47474).
 		if p.appStats != nil && p.appStats.shouldSaveLogicalPlanDescription(
 			p.stmt,
-			p.flags.IsSet(planFlagDistributed),
+			p.flags.IsDistributed(),
 			p.flags.IsSet(planFlagVectorized),
 			p.flags.IsSet(planFlagImplicitTxn),
 			p.execErr,
@@ -530,13 +530,16 @@ const (
 	// did not find one.
 	planFlagOptCacheMiss
 
-	// planFlagDistributed is set if the plan is for the DistSQL engine, in
-	// distributed mode.
-	planFlagDistributed
+	// planFlagFullyDistributed is set if the query execution is is fully
+	// distributed.
+	planFlagFullyDistributed
 
-	// planFlagDistSQLLocal is set if the plan is for the DistSQL engine,
-	// but in local mode.
-	planFlagDistSQLLocal
+	// planFlagPartiallyDistributed is set if the query execution is is partially
+	// distributed (see physicalplan.PartiallyDistributedPlan).
+	planFlagPartiallyDistributed
+
+	// planFlagNotDistributed is set if the query execution is not distributed.
+	planFlagNotDistributed
 
 	// planFlagExecDone marks that execution has been completed.
 	planFlagExecDone
@@ -562,4 +565,10 @@ func (pf planFlags) IsSet(flag planFlags) bool {
 
 func (pf *planFlags) Set(flag planFlags) {
 	*pf |= flag
+}
+
+// IsDistributed returns true if either the fully or the partially distributed
+// flags is set.
+func (pf planFlags) IsDistributed() bool {
+	return pf.IsSet(planFlagFullyDistributed) || pf.IsSet(planFlagPartiallyDistributed)
 }

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -14,12 +14,14 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
@@ -184,8 +186,6 @@ func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) 
 // makeOptimizerPlan generates a plan using the cost-based optimizer.
 // On success, it populates p.curPlan.
 func (p *planner) makeOptimizerPlan(ctx context.Context) error {
-	stmt := p.stmt
-
 	opc := &p.optPlanningCtx
 	opc.reset()
 
@@ -195,11 +195,6 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 	}
 
 	// Build the plan tree.
-	root := execMemo.RootExpr()
-	var (
-		plan exec.Plan
-		bld  *execbuilder.Builder
-	)
 	// TODO(yuzefovich): we're creating a new exec.Factory for every query, but
 	// we probably could pool those allocations using sync.Pool. Investigate
 	// this.
@@ -211,11 +206,15 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 		if p.Descriptors().HasUncommittedTypes() {
 			planningMode = distSQLLocalOnlyPlanning
 		}
-		bld = execbuilder.New(
-			newDistSQLSpecExecFactory(p, planningMode), execMemo, &opc.catalog, root,
-			p.EvalContext(), p.autoCommit,
+		err := opc.runExecBuilder(
+			&p.curPlan,
+			p.stmt,
+			newDistSQLSpecExecFactory(p, planningMode),
+			execMemo,
+			p.EvalContext(),
+			p.ExecCfg().Codec,
+			p.autoCommit,
 		)
-		plan, err = bld.Build()
 		if err != nil {
 			if mode == sessiondata.ExperimentalDistSQLPlanningAlways &&
 				!strings.Contains(p.stmt.AST.StatementTag(), "SET") {
@@ -229,12 +228,11 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 				return err
 			}
 			// We will fallback to the old path.
-		}
-		if err == nil {
+		} else {
 			// TODO(yuzefovich): think through whether subqueries or
 			// postqueries can be distributed. If that's the case, we might
 			// need to also look at the plan distribution of those.
-			m := plan.(*planComponents).main
+			m := p.curPlan.main
 			isPartiallyDistributed := m.physPlan.Distribution == physicalplan.PartiallyDistributedPlan
 			if isPartiallyDistributed && p.SessionData().PartiallyDistributedPlansDisabled {
 				// The planning has succeeded, but we've created a partially
@@ -243,51 +241,36 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 				// that forces local planning.
 				// TODO(yuzefovich): remove this logic when deleting old
 				// execFactory.
-				bld = execbuilder.New(
-					newDistSQLSpecExecFactory(p, distSQLLocalOnlyPlanning), execMemo, &opc.catalog, root,
-					p.EvalContext(), p.autoCommit,
+				err = opc.runExecBuilder(
+					&p.curPlan,
+					p.stmt,
+					newDistSQLSpecExecFactory(p, distSQLLocalOnlyPlanning),
+					execMemo,
+					p.EvalContext(),
+					p.ExecCfg().Codec,
+					p.autoCommit,
 				)
-				plan, err = bld.Build()
+			}
+			if err == nil {
+				return nil
 			}
 		}
-		if err != nil {
-			bld = nil
-			// TODO(yuzefovich): make the logging conditional on the verbosity
-			// level once new DistSQL planning is no longer experimental.
-			log.Infof(ctx, "distSQLSpecExecFactory failed planning with %v, "+
-				"falling back to the old path", err)
-		}
-	}
-	if bld == nil {
-		// If bld is non-nil, then experimental planning has succeeded and has
-		// already created a plan.
-		bld = execbuilder.New(
-			newExecFactory(p), execMemo, &opc.catalog, root, p.EvalContext(), p.autoCommit,
+		// TODO(yuzefovich): make the logging conditional on the verbosity
+		// level once new DistSQL planning is no longer experimental.
+		log.Infof(
+			ctx, "distSQLSpecExecFactory failed planning with %v, falling back to the old path", err,
 		)
-		plan, err = bld.Build()
-		if err != nil {
-			return err
-		}
 	}
-
-	result := plan.(*planComponents)
-	cols := result.main.planColumns()
-	if stmt.ExpectedTypes != nil {
-		if !stmt.ExpectedTypes.TypesEqual(cols) {
-			return pgerror.New(pgcode.FeatureNotSupported, "cached plan must not change result type")
-		}
-	}
-
-	p.curPlan.planComponents = *result
-	p.curPlan.mem = execMemo
-	p.curPlan.catalog = &opc.catalog
-	p.curPlan.stmt = stmt
-	p.curPlan.flags = opc.flags
-	if bld.IsDDL {
-		p.curPlan.flags.Set(planFlagIsDDL)
-	}
-
-	return nil
+	// If we got here, we did not create a plan above.
+	return opc.runExecBuilder(
+		&p.curPlan,
+		p.stmt,
+		newExecFactory(p),
+		execMemo,
+		p.EvalContext(),
+		p.ExecCfg().Codec,
+		p.autoCommit,
+	)
 }
 
 type optPlanningCtx struct {
@@ -549,4 +532,61 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 	}
 
 	return f.Memo(), nil
+}
+
+// runExecBuilder execbuilds a plan using the given factory and stores the
+// result in planTop. If required, also captures explain data using the explain
+// factory.
+func (opc *optPlanningCtx) runExecBuilder(
+	planTop *planTop,
+	stmt *Statement,
+	f exec.Factory,
+	mem *memo.Memo,
+	evalCtx *tree.EvalContext,
+	codec keys.SQLCodec,
+	allowAutoCommit bool,
+) error {
+	var result *planComponents
+	var explainPlan *explain.Plan
+	var isDDL bool
+	if !planTop.savePlanString {
+		// No instrumentation.
+		bld := execbuilder.New(f, mem, &opc.catalog, mem.RootExpr(), evalCtx, allowAutoCommit)
+		plan, err := bld.Build()
+		if err != nil {
+			return err
+		}
+		result = plan.(*planComponents)
+		isDDL = bld.IsDDL
+	} else {
+		// Create an explain factory and record the explain.Plan.
+		explainFactory := explain.NewFactory(f)
+		bld := execbuilder.New(explainFactory, mem, &opc.catalog, mem.RootExpr(), evalCtx, allowAutoCommit)
+		plan, err := bld.Build()
+		if err != nil {
+			return err
+		}
+		explainPlan = plan.(*explain.Plan)
+		result = explainPlan.WrappedPlan.(*planComponents)
+		isDDL = bld.IsDDL
+	}
+
+	if stmt.ExpectedTypes != nil {
+		cols := result.main.planColumns()
+		if !stmt.ExpectedTypes.TypesEqual(cols) {
+			return pgerror.New(pgcode.FeatureNotSupported, "cached plan must not change result type")
+		}
+	}
+
+	planTop.planComponents = *result
+	planTop.explainPlan = explainPlan
+	planTop.mem = mem
+	planTop.catalog = &opc.catalog
+	planTop.codec = codec
+	planTop.stmt = stmt
+	planTop.flags = opc.flags
+	if isDDL {
+		planTop.flags.Set(planFlagIsDDL)
+	}
+	return nil
 }

--- a/pkg/sql/recursive_cte.go
+++ b/pkg/sql/recursive_cte.go
@@ -121,7 +121,7 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 		return false, err
 	}
 
-	if err := runPlanInsidePlan(params, newPlan.(*planTop), n.workingRows); err != nil {
+	if err := runPlanInsidePlan(params, newPlan.(*planComponents), n.workingRows); err != nil {
 		return false, err
 	}
 	n.nextRowIdx = 1

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -6,9 +6,12 @@ CREATE TABLE t.orders (oid INT PRIMARY KEY, cid INT, value DECIMAL, date DATE)
 plan-string
 SELECT oid FROM t.orders WHERE oid = 123
 ----
-scan                         (oid int)
-      table  orders@primary
-      spans  /123-/123/#
+      distribution         local
+      vectorized           false
+scan                                          (oid int)
+      estimated row count  1 (missing stats)
+      table                orders@primary
+      spans                /123-/123/#
 
 plan-tree
 SELECT oid FROM t.orders WHERE oid = 123
@@ -24,13 +27,13 @@ children: []
 plan-string
 SELECT cid, date, value FROM t.orders
 ----
-render                               (cid int, date date, value decimal)
- │         render 0  (@1)[int]
- │         render 1  (@3)[date]
- │         render 2  (@2)[decimal]
- └── scan                            (cid int, value decimal, date date)
-           table     orders@primary
-           spans     FULL SCAN
+           distribution         local
+           vectorized           false
+project                                               (cid int, date date, value decimal)
+ └── scan                                             (cid int, value decimal, date date)
+           estimated row count  1000 (missing stats)
+           table                orders@primary
+           spans                FULL SCAN
 
 plan-tree
 SELECT cid, date, value FROM t.orders
@@ -55,26 +58,29 @@ children:
 plan-string
 SELECT cid, sum(value) FROM t.orders WHERE date > '2015-01-01' GROUP BY cid ORDER BY 1 - sum(value)
 ----
-render                                                                                      (cid int, sum decimal)
- │                                  render 0     (@2)[int]
- │                                  render 1     (@3)[decimal]
- └── sort                                                                                   (column7 decimal, cid int, sum decimal)  +column7
-      │                             order        +column7
-      └── render                                                                            (column7 decimal, cid int, sum decimal)
-           │                        render 0     ((1)[decimal] - (@2)[decimal])[decimal]
-           │                        render 1     (@1)[int]
-           │                        render 2     (@2)[decimal]
-           └── group                                                                        (cid int, sum decimal)
-                │                   aggregate 0  sum(value)
-                │                   group by     cid
-                └── render                                                                  (cid int, value decimal)
-                     │              render 0     (@1)[int]
-                     │              render 1     (@2)[decimal]
-                     └── filter                                                             (cid int, value decimal, date date)
-                          │         filter       ((@3)[date] > ('2015-01-01')[date])[bool]
-                          └── scan                                                          (cid int, value decimal, date date)
-                                    table        orders@primary
-                                    spans        FULL SCAN
+                                    distribution         local
+                                    vectorized           false
+project                                                                                               (cid int, sum decimal)
+ └── sort                                                                                             (column7 decimal, cid int, sum decimal)  +column7
+      │                             estimated row count  98 (missing stats)
+      │                             order                +column7
+      └── render                                                                                      (column7 decimal, cid int, sum decimal)
+           │                        estimated row count  98 (missing stats)
+           │                        render 0             ((1)[decimal] - (sum)[decimal])[decimal]
+           │                        render 1             (cid)[int]
+           │                        render 2             (sum)[decimal]
+           └── group                                                                                  (cid int, sum decimal)
+                │                   estimated row count  98 (missing stats)
+                │                   aggregate 0          sum(value)
+                │                   group by             cid
+                └── project                                                                           (cid int, value decimal)
+                     └── filter                                                                       (cid int, value decimal, date date)
+                          │         estimated row count  333 (missing stats)
+                          │         filter               ((date)[date] > ('2015-01-01')[date])[bool]
+                          └── scan                                                                    (cid int, value decimal, date date)
+                                    estimated row count  1000 (missing stats)
+                                    table                orders@primary
+                                    spans                FULL SCAN
 
 plan-tree
 SELECT cid, sum(value) FROM t.orders WHERE date > '2015-01-01' GROUP BY cid ORDER BY 1 - sum(value)
@@ -130,9 +136,12 @@ children:
 plan-string
 SELECT value FROM (SELECT cid, date, value FROM t.orders)
 ----
-scan                         (value decimal)
-      table  orders@primary
-      spans  FULL SCAN
+      distribution         local
+      vectorized           false
+scan                                             (value decimal)
+      estimated row count  1000 (missing stats)
+      table                orders@primary
+      spans                FULL SCAN
 
 plan-tree
 SELECT value FROM (SELECT cid, date, value FROM t.orders)
@@ -148,22 +157,27 @@ children: []
 plan-string
 SELECT cid, date, value FROM t.orders WHERE date IN (SELECT date FROM t.orders)
 ----
-render                                                    (cid int, date date, value decimal)
- │                   render 0            (@1)[int]
- │                   render 1            (@3)[date]
- │                   render 2            (@2)[decimal]
- └── hash join                                            (cid int, value decimal, date date, date date)
-      │              type                inner
-      │              equality            (date) = (date)
-      │              right cols are key
-      ├── scan                                            (cid int, value decimal, date date)
-      │              table               orders@primary
-      │              spans               FULL SCAN
-      └── distinct                                        (date date)
-           │         distinct on         date
-           └── scan                                       (date date)
-                     table               orders@primary
-                     spans               FULL SCAN
+                          distribution         local
+                          vectorized           false
+project                                                              (cid int, date date, value decimal)
+ └── project                                                         (cid int, value decimal, date date)
+      │                   estimated row count  1000 (missing stats)
+      └── hash join                                                  (cid int, value decimal, date date, date date)
+           │              estimated row count  980 (missing stats)
+           │              type                 inner
+           │              equality             (date) = (date)
+           │              right cols are key
+           ├── scan                                                  (cid int, value decimal, date date)
+           │              estimated row count  1000 (missing stats)
+           │              table                orders@primary
+           │              spans                FULL SCAN
+           └── distinct                                              (date date)
+                │         estimated row count  100 (missing stats)
+                │         distinct on          date
+                └── scan                                             (date date)
+                          estimated row count  1000 (missing stats)
+                          table                orders@primary
+                          spans                FULL SCAN
 
 plan-tree
 SELECT cid, date, value FROM t.orders WHERE date IN (SELECT date FROM t.orders)
@@ -225,24 +239,32 @@ CREATE TABLE t.actors (
 plan-string
 SELECT id AS movie_id, title, (SELECT name FROM t.actors WHERE name = 'Foo') FROM t.movies
 ----
-root                                                                                    (movie_id int, title string, name string)
- ├── render                                                                             (movie_id int, title string, name string)
- │    │                   render 0      (@1)[int]
- │    │                   render 1      (@2)[string]
- │    │                   render 2      (@S1)[string]
- │    └── scan                                                                          (id int, title string)
- │                        table         movies@primary
- │                        spans         FULL SCAN
+                          distribution         local
+                          vectorized           false
+root                                                                                           (movie_id int, title string, name string)
+ ├── project                                                                                   (movie_id int, title string, name string)
+ │    └── render                                                                               (name string, id int, title string)
+ │         │              estimated row count  1000 (missing stats)
+ │         │              render 0             (@S1)[string]
+ │         │              render 1             (id)[int]
+ │         │              render 2             (title)[string]
+ │         └── scan                                                                            (id int, title string)
+ │                        estimated row count  1000 (missing stats)
+ │                        table                movies@primary
+ │                        spans                FULL SCAN
  └── subquery
-      │                   id            @S1
-      │                   original sql  (SELECT name FROM t.actors WHERE name = 'Foo')
-      │                   exec mode     one row
-      └── max1row                                                                       (name string)
-           └── filter                                                                   (name string)
-                │         filter        ((@1)[string] = ('Foo')[string])[bool]
-                └── scan                                                                (name string)
-                          table         actors@primary
-                          spans         FULL SCAN
+      │                   id                   @S1
+      │                   original sql         (SELECT name FROM t.actors WHERE name = 'Foo')
+      │                   exec mode            one row
+      └── max1row                                                                              (name string)
+           │              estimated row count  1
+           └── filter                                                                          (name string)
+                │         estimated row count  10 (missing stats)
+                │         filter               ((name)[string] = ('Foo')[string])[bool]
+                └── scan                                                                       (name string)
+                          estimated row count  1000 (missing stats)
+                          table                actors@primary
+                          spans                FULL SCAN
 
 plan-tree
 SELECT id AS movie_id, title, (SELECT name FROM t.actors WHERE name = 'Foo') FROM t.movies


### PR DESCRIPTION
#### sql: produce planComponents instead of planTop

Currently the `ConstructPlan` implementation produces a `planTop`, which is not
right conceptually; `planTop` encompasses higher-level plan state. There is a
hack that copies some of the existing state from the planner.

This change cleans this up by returning just the `*planComponents`.

Release note: None

#### sql: fold planInstrumentation back into planTop

The separation between `planTop` and `planInstrumentation` is not very useful or
clean (e.g. we have to pass `*planTop` down). This change folds the latter back
into the former.

Release note: None

#### sql: add fully and partially distributed plan flags

This change adds separate plan flags for the two distribution modes.

Release note: None

#### sql: migrate planToString to new infrastructure

This change reworks `planToString` (used to populate the plan file in statement
diagnostic bundles) to use the new explain infrastructure.

Release note: None