### PR TITLE
sql/opt/memo: fix merge skew in Memo.CheckExpr

### DIFF
--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -180,7 +180,7 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 		// Ensure that insert columns include all columns except for delete-only
 		// mutation columns (which do not need to be part of INSERT).
 		for i, n := 0, tab.ColumnCount(); i < n; i++ {
-			kind := tab.ColumnKind(i)
+			kind := tab.Column(i).Kind()
 			if (kind == cat.Ordinary || kind == cat.WriteOnly) && t.InsertCols[i] == 0 {
 				panic(errors.AssertionFailedf("insert values not provided for all table columns"))
 			}
@@ -205,12 +205,12 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 		meta := m.Metadata()
 		left, right := meta.Table(t.LeftTable), meta.Table(t.RightTable)
 		for i := 0; i < left.ColumnCount(); i++ {
-			if cat.IsSystemColumn(left, i) && t.Cols.Contains(t.LeftTable.ColumnID(i)) {
+			if left.Column(i).Kind() == cat.System && t.Cols.Contains(t.LeftTable.ColumnID(i)) {
 				panic(errors.AssertionFailedf("zigzag join should not contain system column"))
 			}
 		}
 		for i := 0; i < right.ColumnCount(); i++ {
-			if cat.IsSystemColumn(right, i) && t.Cols.Contains(t.RightTable.ColumnID(i)) {
+			if right.Column(i).Kind() == cat.System && t.Cols.Contains(t.RightTable.ColumnID(i)) {
 				panic(errors.AssertionFailedf("zigzag join should not contain system column"))
 			}
 		}
@@ -267,7 +267,7 @@ func (m *Memo) checkMutationExpr(rel RelExpr, private *MutationPrivate) {
 	tab := m.Metadata().Table(private.Table)
 	var mutCols opt.ColSet
 	for i, n := 0, tab.ColumnCount(); i < n; i++ {
-		if cat.IsMutationColumn(tab, i) {
+		if tab.Column(i).IsMutation() {
 			mutCols.Add(private.Table.ColumnID(i))
 		}
 	}


### PR DESCRIPTION
The changes in #52846 skewed with master (#51656 and #51681), but only under race compilation so it wasn't detected by bors. This fixes the breakage.