### PR TITLE
release-19.2: build: in make and publish build, change dryrun s3 bucket name

### DIFF
--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -16,7 +16,7 @@ if [[ -z "${DRY_RUN}" ]] ; then
   google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_CREDENTIALS
   gcr_repository="us.gcr.io/cockroach-cloud-images/cockroach"
 else
-  bucket="${BUCKET:-cockroach-release-test}"
+  bucket="${BUCKET:-cockroach-builds-test}"
   google_credentials="$GOOGLE_COCKROACH_RELEASE_CREDENTIALS"
   gcr_repository="us.gcr.io/cockroach-release/cockroach-test"
   build_name="${build_name}.dryrun"


### PR DESCRIPTION
Backport 1/1 commits from #52805.

/cc @cockroachdb/release

---

Before: The bucket name was not consistently named with other buckets.

Why: Make the dryrun bucket named to match other buckets used by the
release process.

Now: The bucket name cockroach-builds-test fits with the names of the
other buckets.

Release note: None
