### PR TITLE
sql: implement idle_in_transaction_session_timeout

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -880,6 +880,7 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 	// Stop idle timer if the connExecutor is closed to ensure cancel session
 	// is not called.
 	ex.mu.IdleInSessionTimeout.Stop()
+	ex.mu.IdleInTransactionSessionTimeout.Stop()
 
 	if closeType != panicClose {
 		ex.state.mon.Stop(ctx)
@@ -1073,6 +1074,11 @@ type connExecutor struct {
 		// IdleInSessionTimeout is returned by the AfterFunc call that cancels the
 		// session if the idle time exceeds the idle_in_session_timeout.
 		IdleInSessionTimeout timeout
+
+		// IdleInTransactionSessionTimeout is returned by the AfterFunc call that
+		// cancels the session if the idle time in a transaction exceeds the
+		// idle_in_transaction_session_timeout.
+		IdleInTransactionSessionTimeout timeout
 	}
 
 	// curStmt is the statement that's currently being prepared or executed, if

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2162,6 +2162,10 @@ func (m *sessionDataMutator) SetIdleInSessionTimeout(timeout time.Duration) {
 	m.data.IdleInSessionTimeout = timeout
 }
 
+func (m *sessionDataMutator) SetIdleInTransactionSessionTimeout(timeout time.Duration) {
+	m.data.IdleInTransactionSessionTimeout = timeout
+}
+
 func (m *sessionDataMutator) SetAllowPrepareAsOptPlan(val bool) {
 	m.data.AllowPrepareAsOptPlan = val
 }

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -77,6 +77,10 @@ type SessionData struct {
 	// IdleInSessionTimeout is the duration a session is permitted to idle before
 	// the session is canceled. If set to 0, there is no timeout.
 	IdleInSessionTimeout time.Duration
+	// IdleInTransactionSessionTimeout is the duration a session is permitted to
+	// idle in a transaction before the session is canceled.
+	// If set to 0, there is no timeout.
+	IdleInTransactionSessionTimeout time.Duration
 	// User is the name of the user logged into the session.
 	User string
 	// SafeUpdates causes errors when the client

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -377,6 +377,19 @@ func idleInSessionTimeoutVarSet(ctx context.Context, m *sessionDataMutator, s st
 	return nil
 }
 
+func idleInTransactionSessionTimeoutVarSet(
+	ctx context.Context, m *sessionDataMutator, s string,
+) error {
+	timeout, err := validateTimeoutVar(s,
+		"idle_in_transaction_session_timeout")
+	if err != nil {
+		return err
+	}
+
+	m.SetIdleInTransactionSessionTimeout(timeout)
+	return nil
+}
+
 func intervalToDuration(interval *tree.DInterval) (time.Duration, error) {
 	nanos, _, _, err := interval.Encode()
 	if err != nil {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -826,10 +826,6 @@ var varGen = map[string]sessionVar{
 	// See https://www.postgresql.org/docs/10/static/runtime-config-client.html#GUC-LOC-TIMEOUT
 	`lock_timeout`: makeCompatIntVar(`lock_timeout`, 0),
 
-	// See https://www.postgresql.org/docs/10/static/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT
-	// See also issue #5924.
-	`idle_in_transaction_session_timeout`: makeCompatIntVar(`idle_in_transaction_session_timeout`, 0),
-
 	// Supported for PG compatibility only.
 	// See https://www.postgresql.org/docs/10/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 	`max_identifier_length`: {
@@ -1000,6 +996,16 @@ var varGen = map[string]sessionVar{
 		GlobalDefault: func(sv *settings.Values) string {
 			return clusterIdleInSessionTimeout.String(sv)
 		},
+	},
+
+	`idle_in_transaction_session_timeout`: {
+		GetStringVal: makeTimeoutVarGetter(`idle_in_transaction_session_timeout`),
+		Set:          idleInTransactionSessionTimeoutVarSet,
+		Get: func(evalCtx *extendedEvalContext) string {
+			ms := evalCtx.SessionData.StmtTimeout.Nanoseconds() / int64(time.Millisecond)
+			return strconv.FormatInt(ms, 10)
+		},
+		GlobalDefault: func(sv *settings.Values) string { return "0" },
 	},
 
 	// See https://www.postgresql.org/docs/10/static/runtime-config-client.html#GUC-TIMEZONE


### PR DESCRIPTION
Release note (sql change): Implement IdleInTransactionSessionTimeout
variable to allow terminating sessions that are idle in a transaction
past the provides threshold.

Set the variable by using SET idle_in_transaction_session_timeout = 'time'.

Sessions that are idle in OPEN, ABORTED and DONE(COMMITWAIT) transaction states
will be terminated if the user idles longer than the threshold time.

Fixes #5924