### PR TITLE
kv: specify request type in shared QueryTxn/RecoverTxn assertions

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_query_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_txn.go
@@ -11,7 +11,6 @@
 package batcheval
 
 import (
-	"bytes"
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -56,10 +55,12 @@ func QueryTxn(
 	}
 	if h.Timestamp.Less(args.Txn.WriteTimestamp) {
 		// This condition must hold for the timestamp cache access to be safe.
-		return result.Result{}, errors.Errorf("request timestamp %s less than txn timestamp %s", h.Timestamp, args.Txn.WriteTimestamp)
+		return result.Result{}, errors.Errorf("QueryTxn request timestamp %s less than txn timestamp %s",
+			h.Timestamp, args.Txn.WriteTimestamp)
 	}
-	if !bytes.Equal(args.Key, args.Txn.Key) {
-		return result.Result{}, errors.Errorf("request key %s does not match txn key %s", args.Key, args.Txn.Key)
+	if !args.Key.Equal(args.Txn.Key) {
+		return result.Result{}, errors.Errorf("QueryTxn request key %s does not match txn key %s",
+			args.Key, args.Txn.Key)
 	}
 	key := keys.TransactionKey(args.Txn.Key, args.Txn.ID)
 

--- a/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
@@ -11,7 +11,6 @@
 package batcheval
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
@@ -56,15 +55,17 @@ func RecoverTxn(
 	h := cArgs.Header
 	reply := resp.(*roachpb.RecoverTxnResponse)
 
-	if cArgs.Header.Txn != nil {
+	if h.Txn != nil {
 		return result.Result{}, ErrTransactionUnsupported
-	}
-	if !bytes.Equal(args.Key, args.Txn.Key) {
-		return result.Result{}, errors.Errorf("request key %s does not match txn key %s", args.Key, args.Txn.Key)
 	}
 	if h.Timestamp.Less(args.Txn.WriteTimestamp) {
 		// This condition must hold for the timestamp cache access/update to be safe.
-		return result.Result{}, errors.Errorf("request timestamp %s less than txn timestamp %s", h.Timestamp, args.Txn.WriteTimestamp)
+		return result.Result{}, errors.Errorf("RecoverTxn request timestamp %s less than txn timestamp %s",
+			h.Timestamp, args.Txn.WriteTimestamp)
+	}
+	if !args.Key.Equal(args.Txn.Key) {
+		return result.Result{}, errors.Errorf("RecoverTxn request key %s does not match txn key %s",
+			args.Key, args.Txn.Key)
 	}
 	key := keys.TransactionKey(args.Txn.Key, args.Txn.ID)
 


### PR DESCRIPTION
Otherwise we can't tell them apart, as we see in #52882.