### PR TITLE
geo: implement ST_PointFromGeoHash({text,int4}) -> geometry

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1450,6 +1450,10 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 </span></td></tr>
 <tr><td><a name="st_point"></a><code>st_point(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a new Point with the given X and Y coordinates.</p>
 </span></td></tr>
+<tr><td><a name="st_pointfromgeohash"></a><code>st_pointfromgeohash(geohash: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Return a Geometry point from a GeoHash string with max precision.</p>
+</span></td></tr>
+<tr><td><a name="st_pointfromgeohash"></a><code>st_pointfromgeohash(geohash: <a href="string.html">string</a>, precision: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Return a Geometry point from a GeoHash string with supplied precision.</p>
+</span></td></tr>
 <tr><td><a name="st_pointfromtext"></a><code>st_pointfromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation with an SRID. If the shape underneath is not Point, NULL is returned. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>
 </span></td></tr>
 <tr><td><a name="st_pointfromtext"></a><code>st_pointfromtext(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation. If the shape underneath is not Point, NULL is returned.</p>

--- a/pkg/geo/geohash.go
+++ b/pkg/geo/geohash.go
@@ -1,0 +1,41 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geo
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/pierrre/geohash"
+)
+
+// NewGeometryPointFromGeoHash converts a GeoHash to a Geometry Point
+// using a Lng/Lat Point representation of the GeoHash.
+func NewGeometryPointFromGeoHash(g string, precision int) (*Geometry, error) {
+	if len(g) == 0 {
+		return nil, errors.Newf("Length of geohash must be greater than 0")
+	}
+
+	// If precision is more than the length of the geohash
+	// or if precision is less than 0 then set
+	// precision equal to length of geohash.
+	if precision > len(g) || precision < 0 {
+		precision = len(g)
+	}
+	box, err := geohash.Decode(g[0:precision])
+	if err != nil {
+		return nil, err
+	}
+	point := box.Round()
+	geom, gErr := NewGeometryFromPointCoords(point.Lon, point.Lat)
+	if gErr != nil {
+		return nil, gErr
+	}
+	return geom, nil
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -811,6 +811,28 @@ FROM parse_test ORDER BY id ASC
 0101000000000000000000F87F000000000000F87F  0101000020E6100000000000000000F87F000000000000F87F  0101000020E6100000000000000000F87F000000000000F87F  0020000001000010E67FF80000000000007FF8000000000000
 NULL                                        NULL                                                NULL                                                NULL
 
+subtest ST_PointFromGeoHash
+query T
+SELECT ST_AsText(ST_PointFromGeoHash('s000000000000000'))
+----
+POINT (0 0)
+
+query T
+SELECT ST_AsText(ST_PointFromGeoHash('kkqnpkue9ktbpe5'))
+----
+POINT (20.012345 -20.012345)
+
+query T
+SELECT ST_AsText(ST_PointFromGeoHash('w000000000000000',16))
+----
+POINT (90 0)
+
+statement error pq: st_pointfromgeohash\(\): geohash decode '----': invalid character at index 0
+SELECT ST_AsText(ST_PointFromGeoHash('----'))
+
+statement error pq: st_pointfromgeohash\(\): Length of geohash must be greater than 0
+SELECT ST_AsText(ST_PointFromGeoHash(''))
+
 query TTTTTTTT
 SELECT
   ST_PointFromText('POINT(1.0 1.0)'),

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1176,7 +1176,48 @@ var geoBuiltins = map[string]builtinDefinition{
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
-
+	"st_pointfromgeohash": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geohash", types.String},
+				{"precision", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := args[0].(*tree.DString)
+				p := args[1].(*tree.DInt)
+				ret, err := geo.NewGeometryPointFromGeoHash(string(*g), int(*p))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: "Return a Geometry point from a GeoHash string with supplied precision.",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geohash", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := args[0].(*tree.DString)
+				p := len(string(*g))
+				ret, err := geo.NewGeometryPointFromGeoHash(string(*g), p)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: "Return a Geometry point from a GeoHash string with max precision.",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
 	"st_asgeojson": makeBuiltin(
 		defProps(),
 		tree.Overload{


### PR DESCRIPTION
fixes: #48820
This PR adds a function to calculate the convert 
geohash representation to point representation,
imitating the PostGIS funcitonality.

if no precision is specified ST_PointFromGeoHash returns a point based on full precision of the input GeoHash string.
If precision is specified ST_PointFromGeoHash will use that many characters from the GeoHash to create the point.

Release note (sql change): Implements ST_PointFromGeoHash
which converts geohash to point