### PR TITLE
roachtest: don't set changefeed.push.enabled

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -65,9 +65,6 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 	if _, err := db.Exec(`SET CLUSTER SETTING kv.rangefeed.enabled = true`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`SET CLUSTER SETTING changefeed.push.enabled = true`); err != nil {
-		t.Fatal(err)
-	}
 	kafka := kafkaManager{
 		c:     c,
 		nodes: kafkaNode,

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -483,12 +483,9 @@ func runCDCSchemaRegistry(ctx context.Context, t *test, c *cluster) {
 
 func registerCDC(r *testRegistry) {
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("cdc/tpcc-1000"),
-		Owner: OwnerCDC,
-		// RangeFeed is not production ready in 2.1; we could run the tests with the
-		// old poller, but it's not worth it.
-		MinVersion: "v19.1.0",
-		Cluster:    makeClusterSpec(4, cpu(16)),
+		Name:    fmt.Sprintf("cdc/tpcc-1000"),
+		Owner:   OwnerCDC,
+		Cluster: makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -500,10 +497,9 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:       fmt.Sprintf("cdc/initial-scan"),
-		Owner:      OwnerCDC,
-		MinVersion: "v2.1.0",
-		Cluster:    makeClusterSpec(4, cpu(16)),
+		Name:    fmt.Sprintf("cdc/initial-scan"),
+		Owner:   OwnerCDC,
+		Cluster: makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -516,13 +512,9 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:  "cdc/poller/rangefeed=false",
-		Owner: OwnerCDC,
-		// When testing a 2.1 binary, we use the poller for all the other tests
-		// and this is close enough to cdc/tpcc-1000 test to be redundant, so
-		// skip it.
-		MinVersion: "v19.1.0",
-		Cluster:    makeClusterSpec(4, cpu(16)),
+		Name:    "cdc/poller/rangefeed=false",
+		Owner:   OwnerCDC,
+		Cluster: makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -534,11 +526,9 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("cdc/sink-chaos"),
-		Owner: `cdc`,
-		// TODO(dan): Re-enable this test on 2.1 if we decide to backport #36852.
-		MinVersion: "v19.1.0",
-		Cluster:    makeClusterSpec(4, cpu(16)),
+		Name:    fmt.Sprintf("cdc/sink-chaos"),
+		Owner:   `cdc`,
+		Cluster: makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -551,12 +541,10 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("cdc/crdb-chaos"),
-		Owner: `cdc`,
-		Skip:  "#37716",
-		// TODO(dan): Re-enable this test on 2.1 if we decide to backport #36852.
-		MinVersion: "v19.1.0",
-		Cluster:    makeClusterSpec(4, cpu(16)),
+		Name:    fmt.Sprintf("cdc/crdb-chaos"),
+		Owner:   `cdc`,
+		Skip:    "#37716",
+		Cluster: makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -573,9 +561,8 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:       fmt.Sprintf("cdc/ledger"),
-		Owner:      `cdc`,
-		MinVersion: "v2.1.0",
+		Name:  fmt.Sprintf("cdc/ledger"),
+		Owner: `cdc`,
 		// TODO(mrtracy): This workload is designed to be running on a 20CPU nodes,
 		// but this cannot be allocated without some sort of configuration outside
 		// of this test. Look into it.
@@ -592,10 +579,9 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:       "cdc/cloud-sink-gcs/rangefeed=true",
-		Owner:      `cdc`,
-		MinVersion: "v19.1.0",
-		Cluster:    makeClusterSpec(4, cpu(16)),
+		Name:    "cdc/cloud-sink-gcs/rangefeed=true",
+		Owner:   `cdc`,
+		Cluster: makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType: tpccWorkloadType,
@@ -614,19 +600,17 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:       "cdc/bank",
-		Owner:      `cdc`,
-		MinVersion: "v2.1.0",
-		Cluster:    makeClusterSpec(4),
+		Name:    "cdc/bank",
+		Owner:   `cdc`,
+		Cluster: makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCDCBank(ctx, t, c)
 		},
 	})
 	r.Add(testSpec{
-		Name:       "cdc/schemareg",
-		Owner:      `cdc`,
-		MinVersion: "v19.1.0",
-		Cluster:    makeClusterSpec(1),
+		Name:    "cdc/schemareg",
+		Owner:   `cdc`,
+		Cluster: makeClusterSpec(1),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCDCSchemaRegistry(ctx, t, c)
 		},


### PR DESCRIPTION
Fixes #52875.
Fixes #52874.
Fixes #52873.
Fixes #52872.
Fixes #52871.
Fixes #52870.
Fixes #52856.
Fixes #52855.
Fixes #52854.
Fixes #52853.
Fixes #52852.
Fixes #52544.

In 8a81eac, we stopped ignoring "unknown cluster setting" errors when setting `changefeed.push.enabled` in a number of cdc tests. The comment on the code mentioned v2.1, but it turns out that it was also saving us on v19.2 onward because this cluster setting was removed in v19.2 in c7a195c.

We can remove the code to set the cluster setting entirely. It's dead code when testing v19.2 onward, and the cluster setting defaults to [`true` in v19.1](https://github.com/cockroachdb/cockroach/blob/cebc92d5ad596d721382df9ef18fac2ded589547/pkg/ccl/changefeedccl/changefeed.go#L48).
