### PR TITLE
roachtest: bump min version on kv/contention/nodes=4

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -192,7 +192,7 @@ func registerKVContention(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("kv/contention/nodes=%d", nodes),
 		Owner:      OwnerKV,
-		MinVersion: "v19.2.0",
+		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(nodes + 1),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))


### PR DESCRIPTION
This was known to be flaky in v19.2 for various reasons.
v20.1 is the first release that we're being strict on it,
so we might as well skip it in earlier releases.