### PR TITLE
opt: support INSERT ON CONFLICT with unique partial indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -639,6 +639,69 @@ SELECT * FROM l@a_b_gt_5 WHERE b > 5
 ----
 7  7
 
+# Test unique partial indexes.
+subtest unique
+
+statement ok
+CREATE TABLE u (
+    a INT,
+    b INT,
+    UNIQUE INDEX i (a) WHERE b > 0
+)
+
+# Inserting multiple rows that conflicts fails.
+statement error pgcode 23505 duplicate key value \(a\)=\(1\) violates unique constraint \"i\"
+INSERT INTO u VALUES (1, 1), (1, 2)
+
+# Inserting multiple rows that don't conflict succeeds.
+statement ok
+INSERT INTO u VALUES (1, 1), (2, 2), (1, -1)
+
+# Inserting a row that conflicts with an existing row fails.
+statement error pgcode 23505 duplicate key value \(a\)=\(1\) violates unique constraint \"i\"
+INSERT INTO u VALUES (1, 3)
+
+query II rowsort
+SELECT * FROM u
+----
+1  1
+2  2
+1  -1
+
+# Deleting and re-inserting a conflicting row is successful.
+statement ok
+DELETE FROM u WHERE a = 2;
+INSERT INTO u VALUES (2, 2);
+
+# Updating a row in the unique partial index to conflict with another row fails.
+statement error pgcode 23505 duplicate key value \(a\)=\(2\) violates unique constraint \"i\"
+UPDATE u SET a = 2 WHERE b = 1
+
+# Updating a row not in the unique partial index to conflict with a row in the
+# index fails.
+statement error pgcode 23505 duplicate key value \(a\)=\(2\) violates unique constraint \"i\"
+UPDATE u SET a = 2, b = 1 WHERE b = -1
+
+# Updating a row not in the unique index to remain out of the unique index
+# succeeds.
+statement ok
+UPDATE u SET a = 2, b = -2 WHERE b = -1
+
+# Updating a row in the unique index to a non-conflicting value in the unqiue
+# index succeeds.
+statement ok
+UPDATE u SET a = 3, b = 3  WHERE b = 2
+
+query II rowsort
+SELECT * FROM u
+----
+1  1
+3  3
+2  -2
+
+statement ok
+DELETE FROM u
+
 # Test partial indexes with an ENUM in the predicate.
 subtest enum
 

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -702,6 +702,135 @@ SELECT * FROM u
 statement ok
 DELETE FROM u
 
