### PR TITLE
roachtest: continue using experimental_follower_read_timestamp() builtin

### DIFF
--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -116,7 +116,7 @@ func runFollowerReadsTest(ctx context.Context, t *test, c *cluster) {
 		return func() error {
 			nodeDB := conns[node-1]
 			r := nodeDB.QueryRowContext(ctx, "SELECT v FROM test.test AS OF SYSTEM "+
-				"TIME follower_read_timestamp() WHERE k = $1", k)
+				"TIME experimental_follower_read_timestamp() WHERE k = $1", k)
 			var got int64
 			if err := r.Scan(&got); err != nil {
 				// Ignore errors due to cancellation.


### PR DESCRIPTION
Fixes #52612.
Fixes #52614.
Fixes #52615.
Fixes #52876.

In 7284376, we removed the "experimental_" prefix from the
`experimental_follower_read_timestamp()` builtin. This accidentally
broke the `follower-reads/nodes=3` roachtest on everything but `master`.
To maintain backwards compatibility, continue using the old form of the
builtin in roachtests.