### PR TITLE
rowexec: joinReader optimizations for index joins

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1945,6 +1945,7 @@ func (dsp *DistSQLPlanner) createPlanForIndexJoin(
 		Visibility:        n.table.colCfg.visibility,
 		LockingStrength:   n.table.lockingStrength,
 		LockingWaitPolicy: n.table.lockingWaitPolicy,
+		MaintainOrdering:  len(n.reqOrdering) > 0,
 		SystemColumns:     n.table.systemColumns,
 	}
 

--- a/pkg/sql/execinfrapb/processors_sql.pb.go
+++ b/pkg/sql/execinfrapb/processors_sql.pb.go
@@ -64,7 +64,7 @@ func (x *ScanVisibility) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanVisibility) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{0}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{0}
 }
 
 // These mirror the aggregate functions supported by sql/parser. See
@@ -196,7 +196,7 @@ func (x *AggregatorSpec_Func) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Func) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{12, 0}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{12, 0}
 }
 
 type AggregatorSpec_Type int32
@@ -242,7 +242,7 @@ func (x *AggregatorSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{12, 1}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{12, 1}
 }
 
 type WindowerSpec_WindowFunc int32
@@ -306,7 +306,7 @@ func (x *WindowerSpec_WindowFunc) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_WindowFunc) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{15, 0}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{15, 0}
 }
 
 // Mode indicates which mode of framing is used.
@@ -350,7 +350,7 @@ func (x *WindowerSpec_Frame_Mode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Mode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{15, 1, 0}
 }
 
 // BoundType indicates which type of boundary is used.
@@ -397,7 +397,7 @@ func (x *WindowerSpec_Frame_BoundType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_BoundType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{15, 1, 1}
 }
 
 // Exclusion specifies the type of frame exclusion.
@@ -440,7 +440,7 @@ func (x *WindowerSpec_Frame_Exclusion) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Exclusion) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{15, 1, 2}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{15, 1, 2}
 }
 
 // ValuesCoreSpec is the core of a processor that has no inputs and generates
