### PR TITLE
[DNM] lease,sql: track sql leases through the table collection, update commit deadline

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -97,7 +97,7 @@ const (
 	DefaultDescriptorLeaseJitterFraction = 0.05
 
 	// DefaultDescriptorLeaseRenewalTimeout is the default time
-	// before a lease expires when acquisition to renew the lease begins.
+	//	// before a lease expires when acquisition to renew the lease begins.
 	DefaultDescriptorLeaseRenewalTimeout = time.Minute
 )
 
@@ -584,30 +584,5 @@ func TempStorageConfigFromEnv(
 		InMemory: inMem,
 		Mon:      monitor,
 		Spec:     useStore,
-	}
-}
-
-// LeaseManagerConfig holds lease manager parameters.
-type LeaseManagerConfig struct {
-	// DescriptorLeaseDuration is the mean duration a lease will be
-	// acquired for.
-	DescriptorLeaseDuration time.Duration
-
-	// DescriptorLeaseJitterFraction is the factor that we use to
-	// randomly jitter the lease duration when acquiring a new lease and
-	// the lease renewal timeout.
-	DescriptorLeaseJitterFraction float64
-
-	// DefaultDescriptorLeaseRenewalTimeout is the default time
-	// before a lease expires when acquisition to renew the lease begins.
-	DescriptorLeaseRenewalTimeout time.Duration
-}
-
-// NewLeaseManagerConfig initializes a LeaseManagerConfig with default values.
-func NewLeaseManagerConfig() *LeaseManagerConfig {
-	return &LeaseManagerConfig{
-		DescriptorLeaseDuration:       DefaultDescriptorLeaseDuration,
-		DescriptorLeaseJitterFraction: DefaultDescriptorLeaseJitterFraction,
-		DescriptorLeaseRenewalTimeout: DefaultDescriptorLeaseRenewalTimeout,
 	}
 }

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -34,9 +34,6 @@ type TestServerArgs struct {
 	*cluster.Settings
 	RaftConfig
 
-	// LeaseManagerConfig holds configuration values specific to the LeaseManager.
-	LeaseManagerConfig *LeaseManagerConfig
-
 	// PartOfCluster must be set if the TestServer is joining others in a cluster.
 	// If not set (and hence the server is the only one in the cluster), the
 	// default zone config will be overridden to disable all replication - so that

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -467,20 +467,20 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 
 			case 1:
 				// Past deadline.
-				if !txn.UpdateDeadlineMaybe(ctx, pushedTimestamp.Prev()) {
+				if !txn.UpdateDeadline(ctx, pushedTimestamp.Prev()) {
 					t.Fatalf("did not update deadline")
 				}
 
 			case 2:
 				// Equal deadline.
-				if !txn.UpdateDeadlineMaybe(ctx, pushedTimestamp) {
+				if !txn.UpdateDeadline(ctx, pushedTimestamp) {
 					t.Fatalf("did not update deadline")
 				}
 
 			case 3:
 				// Future deadline.
 
-				if !txn.UpdateDeadlineMaybe(ctx, pushedTimestamp.Next()) {
+				if !txn.UpdateDeadline(ctx, pushedTimestamp.Next()) {
 					t.Fatalf("did not update deadline")
 				}
 			}
@@ -2105,7 +2105,7 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	t.Run("standalone commit", func(t *testing.T) {
 		txn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
 		// Set a deadline. We'll generate a retriable error with a higher timestamp.
-		txn.UpdateDeadlineMaybe(ctx, clock.Now())
+		txn.UpdateDeadline(ctx, clock.Now())
 		if _, err := txn.Get(ctx, "k"); err != nil {
 			t.Fatal(err)
 		}
@@ -2119,7 +2119,7 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	t.Run("commit in batch", func(t *testing.T) {
 		txn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
 		// Set a deadline. We'll generate a retriable error with a higher timestamp.
-		txn.UpdateDeadlineMaybe(ctx, clock.Now())
+		txn.UpdateDeadline(ctx, clock.Now())
 		b := txn.NewBatch()
 		b.Get("k")
 		err := txn.CommitInBatch(ctx, b)

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -667,29 +667,26 @@ func (txn *Txn) CommitOrCleanup(ctx context.Context) error {
 	return err
 }
 
-// UpdateDeadlineMaybe sets the transactions deadline to the lower of the
-// current one (if any) and the passed value.
+// UpdateDeadline sets the transactions deadline to the passed deadline.
+// It may move the deadline further into the future.
 //
 // The deadline cannot be lower than txn.ReadTimestamp.
-func (txn *Txn) UpdateDeadlineMaybe(ctx context.Context, deadline hlc.Timestamp) bool {
+func (txn *Txn) UpdateDeadline(ctx context.Context, deadline hlc.Timestamp) {
 	if txn.typ != RootTxn {
-		panic(errors.WithContextTags(errors.AssertionFailedf("UpdateDeadlineMaybe() called on leaf txn"), ctx))
+		panic(errors.WithContextTags(errors.AssertionFailedf("UpdateDeadline() called on leaf txn"), ctx))
 	}
 
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
-	if txn.mu.deadline == nil || deadline.Less(*txn.mu.deadline) {
-		readTimestamp := txn.readTimestampLocked()
-		if deadline.Less(txn.readTimestampLocked()) {
-			log.Fatalf(ctx, "deadline below read timestamp is nonsensical; "+
-				"txn has would have no change to commit. Deadline: %s. Read timestamp: %s.",
-				deadline, readTimestamp)
-		}
-		txn.mu.deadline = new(hlc.Timestamp)
-		*txn.mu.deadline = deadline
-		return true
+
+	readTimestamp := txn.readTimestampLocked()
+	if deadline.Less(txn.readTimestampLocked()) {
+		log.Fatalf(ctx, "deadline below read timestamp is nonsensical; "+
+			"txn has would have no change to commit. Deadline: %s. Read timestamp: %s.",
+			deadline, readTimestamp)
 	}
-	return false
+	txn.mu.deadline = new(hlc.Timestamp)
+	*txn.mu.deadline = deadline
 }
 
 // resetDeadlineLocked resets the deadline.

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -497,7 +497,7 @@ func TestUpdateDeadlineMaybe(t *testing.T) {
 	}
 
 	deadline := hlc.Timestamp{WallTime: 10, Logical: 1}
-	if !txn.UpdateDeadlineMaybe(ctx, deadline) {
+	if !txn.UpdateDeadline(ctx, deadline) {
 		t.Errorf("expected update, but it didn't happen")
 	}
 	if d := *txn.deadline(); d != deadline {
@@ -505,7 +505,7 @@ func TestUpdateDeadlineMaybe(t *testing.T) {
 	}
 
 	futureDeadline := hlc.Timestamp{WallTime: 11, Logical: 1}
-	if txn.UpdateDeadlineMaybe(ctx, futureDeadline) {
+	if txn.UpdateDeadline(ctx, futureDeadline) {
 		t.Errorf("expected no update, but update happened")
 	}
 	if d := *txn.deadline(); d != deadline {
@@ -513,7 +513,7 @@ func TestUpdateDeadlineMaybe(t *testing.T) {
 	}
 
 	pastDeadline := hlc.Timestamp{WallTime: 9, Logical: 1}
-	if !txn.UpdateDeadlineMaybe(ctx, pastDeadline) {
+	if !txn.UpdateDeadline(ctx, pastDeadline) {
 		t.Errorf("expected update, but it didn't happen")
 	}
 	if d := *txn.deadline(); d != pastDeadline {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -299,9 +299,6 @@ type SQLConfig struct {
 	// The tenant that the SQL server runs on the behalf of.
 	TenantID roachpb.TenantID
 
-	// LeaseManagerConfig holds configuration values specific to the LeaseManager.
-	LeaseManagerConfig *base.LeaseManagerConfig
-
 	// SocketFile, if non-empty, sets up a TLS-free local listener using
 	// a unix datagram socket at the specified path.
 	SocketFile string
@@ -348,7 +345,6 @@ func MakeSQLConfig(tenID roachpb.TenantID, tempStorageCfg base.TempStorageConfig
 		TableStatCacheSize: defaultSQLTableStatCacheSize,
 		QueryCacheSize:     defaultSQLQueryCacheSize,
 		TempStorageConfig:  tempStorageCfg,
-		LeaseManagerConfig: base.NewLeaseManagerConfig(),
 	}
 	return sqlCfg
 }

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -257,7 +257,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		codec,
 		lmKnobs,
 		cfg.stopper,
-		cfg.LeaseManagerConfig,
 	)
 
 	// Set up internal memory metrics for use by internal SQL executors.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -141,11 +141,6 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.TestingKnobs = params.Knobs
 	cfg.RaftConfig = params.RaftConfig
 	cfg.RaftConfig.SetDefaults()
-	if params.LeaseManagerConfig != nil {
-		cfg.LeaseManagerConfig = params.LeaseManagerConfig
-	} else {
-		cfg.LeaseManagerConfig = base.NewLeaseManagerConfig()
-	}
 	if params.JoinAddr != "" {
 		cfg.JoinList = []string{params.JoinAddr}
 	}

--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -100,12 +100,18 @@ func (w *LeaseRemovalTracker) LeaseRemovedNotification(
 	}
 }
 
+// ExpireLeases ia a hack for testing that manually sets expirations to a past
+// timestamp.
 func (m *Manager) ExpireLeases(clock *hlc.Clock) {
-	past := clock.Now().GoTime().Add(-time.Millisecond)
+	past := hlc.Timestamp{
+		WallTime: clock.Now().GoTime().Add(-time.Millisecond).UnixNano(),
+	}
 
 	m.names.mu.Lock()
 	for _, desc := range m.names.descriptors {
-		desc.expiration = hlc.Timestamp{WallTime: past.UnixNano()}
+		desc.mu.Lock()
+		desc.mu.expiration = past
+		desc.mu.Unlock()
 	}
 	m.names.mu.Unlock()
 }

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -94,21 +94,22 @@ type storedLease struct {
 // TODO(vivek): A node only needs to manage lease information on what it
 // thinks is the latest version for a descriptor.
 type descriptorVersionState struct {
+	t *descriptorState
 	// This descriptor is immutable and can be shared by many goroutines.
 	// Care must be taken to not modify it.
 	catalog.Descriptor
 
-	// The expiration time for the descriptor version. A transaction with
-	// timestamp T can use this descriptor version iff
-	// Descriptor.GetDescriptorModificationTime() <= T < expiration
-	//
-	// The expiration time is either the expiration time of the lease when a lease
-	// is associated with the version, or the ModificationTime of the next version
-	// when the version isn't associated with a lease.
-	expiration hlc.Timestamp
-
 	mu struct {
 		syncutil.Mutex
+
+		// The expiration time for the descriptor version. A transaction with
+		// timestamp T can use this descriptor version iff
+		// Descriptor.GetDescriptorModificationTime() <= T < expiration
+		//
+		// The expiration time is either the expiration time of the lease when a lease
+		// is associated with the version, or the ModificationTime of the next version
+		// when the version isn't associated with a lease.
+		expiration hlc.Timestamp
 
 		refcount int
 		// Set if the node has a lease on this descriptor version.
@@ -121,10 +122,24 @@ type descriptorVersionState struct {
 	}
 }
 
+func (s *descriptorVersionState) Release(ctx context.Context) {
+	s.t.release(ctx, s)
+}
+
+func (s *descriptorVersionState) Desc() catalog.Descriptor {
+	return s.Descriptor
+}
+
+func (s *descriptorVersionState) Expiration() hlc.Timestamp {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mu.expiration
+}
+
 func (s *descriptorVersionState) SafeMessage() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return fmt.Sprintf("%d ver=%d:%s, refcount=%d", s.GetID(), s.GetVersion(), s.expiration, s.mu.refcount)
+	return fmt.Sprintf("%d ver=%d:%s, refcount=%d", s.GetID(), s.GetVersion(), s.mu.expiration, s.mu.refcount)
 }
 
 func (s *descriptorVersionState) String() string {
@@ -135,21 +150,21 @@ func (s *descriptorVersionState) String() string {
 
 // stringLocked reads mu.refcount and thus needs to have mu held.
 func (s *descriptorVersionState) stringLocked() string {
-	return fmt.Sprintf("%d(%q) ver=%d:%s, refcount=%d", s.GetID(), s.GetName(), s.GetVersion(), s.expiration, s.mu.refcount)
+	return fmt.Sprintf("%d(%q) ver=%d:%s, refcount=%d", s.GetID(), s.GetName(), s.GetVersion(), s.mu.expiration, s.mu.refcount)
 }
 
 // hasExpired checks if the descriptor is too old to be used (by a txn
 // operating) at the given timestamp.
 func (s *descriptorVersionState) hasExpired(timestamp hlc.Timestamp) bool {
-	return s.expiration.LessEq(timestamp)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hasExpiredLocked(timestamp)
 }
 
-// hasValidExpiration checks that this descriptor has a later expiration than
-// the existing one it is replacing. This can be used to check the
-// monotonicity of the expiration times on a descriptor at a particular version.
-// The version is not explicitly checked here.
-func (s *descriptorVersionState) hasValidExpiration(existing *descriptorVersionState) bool {
-	return existing.expiration.Less(s.expiration)
+// hasExpired checks if the descriptor is too old to be used (by a txn
+// operating) at the given timestamp.
+func (s *descriptorVersionState) hasExpiredLocked(timestamp hlc.Timestamp) bool {
+	return s.mu.expiration.LessEq(timestamp)
 }
 
 func (s *descriptorVersionState) incRefcount() {
@@ -163,6 +178,12 @@ func (s *descriptorVersionState) incRefcountLocked() {
 	if log.V(2) {
 		log.VEventf(context.TODO(), 2, "descriptorVersionState.incRef: %s", s.stringLocked())
 	}
+}
+
+func (s *descriptorVersionState) getExpiration() hlc.Timestamp {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mu.expiration
 }
 
 // The lease expiration stored in the database is of a different type.
@@ -208,9 +229,8 @@ func (s storage) jitteredLeaseDuration() time.Duration {
 // inactiveTableError. The expiration time set for the lease > minExpiration.
 func (s storage) acquire(
 	ctx context.Context, minExpiration hlc.Timestamp, id descpb.ID,
-) (*descriptorVersionState, error) {
-	var descVersionState *descriptorVersionState
-	err := s.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+) (desc catalog.Descriptor, expiration hlc.Timestamp, _ error) {
+	err := s.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 		// Run the descriptor read as high-priority, thereby pushing any intents out
 		// of its way. We don't want schema changes to prevent lease acquisitions;
 		// we'd rather force them to refresh. Also this prevents deadlocks in cases
@@ -219,7 +239,7 @@ func (s storage) acquire(
 		if err := txn.SetUserPriority(roachpb.MaxUserPriority); err != nil {
 			return err
 		}
-		expiration := txn.ReadTimestamp()
+		expiration = txn.ReadTimestamp()
 		expiration.WallTime += int64(s.jitteredLeaseDuration())
 		if expiration.LessEq(minExpiration) {
 			// In the rare circumstances where expiration <= minExpiration
@@ -232,7 +252,7 @@ func (s storage) acquire(
 		// to ValidateTable() instead of Validate(), to avoid the cross-table
 		// checks. Does this actually matter? We already potentially do cross-table
 		// checks when populating pre-19.2 foreign keys.
-		desc, err := catalogkv.GetDescriptorByID(ctx, txn, s.codec, id, catalogkv.Immutable,
+		desc, err = catalogkv.GetDescriptorByID(ctx, txn, s.codec, id, catalogkv.Immutable,
 			catalogkv.AnyDescriptorKind, true /* required */)
 		if err != nil {
 			return err
@@ -240,20 +260,7 @@ func (s storage) acquire(
 		if err := catalog.FilterDescriptorState(desc); err != nil {
 			return err
 		}
-		// Once the descriptor is set it is immutable and care must be taken
-		// to not modify it.
-		storedLease := &storedLease{
-			id:         desc.GetID(),
-			version:    int(desc.GetVersion()),
-			expiration: storedLeaseExpiration(expiration),
-		}
-		descVersionState = &descriptorVersionState{
-			Descriptor: desc,
-			expiration: expiration,
-		}
-		log.VEventf(ctx, 2, "storage acquired lease %+v", storedLease)
-		descVersionState.mu.lease = storedLease
-
+		log.VEventf(ctx, 2, "storage acquired lease %v@%v", desc, expiration)
 		nodeID := s.nodeIDContainer.SQLInstanceID()
 		if nodeID == 0 {
 			panic("zero nodeID")
@@ -265,9 +272,10 @@ func (s storage) acquire(
 		// general cost of preparing, preparing this statement always requires a
 		// read from the database for the special descriptor of a system table
 		// (#23937).
+		ts := storedLeaseExpiration(expiration)
 		insertLease := fmt.Sprintf(
 			`INSERT INTO system.public.lease ("descID", version, "nodeID", expiration) VALUES (%d, %d, %d, %s)`,
-			storedLease.id, storedLease.version, nodeID, &storedLease.expiration,
+			desc.GetID(), desc.GetVersion(), nodeID, &ts,
 		)
 		count, err := s.internalExecutor.Exec(ctx, "lease-insert", txn, insertLease)
 		if err != nil {
@@ -278,10 +286,13 @@ func (s storage) acquire(
 		}
 		return nil
 	})
-	if err == nil && s.testingKnobs.LeaseAcquiredEvent != nil {
-		s.testingKnobs.LeaseAcquiredEvent(descVersionState.Descriptor, nil)
+	if s.testingKnobs.LeaseAcquiredEvent != nil {
+		s.testingKnobs.LeaseAcquiredEvent(desc, err)
 	}
-	return descVersionState, err
+	if err != nil {
+		return nil, hlc.Timestamp{}, err
+	}
+	return desc, expiration, nil
 }
 
 // Release a previously acquired descriptor. Never let this method
@@ -591,12 +602,12 @@ func CountLeases(
 // layer GC threshold.
 func (s storage) getForExpiration(
 	ctx context.Context, expiration hlc.Timestamp, id descpb.ID,
-) (*descriptorVersionState, error) {
-	var descVersionState *descriptorVersionState
-	err := s.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+) (catalog.Descriptor, error) {
+	var desc catalog.Descriptor
+	err := s.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 		prevTimestamp := expiration.Prev()
 		txn.SetFixedTimestamp(ctx, prevTimestamp)
-		desc, err := catalogkv.GetDescriptorByID(ctx, txn, s.codec, id, catalogkv.Immutable,
+		desc, err = catalogkv.GetDescriptorByID(ctx, txn, s.codec, id, catalogkv.Immutable,
 			catalogkv.AnyDescriptorKind, true /* required */)
 		if err != nil {
 			return err
@@ -605,19 +616,10 @@ func (s storage) getForExpiration(
 			return errors.AssertionFailedf("unable to read descriptor (%d, %s)", id, expiration)
 		}
 		// Create a descriptorVersionState with the descriptor and without a lease.
-		descVersionState = &descriptorVersionState{
-			Descriptor: desc,
-			expiration: expiration,
-		}
 		return nil
 	})
-	return descVersionState, err
+	return desc, err
 }
-
-// leaseToken is an opaque token representing a lease. It's distinct from a
-// lease to define restricted capabilities and prevent improper use of a lease
-// where we instead have leaseTokens.
-type leaseToken *descriptorVersionState
 
 func (s storage) leaseRenewalTimeout() time.Duration {
 	return LeaseRenewalDuration.Get(&s.settings.SV)
@@ -643,7 +645,7 @@ func (l *descriptorSet) String() string {
 		if i > 0 {
 			buf.WriteString(" ")
 		}
-		buf.WriteString(fmt.Sprintf("%d:%d", s.GetVersion(), s.expiration.WallTime))
+		buf.WriteString(fmt.Sprintf("%d:%d", s.GetVersion(), s.getExpiration().WallTime))
 	}
 	return buf.String()
 }
@@ -719,6 +721,7 @@ func (l *descriptorSet) findVersion(version descpb.DescriptorVersion) *descripto
 }
 
 type descriptorState struct {
+	m       *Manager
 	id      descpb.ID
 	stopper *stop.Stopper
 
@@ -828,6 +831,11 @@ func (t *descriptorState) findForTimestamp(
 	return nil, false, errReadOlderVersion
 }
 
+type historicalDescriptor struct {
+	desc       catalog.Descriptor
+	expiration hlc.Timestamp // ModificationTime of the next descriptor
+}
+
 // Read an older descriptor version for the particular timestamp
 // from the store. We unfortunately need to read more than one descriptor
 // version just so that we can set the expiration time on the descriptor
@@ -841,7 +849,7 @@ func (t *descriptorState) findForTimestamp(
 //    They are currently purged in PurgeOldVersions.
 func (m *Manager) readOlderVersionForTimestamp(
 	ctx context.Context, id descpb.ID, timestamp hlc.Timestamp,
-) ([]*descriptorVersionState, error) {
+) ([]historicalDescriptor, error) {
 	expiration, done := func() (hlc.Timestamp, bool) {
 		t := m.findDescriptorState(id, false /* create */)
 		t.mu.Lock()
@@ -851,9 +859,9 @@ func (m *Manager) readOlderVersionForTimestamp(
 		for i := len(t.mu.active.data) - 1; i >= 0; i-- {
 			// Check to see if the ModificationTime is valid.
 			if desc := t.mu.active.data[i]; desc.GetModificationTime().LessEq(timestamp) {
-				if timestamp.Less(desc.expiration) {
+				if expiration := desc.getExpiration(); timestamp.Less(expiration) {
 					// Existing valid descriptor version.
-					return desc.expiration, true
+					return expiration, true
 				}
 				// We need a version after data[i], but before data[i+1].
 				// We could very well use the timestamp to read the
@@ -880,13 +888,16 @@ func (m *Manager) readOlderVersionForTimestamp(
 	}
 
 	// Read descriptors from the store.
-	var versions []*descriptorVersionState
+	var versions []historicalDescriptor
 	for {
 		desc, err := m.storage.getForExpiration(ctx, expiration, id)
 		if err != nil {
 			return nil, err
 		}
-		versions = append(versions, desc)
+		versions = append(versions, historicalDescriptor{
+			desc:       desc,
+			expiration: expiration,
+		})
 		if desc.GetModificationTime().LessEq(timestamp) {
 			break
 		}
@@ -899,17 +910,18 @@ func (m *Manager) readOlderVersionForTimestamp(
 
 // Insert descriptor versions. The versions provided are not in
 // any particular order.
-func (m *Manager) insertDescriptorVersions(id descpb.ID, versions []*descriptorVersionState) {
+func (m *Manager) insertDescriptorVersions(id descpb.ID, versions []historicalDescriptor) {
 	t := m.findDescriptorState(id, false /* create */)
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	for _, version := range versions {
+	for i := range versions {
 		// Since we gave up the lock while reading the versions from
 		// the store we have to ensure that no one else inserted the
 		// same version.
-		existingVersion := t.mu.active.findVersion(version.GetVersion())
+		existingVersion := t.mu.active.findVersion(versions[i].desc.GetVersion())
 		if existingVersion == nil {
-			t.mu.active.insert(version)
+			t.mu.active.insert(
+				newDescriptorVersionState(t, versions[i].desc, versions[i].expiration, false))
 		}
 	}
 }
@@ -962,48 +974,66 @@ func (m *Manager) AcquireFreshestFromStore(ctx context.Context, id descpb.ID) er
 
 var _ safedetails.SafeMessager = (*descriptorVersionState)(nil)
 
-// upsertLocked inserts a lease for a particular descriptor version.
+// upsertLeaseLocked inserts a lease for a particular descriptor version.
 // If an existing lease exists for the descriptor version it replaces
 // it and returns it.
-func (t *descriptorState) upsertLocked(
-	ctx context.Context, desc *descriptorVersionState,
-) (_ *storedLease, _ error) {
+func (t *descriptorState) upsertLeaseLocked(
+	ctx context.Context, desc catalog.Descriptor, expiration hlc.Timestamp,
+) (createdDescriptorVersionState *descriptorVersionState, toRelease *storedLease, _ error) {
 	s := t.mu.active.find(desc.GetVersion())
 	if s == nil {
 		if t.mu.active.findNewest() != nil {
 			log.Infof(ctx, "new lease: %s", desc)
 		}
-		t.mu.active.insert(desc)
-		return nil, nil
-	}
-
-	// The desc is replacing an existing one at the same version.
-	if !desc.hasValidExpiration(s) {
-		// This is a violation of an invariant and can actually not
-		// happen. We return an error here to aid in further investigations.
-		return nil, errors.AssertionFailedf("lease expiration monotonicity violation, (%s) vs (%s)", s, desc)
+		descState := newDescriptorVersionState(t, desc, expiration, true /* isLease */)
+		t.mu.active.insert(descState)
+		return descState, nil, nil
 	}
 
 	s.mu.Lock()
-	desc.mu.Lock()
+	defer s.mu.Unlock()
+	// The desc is replacing an existing one at the same version.
+	if !s.mu.expiration.Less(expiration) {
+		// This is a violation of an invariant and can actually not
+		// happen. We return an error here to aid in further investigations.
+		return nil, nil, errors.AssertionFailedf("lease expiration monotonicity violation, (%s) vs (%s)", s, desc)
+	}
+
 	// subsume the refcount of the older lease. This is permitted because
 	// the new lease has a greater expiration than the older lease and
 	// any transaction using the older lease can safely use a deadline set
 	// to the older lease's expiration even though the older lease is
 	// released! This is because the new lease is valid at the same desc
 	// version at a greater expiration.
-	desc.mu.refcount += s.mu.refcount
-	s.mu.refcount = 0
-	l := s.mu.lease
-	s.mu.lease = nil
-	if log.V(2) {
-		log.VEventf(ctx, 2, "replaced lease: %s with %s", s.stringLocked(), desc.stringLocked())
+	s.mu.expiration = expiration
+	toRelease = s.mu.lease
+	s.mu.lease = &storedLease{
+		id:         desc.GetID(),
+		version:    int(desc.GetVersion()),
+		expiration: storedLeaseExpiration(expiration),
 	}
-	desc.mu.Unlock()
-	s.mu.Unlock()
-	t.mu.active.remove(s)
-	t.mu.active.insert(desc)
-	return l, nil
+	if log.ExpensiveLogEnabled(ctx, 2) {
+		log.VEventf(ctx, 2, "replaced lease: %s with %s", toRelease, s.mu.lease)
+	}
+	return nil, toRelease, nil
+}
+
+func newDescriptorVersionState(
+	t *descriptorState, desc catalog.Descriptor, expiration hlc.Timestamp, isLease bool,
+) *descriptorVersionState {
+	descState := &descriptorVersionState{
+		t:          t,
+		Descriptor: desc,
+	}
+	descState.mu.expiration = expiration
+	if isLease {
+		descState.mu.lease = &storedLease{
+			id:         desc.GetID(),
+			version:    int(desc.GetVersion()),
+			expiration: storedLeaseExpiration(expiration),
+		}
+	}
+	return descState
 }
 
 // removeInactiveVersions removes inactive versions in t.mu.active.data with
@@ -1047,24 +1077,27 @@ func acquireNodeLease(ctx context.Context, m *Manager, id descpb.ID) (bool, erro
 		newest := m.findNewest(id)
 		var minExpiration hlc.Timestamp
 		if newest != nil {
-			minExpiration = newest.expiration
+			minExpiration = newest.getExpiration()
 		}
-		desc, err := m.storage.acquire(newCtx, minExpiration, id)
+		desc, expiration, err := m.storage.acquire(newCtx, minExpiration, id)
 		if err != nil {
 			return nil, err
 		}
 		t := m.findDescriptorState(id, false /* create */)
 		t.mu.Lock()
 		defer t.mu.Unlock()
-		toRelease, err = t.upsertLocked(newCtx, desc)
+		var newDescVersionState *descriptorVersionState
+		newDescVersionState, toRelease, err = t.upsertLeaseLocked(newCtx, desc, expiration)
 		if err != nil {
 			return nil, err
 		}
-		m.names.insert(desc)
+		if newDescVersionState != nil {
+			m.names.insert(newDescVersionState)
+		}
 		if toRelease != nil {
 			releaseLease(toRelease, m)
 		}
-		return leaseToken(desc), nil
+		return true, nil
 	})
 	select {
 	case <-ctx.Done():
@@ -1079,23 +1112,15 @@ func acquireNodeLease(ctx context.Context, m *Manager, id descpb.ID) (bool, erro
 
 // release returns a descriptorVersionState that needs to be released from
 // the store.
-func (t *descriptorState) release(
-	desc catalog.Descriptor, removeOnceDereferenced bool,
-) (*storedLease, error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+func (t *descriptorState) release(ctx context.Context, s *descriptorVersionState) {
 
-	s := t.mu.active.find(desc.GetVersion())
-	if s == nil {
-		return nil, errors.Errorf("descriptor %d version %d not found", desc.GetID(), desc.GetVersion())
-	}
 	// Decrements the refcount and returns true if the lease has to be removed
 	// from the store.
 	decRefcount := func(s *descriptorVersionState) *storedLease {
 		// Figure out if we'd like to remove the lease from the store asap (i.e.
 		// when the refcount drops to 0). If so, we'll need to mark the lease as
 		// invalid.
-		removeOnceDereferenced = removeOnceDereferenced ||
+		removeOnceDereferenced := t.m.removeOnceDereferenced() ||
 			// Release from the store if the descriptor has been dropped; no leases
 			// can be acquired any more.
 			t.mu.dropped ||
@@ -1120,11 +1145,19 @@ func (t *descriptorState) release(
 		}
 		return nil
 	}
-	if l := decRefcount(s); l != nil {
-		t.mu.active.remove(s)
-		return l, nil
+	maybeRemoveLease := func() *storedLease {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		if l := decRefcount(s); l != nil {
+			t.mu.active.remove(s)
+			return l
+		}
+		return nil
 	}
-	return nil, nil
+	if l := maybeRemoveLease(); l != nil {
+		releaseLease(l, t.m)
+	}
+	return
 }
 
 // releaseLease from store.
@@ -1200,13 +1233,7 @@ func purgeOldVersions(
 	if isInactive := catalog.HasInactiveDescriptorError(err); err == nil || isInactive {
 		removeInactives(isInactive)
 		if desc != nil {
-			s, err := t.release(desc.Descriptor, m.removeOnceDereferenced())
-			if err != nil {
-				return err
-			}
-			if s != nil {
-				releaseLease(s, m)
-			}
+			t.release(ctx, desc)
 			return nil
 		}
 		return nil
@@ -1390,7 +1417,7 @@ func (c *nameCache) get(
 	}
 
 	// Expired descriptor. Don't hand it out.
-	if desc.hasExpired(timestamp) {
+	if desc.hasExpiredLocked(timestamp) {
 		return nil
 	}
 
@@ -1411,7 +1438,8 @@ func (c *nameCache) insert(desc *descriptorVersionState) {
 	// If we already have a lease in the cache for this name, see if this one is
 	// better (higher version or later expiration).
 	if desc.GetVersion() > existing.GetVersion() ||
-		(desc.GetVersion() == existing.GetVersion() && desc.hasValidExpiration(existing)) {
+		(desc.GetVersion() == existing.GetVersion() &&
+			existing.getExpiration().Less(desc.getExpiration())) {
 		// Overwrite the old lease. The new one is better. From now on, we want
 		// clients to use the new one.
 		c.descriptors[key] = desc
@@ -1566,32 +1594,33 @@ func (m *Manager) AcquireByName(
 	parentID descpb.ID,
 	parentSchemaID descpb.ID,
 	name string,
-) (catalog.Descriptor, hlc.Timestamp, error) {
+) (LeasedDescriptor, error) {
 	// Check if we have cached an ID for this name.
 	descVersion := m.names.get(parentID, parentSchemaID, name, timestamp)
 	if descVersion != nil {
 		if descVersion.GetModificationTime().LessEq(timestamp) {
+			expiration := descVersion.getExpiration()
 			// If this lease is nearly expired, ensure a renewal is queued.
-			durationUntilExpiry := time.Duration(descVersion.expiration.WallTime - timestamp.WallTime)
+			durationUntilExpiry := time.Duration(expiration.WallTime - timestamp.WallTime)
 			if durationUntilExpiry < m.storage.leaseRenewalTimeout() {
 				if t := m.findDescriptorState(descVersion.GetID(), false /* create */); t != nil {
 					if err := t.maybeQueueLeaseRenewal(
 						ctx, m, descVersion.GetID(), name); err != nil {
-						return nil, hlc.Timestamp{}, err
+						return nil, err
 					}
 				}
 			}
-			return descVersion.Descriptor, descVersion.expiration, nil
+			return descVersion, nil
 		}
-		if err := m.Release(descVersion); err != nil {
-			return nil, hlc.Timestamp{}, err
-		}
+		// m.names.get() incremented the refcount, we decrement it to get a new
+		// version.
+		descVersion.Release(ctx)
 		// Return a valid descriptor for the timestamp.
-		desc, expiration, err := m.Acquire(ctx, timestamp, descVersion.GetID())
+		leasedDesc, err := m.Acquire(ctx, timestamp, descVersion.GetID())
 		if err != nil {
-			return nil, hlc.Timestamp{}, err
+			return nil, err
 		}
-		return desc, expiration, nil
+		return leasedDesc, nil
 	}
 
 	// We failed to find something in the cache, or what we found is not
@@ -1601,13 +1630,13 @@ func (m *Manager) AcquireByName(
 	var err error
 	id, err := m.resolveName(ctx, timestamp, parentID, parentSchemaID, name)
 	if err != nil {
-		return nil, hlc.Timestamp{}, err
+		return nil, err
 	}
-	desc, expiration, err := m.Acquire(ctx, timestamp, id)
+	desc, err := m.Acquire(ctx, timestamp, id)
 	if err != nil {
-		return nil, hlc.Timestamp{}, err
+		return nil, err
 	}
-	if !NameMatchesDescriptor(desc, parentID, parentSchemaID, name) {
+	if !NameMatchesDescriptor(desc.Desc(), parentID, parentSchemaID, name) {
 		// We resolved name `name`, but the lease has a different name in it.
 		// That can mean two things. Assume the descriptor is being renamed from A to B.
 		// a) `name` is A. The transaction doing the RENAME committed (so the
@@ -1641,26 +1670,22 @@ func (m *Manager) AcquireByName(
 		//
 		// TODO(vivek): check if the entire above comment is indeed true. Review the
 		// use of NameMatchesDescriptor() throughout this function.
-		if err := m.Release(desc); err != nil {
-			log.Warningf(ctx, "error releasing lease: %s", err)
-		}
+		desc.Release(ctx)
 		if err := m.AcquireFreshestFromStore(ctx, id); err != nil {
-			return nil, hlc.Timestamp{}, err
+			return nil, err
 		}
-		desc, expiration, err = m.Acquire(ctx, timestamp, id)
+		desc, err = m.Acquire(ctx, timestamp, id)
 		if err != nil {
-			return nil, hlc.Timestamp{}, err
+			return nil, err
 		}
-		if !NameMatchesDescriptor(desc, parentID, parentSchemaID, name) {
+		if !NameMatchesDescriptor(desc.Desc(), parentID, parentSchemaID, name) {
 			// If the name we had doesn't match the newest descriptor in the DB, then
 			// we're trying to use an old name.
-			if err := m.Release(desc); err != nil {
-				log.Warningf(ctx, "error releasing lease: %s", err)
-			}
-			return nil, hlc.Timestamp{}, sqlbase.ErrDescriptorNotFound
+			desc.Release(ctx)
+			return nil, sqlbase.ErrDescriptorNotFound
 		}
 	}
-	return desc, expiration, nil
+	return desc, nil
 }
 
 // resolveName resolves a descriptor name to a descriptor ID at a particular
@@ -1703,6 +1728,12 @@ func (m *Manager) resolveName(
 	return id, nil
 }
 
+type LeasedDescriptor interface {
+	Desc() catalog.Descriptor
+	Expiration() hlc.Timestamp
+	Release(ctx context.Context)
+}
+
 // Acquire acquires a read lease for the specified descriptor ID valid for
 // the timestamp. It returns the descriptor and a expiration time.
 // A transaction using this descriptor must ensure that its
@@ -1716,21 +1747,21 @@ func (m *Manager) resolveName(
 // can be leased; as it stands a dropped descriptor cannot be leased.
 func (m *Manager) Acquire(
 	ctx context.Context, timestamp hlc.Timestamp, id descpb.ID,
-) (catalog.Descriptor, hlc.Timestamp, error) {
+) (LeasedDescriptor, error) {
 	for {
 		t := m.findDescriptorState(id, true /*create*/)
 		desc, latest, err := t.findForTimestamp(ctx, timestamp)
 		if err == nil {
 			// If the latest lease is nearly expired, ensure a renewal is queued.
 			if latest {
-				durationUntilExpiry := time.Duration(desc.expiration.WallTime - timestamp.WallTime)
+				durationUntilExpiry := time.Duration(desc.getExpiration().WallTime - timestamp.WallTime)
 				if durationUntilExpiry < m.storage.leaseRenewalTimeout() {
 					if err := t.maybeQueueLeaseRenewal(ctx, m, id, desc.GetName()); err != nil {
-						return nil, hlc.Timestamp{}, err
+						return nil, err
 					}
 				}
 			}
-			return desc.Descriptor, desc.expiration, nil
+			return desc, nil
 		}
 		switch {
 		case errors.Is(err, errRenewLease):
@@ -1741,7 +1772,7 @@ func (m *Manager) Acquire(
 				_, errLease := acquireNodeLease(ctx, m, id)
 				return errLease
 			}(); err != nil {
-				return nil, hlc.Timestamp{}, err
+				return nil, err
 			}
 
 			if m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent != nil {
@@ -1752,36 +1783,14 @@ func (m *Manager) Acquire(
 			// Read old versions from the store. This can block while reading.
 			versions, errRead := m.readOlderVersionForTimestamp(ctx, id, timestamp)
 			if errRead != nil {
-				return nil, hlc.Timestamp{}, errRead
+				return nil, errRead
 			}
 			m.insertDescriptorVersions(id, versions)
 
 		default:
-			return nil, hlc.Timestamp{}, err
+			return nil, err
 		}
 	}
-}
-
-// Release releases a previously acquired lease.
-func (m *Manager) Release(desc catalog.Descriptor) error {
-	t := m.findDescriptorState(desc.GetID(), false /* create */)
-	if t == nil {
-		return errors.Errorf("descriptor %d not found", desc.GetID())
-	}
-	// TODO(pmattis): Can/should we delete from Manager.descriptors if the
-	// descriptorState becomes empty?
-	// TODO(andrei): I think we never delete from Manager.descriptors... which
-	// could be bad if a lot of descriptors keep being created. I looked into cleaning
-	// up a bit, but it seems tricky to do with the current locking which is split
-	// between Manager and descriptorState.
-	l, err := t.release(desc, m.removeOnceDereferenced())
-	if err != nil {
-		return err
-	}
-	if l != nil {
-		releaseLease(l, m)
-	}
-	return nil
 }
 
 // removeOnceDereferenced returns true if the Manager thinks
@@ -1831,7 +1840,7 @@ func (m *Manager) findDescriptorState(id descpb.ID, create bool) *descriptorStat
 	defer m.mu.Unlock()
 	t := m.mu.descriptors[id]
 	if t == nil && create {
-		t = &descriptorState{id: id, stopper: m.stopper}
+		t = &descriptorState{m: m, id: id, stopper: m.stopper}
 		m.mu.descriptors[id] = t
 	}
 	return t
@@ -2368,14 +2377,14 @@ func (m *Manager) VisitLeases(
 // context.
 func (m *Manager) TestingAcquireAndAssertMinVersion(
 	ctx context.Context, timestamp hlc.Timestamp, id descpb.ID, minVersion descpb.DescriptorVersion,
-) (catalog.Descriptor, hlc.Timestamp, error) {
+) (LeasedDescriptor, error) {
 	t := m.findDescriptorState(id, true)
 	if err := ensureVersion(ctx, id, minVersion, m); err != nil {
-		return nil, hlc.Timestamp{}, err
+		return nil, err
 	}
 	desc, _, err := t.findForTimestamp(ctx, timestamp)
 	if err != nil {
-		return nil, hlc.Timestamp{}, err
+		return nil, err
 	}
-	return desc.Descriptor, desc.expiration, nil
+	return desc, nil
 }

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -835,12 +835,11 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 
 			serverArgs := base.TestServerArgs{Knobs: testingKnobs}
 
-			serverArgs.LeaseManagerConfig = base.NewLeaseManagerConfig()
 			// The LeaseJitterFraction is zero so leases will have
 			// monotonically increasing expiration. This prevents two leases
 			// from having the same expiration due to randomness, as the
 			// leases are checked for having a different expiration.
-			serverArgs.LeaseManagerConfig.DescriptorLeaseJitterFraction = 0.0
+			LeaseJitterFraction.Override(&serverArgs.SV, 0)
 
 			s, _, _ := serverutils.StartServer(
 				t, serverArgs)


### PR DESCRIPTION
Fixes #51042

Release note (bug fix): Fixed a bug that prevent transactions which lasted
longer than 5 minutes and then performed writes from committing.