+# Tests for ON CONFLICT DO NOTHING.
+
+# Inserting a row not contained in the unique index succeeds.
+statement ok
+INSERT INTO u VALUES (1, -1) ON CONFLICT DO NOTHING
+
+query II rowsort
+SELECT * FROM u
+----
+1  -1
+
+# Inserting a non-conflicting row succeeds.
+statement ok
+INSERT INTO u VALUES (1, 1) ON CONFLICT DO NOTHING;
+
+query II rowsort
+SELECT * FROM u
+----
+1  1
+1  -1
+
+# Inserting rows that aren't contained by the unique index succeeds.
+statement ok
+INSERT INTO u VALUES (1, -10), (1, -100) ON CONFLICT DO NOTHING;
+INSERT INTO u VALUES (1, -1000) ON CONFLICT DO NOTHING;
+
+query II rowsort
+SELECT * FROM u
+----
+1  1
+1  -1
+1  -10
+1  -100
+1  -1000
+
+statement ok
+DELETE FROM u WHERE b IN (-10, -100, -1000)
+
+# Inserting multiple rows that conflict with each other inserts some of the
+# rows.
+statement ok
+INSERT INTO u VALUES (2, 2), (2, 20), (2, -2) ON CONFLICT DO NOTHING
+
+query II rowsort
+SELECT * FROM u
+----
+1  1
+2  2
+1  -1
+2  -2
+
+# Inserting a row that conflicts with an existing row is a no-op.
+statement ok
+INSERT INTO u VALUES (1, 10) ON CONFLICT DO NOTHING
+
+query II rowsort
+SELECT * FROM u
+----
+1  1
+2  2
+1  -1
+2  -2
+
+# Inserting one conflicting and one non-conflicting row inserts the
+# non-conflicting row.
+statement ok
+INSERT INTO u VALUES (2, 20), (3, 3) ON CONFLICT DO NOTHING
+
+query II rowsort
+SELECT * FROM u
+----
+1  1
+2  2
+3  3
+1  -1
+2  -2
+
+statement ok
+CREATE UNIQUE INDEX i2 ON u (b) WHERE a > 0
+
+# Inserting a row that conflicts with a row via a second unique index is a
+# no-op.
+statement ok
+INSERT INTO u VALUES (4, 3) ON CONFLICT DO NOTHING
+
+query II rowsort
+SELECT * FROM u
+----
+1  1
+2  2
+3  3
+1  -1
+2  -2
+
+# Inserting a row that conflicts with rows via two unique indexes is a no-op.
+statement ok
+INSERT INTO u VALUES (1, 3) ON CONFLICT DO NOTHING
+
+query II rowsort
+SELECT * FROM u
+----
+1  1
+2  2
+3  3
+1  -1
+2  -2
+
+# Inserting rows that conflict with neither unique index succeeds.
+statement ok
+INSERT INTO u VALUES (4, 4), (1, -10), (-10, 2) ON CONFLICT DO NOTHING
+
+query II rowsort
+SELECT * FROM u
+----
+1    1
+2    2
+3    3
+4    4
+1    -1
+1    -10
+2    -2
+-10  2
+
+statement ok
+DROP INDEX i2
+
+statement ok
+DELETE from u
+
 # Test partial indexes with an ENUM in the predicate.
 subtest enum
 

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -656,9 +656,9 @@ define IfErr {
 # returned.
 #
 # Note that the Whens list inside Case is used to represent all the WHEN
-# branches as well as the ELSE statement if it exists. It is of the form:
+# branches. It is of the form:
 #
-#   [(When <condval1> <expr1>),(When <condval2> <expr2>),...,<expr>]
+#   [(When <condval1> <expr1>),(When <condval2> <expr2>),...]
 #
 [Scalar]
 define Case {

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -2089,3 +2089,91 @@ build
 INSERT INTO partial_indexes (a, b, c) VALUES (1, 1, 'foo') ON CONFLICT (a) DO UPDATE SET b = b + 1
 ----
 error (42702): column reference "b" is ambiguous (candidates: excluded.b, partial_indexes.b)
+
+# ------------------------------------------------------------------------------
+# Test unique partial indexes.
+# ------------------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE unique_partial_indexes (
+    a INT PRIMARY KEY,
+    b INT,
+    c STRING,
+    UNIQUE INDEX (b) WHERE c = 'foo'
+)
+----
+
+build
+INSERT INTO unique_partial_indexes VALUES (1, 1, 'bar') ON CONFLICT DO NOTHING
+----
+insert unique_partial_indexes
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    ├── column2:6 => b:2
+ │    └── column3:7 => c:3
+ ├── partial index put columns: column17:17
+ └── project
+      ├── columns: column17:17!null column1:5!null column2:6!null column3:7!null
+      ├── project
+      │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    └── upsert-distinct-on
+      │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct1:16
+      │         ├── grouping columns: column2:6!null upsert_partial_index_distinct1:16
+      │         ├── project
+      │         │    ├── columns: upsert_partial_index_distinct1:16 column1:5!null column2:6!null column3:7!null
+      │         │    ├── project
+      │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │    └── select
+      │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
+      │         │    │         ├── left-join (hash)
+      │         │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:12 b:13 c:14
+      │         │    │         │    ├── upsert-distinct-on
+      │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │         │    │    ├── grouping columns: column1:5!null
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │         │    │    │    └── select
+      │         │    │         │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
+      │         │    │         │    │    │         ├── left-join (hash)
+      │         │    │         │    │    │         │    ├── columns: column1:5!null column2:6!null column3:7!null a:8 b:9 c:10
+      │         │    │         │    │    │         │    ├── values
+      │         │    │         │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │         │    │    │         │    │    └── (1, 1, 'bar')
+      │         │    │         │    │    │         │    ├── scan unique_partial_indexes
+      │         │    │         │    │    │         │    │    ├── columns: a:8!null b:9 c:10
+      │         │    │         │    │    │         │    │    └── partial index predicates
+      │         │    │         │    │    │         │    │         └── secondary: filters
+      │         │    │         │    │    │         │    │              └── c:10 = 'foo'
+      │         │    │         │    │    │         │    └── filters
+      │         │    │         │    │    │         │         └── column1:5 = a:8
+      │         │    │         │    │    │         └── filters
+      │         │    │         │    │    │              └── a:8 IS NULL
+      │         │    │         │    │    └── aggregations
+      │         │    │         │    │         ├── first-agg [as=column2:6]
+      │         │    │         │    │         │    └── column2:6
+      │         │    │         │    │         └── first-agg [as=column3:7]
+      │         │    │         │    │              └── column3:7
+      │         │    │         │    ├── select
+      │         │    │         │    │    ├── columns: a:12!null b:13 c:14!null
+      │         │    │         │    │    ├── scan unique_partial_indexes
+      │         │    │         │    │    │    ├── columns: a:12!null b:13 c:14
+      │         │    │         │    │    │    └── partial index predicates
+      │         │    │         │    │    │         └── secondary: filters
+      │         │    │         │    │    │              └── c:14 = 'foo'
+      │         │    │         │    │    └── filters
+      │         │    │         │    │         └── c:14 = 'foo'
+      │         │    │         │    └── filters
+      │         │    │         │         ├── column2:6 = b:13
+      │         │    │         │         └── column3:7 = 'foo'
+      │         │    │         └── filters
+      │         │    │              └── a:12 IS NULL
+      │         │    └── projections
+      │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct1:16]
+      │         └── aggregations
+      │              ├── first-agg [as=column1:5]
+      │              │    └── column1:5
+      │              └── first-agg [as=column3:7]
+      │                   └── column3:7
+      └── projections
+           └── column3:7 = 'foo' [as=column17:17]


### PR DESCRIPTION
#### sql: add basic tests for unique partial indexes

This commit adds tests for INSERT, UPDATE, and DELETE operations on
tables with unique partial indexes.

Release note: None

#### opt: support INSERT ON CONFLICT DO NOTHING and unique partial indexes

This commit adds support for `INSERT ON CONFLICT DO NOTHING` statements
on tables with unique partial indexes. In order to support the correct
behavior, there are three primary changes to the expression tree built
by `optbuilder`.

  1. Existing rows that are not in the unique partial index cannot
  conflict with insert rows. Therefore, the Scans that search for
  existing, conflicting rows are wrapped in Selects with the partial
  index predicate as a filter.

  2. Insert rows that do not satisfy the partial index predicate cannot
  conflict with existing rows in the unique partial index. Therefore,
  the left outer join ON filter now includes the partial index
  predicate.

  3. Insert rows that do not satisfy the partial index predicate cannot
  conflict with other insert rows in the same `INSERT` and they should
  not be de-duplicated. Therefore, we project a new column that allows
  the UpsertDistinctOn expression to de-duplicate only the rows that
  satisfy the partial index predicate.

Future work includes handling `INSERT ON CONFLICT (column)` and
`INSERT ON CONFLICT DO UPDATE`.

Informs #52603

Release note: None