@@ -460,7 +460,7 @@ func (m *ValuesCoreSpec) Reset()         { *m = ValuesCoreSpec{} }
 func (m *ValuesCoreSpec) String() string { return proto.CompactTextString(m) }
 func (*ValuesCoreSpec) ProtoMessage()    {}
 func (*ValuesCoreSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{0}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{0}
 }
 func (m *ValuesCoreSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -568,7 +568,7 @@ func (m *TableReaderSpec) Reset()         { *m = TableReaderSpec{} }
 func (m *TableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*TableReaderSpec) ProtoMessage()    {}
 func (*TableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{1}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{1}
 }
 func (m *TableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -623,7 +623,7 @@ func (m *IndexSkipTableReaderSpec) Reset()         { *m = IndexSkipTableReaderSp
 func (m *IndexSkipTableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*IndexSkipTableReaderSpec) ProtoMessage()    {}
 func (*IndexSkipTableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{2}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{2}
 }
 func (m *IndexSkipTableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -713,8 +713,9 @@ type JoinReaderSpec struct {
 	// to BLOCK when locking_stength is FOR_NONE.
 	LockingWaitPolicy descpb.ScanLockingWaitPolicy `protobuf:"varint,10,opt,name=locking_wait_policy,json=lockingWaitPolicy,enum=cockroach.sql.sqlbase.ScanLockingWaitPolicy" json:"locking_wait_policy"`
 	// Indicates that the join reader should maintain the ordering of the input
-	// stream. This is only applicable to lookup joins, where doing so is
-	// expensive. Index joins do this by default regardless of the parameter.
+	// stream. This is applicable to both lookup joins and index joins.
+	// Maintaining ordering with lookup joins is expensive. With index joins,
+	// not maintaining ordering allows for optimizations at lower layers.
 	MaintainOrdering bool `protobuf:"varint,11,opt,name=maintain_ordering,json=maintainOrdering" json:"maintain_ordering"`
 	// Indicates what implicit system columns this JoinReader is expected to
 	// synthesize. These system columns will be placed at the end of the row
@@ -730,7 +731,7 @@ func (m *JoinReaderSpec) Reset()         { *m = JoinReaderSpec{} }
 func (m *JoinReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*JoinReaderSpec) ProtoMessage()    {}
 func (*JoinReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{3}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{3}
 }
 func (m *JoinReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -774,7 +775,7 @@ func (m *SorterSpec) Reset()         { *m = SorterSpec{} }
 func (m *SorterSpec) String() string { return proto.CompactTextString(m) }
 func (*SorterSpec) ProtoMessage()    {}
 func (*SorterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{4}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{4}
 }
 func (m *SorterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -836,7 +837,7 @@ func (m *DistinctSpec) Reset()         { *m = DistinctSpec{} }
 func (m *DistinctSpec) String() string { return proto.CompactTextString(m) }
 func (*DistinctSpec) ProtoMessage()    {}
 func (*DistinctSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{5}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{5}
 }
 func (m *DistinctSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -871,7 +872,7 @@ func (m *OrdinalitySpec) Reset()         { *m = OrdinalitySpec{} }
 func (m *OrdinalitySpec) String() string { return proto.CompactTextString(m) }
 func (*OrdinalitySpec) ProtoMessage()    {}
 func (*OrdinalitySpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{6}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{6}
 }
 func (m *OrdinalitySpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -929,7 +930,7 @@ func (m *ZigzagJoinerSpec) Reset()         { *m = ZigzagJoinerSpec{} }
 func (m *ZigzagJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*ZigzagJoinerSpec) ProtoMessage()    {}
 func (*ZigzagJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{7}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{7}
 }
 func (m *ZigzagJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1005,7 +1006,7 @@ func (m *MergeJoinerSpec) Reset()         { *m = MergeJoinerSpec{} }
 func (m *MergeJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*MergeJoinerSpec) ProtoMessage()    {}
 func (*MergeJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{8}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{8}
 }
 func (m *MergeJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1092,7 +1093,7 @@ func (m *HashJoinerSpec) Reset()         { *m = HashJoinerSpec{} }
 func (m *HashJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*HashJoinerSpec) ProtoMessage()    {}
 func (*HashJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{9}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{9}
 }
 func (m *HashJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1186,7 +1187,7 @@ func (m *InvertedJoinerSpec) Reset()         { *m = InvertedJoinerSpec{} }
 func (m *InvertedJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedJoinerSpec) ProtoMessage()    {}
 func (*InvertedJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{10}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{10}
 }
 func (m *InvertedJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1239,7 +1240,7 @@ func (m *InvertedFiltererSpec) Reset()         { *m = InvertedFiltererSpec{} }
 func (m *InvertedFiltererSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedFiltererSpec) ProtoMessage()    {}
 func (*InvertedFiltererSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{11}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{11}
 }
 func (m *InvertedFiltererSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1285,7 +1286,7 @@ func (m *AggregatorSpec) Reset()         { *m = AggregatorSpec{} }
 func (m *AggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec) ProtoMessage()    {}
 func (*AggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{12}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{12}
 }
 func (m *AggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1336,7 +1337,7 @@ func (m *AggregatorSpec_Aggregation) Reset()         { *m = AggregatorSpec_Aggre
 func (m *AggregatorSpec_Aggregation) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec_Aggregation) ProtoMessage()    {}
 func (*AggregatorSpec_Aggregation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{12, 0}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{12, 0}
 }
 func (m *AggregatorSpec_Aggregation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1407,7 +1408,7 @@ func (m *InterleavedReaderJoinerSpec) Reset()         { *m = InterleavedReaderJo
 func (m *InterleavedReaderJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{13}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{13}
 }
 func (m *InterleavedReaderJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1463,7 +1464,7 @@ func (m *InterleavedReaderJoinerSpec_Table) Reset()         { *m = InterleavedRe
 func (m *InterleavedReaderJoinerSpec_Table) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec_Table) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec_Table) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{13, 0}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{13, 0}
 }
 func (m *InterleavedReaderJoinerSpec_Table) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1503,7 +1504,7 @@ func (m *ProjectSetSpec) Reset()         { *m = ProjectSetSpec{} }
 func (m *ProjectSetSpec) String() string { return proto.CompactTextString(m) }
 func (*ProjectSetSpec) ProtoMessage()    {}
 func (*ProjectSetSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{14}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{14}
 }
 func (m *ProjectSetSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1545,7 +1546,7 @@ func (m *WindowerSpec) Reset()         { *m = WindowerSpec{} }
 func (m *WindowerSpec) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec) ProtoMessage()    {}
 func (*WindowerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{15}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{15}
 }
 func (m *WindowerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1581,7 +1582,7 @@ func (m *WindowerSpec_Func) Reset()         { *m = WindowerSpec_Func{} }
 func (m *WindowerSpec_Func) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Func) ProtoMessage()    {}
 func (*WindowerSpec_Func) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{15, 0}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{15, 0}
 }
 func (m *WindowerSpec_Func) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1617,7 +1618,7 @@ func (m *WindowerSpec_Frame) Reset()         { *m = WindowerSpec_Frame{} }
 func (m *WindowerSpec_Frame) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame) ProtoMessage()    {}
 func (*WindowerSpec_Frame) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{15, 1}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{15, 1}
 }
 func (m *WindowerSpec_Frame) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1658,7 +1659,7 @@ func (m *WindowerSpec_Frame_Bound) Reset()         { *m = WindowerSpec_Frame_Bou
 func (m *WindowerSpec_Frame_Bound) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bound) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bound) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{15, 1, 0}
 }
 func (m *WindowerSpec_Frame_Bound) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1694,7 +1695,7 @@ func (m *WindowerSpec_Frame_Bounds) Reset()         { *m = WindowerSpec_Frame_Bo
 func (m *WindowerSpec_Frame_Bounds) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bounds) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bounds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{15, 1, 1}
 }
 func (m *WindowerSpec_Frame_Bounds) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1744,7 +1745,7 @@ func (m *WindowerSpec_WindowFn) Reset()         { *m = WindowerSpec_WindowFn{} }
 func (m *WindowerSpec_WindowFn) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_WindowFn) ProtoMessage()    {}
 func (*WindowerSpec_WindowFn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_87f40537b51e0560, []int{15, 2}
+	return fileDescriptor_processors_sql_0142f18e4635c7a4, []int{15, 2}
 }
 func (m *WindowerSpec_WindowFn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8086,10 +8087,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_87f40537b51e0560)
+	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_0142f18e4635c7a4)
 }
 
-var fileDescriptor_processors_sql_87f40537b51e0560 = []byte{
+var fileDescriptor_processors_sql_0142f18e4635c7a4 = []byte{
 	// 2734 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x3a, 0xcd, 0x73, 0xdb, 0xc6,
 	0xf5, 0x02, 0x3f, 0x24, 0xf2, 0xf1, 0x43, 0xeb, 0xb5, 0x12, 0x33, 0xcc, 0xef, 0x27, 0xcb, 0x4c,

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -250,8 +250,9 @@ message JoinReaderSpec {
   optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 10 [(gogoproto.nullable) = false];
 
   // Indicates that the join reader should maintain the ordering of the input
-  // stream. This is only applicable to lookup joins, where doing so is
-  // expensive. Index joins do this by default regardless of the parameter.
+  // stream. This is applicable to both lookup joins and index joins.
+  // Maintaining ordering with lookup joins is expensive. With index joins,
+  // not maintaining ordering allows for optimizations at lower layers.
   optional bool maintain_ordering = 11 [(gogoproto.nullable) = false];
 
   // Indicates what implicit system columns this JoinReader is expected to

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -198,7 +198,7 @@ func TestClusterFlow(t *testing.T) {
 						},
 						ColumnTypes: rowenc.TwoIntCols,
 					}},
-					Core: execinfrapb.ProcessorCoreUnion{JoinReader: &execinfrapb.JoinReaderSpec{Table: *desc.TableDesc()}},
+					Core: execinfrapb.ProcessorCoreUnion{JoinReader: &execinfrapb.JoinReaderSpec{Table: *desc.TableDesc(), MaintainOrdering: true}},
 					Post: execinfrapb.PostProcessSpec{
 						Projection:    true,
 						OutputColumns: []uint32{2},

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -209,10 +209,10 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
 ----
 fetched: /t/b_desc/2/2 -> NULL
 fetched: /t/b_desc/1/1 -> NULL
-fetched: /t/primary/2/b/c -> /2/2
 fetched: /t/primary/1/b/c -> /1/1
-output row: [2 2 2]
+fetched: /t/primary/2/b/c -> /2/2
 output row: [1 1 1]
+output row: [2 2 2]
 
 statement ok
 DROP table t

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -71,9 +72,10 @@ type joinReader struct {
 
 	diskMonitor *mon.BytesMonitor
 
-	desc      tabledesc.Immutable
-	index     *descpb.IndexDescriptor
-	colIdxMap map[descpb.ColumnID]int
+	desc             tabledesc.Immutable
+	index            *descpb.IndexDescriptor
+	colIdxMap        map[descpb.ColumnID]int
+	maintainOrdering bool
 
 	// fetcher wraps the row.Fetcher used to perform lookups. This enables the
 	// joinReader to wrap the fetcher with a stat collector when necessary.
@@ -136,10 +138,11 @@ func newJoinReader(
 		return nil, errors.Errorf("unsupported joinReaderType")
 	}
 	jr := &joinReader{
-		desc:       tabledesc.MakeImmutable(spec.Table),
-		input:      input,
-		inputTypes: input.OutputTypes(),
-		lookupCols: lookupCols,
+		desc:             tabledesc.MakeImmutable(spec.Table),
+		maintainOrdering: spec.MaintainOrdering,
+		input:            input,
+		inputTypes:       input.OutputTypes(),
+		lookupCols:       lookupCols,
 	}
 
 	var err error
@@ -248,7 +251,7 @@ func newJoinReader(
 		jr.fetcher = &fetcher
 	}
 
-	jr.initJoinReaderStrategy(flowCtx, columnTypes, len(columnIDs), spec.MaintainOrdering, rightCols, readerType)
+	jr.initJoinReaderStrategy(flowCtx, columnTypes, len(columnIDs), rightCols, readerType)
 	jr.batchSizeBytes = jr.strategy.getLookupRowsBatchSizeHint()
 
 	// TODO(radu): verify the input types match the index key types
@@ -259,16 +262,21 @@ func (jr *joinReader) initJoinReaderStrategy(
 	flowCtx *execinfra.FlowCtx,
 	typs []*types.T,
 	numKeyCols int,
-	maintainOrdering bool,
 	neededRightCols util.FastIntSet,
 	readerType joinReaderType,
 ) {
 	spanBuilder := span.MakeBuilder(flowCtx.Codec(), &jr.desc, jr.index)
 	spanBuilder.SetNeededColumns(neededRightCols)
 
+	var keyToInputRowIndices map[string][]int
+	if readerType != indexJoinReaderType {
+		keyToInputRowIndices = make(map[string][]int)
+	}
+	// Else: see the comment in defaultSpanGenerator on why we don't need
+	// this map for index joins.
 	spanGenerator := defaultSpanGenerator{
 		spanBuilder:          spanBuilder,
-		keyToInputRowIndices: make(map[string][]int),
+		keyToInputRowIndices: keyToInputRowIndices,
 		numKeyCols:           numKeyCols,
 		lookupCols:           jr.lookupCols,
 	}
@@ -280,7 +288,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 		return
 	}
 
-	if !maintainOrdering {
+	if !jr.maintainOrdering {
 		jr.strategy = &joinReaderNoOrderingStrategy{
 			joinerBase:           &jr.joinerBase,
 			defaultSpanGenerator: spanGenerator,
@@ -445,13 +453,21 @@ func (jr *joinReader) readInput() (joinReaderState, *execinfrapb.ProducerMetadat
 		return jrEmittingRows, nil
 	}
 
-	if jr.readerType == lookupJoinReaderType {
-		// Sort the spans so that we can rely upon the fetcher to limit the number of
-		// results per batch. It's safe to reorder the spans here because we already
-		// restore the original order of the output during the output collection
-		// phase.
+	// Sort the spans for the following cases:
+	// - For lookupJoinReaderType: this is so that we can rely upon the fetcher
+	//   to limit the number of results per batch. It's safe to reorder the
+	//   spans here because we already restore the original order of the output
+	//   during the output collection phase.
+	// - For indexJoinReaderType when !maintainOrdering: this allows lower
+	//   layers to optimize iteration over the data. Note that the looked up
+	//   rows are output unchanged, in the retrieval order, so it is not safe to
+	//   do this when maintainOrdering is true (the ordering to be maintained
+	//   may be different than the ordering in the index).
+	if jr.readerType == lookupJoinReaderType ||
+		(jr.readerType == indexJoinReaderType && !jr.maintainOrdering) {
 		sort.Sort(spans)
 	}
+
 	log.VEventf(jr.Ctx, 1, "scanning %d spans", len(spans))
 	if err := jr.fetcher.StartScan(
 		jr.Ctx, jr.FlowCtx.Txn, spans, jr.shouldLimitBatches, 0, /* limitHint */
@@ -471,10 +487,16 @@ func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMet
 		// Construct a "partial key" of nCols, so we can match the key format that
 		// was stored in our keyToInputRowIndices map. This matches the format that
 		// is output in jr.generateSpan.
-		key, err := jr.fetcher.PartialKey(nCols)
-		if err != nil {
-			jr.MoveToDraining(err)
-			return jrStateUnknown, jr.DrainHelper()
+		var key roachpb.Key
+		// Index joins do not look at this key parameter so don't bother populating
+		// it, since it is not cheap for long keys.
+		if jr.readerType != indexJoinReaderType {
+			var err error
+			key, err = jr.fetcher.PartialKey(nCols)
+			if err != nil {
+				jr.MoveToDraining(err)
+				return jrStateUnknown, jr.DrainHelper()
+			}
 		}
 
 		// Fetch the next row and copy it into the row container.

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -633,7 +633,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 
 	// Verify that the index foo over v is consistent, and that column x has
 	// been backfilled properly.
-	rows, err := sqlDB.Query(`SELECT v, x from t.test@foo`)
+	rows, err := sqlDB.Query(`SELECT v, x from t.test@foo ORDER BY v`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4520,7 +4520,7 @@ ALTER TABLE t.test ADD COLUMN c INT AS (v + 4) STORED, ADD COLUMN d INT DEFAULT 
 
 	// Verify that the index bar over is consistent, and that columns c, d
 	// have been backfilled properly.
-	rows, err := sqlDB.Query(`SELECT c, d from t.test@bar`)
+	rows, err := sqlDB.Query(`SELECT c, d from t.test@bar ORDER BY c`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4535,7 +4535,7 @@ ALTER TABLE t.test ADD COLUMN c INT AS (v + 4) STORED, ADD COLUMN d INT DEFAULT 
 			continue
 		}
 		if count+4 != c {
-			t.Errorf("e = %d, v = %d", count, c)
+			t.Errorf("e = %d, v = %d", count+4, c)
 		}
 		if d != 23 {
 			t.Errorf("e = %d, v = %d", 23, d)


### PR DESCRIPTION
These small optimizations are for index joins with large
numbers of rows, which are common with geospatial queries.
- No longer uses the keyToInputRowIndices map which
  was consuming about 1.5% in cpu profiles
- Sorts the spans to use optimizations at the storage layer,
  like https://github.com/cockroachdb/pebble/pull/860
- Avoids constructing the partial key string since it is
  not used

Release note: None