### PR TITLE
roachtest: update project column ID for AppDev issues

### DIFF
--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -64,7 +64,7 @@ type OwnerMetadata struct {
 // metadata used for github issue posting/slack rooms, etc.
 var roachtestOwners = map[Owner]OwnerMetadata{
 	OwnerAppDev: {SlackRoom: `app-dev`, ContactEmail: `rafi@cockroachlabs.com`,
-		TriageColumnID: 8532151,
+		TriageColumnID: 7259065,
 	},
 	OwnerBulkIO: {SlackRoom: `bulk-io`, ContactEmail: `david@cockroachlabs.com`,
 		TriageColumnID: 3097123,


### PR DESCRIPTION
This makes the issue go to the "test failures" column instead of the
"triage" column.

Release note: None