### PR TITLE
types: fix Box2DFamily having no SQLStandardName

### DIFF
--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1436,6 +1436,8 @@ func (t *T) SQLStandardNameWithTypmod(haveTypmod bool, typmod int) string {
 		return buf.String()
 	case BoolFamily:
 		return "boolean"
+	case Box2DFamily:
+		return "box2d"
 	case BytesFamily:
 		return "bytea"
 	case DateFamily:

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/lib/pq/oid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTypes(t *testing.T) {
@@ -971,6 +972,14 @@ func TestOidSetDuringUpgrade(t *testing.T) {
 			err := input.upgradeType()
 			assert.NoError(t, err)
 			assert.Equal(t, Oid, input.Oid())
+		})
+	}
+}
+
+func TestSQLStandardName(t *testing.T) {
+	for _, typ := range Scalar {
+		t.Run(typ.Name(), func(t *testing.T) {
+			require.NotEmpty(t, typ.SQLStandardName())
 		})
 	}
 }


### PR DESCRIPTION
Also added a test to catch this kind of regression.

Resolves https://github.com/cockroachdb/cockroach/issues/52851.
Resolves #52668.

Release note: None