### PR TITLE
tpcc: remove uneeded origin FK indexes

### DIFF
--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -90,10 +90,8 @@ const (
 		h_date   timestamp,
 		h_amount decimal(6,2),
 		h_data   varchar(24),
-		primary key (h_w_id, rowid)`
-	tpccHistorySchemaFkSuffix = `
-		index history_customer_fk_idx (h_c_w_id, h_c_d_id, h_c_id),
-		index history_district_fk_idx (h_w_id, h_d_id)`
+		primary key (h_w_id, rowid)
+  )`
 
 	// ORDER table.
 	tpccOrderSchemaBase = `(
@@ -171,9 +169,8 @@ const (
 		ol_quantity     integer,
 		ol_amount       decimal(6,2),
 		ol_dist_info    char(24),
-		primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number)`
-	tpccOrderLineSchemaFkSuffix = `
-		index order_line_stock_fk_idx (ol_supply_w_id, ol_i_id)`
+		primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number)
+  )`
 	tpccOrderLineSchemaInterleaveSuffix = `
 		interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)`
 )

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -466,12 +466,8 @@ func (w *tpcc) Tables() []workload.Table {
 		Stats: w.tpccCustomerStats(),
 	}
 	history := workload.Table{
-		Name: `history`,
-		Schema: maybeAddFkSuffix(
-			w.fks,
-			tpccHistorySchemaBase,
-			tpccHistorySchemaFkSuffix,
-		),
+		Name:   `history`,
+		Schema: tpccHistorySchemaBase,
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numHistoryPerWarehouse * w.warehouses,
 			FillBatch:  w.tpccHistoryInitialRowBatch,
@@ -540,11 +536,7 @@ func (w *tpcc) Tables() []workload.Table {
 		Name: `order_line`,
 		Schema: maybeAddInterleaveSuffix(
 			w.interleaved,
-			maybeAddFkSuffix(
-				w.fks,
-				tpccOrderLineSchemaBase,
-				tpccOrderLineSchemaFkSuffix,
-			),
+			tpccOrderLineSchemaBase,
 			tpccOrderLineSchemaInterleaveSuffix,
 		),
 		InitialRows: workload.BatchedTuples{


### PR DESCRIPTION
Work for #50911.

This commit removes the `history_customer_fk_idx`,
`history_district_fk_idx` and `order_line_stock_fk_idx` indexes from the
TPCC schema, as they are no longer needed.

Release note: None