### PR TITLE
kv: split EndTxn into sub-batch on auto-retry after successful refresh

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -1296,16 +1296,7 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 				br := ba.CreateReply()
 				br.Txn = ba.Txn.Clone()
 
-				if _, hasPut := ba.GetArg(roachpb.Put); hasPut {
-					if _, ok := ba.Requests[0].GetInner().(*roachpb.PutRequest); !ok {
-						t.Fatalf("expected Put")
-					}
-					union := &br.Responses[0] // avoid operating on copy
-					union.MustSetInner(&roachpb.PutResponse{})
-					if ba.Txn != nil && br.Txn == nil {
-						br.Txn.Status = roachpb.PENDING
-					}
-				} else if et, hasET := ba.GetArg(roachpb.EndTxn); hasET {
+				if et, hasET := ba.GetArg(roachpb.EndTxn); hasET {
 					if et.(*roachpb.EndTxnRequest).Commit {
 						commit.Store(true)
 						if test.errFn != nil {
@@ -1314,8 +1305,6 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 						return nil, roachpb.NewErrorWithTxn(test.err, ba.Txn)
 					}
 					abort.Store(true)
-				} else {
-					t.Fatalf("unexpected batch: %s", ba)
 				}
 				return br, nil
 			}


### PR DESCRIPTION
Fixes #51294.

This commit updates the txnSpanRefresher to split off EndTxn requests into their own partial batches on auto-retries after successful refreshes as a means of preventing starvation. This avoids starvation in two ways. First, it helps ensure that we lay down intents if any of the other requests in the batch are writes. Second, it ensures that if any writes are getting pushed due to contention with reads or due to the closed timestamp, they will still succeed and allow the batch to make forward progress. Without this, each retry attempt may get pushed because of writes in the batch and then rejected wholesale when the EndTxn tries to evaluate the pushed batch. When split, the writes will be pushed but succeed, the transaction will be refreshed, and the EndTxn will succeed.

I still need to confirm that this fixes this indefinite stall [here](https://github.com/cockroachlabs/misc_projects_glenn/tree/master/rw_blockage#implicit-query-hangs--explict-query-works), but I suspect that it will.

Release note (bug fix): A change in v20.1 caused a certain class of bulk UPDATEs and DELETE statements to hang indefinitely if run in an implicit transaction. We now break up these statements to avoid starvation and prevent them from hanging indefinitely.