### PR TITLE
sqlbase: split ranges on materialized views

### DIFF
--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -34,7 +34,7 @@ func ShouldSplitAtDesc(rawDesc *roachpb.Value) bool {
 	}
 	switch t := desc.GetUnion().(type) {
 	case *descpb.Descriptor_Table:
-		if t.Table.IsView() {
+		if t.Table.IsView() && !t.Table.MaterializedView() {
 			return false
 		}
 		return true

--- a/pkg/sql/sqlbase/system_test.go
+++ b/pkg/sql/sqlbase/system_test.go
@@ -21,11 +21,12 @@ import (
 
 func TestShouldSplitAtDesc(t *testing.T) {
 	for inner, should := range map[Descriptor]bool{
-		NewImmutableTableDescriptor(descpb.TableDescriptor{}):                    true,
-		NewImmutableTableDescriptor(descpb.TableDescriptor{ViewQuery: "SELECT"}): false,
-		NewInitialDatabaseDescriptor(42, "db", security.AdminRole):               false,
-		NewMutableCreatedTypeDescriptor(descpb.TypeDescriptor{}):                 false,
-		NewImmutableSchemaDescriptor(descpb.SchemaDescriptor{}):                  false,
+		NewImmutableTableDescriptor(descpb.TableDescriptor{}):                                              true,
+		NewImmutableTableDescriptor(descpb.TableDescriptor{ViewQuery: "SELECT"}):                           false,
+		NewImmutableTableDescriptor(descpb.TableDescriptor{ViewQuery: "SELECT", IsMaterializedView: true}): true,
+		NewInitialDatabaseDescriptor(42, "db", security.AdminRole):                                         false,
+		NewMutableCreatedTypeDescriptor(descpb.TypeDescriptor{}):                                           false,
+		NewImmutableSchemaDescriptor(descpb.SchemaDescriptor{}):                                            false,
 	} {
 		var rawDesc roachpb.Value
 		require.NoError(t, rawDesc.SetProto(inner.DescriptorProto()))


### PR DESCRIPTION
Ensure that we split ranges on materialied views like normal tables.

Release note: None