### PR TITLE
roachtest: add encrypted BACKUP and RESTORE roachtest

### DIFF
--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -84,7 +84,8 @@ case "${CLOUD}" in
     PARALLELISM=3
     CPUQUOTA=384
     if [ -z "${TESTS}" ]; then
-      TESTS="kv(0|95)|ycsb|tpcc/(headroom/n4cpu16)|tpccbench/(nodes=3/cpu=16)|scbench/randomload/(nodes=3/ops=2000/conc=1)"
+      TESTS="kv(0|95)|ycsb|tpcc/(headroom/n4cpu16)|tpccbench/(nodes=3/cpu=16)|scbench/randomload/
+      (nodes=3/ops=2000/conc=1)|backup/KMS"
     fi
     ;;
   *)

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -730,8 +730,8 @@ func TestEncryptedBackupRestoreSystemJobs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	regionEnvVariable := "AWS_REGION"
-	keyIDEnvVariable := "AWS_KEY_ARN"
+	regionEnvVariable := "AWS_KMS_REGION_A"
+	keyIDEnvVariable := "AWS_KMS_KEY_ARN_A"
 
 	for _, tc := range []struct {
 		name   string
@@ -3495,8 +3495,8 @@ func TestEncryptedBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	regionEnvVariable := "AWS_REGION"
-	keyIDEnvVariable := "AWS_KEY_ARN"
+	regionEnvVariable := "AWS_KMS_REGION_A"
+	keyIDEnvVariable := "AWS_KMS_KEY_ARN_A"
 
 	for _, tc := range []struct {
 		name   string
@@ -3604,8 +3604,8 @@ func TestRegionalKMSEncryptedBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	regionEnvVariables := []string{"AWS_REGION", "AWS_REGION_2"}
-	keyIDEnvVariables := []string{"AWS_KEY_ARN", "AWS_KEY_ARN_2"}
+	regionEnvVariables := []string{"AWS_KMS_REGION_A", "AWS_KMS_REGION_B"}
+	keyIDEnvVariables := []string{"AWS_KMS_KEY_ARN_A", "AWS_KMS_KEY_ARN_B"}
 
 	var multiRegionKMSURIs []string
 	for i := range regionEnvVariables {

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -13,48 +13,180 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
 )
 
+// The following env variable names match those specified in the TeamCity
+// configuration for the nightly roachtests. Any changes must be made to both
+// references of the name.
+const (
+	KMSRegionAEnvVar = "AWS_KMS_REGION_A"
+	KMSRegionBEnvVar = "AWS_KMS_REGION_B"
+	KMSKeyARNAEnvVar = "AWS_KMS_KEY_ARN_A"
+	KMSKeyARNBEnvVar = "AWS_KMS_KEY_ARN_B"
+)
+
 func registerBackup(r *testRegistry) {
+	importBankData := func(ctx context.Context, rows int, t *test, c *cluster) string {
+		dest := c.name
+
+		if local {
+			rows = 100
+			dest += fmt.Sprintf("%d", timeutil.Now().UnixNano())
+		}
+
+		c.Put(ctx, workload, "./workload")
+		c.Put(ctx, cockroach, "./cockroach")
+
+		// NB: starting the cluster creates the logs dir as a side effect,
+		// needed below.
+		c.Start(ctx, t)
+		c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
+		time.Sleep(time.Second) // wait for csv server to open listener
+
+		c.Run(ctx, c.Node(1), "./workload", "fixtures", "import", "bank",
+			"--db=bank", "--payload-bytes=10240", "--ranges=0", "--csv-server", "http://localhost:8081",
+			fmt.Sprintf("--rows=%d", rows), "--seed=1", "{pgurl:1}")
+
+		return dest
+	}
+
 	backup2TBSpec := makeClusterSpec(10)
 	r.Add(testSpec{
-		Name:       fmt.Sprintf("backup2TB/%s", backup2TBSpec),
+		Name:       fmt.Sprintf("backup/2TB/%s", backup2TBSpec),
 		Owner:      OwnerBulkIO,
 		Cluster:    backup2TBSpec,
 		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			rows := 65104166
-			dest := c.name
-
-			if local {
-				rows = 100
-				dest += fmt.Sprintf("%d", timeutil.Now().UnixNano())
-			}
-
-			c.Put(ctx, workload, "./workload")
-			c.Put(ctx, cockroach, "./cockroach")
-
-			// NB: starting the cluster creates the logs dir as a side effect,
-			// needed below.
-			c.Start(ctx, t)
-			c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
-			time.Sleep(time.Second) // wait for csv server to open listener
-
-			c.Run(ctx, c.Node(1), "./workload", "fixtures", "import", "bank",
-				"--db=bank", "--payload-bytes=10240", "--ranges=0", "--csv-server", "http://localhost:8081",
-				fmt.Sprintf("--rows=%d", rows), "--seed=1", "{pgurl:1}")
-
+			dest := importBankData(ctx, rows, t, c)
 			m := newMonitor(ctx, c)
 			m.Go(func(ctx context.Context) error {
 				t.Status(`running backup`)
 				c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
 				BACKUP bank.bank TO 'gs://cockroachdb-backup-testing/`+dest+`'"`)
+				return nil
+			})
+			m.Wait()
+		},
+	})
+
+	KMSSpec := makeClusterSpec(3)
+	r.Add(testSpec{
+		Name:       fmt.Sprintf("backup/KMS/%s", KMSSpec),
+		Owner:      OwnerBulkIO,
+		Cluster:    KMSSpec,
+		MinVersion: "v20.2.0",
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			if cloud == gce {
+				t.Skip("backupKMS roachtest is only configured to run on AWS", "")
+			}
+
+			// ~10GiB - which is 30Gib replicated.
+			rows := 976562
+			dest := importBankData(ctx, rows, t, c)
+
+			conn := c.Conn(ctx, 1)
+			m := newMonitor(ctx, c)
+			m.Go(func(ctx context.Context) error {
+				_, err := conn.ExecContext(ctx, `
+					CREATE DATABASE restoreA;
+					CREATE DATABASE restoreB;
+				`)
+				return err
+			})
+			m.Wait()
+
+			var kmsURIA, kmsURIB string
+			var err error
+			m = newMonitor(ctx, c)
+			m.Go(func(ctx context.Context) error {
+				t.Status(`running encrypted backup`)
+				kmsURIA, err = getAWSKMSURI(KMSRegionAEnvVar, KMSKeyARNAEnvVar)
+				if err != nil {
+					return err
+				}
+
+				kmsURIB, err = getAWSKMSURI(KMSRegionBEnvVar, KMSKeyARNBEnvVar)
+				if err != nil {
+					return err
+				}
+
+				kmsOptions := fmt.Sprintf("KMS=('%s', '%s')", kmsURIA, kmsURIB)
+				_, err := conn.ExecContext(ctx,
+					`BACKUP bank.bank TO 'nodelocal://1/kmsbackup/`+dest+`' WITH `+kmsOptions)
+				return err
+			})
+			m.Wait()
+
+			// Restore the encrypted BACKUP using each of KMS URI A and B separately.
+			m = newMonitor(ctx, c)
+			m.Go(func(ctx context.Context) error {
+				t.Status(`restore using KMSURIA`)
+				if _, err := conn.ExecContext(ctx,
+					`RESTORE bank.bank FROM $1 WITH into_db=restoreA, kms=$2`,
+					`nodelocal://1/kmsbackup/`+dest, kmsURIA,
+				); err != nil {
+					return err
+				}
+
+				t.Status(`restore using KMSURIB`)
+				if _, err := conn.ExecContext(ctx,
+					`RESTORE bank.bank FROM $1 WITH into_db=restoreB, kms=$2`,
+					`nodelocal://1/kmsbackup/`+dest, kmsURIB,
+				); err != nil {
+					return err
+				}
+
+				t.Status(`fingerprint`)
+				fingerprint := func(db string) (string, error) {
+					var b strings.Builder
+
+					query := fmt.Sprintf("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s.%s", db, "bank")
+					rows, err := conn.QueryContext(ctx, query)
+					if err != nil {
+						return "", err
+					}
+					defer rows.Close()
+					for rows.Next() {
+						var name, fp string
+						if err := rows.Scan(&name, &fp); err != nil {
+							return "", err
+						}
+						fmt.Fprintf(&b, "%s: %s\n", name, fp)
+					}
+
+					return b.String(), rows.Err()
+				}
+
+				originalBank, err := fingerprint("bank")
+				if err != nil {
+					return err
+				}
+				restoreA, err := fingerprint("restoreA")
+				if err != nil {
+					return err
+				}
+				restoreB, err := fingerprint("restoreB")
+				if err != nil {
+					return err
+				}
+
+				if originalBank != restoreA {
+					return errors.Errorf("got %s, expected %s while comparing restoreA with originalBank", restoreA, originalBank)
+				}
+				if originalBank != restoreB {
+					return errors.Errorf("got %s, expected %s while comparing restoreB with originalBank", restoreB, originalBank)
+				}
+
 				return nil
 			})
 			m.Wait()
@@ -126,11 +258,11 @@ func registerBackup(r *testRegistry) {
 				return
 			}
 
-			t.Status(`full backup`)
 			// Use a time slightly in the past to avoid "cannot specify timestamp in the future" errors.
 			tFull := fmt.Sprint(timeutil.Now().Add(time.Second * -2).UnixNano())
 			m = newMonitor(ctx, c)
 			m.Go(func(ctx context.Context) error {
+				t.Status(`full backup`)
 				_, err := conn.ExecContext(ctx,
 					`BACKUP tpcc.* TO $1 AS OF SYSTEM TIME `+tFull,
 					fullDir,
@@ -146,10 +278,10 @@ func registerBackup(r *testRegistry) {
 				return
 			}
 
-			t.Status(`incremental backup`)
 			tInc := fmt.Sprint(timeutil.Now().Add(time.Second * -2).UnixNano())
 			m = newMonitor(ctx, c)
 			m.Go(func(ctx context.Context) error {
+				t.Status(`incremental backup`)
 				_, err := conn.ExecContext(ctx,
 					`BACKUP tpcc.* TO $1 AS OF SYSTEM TIME `+tInc+` INCREMENTAL FROM $2`,
 					incDir,
@@ -190,6 +322,8 @@ func registerBackup(r *testRegistry) {
 				}
 
 				t.Status(`fingerprint`)
+				// TODO(adityamaru): Pull the fingerprint logic into a utility method
+				// which can be shared by multiple roachtests.
 				fingerprint := func(db string, asof string) (string, error) {
 					var b strings.Builder
 
@@ -262,4 +396,33 @@ func registerBackup(r *testRegistry) {
 			m.Wait()
 		},
 	})
+
+}
+
+func getAWSKMSURI(regionEnvVariable, keyIDEnvVariable string) (string, error) {
+	q := make(url.Values)
+	expect := map[string]string{
+		"AWS_ACCESS_KEY_ID":     cloudimpl.AWSAccessKeyParam,
+		"AWS_SECRET_ACCESS_KEY": cloudimpl.AWSSecretParam,
+		regionEnvVariable:       cloudimpl.KMSRegionParam,
+	}
+	for env, param := range expect {
+		v := os.Getenv(env)
+		if v == "" {
+			return "", errors.Newf("env variable %s must be present to run the KMS test", env)
+		}
+		q.Add(param, v)
+	}
+
+	// Get AWS Key ARN from env variable.
+	keyARN := os.Getenv(keyIDEnvVariable)
+	if keyARN == "" {
+		return "", errors.Newf("env variable %s must be present to run the KMS test", keyIDEnvVariable)
+	}
+
+	// Set AUTH to implicit
+	q.Add(cloudimpl.AuthParam, cloudimpl.AuthParamSpecified)
+	correctURI := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
+
+	return correctURI, nil
 }

--- a/pkg/storage/cloudimpl/cloudimpltests/aws_kms_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/aws_kms_test.go
@@ -57,9 +57,9 @@ func TestEncryptDecryptAWS(t *testing.T) {
 	}
 
 	// Get AWS KMS region from env variable.
-	kmsRegion := os.Getenv("AWS_REGION")
+	kmsRegion := os.Getenv("AWS_KMS_REGION_A")
 	if kmsRegion == "" {
-		skip.IgnoreLint(t, "AWS_REGION env var must be set")
+		skip.IgnoreLint(t, "AWS_KMS_REGION_A env var must be set")
 	}
 	q.Add(cloudimpl.KMSRegionParam, kmsRegion)
 
@@ -67,7 +67,7 @@ func TestEncryptDecryptAWS(t *testing.T) {
 	// - AWS_KEY_ARN
 	// - AWS_KEY_ID
 	// - AWS_KEY_ALIAS
-	for _, id := range []string{"AWS_KEY_ARN", "AWS_KEY_ID", "AWS_KEY_ALIAS"} {
+	for _, id := range []string{"AWS_KMS_KEY_ARN_A", "AWS_KEY_ID", "AWS_KEY_ALIAS"} {
 		// Get AWS Key identifier from env variable.
 		keyID := os.Getenv(id)
 		if keyID == "" {
@@ -142,9 +142,9 @@ func TestPutAWSKMSEndpoint(t *testing.T) {
 		q.Add(param, v)
 	}
 
-	keyARN := os.Getenv("AWS_KEY_ARN")
+	keyARN := os.Getenv("AWS_KMS_KEY_ARN_A")
 	if keyARN == "" {
-		skip.IgnoreLint(t, "AWS_KEY_ARN env var must be set")
+		skip.IgnoreLint(t, "AWS_KMS_KEY_ARN_A env var must be set")
 	}
 
 	t.Run("allow-endpoints", func(t *testing.T) {
@@ -165,14 +165,14 @@ func TestPutAWSKMSEndpoint(t *testing.T) {
 func TestAWSKMSDisallowImplicitCredentials(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	q := make(url.Values)
-	q.Add("AWS_REGION", cloudimpl.KMSRegionParam)
+	q.Add(cloudimpl.KMSRegionParam, "region")
 
 	// Set AUTH to implicit
 	q.Add(cloudimpl.AuthParam, cloudimpl.AuthParamImplicit)
 
-	keyARN := os.Getenv("AWS_KEY_ARN")
+	keyARN := os.Getenv("AWS_KMS_KEY_ARN_A")
 	if keyARN == "" {
-		skip.IgnoreLint(t, "AWS_KEY_ARN env var must be set")
+		skip.IgnoreLint(t, "AWS_KMS_KEY_ARN_A env var must be set")
 	}
 	uri := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
 	_, err := cloud.KMSFromURI(uri, &testKMSEnv{cluster.NoSettings,


### PR DESCRIPTION
This change adds a new roachtest which will run as part of the nightly
roachtest suite on the AWS machines only. It creates an encrypted BACKUP
using two AWS KMS regions and then attempts to RESTORE the BACKUP using
each of the AWS KMS regions independently.

The test has been run on roachprod using the same configurations that
we run the nightly tests with.

`bin/roachtest run -d --cloud='aws' 'backupKMS' --cpu-quota=384 --parallelism=3`

Release note: None